### PR TITLE
feat(windows/sponsor): Plan D.2.5 OAuth activation + DPAPI JWT cache

### DIFF
--- a/windows/Ghostty.Core/Ghostty.Core.csproj
+++ b/windows/Ghostty.Core/Ghostty.Core.csproj
@@ -47,5 +47,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.EventSource" Version="9.0.0" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.269" PrivateAssets="all" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="9.0.0" />
   </ItemGroup>
 </Project>

--- a/windows/Ghostty.Core/Logging/LogEvents.cs
+++ b/windows/Ghostty.Core/Logging/LogEvents.cs
@@ -23,4 +23,38 @@ internal static class LogEvents
         public const int LoadFailed  = 1101;
         public const int SaveFailed  = 1102;
     }
+
+    // 1200-1299: Sponsor/Auth (OAuthTokenProvider)
+    internal static class Auth
+    {
+        public const int ReactiveRefreshSucceeded    = 1200;
+        public const int ReactiveRefreshRejected     = 1201;
+        public const int ReactiveRefreshTransient    = 1202;
+        public const int ReactiveRefreshUnexpected   = 1203;
+        public const int DevJwtLoaded                = 1204;
+        public const int DevJwtMalformed             = 1205;
+        public const int StoreReadFailed             = 1206;
+        public const int NoCachedJwt                 = 1207;
+        public const int CachedJwtMalformed          = 1208;
+        public const int CachedJwtStale              = 1209;
+        public const int BootRefreshSucceeded        = 1210;
+        public const int BootRefreshRejected         = 1211;
+        public const int BootRefreshFailed           = 1212;
+        public const int LoadedCachedJwt             = 1213;
+        public const int StoreDeleteFailed           = 1214;
+        public const int ProactiveRefreshSucceeded   = 1215;
+        public const int ProactiveRefreshRejected    = 1216;
+        public const int ProactiveRefreshTransient   = 1217;
+        public const int ProactiveRefreshUnexpected  = 1218;
+        public const int RevokeAcknowledged          = 1219;
+        public const int RevokeBestEffortFailed      = 1220;
+        public const int LoopbackBindFailed          = 1221;
+        public const int SignInTimedOut              = 1222;
+        public const int OAuthErrorQuery             = 1223;
+        public const int NonceMismatch               = 1224;
+        public const int CallbackMissingToken        = 1225;
+        public const int CallbackMalformedJwt        = 1226;
+        public const int CallbackJwtPreExpired       = 1227;
+        public const int SignInComplete              = 1228;
+    }
 }

--- a/windows/Ghostty.Core/Sponsor/Auth/AuthErrorKind.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/AuthErrorKind.cs
@@ -1,0 +1,21 @@
+namespace Ghostty.Core.Sponsor.Auth;
+
+/// <summary>
+/// Coarse failure categories for Worker auth calls (refresh / revoke)
+/// and the OAuth handshake. Mirrors <see cref="Ghostty.Core.Sponsor.Update.UpdateErrorKind"/>
+/// style from D.2 so the token provider can translate at the driver boundary.
+/// </summary>
+public enum AuthErrorKind
+{
+    /// <summary>DNS, TCP, TLS, or timeout failure reaching the Worker.</summary>
+    Network,
+
+    /// <summary>Worker returned 401/403 or the token has been revoked.</summary>
+    Unauthorized,
+
+    /// <summary>Worker returned 5xx or malformed response.</summary>
+    ServerError,
+
+    /// <summary>Protocol-shape violation or invariant failure (nonce mismatch, malformed JWT).</summary>
+    Unknown,
+}

--- a/windows/Ghostty.Core/Sponsor/Auth/AuthErrorKind.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/AuthErrorKind.cs
@@ -5,7 +5,7 @@ namespace Ghostty.Core.Sponsor.Auth;
 /// and the OAuth handshake. Mirrors <see cref="Ghostty.Core.Sponsor.Update.UpdateErrorKind"/>
 /// style from D.2 so the token provider can translate at the driver boundary.
 /// </summary>
-public enum AuthErrorKind
+internal enum AuthErrorKind
 {
     /// <summary>DNS, TCP, TLS, or timeout failure reaching the Worker.</summary>
     Network,

--- a/windows/Ghostty.Core/Sponsor/Auth/AuthException.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/AuthException.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace Ghostty.Core.Sponsor.Auth;
+
+/// <summary>
+/// Auth-layer exception. <see cref="OAuthTokenProvider"/> catches these
+/// and maps to <c>ISponsorTokenProvider</c> state transitions
+/// (TokenInvalidated, silent-skip, silent-reschedule) per the design
+/// spec's error taxonomy bridge.
+/// </summary>
+public sealed class AuthException : Exception
+{
+    public AuthErrorKind Kind { get; }
+
+    public AuthException(AuthErrorKind kind, string message)
+        : base(message)
+    {
+        Kind = kind;
+    }
+
+    public AuthException(AuthErrorKind kind, string message, Exception innerException)
+        : base(message, innerException)
+    {
+        Kind = kind;
+    }
+}

--- a/windows/Ghostty.Core/Sponsor/Auth/AuthException.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/AuthException.cs
@@ -3,24 +3,23 @@ using System;
 namespace Ghostty.Core.Sponsor.Auth;
 
 /// <summary>
-/// Auth-layer exception. <see cref="OAuthTokenProvider"/> catches these
-/// and maps to <c>ISponsorTokenProvider</c> state transitions
-/// (TokenInvalidated, silent-skip, silent-reschedule) per the design
-/// spec's error taxonomy bridge.
+/// Typed failure from a Worker auth call or the OAuth loopback flow.
+/// <c>OAuthTokenProvider</c> catches these and maps <see cref="Kind"/>
+/// to <c>ISponsorTokenProvider</c> state transitions (silent-skip,
+/// reschedule, fire TokenInvalidated).
 /// </summary>
-public sealed class AuthException : Exception
+internal sealed class AuthException : Exception
 {
     public AuthErrorKind Kind { get; }
+    public string? Detail { get; }
 
-    public AuthException(AuthErrorKind kind, string message)
-        : base(message)
+    public AuthException(
+        AuthErrorKind kind,
+        string? detail,
+        Exception? innerException = null)
+        : base($"{kind}: {detail ?? "(no detail)"}", innerException)
     {
         Kind = kind;
-    }
-
-    public AuthException(AuthErrorKind kind, string message, Exception innerException)
-        : base(message, innerException)
-    {
-        Kind = kind;
+        Detail = detail;
     }
 }

--- a/windows/Ghostty.Core/Sponsor/Auth/DesktopBrowserLauncher.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/DesktopBrowserLauncher.cs
@@ -32,7 +32,10 @@ internal sealed class DesktopBrowserLauncher : IBrowserLauncher
                 UseShellExecute = true,
             });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is System.ComponentModel.Win32Exception
+                                      or System.IO.FileNotFoundException
+                                      or InvalidOperationException
+                                      or ObjectDisposedException)
         {
             // ShellExecute can fail if no default browser is registered,
             // the URL scheme is blocked by policy, or the shell denies

--- a/windows/Ghostty.Core/Sponsor/Auth/DesktopBrowserLauncher.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/DesktopBrowserLauncher.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Ghostty.Core.Sponsor.Auth;
+
+/// <summary>
+/// Opens URLs in the user's default browser via Shell Execute. The
+/// caller (<c>OAuthTokenProvider</c>) does not rely on this to succeed;
+/// the loopback listener's timeout is the authoritative "did anything
+/// happen" signal.
+/// </summary>
+internal sealed class DesktopBrowserLauncher : IBrowserLauncher
+{
+    private readonly ILogger<DesktopBrowserLauncher> _logger;
+
+    public DesktopBrowserLauncher(ILogger<DesktopBrowserLauncher> logger)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        _logger = logger;
+    }
+
+    public void Open(Uri url)
+    {
+        ArgumentNullException.ThrowIfNull(url);
+
+        try
+        {
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = url.ToString(),
+                UseShellExecute = true,
+            });
+        }
+        catch (Exception ex)
+        {
+            // ShellExecute can fail if no default browser is registered,
+            // the URL scheme is blocked by policy, or the shell denies
+            // the launch. Non-fatal: loopback timeout handles the
+            // "user never completed" case identically.
+            _logger.LogWarning(ex, "[sponsor/auth] failed to launch browser for {Url}", url);
+        }
+    }
+}

--- a/windows/Ghostty.Core/Sponsor/Auth/DpapiJwtStore.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/DpapiJwtStore.cs
@@ -27,12 +27,13 @@ internal sealed class DpapiJwtStore : IJwtStore
     public const string EntropyLabelV1 = "wintty-sponsor-jwt-v1";
 
     /// <summary>
-    /// Default entropy bytes for DPAPI encryption. Callers building a
-    /// DpapiJwtStore pass <see cref="DefaultEntropy"/>; the constant
-    /// is exposed so the App wiring doesn't have to duplicate the literal.
+    /// Default entropy bytes for DPAPI encryption. Exposed as
+    /// <see cref="ReadOnlySpan{Byte}"/> backed by a UTF-8 string literal
+    /// so the data lives in the PE's read-only section - no heap array
+    /// that an errant caller can mutate out from under every
+    /// subsequent encrypt/decrypt.
     /// </summary>
-    public static readonly byte[] DefaultEntropy =
-        System.Text.Encoding.UTF8.GetBytes(EntropyLabelV1);
+    public static ReadOnlySpan<byte> DefaultEntropy => "wintty-sponsor-jwt-v1"u8;
 
     private const string FileName = "auth.bin";
     private const string PartialSuffix = ".partial";
@@ -40,12 +41,16 @@ internal sealed class DpapiJwtStore : IJwtStore
     private readonly string _root;
     private readonly byte[] _entropy;
 
-    public DpapiJwtStore(string root, byte[] entropy)
+    public DpapiJwtStore(string root, ReadOnlySpan<byte> entropy)
     {
         ArgumentException.ThrowIfNullOrEmpty(root);
-        ArgumentNullException.ThrowIfNull(entropy);
+        if (entropy.IsEmpty)
+            throw new ArgumentException("entropy must not be empty", nameof(entropy));
         _root = root;
-        _entropy = entropy;
+        // Defensive copy: the caller could be handing us a pooled
+        // buffer or a slice of a larger array. We need a stable blob
+        // for the lifetime of this store.
+        _entropy = entropy.ToArray();
 
         Directory.CreateDirectory(_root);
     }
@@ -106,21 +111,15 @@ internal sealed class DpapiJwtStore : IJwtStore
 
     public Task DeleteAsync(CancellationToken ct)
     {
-        try
-        {
-            if (File.Exists(Target))
-                File.Delete(Target);
-            if (File.Exists(Partial))
-                File.Delete(Partial);
-        }
-        catch (IOException)
-        {
-            // Sign-out must not fail on file locks. Logged by caller.
-        }
-        catch (UnauthorizedAccessException)
-        {
-            // Same reasoning.
-        }
+        // Surface IOException / UnauthorizedAccessException to the
+        // caller (OAuthTokenProvider.SafeDeleteAsync) so the single
+        // logger call there sees the actual failure instead of a
+        // silent success. Double-swallow was losing the only useful
+        // signal we had for "JWT still on disk after sign-out".
+        if (File.Exists(Target))
+            File.Delete(Target);
+        if (File.Exists(Partial))
+            File.Delete(Partial);
         return Task.CompletedTask;
     }
 }

--- a/windows/Ghostty.Core/Sponsor/Auth/DpapiJwtStore.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/DpapiJwtStore.cs
@@ -36,45 +36,55 @@ internal sealed class DpapiJwtStore : IJwtStore
     private string Target  => Path.Combine(_root, FileName);
     private string Partial => Path.Combine(_root, FileName + PartialSuffix);
 
-    public Task<byte[]?> ReadAsync(CancellationToken ct)
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT",
+        "IL3050:RequiresDynamicCode",
+        Justification = "ProtectedData.Protect/Unprotect are trim-safe P/Invoke wrappers; no dynamic codegen.")]
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming",
+        "IL2026:RequiresUnreferencedCode",
+        Justification = "ProtectedData.Protect/Unprotect do not require reflection on application types.")]
+    public async Task<byte[]?> ReadAsync(CancellationToken ct)
     {
         if (!File.Exists(Target))
-            return Task.FromResult<byte[]?>(null);
+            return null;
 
         try
         {
-            var encrypted = File.ReadAllBytes(Target);
-#pragma warning disable IL2026, IL3050
-            // ProtectedData is Windows-only and trim-safe in practice.
+            var encrypted = await File.ReadAllBytesAsync(Target, ct).ConfigureAwait(false);
+            // Note: ProtectedData.Unprotect has no async equivalent. It is a
+            // fast in-memory call (microseconds for our ~1KB JWT) so the
+            // sync call on the awaiting thread is fine.
             var plain = ProtectedData.Unprotect(encrypted, _entropy, DataProtectionScope.CurrentUser);
-#pragma warning restore IL2026, IL3050
-            return Task.FromResult<byte[]?>(plain);
+            return plain;
         }
         catch (CryptographicException)
         {
             // Entropy mismatch, corrupted blob, or a different user's
             // session. Treat as "no valid token" and let the caller
             // decide whether to delete.
-            return Task.FromResult<byte[]?>(null);
+            return null;
         }
         catch (IOException)
         {
-            return Task.FromResult<byte[]?>(null);
+            return null;
         }
     }
 
-    public Task WriteAsync(byte[] utf8Token, CancellationToken ct)
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT",
+        "IL3050:RequiresDynamicCode",
+        Justification = "ProtectedData.Protect/Unprotect are trim-safe P/Invoke wrappers; no dynamic codegen.")]
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming",
+        "IL2026:RequiresUnreferencedCode",
+        Justification = "ProtectedData.Protect/Unprotect do not require reflection on application types.")]
+    public async Task WriteAsync(byte[] utf8Token, CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(utf8Token);
 
-#pragma warning disable IL2026, IL3050
-        // ProtectedData is Windows-only and trim-safe in practice.
         var encrypted = ProtectedData.Protect(utf8Token, _entropy, DataProtectionScope.CurrentUser);
-#pragma warning restore IL2026, IL3050
-        File.WriteAllBytes(Partial, encrypted);
-        // File.Move with overwrite:true is atomic on NTFS.
+        await File.WriteAllBytesAsync(Partial, encrypted, ct).ConfigureAwait(false);
+        // File.Move with overwrite:true is atomic on NTFS when source and
+        // target are on the same volume. LocalApplicationData lives on the
+        // user profile drive, so Partial and Target are always co-located.
         File.Move(Partial, Target, overwrite: true);
-        return Task.CompletedTask;
     }
 
     public Task DeleteAsync(CancellationToken ct)

--- a/windows/Ghostty.Core/Sponsor/Auth/DpapiJwtStore.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/DpapiJwtStore.cs
@@ -1,0 +1,99 @@
+using System;
+using System.IO;
+using System.Runtime.Versioning;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Ghostty.Core.Sponsor.Auth;
+
+/// <summary>
+/// DPAPI-backed <see cref="IJwtStore"/>. Persists under
+/// <c>{root}/auth.bin</c> using <see cref="ProtectedData"/> with
+/// <see cref="DataProtectionScope.CurrentUser"/> and an app-specific
+/// entropy blob so the envelope is bound to the current user and this
+/// app's identity. Atomic writes via <c>.partial</c> + <c>File.Move</c>.
+/// </summary>
+[SupportedOSPlatform("windows")]
+internal sealed class DpapiJwtStore : IJwtStore
+{
+    private const string FileName = "auth.bin";
+    private const string PartialSuffix = ".partial";
+
+    private readonly string _root;
+    private readonly byte[] _entropy;
+
+    public DpapiJwtStore(string root, byte[] entropy)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(root);
+        ArgumentNullException.ThrowIfNull(entropy);
+        _root = root;
+        _entropy = entropy;
+
+        Directory.CreateDirectory(_root);
+    }
+
+    private string Target  => Path.Combine(_root, FileName);
+    private string Partial => Path.Combine(_root, FileName + PartialSuffix);
+
+    public Task<byte[]?> ReadAsync(CancellationToken ct)
+    {
+        if (!File.Exists(Target))
+            return Task.FromResult<byte[]?>(null);
+
+        try
+        {
+            var encrypted = File.ReadAllBytes(Target);
+#pragma warning disable IL2026, IL3050
+            // ProtectedData is Windows-only and trim-safe in practice.
+            var plain = ProtectedData.Unprotect(encrypted, _entropy, DataProtectionScope.CurrentUser);
+#pragma warning restore IL2026, IL3050
+            return Task.FromResult<byte[]?>(plain);
+        }
+        catch (CryptographicException)
+        {
+            // Entropy mismatch, corrupted blob, or a different user's
+            // session. Treat as "no valid token" and let the caller
+            // decide whether to delete.
+            return Task.FromResult<byte[]?>(null);
+        }
+        catch (IOException)
+        {
+            return Task.FromResult<byte[]?>(null);
+        }
+    }
+
+    public Task WriteAsync(byte[] utf8Token, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(utf8Token);
+
+#pragma warning disable IL2026, IL3050
+        // ProtectedData is Windows-only and trim-safe in practice.
+        var encrypted = ProtectedData.Protect(utf8Token, _entropy, DataProtectionScope.CurrentUser);
+#pragma warning restore IL2026, IL3050
+        File.WriteAllBytes(Partial, encrypted);
+        // File.Move with overwrite:true is atomic on NTFS.
+        File.Move(Partial, Target, overwrite: true);
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteAsync(CancellationToken ct)
+    {
+        try
+        {
+            if (File.Exists(Target))
+                File.Delete(Target);
+            if (File.Exists(Partial))
+                File.Delete(Partial);
+        }
+        catch (IOException)
+        {
+            // Sign-out must not fail on file locks. Logged by caller.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // Same reasoning.
+        }
+        return Task.CompletedTask;
+    }
+}

--- a/windows/Ghostty.Core/Sponsor/Auth/DpapiJwtStore.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/DpapiJwtStore.cs
@@ -17,6 +17,23 @@ namespace Ghostty.Core.Sponsor.Auth;
 [SupportedOSPlatform("windows")]
 internal sealed class DpapiJwtStore : IJwtStore
 {
+    /// <summary>
+    /// Label embedded in the DPAPI entropy blob. Not a secret; bounds
+    /// the envelope to this app so other user-scoped applications
+    /// calling ProtectedData.Unprotect with default entropy can't read
+    /// our JWT. Increment the -vN suffix if the JWT format ever
+    /// changes in a backwards-incompatible way.
+    /// </summary>
+    public const string EntropyLabelV1 = "wintty-sponsor-jwt-v1";
+
+    /// <summary>
+    /// Default entropy bytes for DPAPI encryption. Callers building a
+    /// DpapiJwtStore pass <see cref="DefaultEntropy"/>; the constant
+    /// is exposed so the App wiring doesn't have to duplicate the literal.
+    /// </summary>
+    public static readonly byte[] DefaultEntropy =
+        System.Text.Encoding.UTF8.GetBytes(EntropyLabelV1);
+
     private const string FileName = "auth.bin";
     private const string PartialSuffix = ".partial";
 

--- a/windows/Ghostty.Core/Sponsor/Auth/HttpLoopbackListener.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/HttpLoopbackListener.cs
@@ -59,6 +59,9 @@ internal sealed class HttpLoopbackListener : ILoopbackListener
             try { _listener.Stop(); } catch { /* already disposed */ }
         });
 
