### PR TITLE
tests: skip SplitButton_BoundsAreNotInsideTitleBarElement TODO

### DIFF
--- a/windows/Ghostty.Tests.Windows/Tabs/TitleBarPassthroughTests.cs
+++ b/windows/Ghostty.Tests.Windows/Tabs/TitleBarPassthroughTests.cs
@@ -4,11 +4,12 @@ namespace Ghostty.Tests.Windows.Tabs;
 
 public class TitleBarPassthroughTests
 {
-    // Skipped until WinUITestHost is wired here (shared with
-    // NewTabSplitButtonSmokeTests). Tracked at # 351. The Assert.Fail
-    // placeholder otherwise turns every test run red, including the
-    // wintty-release bumper validation.
-    [Fact(Skip = "TODO: wire WinUITestHost shared with NewTabSplitButtonSmokeTests; see # 351")]
+    // Placeholder added in PR # 345 with an unimplemented body (needs
+    // the same WinUITestHost as NewTabSplitButtonSmokeTests). Skipped
+    // instead of Assert.Fail so the suite reports a known-skip rather
+    // than red on every run, including the wintty-release bumper
+    // validation. Tracked at # 351.
+    [Fact(Skip = "TODO: wire WinUITestHost. See file header comment and # 351.")]
     public void SplitButton_BoundsAreNotInsideTitleBarElement()
     {
         // Intended assertions:

--- a/windows/Ghostty.Tests.Windows/Tabs/TitleBarPassthroughTests.cs
+++ b/windows/Ghostty.Tests.Windows/Tabs/TitleBarPassthroughTests.cs
@@ -4,11 +4,14 @@ namespace Ghostty.Tests.Windows.Tabs;
 
 public class TitleBarPassthroughTests
 {
-    [Fact]
+    // Skipped until WinUITestHost is wired here (shared with
+    // NewTabSplitButtonSmokeTests). Tracked at # 351. The Assert.Fail
+    // placeholder otherwise turns every test run red, including the
+    // wintty-release bumper validation.
+    [Fact(Skip = "TODO: wire WinUITestHost shared with NewTabSplitButtonSmokeTests; see # 351")]
     public void SplitButton_BoundsAreNotInsideTitleBarElement()
     {
-        // Same WinUITestHost helper as NewTabSplitButtonSmokeTests.
-        // Assertions:
+        // Intended assertions:
         //   1. Find the SplitButton ('ButtonRoot') inside MainWindow.
         //   2. Find the element passed to AppWindow.SetTitleBar
         //      (TabHost.CustomDragRegion = the cell-1 spacer).
@@ -16,7 +19,5 @@ public class TitleBarPassthroughTests
         //      .TransformBounds(Rect.Empty).
         //   4. Assert the SplitButton bounds are NOT contained within
         //      the spacer's bounds (i.e. they live in cell 0, not cell 1).
-
-        Assert.Fail("TODO: wire WinUITestHost (shared with NewTabSplitButtonSmokeTests).");
     }
 }


### PR DESCRIPTION
The `Assert.Fail("TODO: wire WinUITestHost...")` placeholder added in # 345 turns every test run red, including the release bumper validation that gates pin advances.

Mark with `[Fact(Skip = "...")]` and a pointer to # 351 until `WinUITestHost` is wired here (shared with `NewTabSplitButtonSmokeTests`). The intended assertions stay in the body as documentation for the eventual implementation.

6 lines changed, no behavior change beyond the skip status.