+        const int maxInvalidRequests = 10;
+        int invalidCount = 0;
+
         while (!ct.IsCancellationRequested)
         {
             HttpListenerContext ctx;
@@ -82,6 +85,15 @@ internal sealed class HttpLoopbackListener : ILoopbackListener
             {
                 ctx.Response.StatusCode = 404;
                 ctx.Response.Close();
+                invalidCount++;
+                if (invalidCount >= maxInvalidRequests)
+                {
+                    // Bounds a local process flooding the port with junk
+                    // requests. The legitimate OAuth flow makes exactly one
+                    // call to /cb; anything else is either a broken client
+                    // or an attack and we shouldn't keep the listener open.
+                    return new LoopbackResult(null, null, "too many invalid callbacks");
+                }
                 continue;
             }
 

--- a/windows/Ghostty.Core/Sponsor/Auth/HttpLoopbackListener.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/HttpLoopbackListener.cs
@@ -56,7 +56,11 @@ internal sealed class HttpLoopbackListener : ILoopbackListener
 
         using var ctr = ct.Register(() =>
         {
-            try { _listener.Stop(); } catch { /* already disposed */ }
+            // Stop may race Dispose when the caller cancels just as the
+            // listener is being torn down. Only ObjectDisposedException
+            // is expected on that path; everything else bubbles up.
+            try { _listener.Stop(); }
+            catch (ObjectDisposedException) { }
         });
 
         const int maxInvalidRequests = 10;
@@ -136,7 +140,12 @@ internal sealed class HttpLoopbackListener : ILoopbackListener
 
     public void Dispose()
     {
-        try { _listener?.Close(); } catch { /* idempotent */ }
+        // Close is idempotent for the "already stopped" case, but can
+        // still surface ObjectDisposedException when racing a second
+        // Dispose call. Narrow the swallow accordingly so real bugs
+        // (InvalidOperationException from teardown paths) surface.
+        try { _listener?.Close(); }
+        catch (ObjectDisposedException) { }
         _listener = null;
         _started = false;
     }

--- a/windows/Ghostty.Core/Sponsor/Auth/HttpLoopbackListener.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/HttpLoopbackListener.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Net;
+using System.Runtime.Versioning;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Ghostty.Core.Sponsor.Auth;
+
+/// <summary>
+/// One-shot loopback HTTP server for OAuth callback capture. Binds an
+/// ephemeral port on <c>127.0.0.1</c> and responds to the first
+/// <c>/cb</c> request with a confirmation page, then exits. Non-<c>/cb</c>
+/// paths return 404 and listening continues until <c>/cb</c> arrives or
+/// cancellation fires.
+/// </summary>
+[SupportedOSPlatform("windows")]
+internal sealed class HttpLoopbackListener : ILoopbackListener
+{
+    private HttpListener? _listener;
+    private int _port;
+    private bool _started;
+
+    private static readonly byte[] ConfirmPage = Encoding.UTF8.GetBytes(
+        "<!doctype html><html><body style='font-family:sans-serif;padding:2em'>"
+        + "<h1>You can close this window.</h1>"
+        + "<p>wintty is finishing sign-in.</p></body></html>");
+
+    public int Port =>
+        _started
+            ? _port
+            : throw new InvalidOperationException("listener not started");
+
+    public void Start()
+    {
+        if (_started) throw new InvalidOperationException("already started");
+
+        // Bind port 0 first via TcpListener to claim an ephemeral port,
+        // then hand it to HttpListener. HttpListener can't bind port 0
+        // directly on Windows.
+        var tcp = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        tcp.Start();
+        _port = ((IPEndPoint)tcp.LocalEndpoint).Port;
+        tcp.Stop();
+
+        _listener = new HttpListener();
+        _listener.Prefixes.Add($"http://127.0.0.1:{_port}/");
+        _listener.Start();
+        _started = true;
+    }
+
+    public async Task<LoopbackResult> AwaitCallbackAsync(CancellationToken ct)
+    {
+        if (_listener is null || !_started)
+            throw new InvalidOperationException("listener not started");
+
+        using var ctr = ct.Register(() =>
+        {
+            try { _listener.Stop(); } catch { /* already disposed */ }
+        });
+
+        while (!ct.IsCancellationRequested)
+        {
+            HttpListenerContext ctx;
+            try
+            {
+                ctx = await _listener.GetContextAsync().ConfigureAwait(false);
+            }
+            catch (HttpListenerException) when (ct.IsCancellationRequested)
+            {
+                ct.ThrowIfCancellationRequested();
+                throw;
+            }
+            catch (ObjectDisposedException) when (ct.IsCancellationRequested)
+            {
+                ct.ThrowIfCancellationRequested();
+                throw;
+            }
+
+            var req = ctx.Request;
+            if (req.Url?.AbsolutePath != "/cb")
+            {
+                ctx.Response.StatusCode = 404;
+                ctx.Response.Close();
+                continue;
+            }
+
+            var (token, nonce, error) = ParseQuery(req.Url.Query);
+
+            await WriteConfirmationAsync(ctx, ct).ConfigureAwait(false);
+            return new LoopbackResult(token, nonce, error);
+        }
+
+        ct.ThrowIfCancellationRequested();
+        throw new InvalidOperationException("unreachable");
+    }
+
+    private static (string? token, string? nonce, string? error) ParseQuery(string query)
+    {
+        string? t = null, n = null, e = null;
+        if (string.IsNullOrEmpty(query)) return (t, n, e);
+        var qs = query.StartsWith('?') ? query[1..] : query;
+        foreach (var pair in qs.Split('&', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var idx = pair.IndexOf('=');
+            if (idx < 0) continue;
+            var key = Uri.UnescapeDataString(pair[..idx]);
+            var val = Uri.UnescapeDataString(pair[(idx + 1)..]);
+            if (key == "token") t = val;
+            else if (key == "nonce") n = val;
+            else if (key == "error") e = val;
+        }
+        return (t, n, e);
+    }
+
+    private static async Task WriteConfirmationAsync(HttpListenerContext ctx, CancellationToken ct)
+    {
+        ctx.Response.StatusCode = 200;
+        ctx.Response.ContentType = "text/html; charset=utf-8";
+        ctx.Response.ContentLength64 = ConfirmPage.Length;
+        await ctx.Response.OutputStream.WriteAsync(ConfirmPage, ct).ConfigureAwait(false);
+        ctx.Response.Close();
+    }
+
+    public void Dispose()
+    {
+        try { _listener?.Close(); } catch { /* idempotent */ }
+        _listener = null;
+        _started = false;
+    }
+}

--- a/windows/Ghostty.Core/Sponsor/Auth/IBrowserLauncher.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/IBrowserLauncher.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Ghostty.Core.Sponsor.Auth;
+
+/// <summary>
+/// Abstraction over opening the default browser. Production impl uses
+/// <c>Process.Start</c> with <c>UseShellExecute = true</c>; tests assert
+/// the URL shape without spawning a browser.
+/// </summary>
+internal interface IBrowserLauncher
+{
+    /// <summary>
+    /// Opens the URL in the user's default browser. Does not block
+    /// waiting for the browser to close. MUST NOT throw; failures are
+    /// logged by the impl and the caller relies on the loopback timeout
+    /// to notice nothing arrived.
+    /// </summary>
+    void Open(Uri url);
+}

--- a/windows/Ghostty.Core/Sponsor/Auth/IJwtStore.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/IJwtStore.cs
@@ -19,6 +19,8 @@ internal interface IJwtStore
     /// <summary>Persists the UTF-8 encoded JWT. Throws on IO failure.</summary>
     Task WriteAsync(byte[] utf8Token, CancellationToken ct);
 
-    /// <summary>Deletes the stored blob. No-op if absent. Swallows IO errors.</summary>
+    /// <summary>Deletes the stored blob. No-op if absent. Throws on
+    /// filesystem failures; callers log once via
+    /// <c>OAuthTokenProvider.SafeDeleteAsync</c>.</summary>
     Task DeleteAsync(CancellationToken ct);
 }

--- a/windows/Ghostty.Core/Sponsor/Auth/IJwtStore.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/IJwtStore.cs
@@ -1,0 +1,24 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Ghostty.Core.Sponsor.Auth;
+
+/// <summary>
+/// Abstraction over JWT persistence. Production impl is
+/// <c>DpapiJwtStore</c> (Windows-only); tests use in-memory fakes.
+/// Implementations MUST perform atomic writes (write to a temp file +
+/// rename) so a crash mid-write leaves the previous blob intact.
+/// The contract is "return bytes of the persisted JWT as UTF-8" -
+/// impls that encrypt at rest MUST decrypt before returning.
+/// </summary>
+internal interface IJwtStore
+{
+    /// <summary>Returns the stored UTF-8 JWT bytes, or <c>null</c> if no blob exists.</summary>
+    Task<byte[]?> ReadAsync(CancellationToken ct);
+
+    /// <summary>Persists the UTF-8 encoded JWT. Throws on IO failure.</summary>
+    Task WriteAsync(byte[] utf8Token, CancellationToken ct);
+
+    /// <summary>Deletes the stored blob. No-op if absent. Swallows IO errors.</summary>
+    Task DeleteAsync(CancellationToken ct);
+}

--- a/windows/Ghostty.Core/Sponsor/Auth/ILoopbackListener.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/ILoopbackListener.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Ghostty.Core.Sponsor.Auth;
+
+/// <summary>
+/// Abstraction over the ephemeral <c>http://127.0.0.1:N/cb</c>
+/// listener that receives the OAuth callback. Production impl uses
+/// <see cref="System.Net.HttpListener"/>; tests drive the provider with
+/// pre-baked <see cref="LoopbackResult"/> values.
+/// </summary>
+internal interface ILoopbackListener : IDisposable
+{
+    /// <summary>
+    /// Port the listener is bound to. Set after <see cref="Start"/>.
+    /// Read by <c>OAuthTokenProvider</c> to construct the redirect URL.
+    /// </summary>
+    int Port { get; }
+
+    /// <summary>
+    /// Binds an ephemeral port on <c>127.0.0.1</c>. Throws on bind
+    /// failure. Must be called exactly once per listener instance.
+    /// </summary>
+    void Start();
+
+    /// <summary>
+    /// Awaits the first incoming request on <c>/cb</c>, parses query
+    /// params, and returns a <see cref="LoopbackResult"/>. On cancellation,
+    /// throws <see cref="OperationCanceledException"/>. Unknown paths
+    /// return a 404 and keep listening.
+    /// </summary>
+    Task<LoopbackResult> AwaitCallbackAsync(CancellationToken ct);
+}
+
+/// <summary>
+/// Parsed query-string payload from the <c>/cb</c> request. Exactly one
+/// of <see cref="Token"/> / <see cref="Error"/> is non-null on a
+/// well-formed callback; both null indicates a malformed request and
+/// <c>OAuthTokenProvider</c> treats it as a silent failure.
+/// </summary>
+internal sealed record LoopbackResult(string? Token, string? Nonce, string? Error);

--- a/windows/Ghostty.Core/Sponsor/Auth/JwtClaims.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/JwtClaims.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+
+namespace Ghostty.Core.Sponsor.Auth;
+
+/// <summary>
+/// Minimal JWT payload decoder. Reads claims by splitting on <c>.</c> and
+/// base64url-decoding the middle segment. Does NOT validate the
+/// signature: the Worker is authoritative, the client only trusts the
+/// Worker's TLS connection. Claims are read purely to drive the
+/// proactive refresh schedule and for log diagnostics.
+/// </summary>
+internal sealed class JwtClaims
+{
+    public required string Subject { get; init; }
+    public string? Login { get; init; }
+    public int TierCents { get; init; }
+    public IReadOnlyList<string> ChannelAllow { get; init; } = Array.Empty<string>();
+    public string? DefaultChannel { get; init; }
+    public string? JwtId { get; init; }
+    public required DateTime ExpiresAt { get; init; }
+
+    /// <summary>
+    /// Parses a compact JWT string. Throws <see cref="AuthException"/>
+    /// with <see cref="AuthErrorKind.Unknown"/> on any shape, base64, or
+    /// JSON failure. Caller logs and treats as "no usable token".
+    /// </summary>
+    public static JwtClaims Parse(string jwt)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(jwt);
+
+        var parts = jwt.Split('.');
+        if (parts.Length != 3)
+            throw new AuthException(AuthErrorKind.Unknown, $"malformed JWT: expected 3 segments, got {parts.Length}");
+
+        byte[] payloadBytes;
+        try
+        {
+            payloadBytes = DecodeBase64Url(parts[1]);
+        }
+        catch (FormatException ex)
+        {
+            throw new AuthException(AuthErrorKind.Unknown, "malformed JWT: base64url decode failed", ex);
+        }
+
+        JsonElement root;
+        try
+        {
+            using var doc = JsonDocument.Parse(payloadBytes);
+            root = doc.RootElement.Clone();
+        }
+        catch (JsonException ex)
+        {
+            throw new AuthException(AuthErrorKind.Unknown, "malformed JWT: payload is not JSON", ex);
+        }
+
+        var sub = ReadString(root, "sub")
+            ?? throw new AuthException(AuthErrorKind.Unknown, "JWT missing required claim 'sub'");
+        var expUnix = ReadLong(root, "exp")
+            ?? throw new AuthException(AuthErrorKind.Unknown, "JWT missing required claim 'exp'");
+
+        var login     = ReadString(root, "login");
+        var tier      = (int)(ReadLong(root, "tier_cents") ?? 0);
+        var jti       = ReadString(root, "jti");
+        var defaultCh = ReadString(root, "default_channel");
+        var channels  = ReadStringArray(root, "channel_allow");
+
+        return new JwtClaims
+        {
+            Subject        = sub,
+            Login          = login,
+            TierCents      = tier,
+            ChannelAllow   = channels,
+            DefaultChannel = defaultCh,
+            JwtId          = jti,
+            ExpiresAt      = DateTimeOffset.FromUnixTimeSeconds(expUnix).UtcDateTime,
+        };
+    }
+
+    private static byte[] DecodeBase64Url(string s)
+    {
+        // Restore padding. Base64url strips '=' and uses '-'/'_' instead of '+'/'/'.
+        var padded = s.Replace('-', '+').Replace('_', '/');
+        switch (padded.Length % 4)
+        {
+            case 2: padded += "=="; break;
+            case 3: padded += "=";  break;
+            case 0: break;
+            default: throw new FormatException("invalid base64url length");
+        }
+        return Convert.FromBase64String(padded);
+    }
+
+    private static string? ReadString(JsonElement root, string name)
+        => root.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.String
+            ? v.GetString()
+            : null;
+
+    private static long? ReadLong(JsonElement root, string name)
+        => root.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.Number
+            ? v.GetInt64()
+            : null;
+
+    private static IReadOnlyList<string> ReadStringArray(JsonElement root, string name)
+    {
+        if (!root.TryGetProperty(name, out var v) || v.ValueKind != JsonValueKind.Array)
+            return Array.Empty<string>();
+
+        var list = new List<string>(v.GetArrayLength());
+        foreach (var item in v.EnumerateArray())
+        {
+            if (item.ValueKind == JsonValueKind.String)
+                list.Add(item.GetString()!);
+        }
+        return list;
+    }
+}

--- a/windows/Ghostty.Core/Sponsor/Auth/JwtClaims.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/JwtClaims.cs
@@ -12,7 +12,7 @@ namespace Ghostty.Core.Sponsor.Auth;
 /// Worker's TLS connection. Claims are read purely to drive the
 /// proactive refresh schedule and for log diagnostics.
 /// </summary>
-internal sealed class JwtClaims
+internal sealed record JwtClaims
 {
     public required string Subject { get; init; }
     public string? Login { get; init; }

--- a/windows/Ghostty.Core/Sponsor/Auth/JwtClaims.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/JwtClaims.cs
@@ -17,7 +17,7 @@ internal sealed record JwtClaims
     public required string Subject { get; init; }
     public string? Login { get; init; }
     public int TierCents { get; init; }
-    public IReadOnlyList<string> ChannelAllow { get; init; } = Array.Empty<string>();
+    public IReadOnlyList<string> ChannelAllow { get; init; } = [];
     public string? DefaultChannel { get; init; }
     public string? JwtId { get; init; }
     public required DateTime ExpiresAt { get; init; }
@@ -106,7 +106,7 @@ internal sealed record JwtClaims
     private static IReadOnlyList<string> ReadStringArray(JsonElement root, string name)
     {
         if (!root.TryGetProperty(name, out var v) || v.ValueKind != JsonValueKind.Array)
-            return Array.Empty<string>();
+            return [];
 
         var list = new List<string>(v.GetArrayLength());
         foreach (var item in v.EnumerateArray())

--- a/windows/Ghostty.Core/Sponsor/Auth/OAuthTokenProvider.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/OAuthTokenProvider.cs
@@ -403,6 +403,12 @@ internal sealed class OAuthTokenProvider : ISponsorTokenProvider, IDisposable
                 return false;
             }
 
+            // The Worker's /auth/github/start endpoint takes a `nonce` query param
+            // and echoes it verbatim in the final /cb 302. This is an ADDITIONAL
+            // CSRF defense on top of the OAuth `state` param (which the Worker
+            // owns end-to-end and HS256-signs with its own secret). The client
+            // never touches OAuth `state`; our `nonce` is the client-local replay
+            // guard against a rogue local process racing the real callback.
             var nonce = Convert.ToHexString(
                 System.Security.Cryptography.RandomNumberGenerator.GetBytes(16));
             var callback = $"http://127.0.0.1:{_listener.Port}/cb";

--- a/windows/Ghostty.Core/Sponsor/Auth/OAuthTokenProvider.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/OAuthTokenProvider.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Ghostty.Core.Sponsor.Auth;
+
+/// <summary>
+/// Production <see cref="ISponsorTokenProvider"/> backed by the GitHub
+/// OAuth loopback flow and a DPAPI-encrypted JWT cache. Replaces
+/// <see cref="EnvTokenProvider"/> in the DI root for SPONSOR_BUILD
+/// output, with WINTTY_DEV_JWT preserved as a short-circuit
+/// override for dev smoke paths.
+/// </summary>
+internal sealed class OAuthTokenProvider : ISponsorTokenProvider, IDisposable
+{
+    private readonly WinttyAuthClient _auth;
+    private readonly IJwtStore _store;
+    private readonly IBrowserLauncher _browser;
+    private readonly ILoopbackListener _listener;
+    private readonly Uri _apiBase;
+    private readonly ILogger<OAuthTokenProvider> _logger;
+    private readonly TimeProvider _time;
+    private readonly Func<string, string?> _envVarLookup;
+
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private readonly CancellationTokenSource _lifetime = new();
+
+    private volatile string? _cached;
+    private JwtClaims? _claims;
+    private bool _envVarMode;
+    private bool _disposed;
+
+    public OAuthTokenProvider(
+        WinttyAuthClient auth,
+        IJwtStore store,
+        IBrowserLauncher browser,
+        ILoopbackListener listener,
+        Uri apiBase,
+        ILogger<OAuthTokenProvider> logger,
+        TimeProvider time,
+        Func<string, string?>? envVarLookup = null)
+    {
+        ArgumentNullException.ThrowIfNull(auth);
+        ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(browser);
+        ArgumentNullException.ThrowIfNull(listener);
+        ArgumentNullException.ThrowIfNull(apiBase);
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(time);
+
+        _auth = auth;
+        _store = store;
+        _browser = browser;
+        _listener = listener;
+        _apiBase = apiBase;
+        _logger = logger;
+        _time = time;
+        _envVarLookup = envVarLookup ?? Environment.GetEnvironmentVariable;
+    }
+
+    public Task<string?> GetTokenAsync(CancellationToken ct = default)
+        => Task.FromResult(_cached);
+
+    /// <summary>
+    /// Reactive 401 handler. Task 8 skeleton clears the cache and fires
+    /// <see cref="TokenInvalidated"/>. Task 11 replaces this with a
+    /// background refresh attempt that only fires on refresh failure.
+    /// </summary>
+    public void Invalidate()
+    {
+        _cached = null;
+        _claims = null;
+        TokenInvalidated?.Invoke(this, EventArgs.Empty);
+    }
+
+    public event EventHandler? TokenInvalidated;
+
+    /// <summary>
+    /// Raised after a successful sign-in or proactive/reactive refresh
+    /// acquires a new token. The shell-side palette source subscribes
+    /// to re-register the "Sign out" entry visibility.
+    /// </summary>
+    public event EventHandler? TokenAcquired;
+
+    // Internal helper for subsequent tasks that will invoke the event.
+    private void RaiseTokenAcquired() => TokenAcquired?.Invoke(this, EventArgs.Empty);
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        try { _lifetime.Cancel(); } catch { /* idempotent */ }
+        _lifetime.Dispose();
+        _gate.Dispose();
+    }
+}

--- a/windows/Ghostty.Core/Sponsor/Auth/OAuthTokenProvider.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/OAuthTokenProvider.cs
@@ -393,7 +393,8 @@ internal sealed class OAuthTokenProvider : ISponsorTokenProvider, IDisposable
             {
                 _listener.Start();
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is System.Net.HttpListenerException
+                                          or System.Net.Sockets.SocketException)
             {
                 _logger.LogWarning(ex, "[sponsor/auth] loopback bind failed");
                 return false;

--- a/windows/Ghostty.Core/Sponsor/Auth/OAuthTokenProvider.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/OAuthTokenProvider.cs
@@ -68,6 +68,14 @@ internal sealed partial class OAuthTokenProvider : ISponsorTokenProvider, IDispo
         => Task.FromResult(_cached);
 
     /// <summary>
+    /// Snapshot view of whether we currently hold a token. Read from the
+    /// UI thread by palette command sources that need to pick between
+    /// "Sign in" and "Sign out" entries without blocking on
+    /// <see cref="GetTokenAsync"/>. Volatile-backed via <c>_cached</c>.
+    /// </summary>
+    public bool HasToken => !string.IsNullOrEmpty(_cached);
+
+    /// <summary>
     /// Reactive 401 handler called by <c>WinttyManifestClient</c> when
     /// the Worker rejects our current bearer. Kicks off a single-flight
     /// background refresh. Returns synchronously so the calling HTTP
@@ -78,16 +86,31 @@ internal sealed partial class OAuthTokenProvider : ISponsorTokenProvider, IDispo
     public void Invalidate()
     {
         if (_envVarMode) return;
-        _ = Task.Run(() => TryRefreshAsync(_lifetime.Token));
+        if (_disposed) return;
+        // Capture the token before Task.Run schedules; reading
+        // _lifetime.Token after Dispose has disposed the CTS throws
+        // ObjectDisposedException, and we can't observe the exception
+        // from a fire-and-forget Task.Run.
+        CancellationToken token;
+        try { token = _lifetime.Token; }
+        catch (ObjectDisposedException) { return; }
+        _ = Task.Run(() => TryRefreshAsync(token));
     }
 
     private async Task TryRefreshAsync(CancellationToken ct)
     {
-        if (!await _gate.WaitAsync(0, ct).ConfigureAwait(false))
+        if (_disposed) return;
+        try
         {
-            // Another refresh already in flight; let it handle things.
-            return;
+            if (!await _gate.WaitAsync(0, ct).ConfigureAwait(false))
+            {
+                // Another refresh already in flight; let it handle things.
+                return;
+            }
         }
+        catch (ObjectDisposedException) { return; }
+
+        var fireInvalidated = false;
         try
         {
             var current = _cached;
@@ -109,7 +132,7 @@ internal sealed partial class OAuthTokenProvider : ISponsorTokenProvider, IDispo
                 _cached = null;
                 _claims = null;
                 await SafeDeleteAsync(ct).ConfigureAwait(false);
-                TokenInvalidated?.Invoke(this, EventArgs.Empty);
+                fireInvalidated = true;
             }
             catch (AuthException ex)
             {
@@ -126,6 +149,12 @@ internal sealed partial class OAuthTokenProvider : ISponsorTokenProvider, IDispo
         {
             _gate.Release();
         }
+
+        // Raise outside the gate so a subscriber that re-enters the
+        // provider (e.g. kicking off SignIn) does not deadlock on its
+        // own WaitAsync.
+        if (fireInvalidated)
+            TokenInvalidated?.Invoke(this, EventArgs.Empty);
     }
 
     public event EventHandler? TokenInvalidated;
@@ -285,10 +314,20 @@ internal sealed partial class OAuthTokenProvider : ISponsorTokenProvider, IDispo
     private async Task OnRefreshTickAsync()
     {
         if (_disposed) return;
-        if (!await _gate.WaitAsync(0, _lifetime.Token).ConfigureAwait(false))
+        CancellationToken token;
+        try { token = _lifetime.Token; }
+        catch (ObjectDisposedException) { return; }
+
+        try
         {
-            return; // another refresh already running; it will reschedule
+            if (!await _gate.WaitAsync(0, token).ConfigureAwait(false))
+            {
+                return; // another refresh already running; it will reschedule
+            }
         }
+        catch (ObjectDisposedException) { return; }
+
+        var fireInvalidated = false;
         try
         {
             var current = _cached;
@@ -296,9 +335,9 @@ internal sealed partial class OAuthTokenProvider : ISponsorTokenProvider, IDispo
 
             try
             {
-                var refreshed = await _auth.RefreshAsync(current, _lifetime.Token).ConfigureAwait(false);
+                var refreshed = await _auth.RefreshAsync(current, token).ConfigureAwait(false);
                 var parsed = JwtClaims.Parse(refreshed);
-                await _store.WriteAsync(Encoding.UTF8.GetBytes(refreshed), _lifetime.Token).ConfigureAwait(false);
+                await _store.WriteAsync(Encoding.UTF8.GetBytes(refreshed), token).ConfigureAwait(false);
                 _cached = refreshed;
                 _claims = parsed;
                 LogProactiveRefreshSucceeded();
@@ -308,10 +347,10 @@ internal sealed partial class OAuthTokenProvider : ISponsorTokenProvider, IDispo
             {
                 LogProactiveRefreshRejected();
                 _cached = null; _claims = null;
-                await SafeDeleteAsync(_lifetime.Token).ConfigureAwait(false);
+                await SafeDeleteAsync(token).ConfigureAwait(false);
                 _refreshTimer?.Dispose();
                 _refreshTimer = null;
-                TokenInvalidated?.Invoke(this, EventArgs.Empty);
+                fireInvalidated = true;
             }
             catch (AuthException ex)
             {
@@ -332,6 +371,9 @@ internal sealed partial class OAuthTokenProvider : ISponsorTokenProvider, IDispo
         {
             _gate.Release();
         }
+
+        if (fireInvalidated)
+            TokenInvalidated?.Invoke(this, EventArgs.Empty);
     }
 
     /// <summary>
@@ -344,6 +386,7 @@ internal sealed partial class OAuthTokenProvider : ISponsorTokenProvider, IDispo
     public async Task SignOutAsync(CancellationToken ct)
     {
         await _gate.WaitAsync(ct).ConfigureAwait(false);
+        var fireInvalidated = false;
         try
         {
             var current = _cached;
@@ -369,13 +412,16 @@ internal sealed partial class OAuthTokenProvider : ISponsorTokenProvider, IDispo
                     await SafeDeleteAsync(ct).ConfigureAwait(false);
                 }
 
-                TokenInvalidated?.Invoke(this, EventArgs.Empty);
+                fireInvalidated = true;
             }
         }
         finally
         {
             _gate.Release();
         }
+
+        if (fireInvalidated)
+            TokenInvalidated?.Invoke(this, EventArgs.Empty);
     }
 
     private static readonly TimeSpan LoopbackTimeout = TimeSpan.FromSeconds(120);
@@ -390,6 +436,7 @@ internal sealed partial class OAuthTokenProvider : ISponsorTokenProvider, IDispo
     public async Task<bool> SignInAsync(CancellationToken ct)
     {
         await _gate.WaitAsync(ct).ConfigureAwait(false);
+        var fireAcquired = false;
         try
         {
             try
@@ -474,12 +521,18 @@ internal sealed partial class OAuthTokenProvider : ISponsorTokenProvider, IDispo
             _cached = callbackResult.Token;
             _claims = parsed;
             LogSignInComplete(parsed.ExpiresAt);
-            RaiseTokenAcquired();
+            fireAcquired = true;
             return true;
         }
         finally
         {
             _gate.Release();
+
+            // Raise outside the gate: a subscriber (e.g. a palette command
+            // source) that re-enters the provider on state change must not
+            // deadlock on its own WaitAsync.
+            if (fireAcquired)
+                RaiseTokenAcquired();
         }
     }
 
@@ -487,7 +540,11 @@ internal sealed partial class OAuthTokenProvider : ISponsorTokenProvider, IDispo
     {
         if (_disposed) return;
         _disposed = true;
-        try { _lifetime.Cancel(); } catch { /* idempotent */ }
+        // Dispose racing with a callback already inside Cancel() can
+        // observe ObjectDisposedException; all other throws indicate a
+        // real bug and should not be swallowed.
+        try { _lifetime.Cancel(); }
+        catch (ObjectDisposedException) { }
         _refreshTimer?.Dispose();
         _lifetime.Dispose();
         _gate.Dispose();

--- a/windows/Ghostty.Core/Sponsor/Auth/OAuthTokenProvider.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/OAuthTokenProvider.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -85,6 +86,118 @@ internal sealed class OAuthTokenProvider : ISponsorTokenProvider, IDisposable
 
     // Internal helper for subsequent tasks that will invoke the event.
     private void RaiseTokenAcquired() => TokenAcquired?.Invoke(this, EventArgs.Empty);
+
+    /// <summary>
+    /// Called once at app launch from <c>SponsorOverlayBootstrapper</c>.
+    /// Loads any cached JWT from the store, validates shape + freshness,
+    /// attempts a synchronous refresh if the token is expired-but-within-
+    /// 24h, and deletes the blob on any unrecoverable state. Does NOT
+    /// schedule the proactive refresh timer - that's Task 12's job so
+    /// tests can assert boot behavior deterministically without wall
+    /// clock interference.
+    /// </summary>
+    public async Task InitializeAsync(CancellationToken ct)
+    {
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            // Env-var short-circuit: dev path, never refreshes, skips store.
+            var env = _envVarLookup("WINTTY_DEV_JWT");
+            if (!string.IsNullOrEmpty(env))
+            {
+                try
+                {
+                    _claims = JwtClaims.Parse(env);
+                    _cached = env;
+                    _envVarMode = true;
+                    _logger.LogInformation("[sponsor/auth] using WINTTY_DEV_JWT (expires {Exp})", _claims.ExpiresAt);
+                }
+                catch (AuthException ex)
+                {
+                    _logger.LogWarning(ex, "[sponsor/auth] WINTTY_DEV_JWT is malformed; ignoring");
+                }
+                return;
+            }
+
+            byte[]? blob;
+            try
+            {
+                blob = await _store.ReadAsync(ct).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "[sponsor/auth] JWT store read failed");
+                blob = null;
+            }
+
+            if (blob is null || blob.Length == 0)
+            {
+                _logger.LogInformation("[sponsor/auth] no cached JWT; sign-in required");
+                return;
+            }
+
+            var jwt = Encoding.UTF8.GetString(blob);
+            JwtClaims parsed;
+            try
+            {
+                parsed = JwtClaims.Parse(jwt);
+            }
+            catch (AuthException ex)
+            {
+                _logger.LogWarning(ex, "[sponsor/auth] cached JWT malformed; deleting");
+                await SafeDeleteAsync(ct).ConfigureAwait(false);
+                return;
+            }
+
+            var now = _time.GetUtcNow().UtcDateTime;
+            if (parsed.ExpiresAt <= now - TimeSpan.FromHours(24))
+            {
+                _logger.LogInformation("[sponsor/auth] cached JWT stale by more than 24h; deleting");
+                await SafeDeleteAsync(ct).ConfigureAwait(false);
+                return;
+            }
+
+            if (parsed.ExpiresAt <= now)
+            {
+                try
+                {
+                    var refreshed = await _auth.RefreshAsync(jwt, ct).ConfigureAwait(false);
+                    var newClaims = JwtClaims.Parse(refreshed);
+                    await _store.WriteAsync(Encoding.UTF8.GetBytes(refreshed), ct).ConfigureAwait(false);
+                    _cached = refreshed;
+                    _claims = newClaims;
+                    _logger.LogInformation("[sponsor/auth] refreshed expired JWT on boot");
+                    return;
+                }
+                catch (AuthException ex) when (ex.Kind == AuthErrorKind.Unauthorized)
+                {
+                    _logger.LogInformation("[sponsor/auth] expired JWT rejected on refresh; deleting");
+                    await SafeDeleteAsync(ct).ConfigureAwait(false);
+                    return;
+                }
+                catch (AuthException ex)
+                {
+                    _logger.LogWarning(ex, "[sponsor/auth] refresh failed on boot; keeping nothing cached");
+                    await SafeDeleteAsync(ct).ConfigureAwait(false);
+                    return;
+                }
+            }
+
+            _cached = jwt;
+            _claims = parsed;
+            _logger.LogInformation("[sponsor/auth] loaded cached JWT (expires {Exp})", parsed.ExpiresAt);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private async Task SafeDeleteAsync(CancellationToken ct)
+    {
+        try { await _store.DeleteAsync(ct).ConfigureAwait(false); }
+        catch (Exception ex) { _logger.LogDebug(ex, "[sponsor/auth] store delete failed"); }
+    }
 
     public void Dispose()
     {

--- a/windows/Ghostty.Core/Sponsor/Auth/OAuthTokenProvider.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/OAuthTokenProvider.cs
@@ -331,6 +331,50 @@ internal sealed class OAuthTokenProvider : ISponsorTokenProvider, IDisposable
         }
     }
 
+    /// <summary>
+    /// Revokes the current session best-effort against the Worker, then
+    /// deletes the local blob. Fires <see cref="TokenInvalidated"/>
+    /// only if there was a token to sign out of. Network/server failures
+    /// on revoke are swallowed - the JWT remains valid on the Worker
+    /// until <c>exp</c> but the local machine no longer has it.
+    /// </summary>
+    public async Task SignOutAsync(CancellationToken ct)
+    {
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var current = _cached;
+            _cached = null;
+            _claims = null;
+            _refreshTimer?.Dispose();
+            _refreshTimer = null;
+
+            if (!string.IsNullOrEmpty(current))
+            {
+                if (!_envVarMode)
+                {
+                    try
+                    {
+                        await _auth.RevokeAsync(current, ct).ConfigureAwait(false);
+                        _logger.LogInformation("[sponsor/auth] revoke acknowledged");
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogDebug(ex, "[sponsor/auth] revoke best-effort failed");
+                    }
+
+                    await SafeDeleteAsync(ct).ConfigureAwait(false);
+                }
+
+                TokenInvalidated?.Invoke(this, EventArgs.Empty);
+            }
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
     private static readonly TimeSpan LoopbackTimeout = TimeSpan.FromSeconds(120);
 
     /// <summary>

--- a/windows/Ghostty.Core/Sponsor/Auth/OAuthTokenProvider.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/OAuthTokenProvider.cs
@@ -13,7 +13,7 @@ namespace Ghostty.Core.Sponsor.Auth;
 /// output, with WINTTY_DEV_JWT preserved as a short-circuit
 /// override for dev smoke paths.
 /// </summary>
-internal sealed class OAuthTokenProvider : ISponsorTokenProvider, IDisposable
+internal sealed partial class OAuthTokenProvider : ISponsorTokenProvider, IDisposable
 {
     private readonly WinttyAuthClient _auth;
     private readonly IJwtStore _store;
@@ -100,12 +100,12 @@ internal sealed class OAuthTokenProvider : ISponsorTokenProvider, IDisposable
                 await _store.WriteAsync(Encoding.UTF8.GetBytes(refreshed), ct).ConfigureAwait(false);
                 _cached = refreshed;
                 _claims = parsed;
-                _logger.LogInformation("[sponsor/auth] reactive refresh succeeded");
+                LogReactiveRefreshSucceeded();
                 ScheduleNextRefresh();
             }
             catch (AuthException ex) when (ex.Kind == AuthErrorKind.Unauthorized)
             {
-                _logger.LogInformation("[sponsor/auth] reactive refresh rejected; clearing cache");
+                LogReactiveRefreshRejected();
                 _cached = null;
                 _claims = null;
                 await SafeDeleteAsync(ct).ConfigureAwait(false);
@@ -113,14 +113,14 @@ internal sealed class OAuthTokenProvider : ISponsorTokenProvider, IDisposable
             }
             catch (AuthException ex)
             {
-                _logger.LogWarning(ex, "[sponsor/auth] reactive refresh transient failure");
+                LogReactiveRefreshTransient(ex);
                 // Leave cache alone; next 401 will retry.
             }
         }
         catch (OperationCanceledException) { /* shutdown */ }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "[sponsor/auth] reactive refresh unexpected failure");
+            LogReactiveRefreshUnexpected(ex);
         }
         finally
         {
@@ -163,11 +163,11 @@ internal sealed class OAuthTokenProvider : ISponsorTokenProvider, IDisposable
                     _claims = JwtClaims.Parse(env);
                     _cached = env;
                     _envVarMode = true;
-                    _logger.LogInformation("[sponsor/auth] using WINTTY_DEV_JWT (expires {Exp})", _claims.ExpiresAt);
+                    LogDevJwtLoaded(_claims.ExpiresAt);
                 }
                 catch (AuthException ex)
                 {
-                    _logger.LogWarning(ex, "[sponsor/auth] WINTTY_DEV_JWT is malformed; ignoring");
+                    LogDevJwtMalformed(ex);
                 }
                 return;
             }
@@ -179,13 +179,13 @@ internal sealed class OAuthTokenProvider : ISponsorTokenProvider, IDisposable
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "[sponsor/auth] JWT store read failed");
+                LogStoreReadFailed(ex);
                 blob = null;
             }
 
             if (blob is null || blob.Length == 0)
             {
-                _logger.LogInformation("[sponsor/auth] no cached JWT; sign-in required");
+                LogNoCachedJwt();
                 return;
             }
 
@@ -197,7 +197,7 @@ internal sealed class OAuthTokenProvider : ISponsorTokenProvider, IDisposable
             }
             catch (AuthException ex)
             {
-                _logger.LogWarning(ex, "[sponsor/auth] cached JWT malformed; deleting");
+                LogCachedJwtMalformed(ex);
                 await SafeDeleteAsync(ct).ConfigureAwait(false);
                 return;
             }
@@ -205,7 +205,7 @@ internal sealed class OAuthTokenProvider : ISponsorTokenProvider, IDisposable
             var now = _time.GetUtcNow().UtcDateTime;
             if (parsed.ExpiresAt <= now - TimeSpan.FromHours(24))
             {
-                _logger.LogInformation("[sponsor/auth] cached JWT stale by more than 24h; deleting");
+                LogCachedJwtStale();
                 await SafeDeleteAsync(ct).ConfigureAwait(false);
                 return;
             }
@@ -219,19 +219,19 @@ internal sealed class OAuthTokenProvider : ISponsorTokenProvider, IDisposable
                     await _store.WriteAsync(Encoding.UTF8.GetBytes(refreshed), ct).ConfigureAwait(false);
                     _cached = refreshed;
                     _claims = newClaims;
-                    _logger.LogInformation("[sponsor/auth] refreshed expired JWT on boot");
+                    LogBootRefreshSucceeded();
                     ScheduleNextRefresh();
                     return;
                 }
                 catch (AuthException ex) when (ex.Kind == AuthErrorKind.Unauthorized)
                 {
-                    _logger.LogInformation("[sponsor/auth] expired JWT rejected on refresh; deleting");
+                    LogBootRefreshRejected();
                     await SafeDeleteAsync(ct).ConfigureAwait(false);
                     return;
                 }
                 catch (AuthException ex)
                 {
-                    _logger.LogWarning(ex, "[sponsor/auth] refresh failed on boot; keeping nothing cached");
+                    LogBootRefreshFailed(ex);
                     await SafeDeleteAsync(ct).ConfigureAwait(false);
                     return;
                 }
@@ -239,7 +239,7 @@ internal sealed class OAuthTokenProvider : ISponsorTokenProvider, IDisposable
 
             _cached = jwt;
             _claims = parsed;
-            _logger.LogInformation("[sponsor/auth] loaded cached JWT (expires {Exp})", parsed.ExpiresAt);
+            LogLoadedCachedJwt(parsed.ExpiresAt);
         }
         finally
         {
@@ -250,7 +250,7 @@ internal sealed class OAuthTokenProvider : ISponsorTokenProvider, IDisposable
     private async Task SafeDeleteAsync(CancellationToken ct)
     {
         try { await _store.DeleteAsync(ct).ConfigureAwait(false); }
-        catch (Exception ex) { _logger.LogDebug(ex, "[sponsor/auth] store delete failed"); }
+        catch (Exception ex) { LogStoreDeleteFailed(ex); }
     }
 
     /// <summary>
@@ -301,12 +301,12 @@ internal sealed class OAuthTokenProvider : ISponsorTokenProvider, IDisposable
                 await _store.WriteAsync(Encoding.UTF8.GetBytes(refreshed), _lifetime.Token).ConfigureAwait(false);
                 _cached = refreshed;
                 _claims = parsed;
-                _logger.LogInformation("[sponsor/auth] proactive refresh succeeded");
+                LogProactiveRefreshSucceeded();
                 ScheduleNextRefresh();
             }
             catch (AuthException ex) when (ex.Kind == AuthErrorKind.Unauthorized)
             {
-                _logger.LogInformation("[sponsor/auth] proactive refresh rejected; clearing");
+                LogProactiveRefreshRejected();
                 _cached = null; _claims = null;
                 await SafeDeleteAsync(_lifetime.Token).ConfigureAwait(false);
                 _refreshTimer?.Dispose();
@@ -315,7 +315,7 @@ internal sealed class OAuthTokenProvider : ISponsorTokenProvider, IDisposable
             }
             catch (AuthException ex)
             {
-                _logger.LogWarning(ex, "[sponsor/auth] proactive refresh transient; retry in 10m");
+                LogProactiveRefreshTransient(ex);
                 _refreshTimer?.Dispose();
                 if (_disposed) return;
                 _refreshTimer = _time.CreateTimer(
@@ -326,7 +326,7 @@ internal sealed class OAuthTokenProvider : ISponsorTokenProvider, IDisposable
         catch (OperationCanceledException) { /* shutdown */ }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "[sponsor/auth] proactive refresh unexpected failure");
+            LogProactiveRefreshUnexpected(ex);
         }
         finally
         {
@@ -359,11 +359,11 @@ internal sealed class OAuthTokenProvider : ISponsorTokenProvider, IDisposable
                     try
                     {
                         await _auth.RevokeAsync(current, ct).ConfigureAwait(false);
-                        _logger.LogInformation("[sponsor/auth] revoke acknowledged");
+                        LogRevokeAcknowledged();
                     }
                     catch (Exception ex)
                     {
-                        _logger.LogDebug(ex, "[sponsor/auth] revoke best-effort failed");
+                        LogRevokeBestEffortFailed(ex);
                     }
 
                     await SafeDeleteAsync(ct).ConfigureAwait(false);
@@ -399,7 +399,7 @@ internal sealed class OAuthTokenProvider : ISponsorTokenProvider, IDisposable
             catch (Exception ex) when (ex is System.Net.HttpListenerException
                                           or System.Net.Sockets.SocketException)
             {
-                _logger.LogWarning(ex, "[sponsor/auth] loopback bind failed");
+                LogLoopbackBindFailed(ex);
                 return false;
             }
 
@@ -429,27 +429,26 @@ internal sealed class OAuthTokenProvider : ISponsorTokenProvider, IDisposable
             }
             catch (OperationCanceledException)
             {
-                _logger.LogInformation("[sponsor/auth] sign-in timed out or cancelled");
+                LogSignInTimedOut();
                 return false;
             }
 
             if (!string.IsNullOrEmpty(callbackResult.Error))
             {
                 // Log length only - never log raw attacker-supplied query strings.
-                _logger.LogInformation("[sponsor/auth] OAuth error query ({Length} chars)",
-                    callbackResult.Error.Length);
+                LogOAuthErrorQuery(callbackResult.Error.Length);
                 return false;
             }
 
             if (callbackResult.Nonce != nonce)
             {
-                _logger.LogWarning("[sponsor/auth] nonce mismatch on callback");
+                LogNonceMismatch();
                 return false;
             }
 
             if (string.IsNullOrEmpty(callbackResult.Token))
             {
-                _logger.LogWarning("[sponsor/auth] callback missing token");
+                LogCallbackMissingToken();
                 return false;
             }
 
@@ -460,13 +459,13 @@ internal sealed class OAuthTokenProvider : ISponsorTokenProvider, IDisposable
             }
             catch (AuthException ex)
             {
-                _logger.LogWarning(ex, "[sponsor/auth] callback returned malformed JWT");
+                LogCallbackMalformedJwt(ex);
                 return false;
             }
 
             if (parsed.ExpiresAt <= _time.GetUtcNow().UtcDateTime)
             {
-                _logger.LogWarning("[sponsor/auth] callback JWT is pre-expired");
+                LogCallbackJwtPreExpired();
                 return false;
             }
 
@@ -474,7 +473,7 @@ internal sealed class OAuthTokenProvider : ISponsorTokenProvider, IDisposable
                 Encoding.UTF8.GetBytes(callbackResult.Token), ct).ConfigureAwait(false);
             _cached = callbackResult.Token;
             _claims = parsed;
-            _logger.LogInformation("[sponsor/auth] sign-in complete (exp {Exp})", parsed.ExpiresAt);
+            LogSignInComplete(parsed.ExpiresAt);
             RaiseTokenAcquired();
             return true;
         }

--- a/windows/Ghostty.Core/Sponsor/Auth/OAuthTokenProvider.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/OAuthTokenProvider.cs
@@ -32,6 +32,10 @@ internal sealed class OAuthTokenProvider : ISponsorTokenProvider, IDisposable
     private bool _envVarMode;
     private bool _disposed;
 
+    private ITimer? _refreshTimer;
+    private static readonly TimeSpan RefreshLead    = TimeSpan.FromHours(24);
+    private static readonly TimeSpan TransientRetry = TimeSpan.FromMinutes(10);
+
     public OAuthTokenProvider(
         WinttyAuthClient auth,
         IJwtStore store,
@@ -97,6 +101,7 @@ internal sealed class OAuthTokenProvider : ISponsorTokenProvider, IDisposable
                 _cached = refreshed;
                 _claims = parsed;
                 _logger.LogInformation("[sponsor/auth] reactive refresh succeeded");
+                ScheduleNextRefresh();
             }
             catch (AuthException ex) when (ex.Kind == AuthErrorKind.Unauthorized)
             {
@@ -215,6 +220,7 @@ internal sealed class OAuthTokenProvider : ISponsorTokenProvider, IDisposable
                     _cached = refreshed;
                     _claims = newClaims;
                     _logger.LogInformation("[sponsor/auth] refreshed expired JWT on boot");
+                    ScheduleNextRefresh();
                     return;
                 }
                 catch (AuthException ex) when (ex.Kind == AuthErrorKind.Unauthorized)
@@ -245,6 +251,84 @@ internal sealed class OAuthTokenProvider : ISponsorTokenProvider, IDisposable
     {
         try { await _store.DeleteAsync(ct).ConfigureAwait(false); }
         catch (Exception ex) { _logger.LogDebug(ex, "[sponsor/auth] store delete failed"); }
+    }
+
+    /// <summary>
+    /// Starts the proactive refresh timer after a successful
+    /// InitializeAsync or SignInAsync. No-op in env-var mode (no refresh
+    /// path) and when there is no cached token.
+    /// </summary>
+    public void StartRefreshTimer()
+    {
+        if (_envVarMode) return;
+        if (_claims is null) return;
+        ScheduleNextRefresh();
+    }
+
+    private void ScheduleNextRefresh()
+    {
+        if (_claims is null) return;
+        var now = _time.GetUtcNow();
+        var due = _claims.ExpiresAt - RefreshLead - now.UtcDateTime;
+        if (due <= TimeSpan.Zero) due = TimeSpan.Zero;
+
+        _refreshTimer?.Dispose();
+        _refreshTimer = _time.CreateTimer(
+            _ => _ = OnRefreshTickAsync(),
+            state: null,
+            dueTime: due,
+            period: Timeout.InfiniteTimeSpan);
+    }
+
+    private async Task OnRefreshTickAsync()
+    {
+        if (_disposed) return;
+        if (!await _gate.WaitAsync(0, _lifetime.Token).ConfigureAwait(false))
+        {
+            return; // another refresh already running; it will reschedule
+        }
+        try
+        {
+            var current = _cached;
+            if (string.IsNullOrEmpty(current)) return;
+
+            try
+            {
+                var refreshed = await _auth.RefreshAsync(current, _lifetime.Token).ConfigureAwait(false);
+                var parsed = JwtClaims.Parse(refreshed);
+                await _store.WriteAsync(Encoding.UTF8.GetBytes(refreshed), _lifetime.Token).ConfigureAwait(false);
+                _cached = refreshed;
+                _claims = parsed;
+                _logger.LogInformation("[sponsor/auth] proactive refresh succeeded");
+                ScheduleNextRefresh();
+            }
+            catch (AuthException ex) when (ex.Kind == AuthErrorKind.Unauthorized)
+            {
+                _logger.LogInformation("[sponsor/auth] proactive refresh rejected; clearing");
+                _cached = null; _claims = null;
+                await SafeDeleteAsync(_lifetime.Token).ConfigureAwait(false);
+                _refreshTimer?.Dispose();
+                _refreshTimer = null;
+                TokenInvalidated?.Invoke(this, EventArgs.Empty);
+            }
+            catch (AuthException ex)
+            {
+                _logger.LogWarning(ex, "[sponsor/auth] proactive refresh transient; retry in 10m");
+                _refreshTimer?.Dispose();
+                _refreshTimer = _time.CreateTimer(
+                    _ => _ = OnRefreshTickAsync(), null,
+                    TransientRetry, Timeout.InfiniteTimeSpan);
+            }
+        }
+        catch (OperationCanceledException) { /* shutdown */ }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[sponsor/auth] proactive refresh unexpected failure");
+        }
+        finally
+        {
+            _gate.Release();
+        }
     }
 
     private static readonly TimeSpan LoopbackTimeout = TimeSpan.FromSeconds(120);
@@ -351,6 +435,7 @@ internal sealed class OAuthTokenProvider : ISponsorTokenProvider, IDisposable
         if (_disposed) return;
         _disposed = true;
         try { _lifetime.Cancel(); } catch { /* idempotent */ }
+        _refreshTimer?.Dispose();
         _lifetime.Dispose();
         _gate.Dispose();
     }

--- a/windows/Ghostty.Core/Sponsor/Auth/OAuthTokenProvider.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/OAuthTokenProvider.cs
@@ -64,15 +64,63 @@ internal sealed class OAuthTokenProvider : ISponsorTokenProvider, IDisposable
         => Task.FromResult(_cached);
 
     /// <summary>
-    /// Reactive 401 handler. Task 8 skeleton clears the cache and fires
-    /// <see cref="TokenInvalidated"/>. Task 11 replaces this with a
-    /// background refresh attempt that only fires on refresh failure.
+    /// Reactive 401 handler called by <c>WinttyManifestClient</c> when
+    /// the Worker rejects our current bearer. Kicks off a single-flight
+    /// background refresh. Returns synchronously so the calling HTTP
+    /// retry can proceed. In env-var mode this is a no-op (no refresh
+    /// path exists for env tokens). If another refresh is already in
+    /// flight, this caller's retry rides on its result.
     /// </summary>
     public void Invalidate()
     {
-        _cached = null;
-        _claims = null;
-        TokenInvalidated?.Invoke(this, EventArgs.Empty);
+        if (_envVarMode) return;
+        _ = Task.Run(() => TryRefreshAsync(_lifetime.Token));
+    }
+
+    private async Task TryRefreshAsync(CancellationToken ct)
+    {
+        if (!await _gate.WaitAsync(0, ct).ConfigureAwait(false))
+        {
+            // Another refresh already in flight; let it handle things.
+            return;
+        }
+        try
+        {
+            var current = _cached;
+            if (string.IsNullOrEmpty(current)) return;
+
+            try
+            {
+                var refreshed = await _auth.RefreshAsync(current, ct).ConfigureAwait(false);
+                var parsed = JwtClaims.Parse(refreshed);
+                await _store.WriteAsync(Encoding.UTF8.GetBytes(refreshed), ct).ConfigureAwait(false);
+                _cached = refreshed;
+                _claims = parsed;
+                _logger.LogInformation("[sponsor/auth] reactive refresh succeeded");
+            }
+            catch (AuthException ex) when (ex.Kind == AuthErrorKind.Unauthorized)
+            {
+                _logger.LogInformation("[sponsor/auth] reactive refresh rejected; clearing cache");
+                _cached = null;
+                _claims = null;
+                await SafeDeleteAsync(ct).ConfigureAwait(false);
+                TokenInvalidated?.Invoke(this, EventArgs.Empty);
+            }
+            catch (AuthException ex)
+            {
+                _logger.LogWarning(ex, "[sponsor/auth] reactive refresh transient failure");
+                // Leave cache alone; next 401 will retry.
+            }
+        }
+        catch (OperationCanceledException) { /* shutdown */ }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[sponsor/auth] reactive refresh unexpected failure");
+        }
+        finally
+        {
+            _gate.Release();
+        }
     }
 
     public event EventHandler? TokenInvalidated;

--- a/windows/Ghostty.Core/Sponsor/Auth/OAuthTokenProvider.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/OAuthTokenProvider.cs
@@ -267,12 +267,14 @@ internal sealed class OAuthTokenProvider : ISponsorTokenProvider, IDisposable
 
     private void ScheduleNextRefresh()
     {
+        if (_disposed) return;
         if (_claims is null) return;
         var now = _time.GetUtcNow();
         var due = _claims.ExpiresAt - RefreshLead - now.UtcDateTime;
         if (due <= TimeSpan.Zero) due = TimeSpan.Zero;
 
         _refreshTimer?.Dispose();
+        if (_disposed) return;  // double-check after the tiny window between the Dispose call above and here
         _refreshTimer = _time.CreateTimer(
             _ => _ = OnRefreshTickAsync(),
             state: null,
@@ -315,6 +317,7 @@ internal sealed class OAuthTokenProvider : ISponsorTokenProvider, IDisposable
             {
                 _logger.LogWarning(ex, "[sponsor/auth] proactive refresh transient; retry in 10m");
                 _refreshTimer?.Dispose();
+                if (_disposed) return;
                 _refreshTimer = _time.CreateTimer(
                     _ => _ = OnRefreshTickAsync(), null,
                     TransientRetry, Timeout.InfiniteTimeSpan);

--- a/windows/Ghostty.Core/Sponsor/Auth/OAuthTokenProvider.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/OAuthTokenProvider.cs
@@ -199,6 +199,105 @@ internal sealed class OAuthTokenProvider : ISponsorTokenProvider, IDisposable
         catch (Exception ex) { _logger.LogDebug(ex, "[sponsor/auth] store delete failed"); }
     }
 
+    private static readonly TimeSpan LoopbackTimeout = TimeSpan.FromSeconds(120);
+
+    /// <summary>
+    /// Runs the one-shot OAuth loopback flow: starts the listener,
+    /// opens the browser, awaits the callback, validates nonce and
+    /// JWT shape, persists. Returns true on success. Returns false
+    /// on timeout, user cancel, error query, nonce mismatch, or
+    /// pre-expired JWT. Unexpected exceptions propagate.
+    /// </summary>
+    public async Task<bool> SignInAsync(CancellationToken ct)
+    {
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            try
+            {
+                _listener.Start();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "[sponsor/auth] loopback bind failed");
+                return false;
+            }
+
+            var nonce = Convert.ToHexString(
+                System.Security.Cryptography.RandomNumberGenerator.GetBytes(16));
+            var callback = $"http://127.0.0.1:{_listener.Port}/cb";
+
+            var url = new Uri(
+                $"{_apiBase.GetLeftPart(UriPartial.Authority)}/auth/github/start"
+                + $"?redirect={Uri.EscapeDataString(callback)}"
+                + $"&nonce={nonce}");
+            _browser.Open(url);
+
+            using var timeoutCts = new CancellationTokenSource(LoopbackTimeout);
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
+
+            LoopbackResult callbackResult;
+            try
+            {
+                callbackResult = await _listener.AwaitCallbackAsync(linked.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                _logger.LogInformation("[sponsor/auth] sign-in timed out or cancelled");
+                return false;
+            }
+
+            if (!string.IsNullOrEmpty(callbackResult.Error))
+            {
+                // Log length only - never log raw attacker-supplied query strings.
+                _logger.LogInformation("[sponsor/auth] OAuth error query ({Length} chars)",
+                    callbackResult.Error.Length);
+                return false;
+            }
+
+            if (callbackResult.Nonce != nonce)
+            {
+                _logger.LogWarning("[sponsor/auth] nonce mismatch on callback");
+                return false;
+            }
+
+            if (string.IsNullOrEmpty(callbackResult.Token))
+            {
+                _logger.LogWarning("[sponsor/auth] callback missing token");
+                return false;
+            }
+
+            JwtClaims parsed;
+            try
+            {
+                parsed = JwtClaims.Parse(callbackResult.Token);
+            }
+            catch (AuthException ex)
+            {
+                _logger.LogWarning(ex, "[sponsor/auth] callback returned malformed JWT");
+                return false;
+            }
+
+            if (parsed.ExpiresAt <= _time.GetUtcNow().UtcDateTime)
+            {
+                _logger.LogWarning("[sponsor/auth] callback JWT is pre-expired");
+                return false;
+            }
+
+            await _store.WriteAsync(
+                Encoding.UTF8.GetBytes(callbackResult.Token), ct).ConfigureAwait(false);
+            _cached = callbackResult.Token;
+            _claims = parsed;
+            _logger.LogInformation("[sponsor/auth] sign-in complete (exp {Exp})", parsed.ExpiresAt);
+            RaiseTokenAcquired();
+            return true;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
     public void Dispose()
     {
         if (_disposed) return;

--- a/windows/Ghostty.Core/Sponsor/Auth/OAuthTokenProviderLog.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/OAuthTokenProviderLog.cs
@@ -1,0 +1,153 @@
+using System;
+using Ghostty.Core.Logging;
+using Microsoft.Extensions.Logging;
+
+namespace Ghostty.Core.Sponsor.Auth;
+
+internal sealed partial class OAuthTokenProvider
+{
+    [LoggerMessage(EventId = LogEvents.Auth.ReactiveRefreshSucceeded,
+                   Level = LogLevel.Information,
+                   Message = "[sponsor/auth] reactive refresh succeeded")]
+    private partial void LogReactiveRefreshSucceeded();
+
+    [LoggerMessage(EventId = LogEvents.Auth.ReactiveRefreshRejected,
+                   Level = LogLevel.Information,
+                   Message = "[sponsor/auth] reactive refresh rejected; clearing cache")]
+    private partial void LogReactiveRefreshRejected();
+
+    [LoggerMessage(EventId = LogEvents.Auth.ReactiveRefreshTransient,
+                   Level = LogLevel.Warning,
+                   Message = "[sponsor/auth] reactive refresh transient failure")]
+    private partial void LogReactiveRefreshTransient(Exception ex);
+
+    [LoggerMessage(EventId = LogEvents.Auth.ReactiveRefreshUnexpected,
+                   Level = LogLevel.Error,
+                   Message = "[sponsor/auth] reactive refresh unexpected failure")]
+    private partial void LogReactiveRefreshUnexpected(Exception ex);
+
+    [LoggerMessage(EventId = LogEvents.Auth.DevJwtLoaded,
+                   Level = LogLevel.Information,
+                   Message = "[sponsor/auth] using WINTTY_DEV_JWT (expires {Exp})")]
+    private partial void LogDevJwtLoaded(DateTime exp);
+
+    [LoggerMessage(EventId = LogEvents.Auth.DevJwtMalformed,
+                   Level = LogLevel.Warning,
+                   Message = "[sponsor/auth] WINTTY_DEV_JWT is malformed; ignoring")]
+    private partial void LogDevJwtMalformed(Exception ex);
+
+    [LoggerMessage(EventId = LogEvents.Auth.StoreReadFailed,
+                   Level = LogLevel.Warning,
+                   Message = "[sponsor/auth] JWT store read failed")]
+    private partial void LogStoreReadFailed(Exception ex);
+
+    [LoggerMessage(EventId = LogEvents.Auth.NoCachedJwt,
+                   Level = LogLevel.Information,
+                   Message = "[sponsor/auth] no cached JWT; sign-in required")]
+    private partial void LogNoCachedJwt();
+
+    [LoggerMessage(EventId = LogEvents.Auth.CachedJwtMalformed,
+                   Level = LogLevel.Warning,
+                   Message = "[sponsor/auth] cached JWT malformed; deleting")]
+    private partial void LogCachedJwtMalformed(Exception ex);
+
+    [LoggerMessage(EventId = LogEvents.Auth.CachedJwtStale,
+                   Level = LogLevel.Information,
+                   Message = "[sponsor/auth] cached JWT stale by more than 24h; deleting")]
+    private partial void LogCachedJwtStale();
+
+    [LoggerMessage(EventId = LogEvents.Auth.BootRefreshSucceeded,
+                   Level = LogLevel.Information,
+                   Message = "[sponsor/auth] refreshed expired JWT on boot")]
+    private partial void LogBootRefreshSucceeded();
+
+    [LoggerMessage(EventId = LogEvents.Auth.BootRefreshRejected,
+                   Level = LogLevel.Information,
+                   Message = "[sponsor/auth] expired JWT rejected on refresh; deleting")]
+    private partial void LogBootRefreshRejected();
+
+    [LoggerMessage(EventId = LogEvents.Auth.BootRefreshFailed,
+                   Level = LogLevel.Warning,
+                   Message = "[sponsor/auth] refresh failed on boot; keeping nothing cached")]
+    private partial void LogBootRefreshFailed(Exception ex);
+
+    [LoggerMessage(EventId = LogEvents.Auth.LoadedCachedJwt,
+                   Level = LogLevel.Information,
+                   Message = "[sponsor/auth] loaded cached JWT (expires {Exp})")]
+    private partial void LogLoadedCachedJwt(DateTime exp);
+
+    [LoggerMessage(EventId = LogEvents.Auth.StoreDeleteFailed,
+                   Level = LogLevel.Debug,
+                   Message = "[sponsor/auth] store delete failed")]
+    private partial void LogStoreDeleteFailed(Exception ex);
+
+    [LoggerMessage(EventId = LogEvents.Auth.ProactiveRefreshSucceeded,
+                   Level = LogLevel.Information,
+                   Message = "[sponsor/auth] proactive refresh succeeded")]
+    private partial void LogProactiveRefreshSucceeded();
+
+    [LoggerMessage(EventId = LogEvents.Auth.ProactiveRefreshRejected,
+                   Level = LogLevel.Information,
+                   Message = "[sponsor/auth] proactive refresh rejected; clearing")]
+    private partial void LogProactiveRefreshRejected();
+
+    [LoggerMessage(EventId = LogEvents.Auth.ProactiveRefreshTransient,
+                   Level = LogLevel.Warning,
+                   Message = "[sponsor/auth] proactive refresh transient; retry in 10m")]
+    private partial void LogProactiveRefreshTransient(Exception ex);
+
+    [LoggerMessage(EventId = LogEvents.Auth.ProactiveRefreshUnexpected,
+                   Level = LogLevel.Error,
+                   Message = "[sponsor/auth] proactive refresh unexpected failure")]
+    private partial void LogProactiveRefreshUnexpected(Exception ex);
+
+    [LoggerMessage(EventId = LogEvents.Auth.RevokeAcknowledged,
+                   Level = LogLevel.Information,
+                   Message = "[sponsor/auth] revoke acknowledged")]
+    private partial void LogRevokeAcknowledged();
+
+    [LoggerMessage(EventId = LogEvents.Auth.RevokeBestEffortFailed,
+                   Level = LogLevel.Debug,
+                   Message = "[sponsor/auth] revoke best-effort failed")]
+    private partial void LogRevokeBestEffortFailed(Exception ex);
+
+    [LoggerMessage(EventId = LogEvents.Auth.LoopbackBindFailed,
+                   Level = LogLevel.Warning,
+                   Message = "[sponsor/auth] loopback bind failed")]
+    private partial void LogLoopbackBindFailed(Exception ex);
+
+    [LoggerMessage(EventId = LogEvents.Auth.SignInTimedOut,
+                   Level = LogLevel.Information,
+                   Message = "[sponsor/auth] sign-in timed out or cancelled")]
+    private partial void LogSignInTimedOut();
+
+    [LoggerMessage(EventId = LogEvents.Auth.OAuthErrorQuery,
+                   Level = LogLevel.Information,
+                   Message = "[sponsor/auth] OAuth error query ({Length} chars)")]
+    private partial void LogOAuthErrorQuery(int length);
+
+    [LoggerMessage(EventId = LogEvents.Auth.NonceMismatch,
+                   Level = LogLevel.Warning,
+                   Message = "[sponsor/auth] nonce mismatch on callback")]
+    private partial void LogNonceMismatch();
+
+    [LoggerMessage(EventId = LogEvents.Auth.CallbackMissingToken,
+                   Level = LogLevel.Warning,
+                   Message = "[sponsor/auth] callback missing token")]
+    private partial void LogCallbackMissingToken();
+
+    [LoggerMessage(EventId = LogEvents.Auth.CallbackMalformedJwt,
+                   Level = LogLevel.Warning,
+                   Message = "[sponsor/auth] callback returned malformed JWT")]
+    private partial void LogCallbackMalformedJwt(Exception ex);
+
+    [LoggerMessage(EventId = LogEvents.Auth.CallbackJwtPreExpired,
+                   Level = LogLevel.Warning,
+                   Message = "[sponsor/auth] callback JWT is pre-expired")]
+    private partial void LogCallbackJwtPreExpired();
+
+    [LoggerMessage(EventId = LogEvents.Auth.SignInComplete,
+                   Level = LogLevel.Information,
+                   Message = "[sponsor/auth] sign-in complete (exp {Exp})")]
+    private partial void LogSignInComplete(DateTime exp);
+}

--- a/windows/Ghostty.Core/Sponsor/Auth/WinttyAuthClient.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/WinttyAuthClient.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Ghostty.Core.Sponsor.Auth;
+
+/// <summary>
+/// Velopack-free HTTP client for the api.wintty.io auth endpoints
+/// (<c>/auth/refresh</c> and <c>/auth/revoke</c>). Mirrors
+/// <see cref="Ghostty.Core.Sponsor.Update.WinttyManifestClient"/> in
+/// style. All public methods throw <see cref="AuthException"/> on
+/// failure; the <see cref="AuthErrorKind"/> drives retry policy in
+/// <c>OAuthTokenProvider</c>.
+/// </summary>
+internal sealed class WinttyAuthClient
+{
+    private readonly HttpClient _http;
+    private readonly Uri _apiBase;
+
+    public WinttyAuthClient(HttpClient http, Uri apiBase)
+    {
+        ArgumentNullException.ThrowIfNull(http);
+        ArgumentNullException.ThrowIfNull(apiBase);
+        _http = http;
+        _apiBase = apiBase;
+    }
+
+    /// <summary>
+    /// POSTs to <c>/auth/refresh</c> with the current bearer. Returns
+    /// the new JWT string on success. Throws on any non-2xx, network
+    /// failure, or malformed response body.
+    /// </summary>
+    public async Task<string> RefreshAsync(string currentToken, CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(currentToken);
+
+        using var req = new HttpRequestMessage(HttpMethod.Post, new Uri(_apiBase, "/auth/refresh"));
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", currentToken);
+
+        HttpResponseMessage resp;
+        try
+        {
+            resp = await _http.SendAsync(req, ct).ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new AuthException(AuthErrorKind.Network, "refresh: network failure", ex);
+        }
+        catch (TaskCanceledException ex) when (!ct.IsCancellationRequested)
+        {
+            throw new AuthException(AuthErrorKind.Network, "refresh: timed out", ex);
+        }
+
+        using (resp)
+        {
+            if (resp.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+                throw new AuthException(AuthErrorKind.Unauthorized, $"refresh: {(int)resp.StatusCode}");
+            if ((int)resp.StatusCode >= 500)
+                throw new AuthException(AuthErrorKind.ServerError, $"refresh: {(int)resp.StatusCode}");
+            if (!resp.IsSuccessStatusCode)
+                throw new AuthException(AuthErrorKind.ServerError, $"refresh: unexpected {(int)resp.StatusCode}");
+
+            var body = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            string? newToken;
+            try
+            {
+                using var doc = JsonDocument.Parse(body);
+                newToken = doc.RootElement.TryGetProperty("token", out var tok) && tok.ValueKind == JsonValueKind.String
+                    ? tok.GetString()
+                    : null;
+            }
+            catch (JsonException ex)
+            {
+                throw new AuthException(AuthErrorKind.ServerError, "refresh: malformed JSON response", ex);
+            }
+
+            if (string.IsNullOrEmpty(newToken))
+                throw new AuthException(AuthErrorKind.ServerError, "refresh: response missing 'token' field");
+
+            return newToken;
+        }
+    }
+
+    /// <summary>
+    /// POSTs to <c>/auth/revoke</c> with the current bearer. No return
+    /// value - success is a 2xx. Non-success throws so the caller can
+    /// log; production callers (<c>OAuthTokenProvider.SignOutAsync</c>)
+    /// swallow all exceptions and delete locally regardless.
+    /// </summary>
+    public async Task RevokeAsync(string currentToken, CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(currentToken);
+
+        using var req = new HttpRequestMessage(HttpMethod.Post, new Uri(_apiBase, "/auth/revoke"));
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", currentToken);
+
+        HttpResponseMessage resp;
+        try
+        {
+            resp = await _http.SendAsync(req, ct).ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new AuthException(AuthErrorKind.Network, "revoke: network failure", ex);
+        }
+        catch (TaskCanceledException ex) when (!ct.IsCancellationRequested)
+        {
+            throw new AuthException(AuthErrorKind.Network, "revoke: timed out", ex);
+        }
+
+        using (resp)
+        {
+            if (!resp.IsSuccessStatusCode)
+                throw new AuthException(AuthErrorKind.ServerError, $"revoke: {(int)resp.StatusCode}");
+        }
+    }
+}

--- a/windows/Ghostty.Tests/Sponsor/Auth/AuthExceptionTests.cs
+++ b/windows/Ghostty.Tests/Sponsor/Auth/AuthExceptionTests.cs
@@ -1,0 +1,26 @@
+using Ghostty.Core.Sponsor.Auth;
+using Xunit;
+
+namespace Ghostty.Tests.Sponsor.Auth;
+
+public class AuthExceptionTests
+{
+    [Fact]
+    public void Ctor_PreservesKindAndMessage()
+    {
+        var ex = new AuthException(AuthErrorKind.Unauthorized, "revoked jti");
+
+        Assert.Equal(AuthErrorKind.Unauthorized, ex.Kind);
+        Assert.Equal("revoked jti", ex.Message);
+    }
+
+    [Fact]
+    public void Ctor_WithInner_PreservesInner()
+    {
+        var inner = new System.Net.Http.HttpRequestException("dns fail");
+
+        var ex = new AuthException(AuthErrorKind.Network, "transient", inner);
+
+        Assert.Same(inner, ex.InnerException);
+    }
+}

--- a/windows/Ghostty.Tests/Sponsor/Auth/AuthExceptionTests.cs
+++ b/windows/Ghostty.Tests/Sponsor/Auth/AuthExceptionTests.cs
@@ -6,21 +6,31 @@ namespace Ghostty.Tests.Sponsor.Auth;
 public class AuthExceptionTests
 {
     [Fact]
-    public void Ctor_PreservesKindAndMessage()
+    public void Constructor_PopulatesKindDetailAndInner()
     {
-        var ex = new AuthException(AuthErrorKind.Unauthorized, "revoked jti");
+        var inner = new System.Net.Http.HttpRequestException("dns fail");
+        var ex = new AuthException(AuthErrorKind.Unauthorized, "revoked jti", inner);
 
         Assert.Equal(AuthErrorKind.Unauthorized, ex.Kind);
-        Assert.Equal("revoked jti", ex.Message);
+        Assert.Equal("revoked jti", ex.Detail);
+        Assert.Same(inner, ex.InnerException);
     }
 
     [Fact]
-    public void Ctor_WithInner_PreservesInner()
+    public void Constructor_InnerIsOptional()
     {
-        var inner = new System.Net.Http.HttpRequestException("dns fail");
+        var ex = new AuthException(AuthErrorKind.Network, null);
 
-        var ex = new AuthException(AuthErrorKind.Network, "transient", inner);
+        Assert.Equal(AuthErrorKind.Network, ex.Kind);
+        Assert.Null(ex.Detail);
+        Assert.Null(ex.InnerException);
+    }
 
-        Assert.Same(inner, ex.InnerException);
+    [Fact]
+    public void Message_IncludesKindForDiagnostics()
+    {
+        var ex = new AuthException(AuthErrorKind.ServerError, "500");
+
+        Assert.Contains("ServerError", ex.Message);
     }
 }

--- a/windows/Ghostty.Tests/Sponsor/Auth/DpapiJwtStoreTests.cs
+++ b/windows/Ghostty.Tests/Sponsor/Auth/DpapiJwtStoreTests.cs
@@ -1,0 +1,99 @@
+using System;
+using System.IO;
+using System.Runtime.Versioning;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Ghostty.Core.Sponsor.Auth;
+using Xunit;
+
+namespace Ghostty.Tests.Sponsor.Auth;
+
+[SupportedOSPlatform("windows")]
+public class DpapiJwtStoreTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly byte[] _entropy = Encoding.UTF8.GetBytes("test-entropy-value");
+
+    public DpapiJwtStoreTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "wintty-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { /* tolerate locks */ }
+    }
+
+    [Fact]
+    public async Task Roundtrip_WritesAndReadsSameBytes()
+    {
+        var store = new DpapiJwtStore(_tempDir, _entropy);
+        var payload = Encoding.UTF8.GetBytes("header.payload.signature");
+
+        await store.WriteAsync(payload, CancellationToken.None);
+        var read = await store.ReadAsync(CancellationToken.None);
+
+        Assert.NotNull(read);
+        Assert.Equal(payload, read);
+    }
+
+    [Fact]
+    public async Task Read_WhenNoFile_ReturnsNull()
+    {
+        var store = new DpapiJwtStore(_tempDir, _entropy);
+
+        var read = await store.ReadAsync(CancellationToken.None);
+
+        Assert.Null(read);
+    }
+
+    [Fact]
+    public async Task Delete_RemovesFile()
+    {
+        var store = new DpapiJwtStore(_tempDir, _entropy);
+        await store.WriteAsync(Encoding.UTF8.GetBytes("x"), CancellationToken.None);
+
+        await store.DeleteAsync(CancellationToken.None);
+
+        var read = await store.ReadAsync(CancellationToken.None);
+        Assert.Null(read);
+    }
+
+    [Fact]
+    public async Task Delete_WhenNoFile_IsNoOp()
+    {
+        var store = new DpapiJwtStore(_tempDir, _entropy);
+
+        await store.DeleteAsync(CancellationToken.None);
+        // no throw = pass
+    }
+
+    [Fact]
+    public async Task Read_WithWrongEntropy_ReturnsNull()
+    {
+        var writer = new DpapiJwtStore(_tempDir, _entropy);
+        await writer.WriteAsync(Encoding.UTF8.GetBytes("payload"), CancellationToken.None);
+
+        var reader = new DpapiJwtStore(_tempDir, Encoding.UTF8.GetBytes("different-entropy"));
+
+        var read = await reader.ReadAsync(CancellationToken.None);
+
+        Assert.Null(read);
+    }
+
+    [Fact]
+    public async Task Write_OverwritesExisting()
+    {
+        var store = new DpapiJwtStore(_tempDir, _entropy);
+        await store.WriteAsync(Encoding.UTF8.GetBytes("first"), CancellationToken.None);
+
+        await store.WriteAsync(Encoding.UTF8.GetBytes("second"), CancellationToken.None);
+
+        var read = await store.ReadAsync(CancellationToken.None);
+        Assert.Equal("second", Encoding.UTF8.GetString(read!));
+        Assert.False(File.Exists(Path.Combine(_tempDir, "auth.bin.partial")),
+            "partial file should be renamed away after atomic write");
+    }
+}

--- a/windows/Ghostty.Tests/Sponsor/Auth/HttpLoopbackListenerTests.cs
+++ b/windows/Ghostty.Tests/Sponsor/Auth/HttpLoopbackListenerTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Net.Http;
+using System.Runtime.Versioning;
+using System.Threading;
+using System.Threading.Tasks;
+using Ghostty.Core.Sponsor.Auth;
+using Xunit;
+
+namespace Ghostty.Tests.Sponsor.Auth;
+
+[SupportedOSPlatform("windows")]
+public class HttpLoopbackListenerTests
+{
+    [Fact]
+    public async Task HappyPath_TokenAndNonceExtracted()
+    {
+        using var listener = new HttpLoopbackListener();
+        listener.Start();
+
+        using var http = new HttpClient();
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(50);
+            await http.GetAsync($"http://127.0.0.1:{listener.Port}/cb?token=abc&nonce=xyz");
+        });
+
+        var result = await listener.AwaitCallbackAsync(CancellationToken.None);
+
+        Assert.Equal("abc", result.Token);
+        Assert.Equal("xyz", result.Nonce);
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    public async Task OAuthErrorQueryParam_Surfaces()
+    {
+        using var listener = new HttpLoopbackListener();
+        listener.Start();
+
+        using var http = new HttpClient();
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(50);
+            await http.GetAsync($"http://127.0.0.1:{listener.Port}/cb?error=access_denied");
+        });
+
+        var result = await listener.AwaitCallbackAsync(CancellationToken.None);
+
+        Assert.Null(result.Token);
+        Assert.Equal("access_denied", result.Error);
+    }
+
+    [Fact]
+    public async Task WrongPath_Returns404AndKeepsListening()
+    {
+        using var listener = new HttpLoopbackListener();
+        listener.Start();
+
+        using var http = new HttpClient();
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(50);
+            var wrong = await http.GetAsync($"http://127.0.0.1:{listener.Port}/wrong");
+            Assert.Equal(System.Net.HttpStatusCode.NotFound, wrong.StatusCode);
+
+            await Task.Delay(50);
+            await http.GetAsync($"http://127.0.0.1:{listener.Port}/cb?token=t&nonce=n");
+        });
+
+        var result = await listener.AwaitCallbackAsync(CancellationToken.None);
+
+        Assert.Equal("t", result.Token);
+    }
+
+    [Fact]
+    public async Task CancellationToken_StopsWait()
+    {
+        using var listener = new HttpLoopbackListener();
+        listener.Start();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => listener.AwaitCallbackAsync(cts.Token));
+    }
+
+    [Fact]
+    public void Port_BeforeStart_Throws()
+    {
+        using var listener = new HttpLoopbackListener();
+
+        Assert.Throws<InvalidOperationException>(() => _ = listener.Port);
+    }
+}

--- a/windows/Ghostty.Tests/Sponsor/Auth/JwtClaimsTests.cs
+++ b/windows/Ghostty.Tests/Sponsor/Auth/JwtClaimsTests.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Text;
+using System.Text.Json;
+using Ghostty.Core.Sponsor.Auth;
+using Xunit;
+
+namespace Ghostty.Tests.Sponsor.Auth;
+
+public class JwtClaimsTests
+{
+    // Helper: build a minimal test JWT. Signature byte sequence is meaningless;
+    // JwtClaims never validates it.
+    private static string MakeJwt(object payload)
+    {
+        static string Base64UrlEncode(byte[] bytes)
+            => Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+        var header = Base64UrlEncode(Encoding.UTF8.GetBytes(
+            """{"alg":"HS256","typ":"JWT"}"""));
+        var body   = Base64UrlEncode(Encoding.UTF8.GetBytes(
+            JsonSerializer.Serialize(payload)));
+        var sig    = Base64UrlEncode(new byte[] { 0xDE, 0xAD, 0xBE, 0xEF });
+        return $"{header}.{body}.{sig}";
+    }
+
+    [Fact]
+    public void Parse_HappyPath_ExtractsAllClaims()
+    {
+        var jwt = MakeJwt(new
+        {
+            sub            = "12345",
+            login          = "alice",
+            tier_cents     = 500,
+            channel_allow  = new[] { "stable", "tip" },
+            default_channel = (string?)null,
+            exp            = 1800000000L,
+            iat            = 1799000000L,
+            jti            = "abc-123",
+        });
+
+        var claims = JwtClaims.Parse(jwt);
+
+        Assert.Equal("12345", claims.Subject);
+        Assert.Equal("alice", claims.Login);
+        Assert.Equal(500, claims.TierCents);
+        Assert.Equal(new[] { "stable", "tip" }, claims.ChannelAllow);
+        Assert.Null(claims.DefaultChannel);
+        Assert.Equal("abc-123", claims.JwtId);
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(1800000000L).UtcDateTime, claims.ExpiresAt);
+    }
+
+    [Fact]
+    public void Parse_MissingOptionalClaims_UsesDefaults()
+    {
+        var jwt = MakeJwt(new { sub = "999", exp = 2000000000L });
+
+        var claims = JwtClaims.Parse(jwt);
+
+        Assert.Equal("999", claims.Subject);
+        Assert.Null(claims.Login);
+        Assert.Equal(0, claims.TierCents);
+        Assert.Empty(claims.ChannelAllow);
+        Assert.Null(claims.DefaultChannel);
+        Assert.Null(claims.JwtId);
+    }
+
+    [Fact]
+    public void Parse_PaddingStrippedOnBase64Url_StillDecodes()
+    {
+        // Payload designed so the base64url encoding requires padding.
+        var jwt = MakeJwt(new { sub = "a", exp = 1L });
+
+        var claims = JwtClaims.Parse(jwt);
+
+        Assert.Equal("a", claims.Subject);
+    }
+
+    [Fact]
+    public void Parse_WrongSegmentCount_Throws()
+    {
+        Assert.Throws<AuthException>(() => JwtClaims.Parse("only.two"));
+        Assert.Throws<AuthException>(() => JwtClaims.Parse("a.b.c.d"));
+    }
+
+    [Fact]
+    public void Parse_EmptyString_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => JwtClaims.Parse(""));
+    }
+
+    [Fact]
+    public void Parse_MalformedJson_Throws()
+    {
+        static string B64(string s) => Convert.ToBase64String(Encoding.UTF8.GetBytes(s))
+            .TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+        var bad = $"{B64("{}")}.{B64("not-json")}.{B64("sig")}";
+
+        var ex = Assert.Throws<AuthException>(() => JwtClaims.Parse(bad));
+        Assert.Equal(AuthErrorKind.Unknown, ex.Kind);
+    }
+
+    [Fact]
+    public void Parse_MissingExp_Throws()
+    {
+        var jwt = MakeJwt(new { sub = "999" });
+
+        var ex = Assert.Throws<AuthException>(() => JwtClaims.Parse(jwt));
+        Assert.Equal(AuthErrorKind.Unknown, ex.Kind);
+        Assert.Contains("exp", ex.Message);
+    }
+}

--- a/windows/Ghostty.Tests/Sponsor/Auth/OAuthTokenProviderTests.cs
+++ b/windows/Ghostty.Tests/Sponsor/Auth/OAuthTokenProviderTests.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Ghostty.Core.Sponsor.Auth;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Ghostty.Tests.Sponsor.Auth;
+
+public partial class OAuthTokenProviderTests
+{
+    // ---------------------------------------------------------------
+    // Test doubles shared across partial class files. Later tasks add
+    // more test methods but use the same fakes.
+    // ---------------------------------------------------------------
+
+    internal sealed class FakeStore : IJwtStore
+    {
+        public byte[]? Bytes;
+        public int Writes; public int Reads; public int Deletes;
+        public Task<byte[]?> ReadAsync(CancellationToken ct) { Reads++; return Task.FromResult(Bytes); }
+        public Task WriteAsync(byte[] utf8Token, CancellationToken ct) { Writes++; Bytes = utf8Token; return Task.CompletedTask; }
+        public Task DeleteAsync(CancellationToken ct) { Deletes++; Bytes = null; return Task.CompletedTask; }
+    }
+
+    internal sealed class FakeBrowser : IBrowserLauncher
+    {
+        public List<Uri> Opened { get; } = new();
+        public void Open(Uri url) => Opened.Add(url);
+    }
+
+    internal sealed class FakeListener : ILoopbackListener
+    {
+        public int Port => 54321;
+        public bool Started;
+        public Func<CancellationToken, Task<LoopbackResult>>? Behavior;
+        public void Start() { Started = true; }
+        public Task<LoopbackResult> AwaitCallbackAsync(CancellationToken ct)
+            => Behavior?.Invoke(ct) ?? Task.FromResult(new LoopbackResult(null, null, null));
+        public void Dispose() { }
+    }
+
+    internal sealed class FakeTime : TimeProvider
+    {
+        public DateTimeOffset Now = DateTimeOffset.UtcNow;
+        public override DateTimeOffset GetUtcNow() => Now;
+    }
+
+    internal sealed class FakeHandler : HttpMessageHandler
+    {
+        public Func<HttpRequestMessage, HttpResponseMessage> Respond = _ => new HttpResponseMessage(HttpStatusCode.NotFound);
+        public List<HttpRequestMessage> Requests { get; } = new();
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+            return Task.FromResult(Respond(request));
+        }
+    }
+
+    // Build helper. Returns all the fakes so individual tests can drive them.
+    internal static (OAuthTokenProvider provider, FakeStore store, FakeBrowser browser, FakeListener listener, FakeHandler handler, FakeTime time) Build(string? envOverride = null)
+    {
+        var handler = new FakeHandler();
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.wintty.io") };
+        var auth = new WinttyAuthClient(http, new Uri("https://api.wintty.io"));
+        var store = new FakeStore();
+        var browser = new FakeBrowser();
+        var listener = new FakeListener();
+        var time = new FakeTime();
+        var provider = new OAuthTokenProvider(
+            auth, store, browser, listener,
+            new Uri("https://api.wintty.io"),
+            NullLogger<OAuthTokenProvider>.Instance,
+            time,
+            envVarLookup: _ => envOverride);
+        return (provider, store, browser, listener, handler, time);
+    }
+
+    // JWT helper: build a test JWT expiring `secondsFromNow` in the future.
+    internal static string MakeJwt(FakeTime time, int secondsFromNow)
+    {
+        static string B64(byte[] b) => Convert.ToBase64String(b).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+        var exp = time.Now.AddSeconds(secondsFromNow).ToUnixTimeSeconds();
+        var header = B64(Encoding.UTF8.GetBytes("""{"alg":"HS256","typ":"JWT"}"""));
+        var body   = B64(Encoding.UTF8.GetBytes($$"""{"sub":"u","exp":{{exp}},"jti":"j"}"""));
+        var sig    = B64(new byte[] { 1, 2, 3 });
+        return $"{header}.{body}.{sig}";
+    }
+
+    // ---------------------------------------------------------------
+    // Task 8 tests
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public async Task GetTokenAsync_WhenNoCache_ReturnsNull()
+    {
+        var (provider, _, _, _, _, _) = Build();
+
+        var token = await provider.GetTokenAsync(CancellationToken.None);
+
+        Assert.Null(token);
+    }
+
+    [Fact]
+    public void Dispose_IsIdempotent()
+    {
+        var (provider, _, _, _, _, _) = Build();
+
+        provider.Dispose();
+        provider.Dispose();
+    }
+
+    [Fact]
+    public void Invalidate_ClearsCache_FiresTokenInvalidated()
+    {
+        // Minimal skeleton behavior for Task 8: Invalidate synchronously
+        // clears the cached token and fires TokenInvalidated. Reactive
+        // refresh behavior lands in Task 11 - this test will be refined
+        // or superseded then.
+        var (provider, _, _, _, _, _) = Build();
+
+        var fired = 0;
+        provider.TokenInvalidated += (_, _) => fired++;
+
+        provider.Invalidate();
+
+        Assert.Equal(1, fired);
+    }
+}

--- a/windows/Ghostty.Tests/Sponsor/Auth/OAuthTokenProviderTests.cs
+++ b/windows/Ghostty.Tests/Sponsor/Auth/OAuthTokenProviderTests.cs
@@ -130,4 +130,104 @@ public partial class OAuthTokenProviderTests
 
         Assert.Equal(1, fired);
     }
+
+    // ---------------------------------------------------------------
+    // Task 9 tests: InitializeAsync
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public async Task InitializeAsync_WithEnvVar_LoadsVerbatimSkipsStore()
+    {
+        var time = new FakeTime { Now = DateTimeOffset.UtcNow };
+        var jwt = MakeJwt(time, secondsFromNow: 3600);
+        var (provider, store, _, _, _, _) = Build(envOverride: jwt);
+
+        await provider.InitializeAsync(CancellationToken.None);
+
+        Assert.Equal(jwt, await provider.GetTokenAsync(CancellationToken.None));
+        Assert.Equal(0, store.Reads);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_WithNoStoredBlob_StaysNoToken()
+    {
+        var (provider, store, _, _, _, _) = Build();
+        store.Bytes = null;
+
+        await provider.InitializeAsync(CancellationToken.None);
+
+        Assert.Null(await provider.GetTokenAsync(CancellationToken.None));
+        Assert.Equal(1, store.Reads);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_WithValidStoredBlob_LoadsIntoCache()
+    {
+        var (provider, store, _, _, _, time) = Build();
+        var jwt = MakeJwt(time, secondsFromNow: 3600);
+        store.Bytes = Encoding.UTF8.GetBytes(jwt);
+
+        await provider.InitializeAsync(CancellationToken.None);
+
+        Assert.Equal(jwt, await provider.GetTokenAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task InitializeAsync_WithExpiredButRefreshableBlob_RefreshesAndReplaces()
+    {
+        var (provider, store, _, _, handler, time) = Build();
+        var oldJwt = MakeJwt(time, secondsFromNow: -3600);
+        store.Bytes = Encoding.UTF8.GetBytes(oldJwt);
+        var newJwt = MakeJwt(time, secondsFromNow: 3600);
+        handler.Respond = _ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent($$"""{"token":"{{newJwt}}"}""",
+                Encoding.UTF8, "application/json"),
+        };
+
+        await provider.InitializeAsync(CancellationToken.None);
+
+        Assert.Equal(newJwt, await provider.GetTokenAsync(CancellationToken.None));
+        Assert.Equal(1, store.Writes);
+        Assert.Equal(newJwt, Encoding.UTF8.GetString(store.Bytes!));
+    }
+
+    [Fact]
+    public async Task InitializeAsync_WithStaleBlobPast24h_DeletesAndStaysNoToken()
+    {
+        var (provider, store, _, _, _, time) = Build();
+        var stale = MakeJwt(time, secondsFromNow: -48 * 3600);
+        store.Bytes = Encoding.UTF8.GetBytes(stale);
+
+        await provider.InitializeAsync(CancellationToken.None);
+
+        Assert.Null(await provider.GetTokenAsync(CancellationToken.None));
+        Assert.Equal(1, store.Deletes);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_WithMalformedBlob_DeletesAndStaysNoToken()
+    {
+        var (provider, store, _, _, _, _) = Build();
+        store.Bytes = Encoding.UTF8.GetBytes("not-a-jwt");
+
+        await provider.InitializeAsync(CancellationToken.None);
+
+        Assert.Null(await provider.GetTokenAsync(CancellationToken.None));
+        Assert.Equal(1, store.Deletes);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_RefreshFailsUnauthorized_DeletesAndStaysNoToken()
+    {
+        var (provider, store, _, _, handler, time) = Build();
+        var expired = MakeJwt(time, secondsFromNow: -60);
+        store.Bytes = Encoding.UTF8.GetBytes(expired);
+        handler.Respond = _ => new HttpResponseMessage(HttpStatusCode.Unauthorized);
+
+        await provider.InitializeAsync(CancellationToken.None);
+
+        Assert.Null(await provider.GetTokenAsync(CancellationToken.None));
+        Assert.Equal(1, store.Deletes);
+    }
 }

--- a/windows/Ghostty.Tests/Sponsor/Auth/OAuthTokenProviderTests.cs
+++ b/windows/Ghostty.Tests/Sponsor/Auth/OAuthTokenProviderTests.cs
@@ -114,23 +114,6 @@ public partial class OAuthTokenProviderTests
         provider.Dispose();
     }
 
-    [Fact]
-    public void Invalidate_ClearsCache_FiresTokenInvalidated()
-    {
-        // Minimal skeleton behavior for Task 8: Invalidate synchronously
-        // clears the cached token and fires TokenInvalidated. Reactive
-        // refresh behavior lands in Task 11 - this test will be refined
-        // or superseded then.
-        var (provider, _, _, _, _, _) = Build();
-
-        var fired = 0;
-        provider.TokenInvalidated += (_, _) => fired++;
-
-        provider.Invalidate();
-
-        Assert.Equal(1, fired);
-    }
-
     // ---------------------------------------------------------------
     // Task 9 tests: InitializeAsync
     // ---------------------------------------------------------------
@@ -336,4 +319,92 @@ public partial class OAuthTokenProviderTests
 
         Assert.False(result);
     }
-}
+
+    // ---------------------------------------------------------------
+    // Task 11 tests: Invalidate reactive refresh
+    // ---------------------------------------------------------------
+        [Fact]
+        public async Task Invalidate_RefreshSucceeds_ReplacesCacheDoesNotFire()
+        {
+            var (provider, store, _, _, handler, time) = Build();
+            var current = MakeJwt(time, secondsFromNow: 60);
+            store.Bytes = Encoding.UTF8.GetBytes(current);
+            await provider.InitializeAsync(CancellationToken.None);
+
+            var refreshed = MakeJwt(time, secondsFromNow: 7 * 24 * 3600);
+            handler.Respond = _ => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent($$"""{"token":"{{refreshed}}"}""",
+                    Encoding.UTF8, "application/json"),
+            };
+
+            var fired = 0;
+            provider.TokenInvalidated += (_, _) => fired++;
+
+            provider.Invalidate();
+            await Task.Delay(200); // wait for background refresh
+
+            Assert.Equal(refreshed, await provider.GetTokenAsync(CancellationToken.None));
+            Assert.Equal(0, fired);
+        }
+
+        [Fact]
+        public async Task Invalidate_RefreshFailsUnauthorized_ClearsAndFires()
+        {
+            var (provider, store, _, _, handler, time) = Build();
+            var current = MakeJwt(time, secondsFromNow: 60);
+            store.Bytes = Encoding.UTF8.GetBytes(current);
+            await provider.InitializeAsync(CancellationToken.None);
+
+            handler.Respond = _ => new HttpResponseMessage(HttpStatusCode.Unauthorized);
+
+            var fired = 0;
+            provider.TokenInvalidated += (_, _) => fired++;
+
+            provider.Invalidate();
+            await Task.Delay(200);
+
+            Assert.Null(await provider.GetTokenAsync(CancellationToken.None));
+            Assert.Equal(1, fired);
+            Assert.Equal(1, store.Deletes);
+        }
+
+        [Fact]
+        public async Task Invalidate_RefreshFailsTransient_KeepsCacheDoesNotFire()
+        {
+            var (provider, store, _, _, handler, time) = Build();
+            var current = MakeJwt(time, secondsFromNow: 60);
+            store.Bytes = Encoding.UTF8.GetBytes(current);
+            await provider.InitializeAsync(CancellationToken.None);
+
+            handler.Respond = _ => new HttpResponseMessage(HttpStatusCode.InternalServerError);
+
+            var fired = 0;
+            provider.TokenInvalidated += (_, _) => fired++;
+
+            provider.Invalidate();
+            await Task.Delay(200);
+
+            Assert.Equal(current, await provider.GetTokenAsync(CancellationToken.None));
+            Assert.Equal(0, fired);
+        }
+
+        [Fact]
+        public async Task Invalidate_InEnvVarMode_IsNoOp()
+        {
+            var time = new FakeTime();
+            var jwt = MakeJwt(time, secondsFromNow: 3600);
+            var (provider, _, _, _, handler, _) = Build(envOverride: jwt);
+            await provider.InitializeAsync(CancellationToken.None);
+
+            var fired = 0;
+            provider.TokenInvalidated += (_, _) => fired++;
+
+            provider.Invalidate();
+            await Task.Delay(100);
+
+            Assert.Equal(jwt, await provider.GetTokenAsync(CancellationToken.None));
+            Assert.Equal(0, fired);
+            Assert.Empty(handler.Requests); // no refresh call
+        }
+    }

--- a/windows/Ghostty.Tests/Sponsor/Auth/OAuthTokenProviderTests.cs
+++ b/windows/Ghostty.Tests/Sponsor/Auth/OAuthTokenProviderTests.cs
@@ -91,10 +91,6 @@ public partial class OAuthTokenProviderTests
         return $"{header}.{body}.{sig}";
     }
 
-    // ---------------------------------------------------------------
-    // Task 8 tests
-    // ---------------------------------------------------------------
-
     [Fact]
     public async Task GetTokenAsync_WhenNoCache_ReturnsNull()
     {
@@ -114,9 +110,7 @@ public partial class OAuthTokenProviderTests
         provider.Dispose();
     }
 
-    // ---------------------------------------------------------------
-    // Task 9 tests: InitializeAsync
-    // ---------------------------------------------------------------
+    // InitializeAsync
 
     [Fact]
     public async Task InitializeAsync_WithEnvVar_LoadsVerbatimSkipsStore()
@@ -214,9 +208,7 @@ public partial class OAuthTokenProviderTests
         Assert.Equal(1, store.Deletes);
     }
 
-    // ---------------------------------------------------------------
-    // Task 10 tests: SignInAsync
-    // ---------------------------------------------------------------
+    // SignInAsync
 
     private static string? GetQueryParam(Uri url, string key)
     {
@@ -320,9 +312,8 @@ public partial class OAuthTokenProviderTests
         Assert.False(result);
     }
 
-    // ---------------------------------------------------------------
-    // Task 11 tests: Invalidate reactive refresh
-    // ---------------------------------------------------------------
+    // Invalidate (reactive refresh)
+
         [Fact]
         public async Task Invalidate_RefreshSucceeds_ReplacesCacheDoesNotFire()
         {
@@ -408,9 +399,7 @@ public partial class OAuthTokenProviderTests
             Assert.Empty(handler.Requests); // no refresh call
         }
 
-    // ---------------------------------------------------------------
-    // Task 12 tests: Proactive refresh timer
-    // ---------------------------------------------------------------
+    // Proactive refresh timer
 
     /// <summary>
     /// TimeProvider that lets tests advance virtual time and triggers
@@ -593,9 +582,7 @@ public partial class OAuthTokenProviderTests
         Assert.Equal(1, store.Deletes);
     }
 
-    // ---------------------------------------------------------------
-    // Task 13 tests: SignOutAsync
-    // ---------------------------------------------------------------
+    // SignOutAsync
 
     [Fact]
     public async Task SignOutAsync_RevokeSucceeds_DeletesLocallyAndFires()

--- a/windows/Ghostty.Tests/Sponsor/Auth/OAuthTokenProviderTests.cs
+++ b/windows/Ghostty.Tests/Sponsor/Auth/OAuthTokenProviderTests.cs
@@ -230,4 +230,110 @@ public partial class OAuthTokenProviderTests
         Assert.Null(await provider.GetTokenAsync(CancellationToken.None));
         Assert.Equal(1, store.Deletes);
     }
+
+    // ---------------------------------------------------------------
+    // Task 10 tests: SignInAsync
+    // ---------------------------------------------------------------
+
+    private static string? GetQueryParam(Uri url, string key)
+    {
+        var q = url.Query.TrimStart('?');
+        foreach (var pair in q.Split('&', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var idx = pair.IndexOf('=');
+            if (idx < 0) continue;
+            if (Uri.UnescapeDataString(pair[..idx]) == key)
+                return Uri.UnescapeDataString(pair[(idx + 1)..]);
+        }
+        return null;
+    }
+
+    [Fact]
+    public async Task SignInAsync_HappyPath_EchoesNoncePersists()
+    {
+        var (provider, store, browser, listener, _, time) = Build();
+        var jwt = MakeJwt(time, secondsFromNow: 3600);
+        listener.Behavior = _ =>
+        {
+            var opened = browser.Opened[^1];
+            var nonce = GetQueryParam(opened, "nonce")!;
+            return Task.FromResult(new LoopbackResult(jwt, nonce, null));
+        };
+
+        var result = await provider.SignInAsync(CancellationToken.None);
+
+        Assert.True(result);
+        Assert.Equal(jwt, await provider.GetTokenAsync(CancellationToken.None));
+        Assert.Equal(1, store.Writes);
+        Assert.Single(browser.Opened);
+        Assert.Equal("api.wintty.io", browser.Opened[0].Host);
+        Assert.Equal("/auth/github/start", browser.Opened[0].AbsolutePath);
+    }
+
+    [Fact]
+    public async Task SignInAsync_NonceMismatch_ReturnsFalse()
+    {
+        var (provider, _, _, listener, _, time) = Build();
+        var jwt = MakeJwt(time, secondsFromNow: 3600);
+        listener.Behavior = _ => Task.FromResult(new LoopbackResult(jwt, "wrong-nonce", null));
+
+        var result = await provider.SignInAsync(CancellationToken.None);
+
+        Assert.False(result);
+        Assert.Null(await provider.GetTokenAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task SignInAsync_ListenerCanceled_ReturnsFalse()
+    {
+        var (provider, _, _, listener, _, _) = Build();
+        listener.Behavior = ct => Task.FromException<LoopbackResult>(new OperationCanceledException(ct));
+
+        var result = await provider.SignInAsync(CancellationToken.None);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task SignInAsync_OAuthErrorQueryParam_ReturnsFalse()
+    {
+        var (provider, _, _, listener, _, _) = Build();
+        listener.Behavior = _ => Task.FromResult(new LoopbackResult(null, null, "access_denied"));
+
+        var result = await provider.SignInAsync(CancellationToken.None);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task SignInAsync_ReturnedJwtPreExpired_ReturnsFalseDoesNotPersist()
+    {
+        var (provider, store, browser, listener, _, time) = Build();
+        var expired = MakeJwt(time, secondsFromNow: -10);
+        listener.Behavior = _ =>
+        {
+            var nonce = GetQueryParam(browser.Opened[^1], "nonce")!;
+            return Task.FromResult(new LoopbackResult(expired, nonce, null));
+        };
+
+        var result = await provider.SignInAsync(CancellationToken.None);
+
+        Assert.False(result);
+        Assert.Equal(0, store.Writes);
+    }
+
+    [Fact]
+    public async Task SignInAsync_TokenMissing_ReturnsFalse()
+    {
+        var (provider, _, browser, listener, _, _) = Build();
+        listener.Behavior = _ =>
+        {
+            var nonce = GetQueryParam(browser.Opened[^1], "nonce")!;
+            return Task.FromResult(new LoopbackResult(null, nonce, null));
+        };
+
+        var result = await provider.SignInAsync(CancellationToken.None);
+
+        Assert.False(result);
+    }
 }

--- a/windows/Ghostty.Tests/Sponsor/Auth/OAuthTokenProviderTests.cs
+++ b/windows/Ghostty.Tests/Sponsor/Auth/OAuthTokenProviderTests.cs
@@ -407,4 +407,189 @@ public partial class OAuthTokenProviderTests
             Assert.Equal(0, fired);
             Assert.Empty(handler.Requests); // no refresh call
         }
+
+    // ---------------------------------------------------------------
+    // Task 12 tests: Proactive refresh timer
+    // ---------------------------------------------------------------
+
+    /// <summary>
+    /// TimeProvider that lets tests advance virtual time and triggers
+    /// timers registered via CreateTimer deterministically.
+    /// </summary>
+    internal sealed class DeterministicTimeProvider : TimeProvider
+    {
+        private readonly List<FakeTimer> _timers = new();
+        public DateTimeOffset Now { get; set; } = DateTimeOffset.UtcNow;
+
+        public override DateTimeOffset GetUtcNow() => Now;
+
+        public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+        {
+            var timer = new FakeTimer(this, callback, state);
+            timer.Schedule(dueTime);
+            return timer;
+        }
+
+        public void Advance(TimeSpan by)
+        {
+            Now = Now.Add(by);
+            // Snapshot + remove fired timers; fire callbacks after the lock.
+            var due = new List<FakeTimer>();
+            lock (_timers)
+            {
+                for (int i = _timers.Count - 1; i >= 0; i--)
+                {
+                    if (_timers[i].DueAt is { } at && at <= Now)
+                    {
+                        due.Add(_timers[i]);
+                        _timers.RemoveAt(i);
+                    }
+                }
+            }
+            foreach (var t in due) t.Fire();
+        }
+
+        internal void Register(FakeTimer timer)
+        {
+            lock (_timers)
+            {
+                _timers.RemoveAll(t => ReferenceEquals(t, timer));
+                _timers.Add(timer);
+            }
+        }
+
+        internal void Unregister(FakeTimer timer)
+        {
+            lock (_timers) { _timers.RemoveAll(t => ReferenceEquals(t, timer)); }
+        }
+    }
+
+    internal sealed class FakeTimer : ITimer
+    {
+        private readonly DeterministicTimeProvider _time;
+        private readonly TimerCallback _callback;
+        private readonly object? _state;
+        public DateTimeOffset? DueAt { get; private set; }
+
+        public FakeTimer(DeterministicTimeProvider time, TimerCallback cb, object? state)
+        {
+            _time = time; _callback = cb; _state = state;
+        }
+
+        public void Schedule(TimeSpan dueTime)
+        {
+            if (dueTime == Timeout.InfiniteTimeSpan) { DueAt = null; _time.Unregister(this); return; }
+            DueAt = _time.GetUtcNow().Add(dueTime);
+            _time.Register(this);
+        }
+
+        public void Fire() => _callback(_state);
+
+        public bool Change(TimeSpan dueTime, TimeSpan period) { Schedule(dueTime); return true; }
+
+        public void Dispose() { _time.Unregister(this); DueAt = null; }
+        public ValueTask DisposeAsync() { Dispose(); return ValueTask.CompletedTask; }
+    }
+
+    private static (OAuthTokenProvider provider, FakeStore store, FakeBrowser browser, FakeListener listener, FakeHandler handler, TimeProvider time) BuildWithTime(TimeProvider time)
+    {
+        var handler = new FakeHandler();
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.wintty.io") };
+        var auth = new WinttyAuthClient(http, new Uri("https://api.wintty.io"));
+        var store = new FakeStore();
+        var browser = new FakeBrowser();
+        var listener = new FakeListener();
+        var provider = new OAuthTokenProvider(
+            auth, store, browser, listener,
+            new Uri("https://api.wintty.io"),
+            NullLogger<OAuthTokenProvider>.Instance,
+            time,
+            envVarLookup: _ => null);
+        return (provider, store, browser, listener, handler, time);
+    }
+
+    private static string MakeJwtExplicit(DateTimeOffset expAt)
+    {
+        static string B64(byte[] b) => Convert.ToBase64String(b).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+        var header = B64(Encoding.UTF8.GetBytes("""{"alg":"HS256","typ":"JWT"}"""));
+        var body   = B64(Encoding.UTF8.GetBytes($$"""{"sub":"u","exp":{{expAt.ToUnixTimeSeconds()}},"jti":"j"}"""));
+        var sig    = B64(new byte[] { 1, 2, 3 });
+        return $"{header}.{body}.{sig}";
+    }
+
+    [Fact]
+    public async Task ProactiveRefresh_AtMinus24h_Succeeds()
+    {
+        var time = new DeterministicTimeProvider();
+        var (provider, store, _, _, handler, _) = BuildWithTime(time);
+        var current = MakeJwtExplicit(time.Now.AddHours(48));
+        store.Bytes = Encoding.UTF8.GetBytes(current);
+        await provider.InitializeAsync(CancellationToken.None);
+
+        var refreshed = MakeJwtExplicit(time.Now.AddDays(7));
+        handler.Respond = _ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent($$"""{"token":"{{refreshed}}"}""",
+                Encoding.UTF8, "application/json"),
+        };
+
+        provider.StartRefreshTimer();
+
+        time.Advance(TimeSpan.FromHours(25)); // cross exp - 24h
+        await Task.Delay(200);
+
+        Assert.Equal(refreshed, await provider.GetTokenAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ProactiveRefresh_TransientFailure_ReschedulesAt10m()
+    {
+        var time = new DeterministicTimeProvider();
+        var (provider, store, _, _, handler, _) = BuildWithTime(time);
+        var current = MakeJwtExplicit(time.Now.AddHours(25));
+        store.Bytes = Encoding.UTF8.GetBytes(current);
+        await provider.InitializeAsync(CancellationToken.None);
+
+        handler.Respond = _ => new HttpResponseMessage(HttpStatusCode.InternalServerError);
+        provider.StartRefreshTimer();
+
+        time.Advance(TimeSpan.FromHours(2)); // past exp-24h
+        await Task.Delay(200);
+
+        Assert.Equal(current, await provider.GetTokenAsync(CancellationToken.None));
+
+        var refreshed = MakeJwtExplicit(time.Now.AddDays(7));
+        handler.Respond = _ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent($$"""{"token":"{{refreshed}}"}""",
+                Encoding.UTF8, "application/json"),
+        };
+        time.Advance(TimeSpan.FromMinutes(11));
+        await Task.Delay(200);
+
+        Assert.Equal(refreshed, await provider.GetTokenAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ProactiveRefresh_AuthFailure_ClearsAndFiresInvalidated()
+    {
+        var time = new DeterministicTimeProvider();
+        var (provider, store, _, _, handler, _) = BuildWithTime(time);
+        var current = MakeJwtExplicit(time.Now.AddHours(25));
+        store.Bytes = Encoding.UTF8.GetBytes(current);
+        await provider.InitializeAsync(CancellationToken.None);
+
+        handler.Respond = _ => new HttpResponseMessage(HttpStatusCode.Unauthorized);
+
+        var fired = 0;
+        provider.TokenInvalidated += (_, _) => fired++;
+
+        provider.StartRefreshTimer();
+        time.Advance(TimeSpan.FromHours(2));
+        await Task.Delay(200);
+
+        Assert.Null(await provider.GetTokenAsync(CancellationToken.None));
+        Assert.Equal(1, fired);
+        Assert.Equal(1, store.Deletes);
+    }
     }

--- a/windows/Ghostty.Tests/Sponsor/Auth/OAuthTokenProviderTests.cs
+++ b/windows/Ghostty.Tests/Sponsor/Auth/OAuthTokenProviderTests.cs
@@ -592,4 +592,74 @@ public partial class OAuthTokenProviderTests
         Assert.Equal(1, fired);
         Assert.Equal(1, store.Deletes);
     }
+
+    // ---------------------------------------------------------------
+    // Task 13 tests: SignOutAsync
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public async Task SignOutAsync_RevokeSucceeds_DeletesLocallyAndFires()
+    {
+        var (provider, store, _, _, handler, time) = Build();
+        var jwt = MakeJwt(time, secondsFromNow: 3600);
+        store.Bytes = Encoding.UTF8.GetBytes(jwt);
+        await provider.InitializeAsync(CancellationToken.None);
+
+        var fired = 0;
+        provider.TokenInvalidated += (_, _) => fired++;
+
+        handler.Respond = _ => new HttpResponseMessage(HttpStatusCode.NoContent);
+
+        await provider.SignOutAsync(CancellationToken.None);
+
+        Assert.Null(await provider.GetTokenAsync(CancellationToken.None));
+        Assert.Equal(1, store.Deletes);
+        Assert.Equal(1, fired);
+        Assert.Single(handler.Requests);
+        Assert.Equal("/auth/revoke", handler.Requests[0].RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
+    public async Task SignOutAsync_RevokeFails_StillDeletesLocally()
+    {
+        var (provider, store, _, _, handler, time) = Build();
+        var jwt = MakeJwt(time, secondsFromNow: 3600);
+        store.Bytes = Encoding.UTF8.GetBytes(jwt);
+        await provider.InitializeAsync(CancellationToken.None);
+
+        handler.Respond = _ => new HttpResponseMessage(HttpStatusCode.InternalServerError);
+
+        await provider.SignOutAsync(CancellationToken.None);
+
+        Assert.Null(await provider.GetTokenAsync(CancellationToken.None));
+        Assert.Equal(1, store.Deletes);
+    }
+
+    [Fact]
+    public async Task SignOutAsync_WhenNotSignedIn_IsNoOp()
+    {
+        var (provider, store, _, _, handler, _) = Build();
+
+        await provider.SignOutAsync(CancellationToken.None);
+
+        Assert.Empty(handler.Requests);
+        Assert.Equal(0, store.Deletes);
+    }
+
+    [Fact]
+    public async Task SignOutAsync_EnvVarMode_SkipsRevokeAndDelete()
+    {
+        var time = new FakeTime();
+        var jwt = MakeJwt(time, secondsFromNow: 3600);
+        var (provider, store, _, _, handler, _) = Build(envOverride: jwt);
+        await provider.InitializeAsync(CancellationToken.None);
+
+        await provider.SignOutAsync(CancellationToken.None);
+
+        // Env-var path: no revoke call, no store delete (there's nothing
+        // on disk to delete in env-var mode anyway). Cache clears locally.
+        Assert.Empty(handler.Requests);
+        Assert.Equal(0, store.Deletes);
+        Assert.Null(await provider.GetTokenAsync(CancellationToken.None));
+    }
     }

--- a/windows/Ghostty.Tests/Sponsor/Auth/WinttyAuthClientTests.cs
+++ b/windows/Ghostty.Tests/Sponsor/Auth/WinttyAuthClientTests.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Ghostty.Core.Sponsor.Auth;
+using Xunit;
+
+namespace Ghostty.Tests.Sponsor.Auth;
+
+public class WinttyAuthClientTests
+{
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        public List<HttpRequestMessage> Requests { get; } = new();
+        public Func<HttpRequestMessage, HttpResponseMessage> Respond { get; set; }
+            = _ => new HttpResponseMessage(HttpStatusCode.NotFound);
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+            return Task.FromResult(Respond(request));
+        }
+    }
+
+    private static (WinttyAuthClient client, StubHandler handler) Build()
+    {
+        var handler = new StubHandler();
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.wintty.io") };
+        var client = new WinttyAuthClient(http, new Uri("https://api.wintty.io"));
+        return (client, handler);
+    }
+
+    [Fact]
+    public async Task RefreshAsync_HappyPath_ReturnsNewTokenWithBearer()
+    {
+        var (client, handler) = Build();
+        handler.Respond = _ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"token":"new-jwt-value"}""",
+                Encoding.UTF8, "application/json"),
+        };
+
+        var result = await client.RefreshAsync("old-jwt", CancellationToken.None);
+
+        Assert.Equal("new-jwt-value", result);
+        Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Post, handler.Requests[0].Method);
+        Assert.Equal("/auth/refresh", handler.Requests[0].RequestUri!.AbsolutePath);
+        Assert.Equal("Bearer", handler.Requests[0].Headers.Authorization?.Scheme);
+        Assert.Equal("old-jwt", handler.Requests[0].Headers.Authorization?.Parameter);
+    }
+
+    [Fact]
+    public async Task RefreshAsync_401_ThrowsUnauthorized()
+    {
+        var (client, handler) = Build();
+        handler.Respond = _ => new HttpResponseMessage(HttpStatusCode.Unauthorized);
+
+        var ex = await Assert.ThrowsAsync<AuthException>(
+            () => client.RefreshAsync("old", CancellationToken.None));
+
+        Assert.Equal(AuthErrorKind.Unauthorized, ex.Kind);
+    }
+
+    [Fact]
+    public async Task RefreshAsync_403_ThrowsUnauthorized()
+    {
+        var (client, handler) = Build();
+        handler.Respond = _ => new HttpResponseMessage(HttpStatusCode.Forbidden);
+
+        var ex = await Assert.ThrowsAsync<AuthException>(
+            () => client.RefreshAsync("old", CancellationToken.None));
+
+        Assert.Equal(AuthErrorKind.Unauthorized, ex.Kind);
+    }
+
+    [Fact]
+    public async Task RefreshAsync_500_ThrowsServerError()
+    {
+        var (client, handler) = Build();
+        handler.Respond = _ => new HttpResponseMessage(HttpStatusCode.InternalServerError);
+
+        var ex = await Assert.ThrowsAsync<AuthException>(
+            () => client.RefreshAsync("old", CancellationToken.None));
+
+        Assert.Equal(AuthErrorKind.ServerError, ex.Kind);
+    }
+
+    [Fact]
+    public async Task RefreshAsync_NetworkFailure_ThrowsNetwork()
+    {
+        var (client, handler) = Build();
+        handler.Respond = _ => throw new HttpRequestException("dns fail");
+
+        var ex = await Assert.ThrowsAsync<AuthException>(
+            () => client.RefreshAsync("old", CancellationToken.None));
+
+        Assert.Equal(AuthErrorKind.Network, ex.Kind);
+    }
+
+    [Fact]
+    public async Task RefreshAsync_MalformedJson_ThrowsServerError()
+    {
+        var (client, handler) = Build();
+        handler.Respond = _ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("not json", Encoding.UTF8, "application/json"),
+        };
+
+        var ex = await Assert.ThrowsAsync<AuthException>(
+            () => client.RefreshAsync("old", CancellationToken.None));
+
+        Assert.Equal(AuthErrorKind.ServerError, ex.Kind);
+    }
+
+    [Fact]
+    public async Task RefreshAsync_MissingTokenField_ThrowsServerError()
+    {
+        var (client, handler) = Build();
+        handler.Respond = _ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"unexpected":"shape"}""",
+                Encoding.UTF8, "application/json"),
+        };
+
+        var ex = await Assert.ThrowsAsync<AuthException>(
+            () => client.RefreshAsync("old", CancellationToken.None));
+
+        Assert.Equal(AuthErrorKind.ServerError, ex.Kind);
+    }
+
+    [Fact]
+    public async Task RevokeAsync_HappyPath_Completes()
+    {
+        var (client, handler) = Build();
+        handler.Respond = _ => new HttpResponseMessage(HttpStatusCode.NoContent);
+
+        await client.RevokeAsync("jwt", CancellationToken.None);
+
+        Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Post, handler.Requests[0].Method);
+        Assert.Equal("/auth/revoke", handler.Requests[0].RequestUri!.AbsolutePath);
+        Assert.Equal("jwt", handler.Requests[0].Headers.Authorization?.Parameter);
+    }
+
+    [Fact]
+    public async Task RevokeAsync_500_Throws()
+    {
+        var (client, handler) = Build();
+        handler.Respond = _ => new HttpResponseMessage(HttpStatusCode.InternalServerError);
+
+        var ex = await Assert.ThrowsAsync<AuthException>(
+            () => client.RevokeAsync("jwt", CancellationToken.None));
+
+        Assert.Equal(AuthErrorKind.ServerError, ex.Kind);
+    }
+}

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -98,9 +98,9 @@ public partial class App : Application
         var localAppData = System.Environment.GetFolderPath(
             System.Environment.SpecialFolder.LocalApplicationData);
         var authDir = System.IO.Path.Combine(localAppData, "Ghostty");
-        var entropy = Ghostty.Core.Sponsor.Auth.DpapiJwtStore.DefaultEntropy;
 
-        var store    = new Ghostty.Core.Sponsor.Auth.DpapiJwtStore(authDir, entropy);
+        var store    = new Ghostty.Core.Sponsor.Auth.DpapiJwtStore(
+            authDir, Ghostty.Core.Sponsor.Auth.DpapiJwtStore.DefaultEntropy);
         var browserLogger = _loggerFactory?.CreateLogger<Ghostty.Core.Sponsor.Auth.DesktopBrowserLauncher>()
             ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<Ghostty.Core.Sponsor.Auth.DesktopBrowserLauncher>.Instance;
         var browser  = new Ghostty.Core.Sponsor.Auth.DesktopBrowserLauncher(browserLogger);

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -82,7 +82,15 @@ public partial class App : Application
 
     private Ghostty.Core.Sponsor.Auth.OAuthTokenProvider BuildTokenProvider()
     {
-        _sponsorAuthHttp = new System.Net.Http.HttpClient
+        // AllowAutoRedirect=false so the bearer JWT is not forwarded to a
+        // redirected host if api.wintty.io ever returns a 302. WinttyAuthClient
+        // expects direct 2xx from /auth/refresh and /auth/revoke; any 3xx is
+        // surfaced as AuthErrorKind.ServerError.
+        _sponsorAuthHttp = new System.Net.Http.HttpClient(
+            new System.Net.Http.SocketsHttpHandler
+            {
+                AllowAutoRedirect = false,
+            })
         {
             Timeout = System.TimeSpan.FromSeconds(30),
         };

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -98,10 +98,7 @@ public partial class App : Application
         var localAppData = System.Environment.GetFolderPath(
             System.Environment.SpecialFolder.LocalApplicationData);
         var authDir = System.IO.Path.Combine(localAppData, "Ghostty");
-        // App-specific entropy salt; not a secret. Bounds the DPAPI
-        // envelope to this app so other user-scoped applications can't
-        // Unprotect with the default (empty) entropy.
-        var entropy = System.Text.Encoding.UTF8.GetBytes("wintty-sponsor-jwt-v1");
+        var entropy = Ghostty.Core.Sponsor.Auth.DpapiJwtStore.DefaultEntropy;
 
         var store    = new Ghostty.Core.Sponsor.Auth.DpapiJwtStore(authDir, entropy);
         var browserLogger = _loggerFactory?.CreateLogger<Ghostty.Core.Sponsor.Auth.DesktopBrowserLauncher>()

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -74,9 +74,41 @@ public partial class App : Application
     private Ghostty.Core.Sponsor.Update.UpdateSimulator? _sharedSimulator;
     internal Ghostty.Core.Sponsor.Update.UpdateSimulator SharedSimulator =>
         _sharedSimulator ??= new Ghostty.Core.Sponsor.Update.UpdateSimulator();
-    private Ghostty.Core.Sponsor.Auth.EnvTokenProvider? _sharedTokens;
-    internal Ghostty.Core.Sponsor.Auth.EnvTokenProvider SharedTokens =>
-        _sharedTokens ??= new Ghostty.Core.Sponsor.Auth.EnvTokenProvider();
+    private Ghostty.Core.Sponsor.Auth.OAuthTokenProvider? _sharedTokens;
+    internal Ghostty.Core.Sponsor.Auth.OAuthTokenProvider SharedTokens =>
+        _sharedTokens ??= BuildTokenProvider();
+
+    private System.Net.Http.HttpClient? _sponsorAuthHttp;
+
+    private Ghostty.Core.Sponsor.Auth.OAuthTokenProvider BuildTokenProvider()
+    {
+        _sponsorAuthHttp = new System.Net.Http.HttpClient
+        {
+            Timeout = System.TimeSpan.FromSeconds(30),
+        };
+
+        var localAppData = System.Environment.GetFolderPath(
+            System.Environment.SpecialFolder.LocalApplicationData);
+        var authDir = System.IO.Path.Combine(localAppData, "Ghostty");
+        // App-specific entropy salt; not a secret. Bounds the DPAPI
+        // envelope to this app so other user-scoped applications can't
+        // Unprotect with the default (empty) entropy.
+        var entropy = System.Text.Encoding.UTF8.GetBytes("wintty-sponsor-jwt-v1");
+
+        var store    = new Ghostty.Core.Sponsor.Auth.DpapiJwtStore(authDir, entropy);
+        var browserLogger = _loggerFactory?.CreateLogger<Ghostty.Core.Sponsor.Auth.DesktopBrowserLauncher>()
+            ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<Ghostty.Core.Sponsor.Auth.DesktopBrowserLauncher>.Instance;
+        var browser  = new Ghostty.Core.Sponsor.Auth.DesktopBrowserLauncher(browserLogger);
+        var listener = new Ghostty.Core.Sponsor.Auth.HttpLoopbackListener();
+
+        var apiBase = new System.Uri("https://api.wintty.io");
+        var auth    = new Ghostty.Core.Sponsor.Auth.WinttyAuthClient(_sponsorAuthHttp, apiBase);
+        var logger  = _loggerFactory?.CreateLogger<Ghostty.Core.Sponsor.Auth.OAuthTokenProvider>()
+            ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<Ghostty.Core.Sponsor.Auth.OAuthTokenProvider>.Instance;
+
+        return new Ghostty.Core.Sponsor.Auth.OAuthTokenProvider(
+            auth, store, browser, listener, apiBase, logger, System.TimeProvider.System);
+    }
 #endif
 
     // Top-level window registry keyed by XamlRoot. Replaces the old
@@ -472,13 +504,29 @@ public partial class App : Application
         var window = new MainWindow(_configService, _bootstrapHost, _lifetimeSupervisor, factory);
         window.Closed += OnAnyWindowClosedInternal;
 #if SPONSOR_BUILD
+        // OAuth boot: load cached JWT + refresh if stale. Intentionally
+        // GetAwaiter().GetResult() because OnLaunched is sync-void and
+        // this must complete before Wire constructs the update pipeline
+        // (which reads GetTokenAsync immediately in its first poll).
+        // Cost: single DPAPI read + at most one HTTP call on expired
+        // tokens; bounded, deterministic, runs on app launch only.
+        SharedTokens.InitializeAsync(System.Threading.CancellationToken.None)
+            .GetAwaiter().GetResult();
+
         // SharedSimulator was already materialized during MainWindow's
         // ctor (CreateCommandPaletteViewModel reads it to register the
         // palette commands). Pass that same instance to Wire so there's
         // one simulator driving both the palette and the update pipeline.
         _sponsorOverlay = Ghostty.Sponsor.Update.SponsorOverlayBootstrapper.Wire(
             window, _configService, DispatcherQueue.GetForCurrentThread(), SharedSimulator,
-            SharedTokens, loggerFactory: null);
+            SharedTokens, loggerFactory: _loggerFactory);
+
+        // Schedule proactive refresh timer AFTER Wire() so the overlay
+        // subscribes to TokenInvalidated first. The timer never fires
+        // until exp-24h so order-of-ops is not load-bearing for Task 12
+        // behavior, but keeping it post-Wire matches the disposal order
+        // below (overlay Dispose runs before provider Dispose).
+        SharedTokens.StartRefreshTimer();
 #if DEBUG
         // Path A: push the real UpdateService into the palette source now
         // that Wire() has run. GetCommands() is called on each palette open,
@@ -536,8 +584,19 @@ public partial class App : Application
                 // supervisor (which throws if anything is still live),
                 // and calls AppFree.
 #if SPONSOR_BUILD
+                // Overlay first: stops driver + unsubscribes from TokenInvalidated.
                 _sponsorOverlay?.Dispose();
                 _sponsorOverlay = null;
+
+                // Then provider: cancels refresh timer + releases semaphore.
+                _sharedTokens?.Dispose();
+                _sharedTokens = null;
+
+                // HttpClient last: provider may have had in-flight refresh
+                // when its Dispose ran; drop the transport after the provider
+                // is quiesced.
+                _sponsorAuthHttp?.Dispose();
+                _sponsorAuthHttp = null;
 #endif
                 _bootstrapHost?.Dispose();
 

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -512,13 +512,14 @@ public partial class App : Application
         var window = new MainWindow(_configService, _bootstrapHost, _lifetimeSupervisor, factory);
         window.Closed += OnAnyWindowClosedInternal;
 #if SPONSOR_BUILD
-        // OAuth boot: load cached JWT + refresh if stale. Intentionally
-        // GetAwaiter().GetResult() because OnLaunched is sync-void and
-        // this must complete before Wire constructs the update pipeline
-        // (which reads GetTokenAsync immediately in its first poll).
-        // Cost: single DPAPI read + at most one HTTP call on expired
-        // tokens; bounded, deterministic, runs on app launch only.
-        SharedTokens.InitializeAsync(System.Threading.CancellationToken.None)
+        // OAuth boot: load cached JWT + refresh if stale. Task.Run pushes the
+        // work off the UI dispatcher so HttpClient continuations never try to
+        // resume on a captured UI SynchronizationContext. Bounded (single DPAPI
+        // read + at most one HTTP call on expired tokens) and must complete
+        // before Wire constructs the update pipeline, which reads GetTokenAsync
+        // immediately in its first poll.
+        System.Threading.Tasks.Task.Run(
+            () => SharedTokens.InitializeAsync(System.Threading.CancellationToken.None))
             .GetAwaiter().GetResult();
 
         // SharedSimulator was already materialized during MainWindow's

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -158,6 +158,9 @@ public sealed partial class MainWindow : Window
 #if SPONSOR_BUILD && DEBUG
     private Ghostty.Sponsor.Update.SponsorUpdateCommandSource? _sponsorSource;
 #endif
+#if SPONSOR_BUILD
+    private Ghostty.Sponsor.Auth.SponsorAuthCommandSource? _sponsorAuthSource;
+#endif
 
     /// <summary>
     /// Palette close state: prevents re-entrant close handling between
@@ -851,6 +854,11 @@ public sealed partial class MainWindow : Window
         _taskbar.Dispose();
         _themeManager.Dispose();
 
+#if SPONSOR_BUILD
+        _sponsorAuthSource?.Dispose();
+        _sponsorAuthSource = null;
+#endif
+
         // Surface lifetime is decoupled from Loaded/Unloaded
         // (see TerminalControl.DisposeSurface), so we have to
         // free every leaf in every tab explicitly before tearing
@@ -1535,6 +1543,20 @@ public sealed partial class MainWindow : Window
         {
             _sponsorSource = new Ghostty.Sponsor.Update.SponsorUpdateCommandSource(sim);
             sources.Add(_sponsorSource);
+        }
+#endif
+
+#if SPONSOR_BUILD
+        // Auth palette entries (sign-in / sign-out). Ships in release
+        // sponsor builds. Separate from the DEBUG-only simulator source
+        // above because users need these entries to activate / revoke
+        // their sponsor session; simulator entries are QA-only.
+        if ((Microsoft.UI.Xaml.Application.Current as App)?.SharedTokens is { } tokens)
+        {
+            var authLogger = App.LoggerFactory?.CreateLogger<Ghostty.Sponsor.Auth.SponsorAuthCommandSource>()
+                ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<Ghostty.Sponsor.Auth.SponsorAuthCommandSource>.Instance;
+            _sponsorAuthSource = new Ghostty.Sponsor.Auth.SponsorAuthCommandSource(tokens, authLogger);
+            sources.Add(_sponsorAuthSource);
         }
 #endif
 

--- a/windows/Ghostty/Sponsor/Auth/SponsorAuthCommandSource.cs
+++ b/windows/Ghostty/Sponsor/Auth/SponsorAuthCommandSource.cs
@@ -1,0 +1,112 @@
+#if SPONSOR_BUILD
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Ghostty.Commands;
+using Ghostty.Core.Sponsor.Auth;
+using Microsoft.Extensions.Logging;
+
+namespace Ghostty.Sponsor.Auth;
+
+/// <summary>
+/// Palette entries for OAuth sign-in / sign-out. Visible in release
+/// sponsor builds (not DEBUG-gated like <c>SponsorUpdateCommandSource</c>).
+/// Re-registers its entries on <c>TokenAcquired</c> / <c>TokenInvalidated</c>
+/// via the palette's <see cref="ICommandSource.Refresh"/> contract -
+/// the host calls <see cref="GetCommands"/> every time the palette
+/// opens, so simply triggering a Refresh is enough to flip the visible
+/// entry between "Sign in" and "Sign out".
+/// </summary>
+internal sealed class SponsorAuthCommandSource : ICommandSource, IDisposable
+{
+    private readonly OAuthTokenProvider _provider;
+    private readonly ILogger<SponsorAuthCommandSource> _logger;
+    private readonly List<CommandItem> _items = new();
+    private bool _disposed;
+
+    public SponsorAuthCommandSource(OAuthTokenProvider provider, ILogger<SponsorAuthCommandSource> logger)
+    {
+        ArgumentNullException.ThrowIfNull(provider);
+        ArgumentNullException.ThrowIfNull(logger);
+        _provider = provider;
+        _logger = logger;
+
+        _provider.TokenAcquired    += OnStateChanged;
+        _provider.TokenInvalidated += OnStateChanged;
+
+        Refresh();
+    }
+
+    public IReadOnlyList<CommandItem> GetCommands() => _items;
+
+    public void Refresh()
+    {
+        _items.Clear();
+
+        // Snapshot current state. GetTokenAsync is a hot-path synchronous
+        // Task.FromResult under the hood, so GetAwaiter().GetResult() is
+        // safe and non-blocking. We need it synchronously because
+        // GetCommands is called on the UI thread on each palette open.
+        var hasToken = _provider.GetTokenAsync(CancellationToken.None)
+            .GetAwaiter().GetResult() is not null;
+
+        if (!hasToken)
+        {
+            _items.Add(new CommandItem
+            {
+                Id = "wintty.signIn",
+                Title = "Sign in to wintty",
+                Description = "Activate sponsor updates via GitHub",
+                Category = CommandCategory.Custom,
+                Execute = _ => SignInFireAndForget(),
+            });
+        }
+        else
+        {
+            _items.Add(new CommandItem
+            {
+                Id = "wintty.signOut",
+                Title = "Sign out of wintty",
+                Description = "Stops sponsor updates on this machine",
+                Category = CommandCategory.Custom,
+                Execute = _ => SignOutFireAndForget(),
+            });
+        }
+    }
+
+    private void SignInFireAndForget()
+    {
+        // Fire-and-forget: the palette close happens on the caller's
+        // UI thread. The provider's sign-in flow runs async; if it fails
+        // we log but show nothing.
+        _ = SignInAsync();
+    }
+
+    private async System.Threading.Tasks.Task SignInAsync()
+    {
+        try { await _provider.SignInAsync(CancellationToken.None); }
+        catch (Exception ex) { _logger.LogWarning(ex, "[sponsor/auth] palette SignIn failed"); }
+    }
+
+    private void SignOutFireAndForget()
+    {
+        _ = SignOutAsync();
+    }
+
+    private async System.Threading.Tasks.Task SignOutAsync()
+    {
+        try { await _provider.SignOutAsync(CancellationToken.None); }
+        catch (Exception ex) { _logger.LogWarning(ex, "[sponsor/auth] palette SignOut failed"); }
+    }
+
+    private void OnStateChanged(object? sender, EventArgs e) => Refresh();
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _provider.TokenAcquired    -= OnStateChanged;
+        _provider.TokenInvalidated -= OnStateChanged;
+    }
+}
+#endif

--- a/windows/Ghostty/Sponsor/Auth/SponsorAuthCommandSource.cs
+++ b/windows/Ghostty/Sponsor/Auth/SponsorAuthCommandSource.cs
@@ -1,7 +1,6 @@
 #if SPONSOR_BUILD
 using System;
 using System.Collections.Generic;
-using System.Threading;
 using Ghostty.Commands;
 using Ghostty.Core.Sponsor.Auth;
 using Microsoft.Extensions.Logging;
@@ -11,17 +10,19 @@ namespace Ghostty.Sponsor.Auth;
 /// <summary>
 /// Palette entries for OAuth sign-in / sign-out. Visible in release
 /// sponsor builds (not DEBUG-gated like <c>SponsorUpdateCommandSource</c>).
-/// Re-registers its entries on <c>TokenAcquired</c> / <c>TokenInvalidated</c>
-/// via the palette's <see cref="ICommandSource.Refresh"/> contract -
-/// the host calls <see cref="GetCommands"/> every time the palette
-/// opens, so simply triggering a Refresh is enough to flip the visible
-/// entry between "Sign in" and "Sign out".
+/// Tracks sign-in state via <c>TokenAcquired</c> / <c>TokenInvalidated</c>
+/// (which can fire on a ThreadPool thread from the reactive / proactive
+/// refresh paths) with a volatile flag, and computes the visible entry
+/// lazily inside <see cref="GetCommands"/> on the UI thread. This avoids
+/// mutating a shared list off-thread - the palette calls
+/// <see cref="ICommandSource.Refresh"/> then <see cref="GetCommands"/> on
+/// each Open.
 /// </summary>
 internal sealed class SponsorAuthCommandSource : ICommandSource, IDisposable
 {
     private readonly OAuthTokenProvider _provider;
     private readonly ILogger<SponsorAuthCommandSource> _logger;
-    private readonly List<CommandItem> _items = new();
+    private volatile bool _hasToken;
     private bool _disposed;
 
     public SponsorAuthCommandSource(OAuthTokenProvider provider, ILogger<SponsorAuthCommandSource> logger)
@@ -31,47 +32,52 @@ internal sealed class SponsorAuthCommandSource : ICommandSource, IDisposable
         _provider = provider;
         _logger = logger;
 
-        _provider.TokenAcquired    += OnStateChanged;
-        _provider.TokenInvalidated += OnStateChanged;
+        _provider.TokenAcquired    += OnTokenAcquired;
+        _provider.TokenInvalidated += OnTokenInvalidated;
 
-        Refresh();
+        // Seed from the provider's current state. After construction
+        // _hasToken is kept in sync by the event handlers above.
+        _hasToken = provider.HasToken;
     }
 
-    public IReadOnlyList<CommandItem> GetCommands() => _items;
-
-    public void Refresh()
+    public IReadOnlyList<CommandItem> GetCommands()
     {
-        _items.Clear();
-
-        // Snapshot current state. GetTokenAsync is a hot-path synchronous
-        // Task.FromResult under the hood, so GetAwaiter().GetResult() is
-        // safe and non-blocking. We need it synchronously because
-        // GetCommands is called on the UI thread on each palette open.
-        var hasToken = _provider.GetTokenAsync(CancellationToken.None)
-            .GetAwaiter().GetResult() is not null;
-
-        if (!hasToken)
+        // Called on the UI thread by CommandPaletteViewModel.Open.
+        // Reads _hasToken (volatile) and returns a fresh list - no
+        // shared mutable buffer to race against.
+        if (_hasToken)
         {
-            _items.Add(new CommandItem
+            return new[]
+            {
+                new CommandItem
+                {
+                    Id = "wintty.signOut",
+                    Title = "Sign out of wintty",
+                    Description = "Stops sponsor updates on this machine",
+                    Category = CommandCategory.Custom,
+                    Execute = _ => SignOutFireAndForget(),
+                },
+            };
+        }
+
+        return new[]
+        {
+            new CommandItem
             {
                 Id = "wintty.signIn",
                 Title = "Sign in to wintty",
                 Description = "Activate sponsor updates via GitHub",
                 Category = CommandCategory.Custom,
                 Execute = _ => SignInFireAndForget(),
-            });
-        }
-        else
-        {
-            _items.Add(new CommandItem
-            {
-                Id = "wintty.signOut",
-                Title = "Sign out of wintty",
-                Description = "Stops sponsor updates on this machine",
-                Category = CommandCategory.Custom,
-                Execute = _ => SignOutFireAndForget(),
-            });
-        }
+            },
+        };
+    }
+
+    public void Refresh()
+    {
+        // No-op: state lives in _hasToken, which is kept in sync by the
+        // provider's events. GetCommands rebuilds the item list each
+        // call anyway.
     }
 
     private void SignInFireAndForget()
@@ -84,7 +90,7 @@ internal sealed class SponsorAuthCommandSource : ICommandSource, IDisposable
 
     private async System.Threading.Tasks.Task SignInAsync()
     {
-        try { await _provider.SignInAsync(CancellationToken.None); }
+        try { await _provider.SignInAsync(System.Threading.CancellationToken.None); }
         catch (Exception ex) { _logger.LogWarning(ex, "[sponsor/auth] palette SignIn failed"); }
     }
 
@@ -95,18 +101,19 @@ internal sealed class SponsorAuthCommandSource : ICommandSource, IDisposable
 
     private async System.Threading.Tasks.Task SignOutAsync()
     {
-        try { await _provider.SignOutAsync(CancellationToken.None); }
+        try { await _provider.SignOutAsync(System.Threading.CancellationToken.None); }
         catch (Exception ex) { _logger.LogWarning(ex, "[sponsor/auth] palette SignOut failed"); }
     }
 
-    private void OnStateChanged(object? sender, EventArgs e) => Refresh();
+    private void OnTokenAcquired(object? sender, EventArgs e) => _hasToken = true;
+    private void OnTokenInvalidated(object? sender, EventArgs e) => _hasToken = false;
 
     public void Dispose()
     {
         if (_disposed) return;
         _disposed = true;
-        _provider.TokenAcquired    -= OnStateChanged;
-        _provider.TokenInvalidated -= OnStateChanged;
+        _provider.TokenAcquired    -= OnTokenAcquired;
+        _provider.TokenInvalidated -= OnTokenInvalidated;
     }
 }
 #endif

--- a/windows/Ghostty/Sponsor/DEV_NOTES.md
+++ b/windows/Ghostty/Sponsor/DEV_NOTES.md
@@ -1,4 +1,4 @@
-# Sponsor — developer notes
+# Sponsor - developer notes
 
 Smoke procedures for sponsor-gated features across Plan D phases.
 

--- a/windows/Ghostty/Sponsor/DEV_NOTES.md
+++ b/windows/Ghostty/Sponsor/DEV_NOTES.md
@@ -1,0 +1,21 @@
+# Sponsor — developer notes
+
+Smoke procedures for sponsor-gated features across Plan D phases.
+
+## D.2.5 - OAuth sign-in smoke (maintainer only)
+
+Requires: a GitHub account linked to deblasis/wintty sponsorship, or a
+self-sponsor test account.
+
+1. Delete `%LocalAppData%\Ghostty\auth.bin` if present.
+2. `Remove-Item Env:WINTTY_DEV_JWT -ErrorAction SilentlyContinue`.
+3. `just run-win` (SPONSOR_BUILD=true flavor).
+4. Command palette -> "Sign in to wintty".
+5. Default browser opens to `https://api.wintty.io/auth/github/start?...`.
+6. Authorize on GitHub.
+7. Redirected to `http://127.0.0.1:<port>/cb`, page says "You can close this window".
+8. App pill transitions from NoToken-silent to Idle.
+9. Verify `auth.bin` exists under `%LocalAppData%\Ghostty\`, non-empty, is binary (not JSON - DPAPI envelope).
+10. Trigger update check via palette -> manifest call succeeds with bearer.
+11. Palette -> "Sign out of wintty".
+12. Verify `auth.bin` deleted, pill goes dormant, next update check emits NoToken.

--- a/windows/Ghostty/Sponsor/README.md
+++ b/windows/Ghostty/Sponsor/README.md
@@ -8,3 +8,21 @@ In default / OSS / user-built builds, every file under this directory is
 excluded from compilation by a `<Compile Remove="Sponsor/**/*.cs" />` rule in
 `windows/Ghostty/Ghostty.csproj`. The sponsor-gated surface is therefore
 visible in source but absent from the output assembly.
+
+## Activation
+
+OAuth + DPAPI-encrypted JWT cache. Production impl is
+`Ghostty.Core.Sponsor.Auth.OAuthTokenProvider` (replaces the dev-only
+`EnvTokenProvider`); Windows-concrete glue lives in
+`Ghostty.Core.Sponsor.Auth.*` under platform-gated classes
+(`DpapiJwtStore`, `HttpLoopbackListener`). Palette entries
+`wintty.signIn` and `wintty.signOut` are the only user-facing surface
+in D.2.5; first-run dialog and settings card deferred.
+
+Token claims: `sub`, `login`, `tier_cents`, `channel_allow`,
+`default_channel`, `jti`, `exp`. Client never verifies the signature;
+Worker is authority.
+
+Refresh: proactive at `exp - 24h`, reactive on Worker 401, transient
+retries every 10 minutes. Sign-out revokes best-effort then deletes the
+local blob.


### PR DESCRIPTION
Replaces D.2's dev-only `EnvTokenProvider` with a production `OAuthTokenProvider` that runs the GitHub OAuth loopback handshake against `api.wintty.io`, persists the minted JWT DPAPI-encrypted at `%LocalAppData%\Ghostty\auth.bin`, refreshes proactively at `exp - 24h` and reactively on Worker 401, and revokes best-effort on sign-out.

Two palette commands: "Sign in to wintty" / "Sign out of wintty". No first-run dialog, no Settings card, no pill changes. Those ship in D.2.6.

`WINTTY_DEV_JWT` env var still works as a dev short-circuit via `EnvTokenProvider` - which stays in the tree for that path.

## Shape

- All new Auth types (pure logic + Windows-concrete glue) live in `Ghostty.Core.Sponsor.Auth`, platform-gated via `[SupportedOSPlatform("windows")]` for `DpapiJwtStore` and `HttpLoopbackListener`. `Ghostty.Core` picked up `System.Security.Cryptography.ProtectedData` 9.0.0.
- Pattern deliberately mirrors D.2's `WinttyManifestClient` / `UpdateCheckException`: `AuthException(Kind, Detail?, Exception?)` with auto-formatted message, `ISponsorTokenProvider` seam preserved, `TokenInvalidated` contract unchanged so `VelopackUpdateDriver` needed no code changes.
- DI rewire in `App.xaml.cs` is the single SPONSOR_BUILD entry point. `SponsorOverlayBootstrapper.Wire` kept its existing signature; `OAuthTokenProvider` owns its own `HttpClient` for the auth endpoints.
- New `SponsorAuthCommandSource` ships in release sponsor builds (separate from the DEBUG-only simulator source), re-registers entries on `TokenAcquired` / `TokenInvalidated`.

## Scope exclusions

- `FirstRunActivationDialog`, `SponsorStatusCard`, pill "Sign in" state - D.2.6.
- End-to-end Worker contract smoke lives in the private release repo; this PR uses fakes.

## Test plan

- [x] 620 tests passing (35 new for the Auth layer)
- [x] Both SPONSOR_BUILD flavors build clean
- [x] Dev env-var smoke unchanged (EnvTokenProvider path preserved)
- [ ] Manual OAuth smoke per `windows/Ghostty/Sponsor/DEV_NOTES.md` (maintainer-run, requires live `api.wintty.io` echo of `nonce` query param in the `/cb` 302)
- [ ] dotnet-windows-reviewer pass

## Known pre-existing issues (not in this PR's scope, worth filing)

- `VelopackUpdateDriverTests.TokenInvalidated_DuringDownload_CancelsAndEmitsError` (line 337, from `882c0d71f`) times out under full-suite load; passes in isolation.
- `scripts/verify-sponsor-gate.ps1` is stale: needs update for `windows/Ghostty.sln` path (#262), `net10.0` TFM (#257), and a reflection-load approach that works from PowerShell 7's .NET 8 host.