### PR TITLE
windows(csproj): fail loud when ghostty.dll missing

### DIFF
--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -130,9 +130,25 @@
     </None>
   </ItemGroup>
 
-  <Target Name="WarnIfNoLibghostty" BeforeTargets="Build"
+  <!--
+    Fail the build (do not just warn) when ghostty.dll is missing. The
+    Condition="Exists(...)" on the <None Include> above is evaluated at
+    MSBuild project-load time, not target-execution time, so a missing
+    dll silently drops the copy item and the produced binary throws
+    DllNotFoundException at startup (the process stays alive but no
+    window paints).
+
+    Not gated on $(PublishAot) because that property is set unconditionally
+    in this csproj (line 26): it only enables AOT analyzers, not AOT
+    compilation. AOT compile fires during `dotnet publish`, while
+    `dotnet build` always produces a managed assembly that loads
+    ghostty.dll via runtime DllImport. A clean `zig build -Dapp-runtime=none`
+    produces both ghostty.dll and ghostty-static.lib together, so requiring
+    the dll is the simplest invariant that covers every consumer.
+  -->
+  <Target Name="ErrorIfNoLibghostty" BeforeTargets="Build"
           Condition="!Exists('..\..\zig-out\lib\ghostty.dll')">
-    <Warning Text="ghostty.dll not found at ..\..\zig-out\lib\. Run 'zig build -Dapp-runtime=none' from the repo root first, or the app will fail to start." />
+    <Error Text="ghostty.dll missing at ..\..\zig-out\lib\. Run 'zig build -Dapp-runtime=none' from the repo root before 'dotnet build'." />
   </Target>
 
   <!--

--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -139,16 +139,18 @@
     window paints).
 
     Not gated on $(PublishAot) because that property is set unconditionally
-    in this csproj (line 26): it only enables AOT analyzers, not AOT
-    compilation. AOT compile fires during `dotnet publish`, while
+    in this csproj's main PropertyGroup: it only enables AOT analyzers,
+    not AOT compilation. AOT compile fires during `dotnet publish`, while
     `dotnet build` always produces a managed assembly that loads
     ghostty.dll via runtime DllImport. A clean `zig build -Dapp-runtime=none`
     produces both ghostty.dll and ghostty-static.lib together, so requiring
-    the dll is the simplest invariant that covers every consumer.
+    the dll covers every consumer (Debug/Release builds AND AOT publish,
+    which still resolves ghostty.dll when launched from bin\ rather than
+    publish\).
   -->
   <Target Name="ErrorIfNoLibghostty" BeforeTargets="Build"
           Condition="!Exists('..\..\zig-out\lib\ghostty.dll')">
-    <Error Text="ghostty.dll missing at ..\..\zig-out\lib\. Run 'zig build -Dapp-runtime=none' from the repo root before 'dotnet build'." />
+    <Error Text="ghostty.dll missing at $([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\..\..\zig-out\lib\ghostty.dll')). Run 'zig build -Dapp-runtime=none' in the directory containing build.zig before 'dotnet build'." />
   </Target>
 
   <!--


### PR DESCRIPTION
## Summary

Promote \`WarnIfNoLibghostty\` to \`ErrorIfNoLibghostty\` in
\`windows/Ghostty/Ghostty.csproj\`.

The \`Condition=\"Exists(...)\"\` on the \`<None Include>\` for ghostty.dll
above is evaluated at MSBuild project-load time, not target-execution
time. A missing dll silently drops the copy item and the produced
binary throws \`DllNotFoundException\` at startup -- the process stays
alive in Task Manager but no window paints because the async-void
\`OnLaunched\` exception plumbing reaches \`Application.UnhandledException\`
with \`Handled=false\` without reliably tearing the process down.

The previous \`<Warning>\` got lost in the surrounding pre-existing
warnings (\`FileStream\` CS0618 etc); \`<Error>\` halts the build.

Not gated on \`\$(PublishAot)\` because that property is set
unconditionally in this csproj (line 26): it enables AOT analyzers,
not AOT compilation. AOT compile fires during \`dotnet publish\`;
\`dotnet build\` always produces a managed assembly that loads
ghostty.dll via runtime DllImport. A clean
\`zig build -Dapp-runtime=none\` produces both ghostty.dll and
ghostty-static.lib together, so requiring the dll is the simplest
invariant that covers every consumer.

Layer B of the fail-loud ghostty.dll series.

## Test plan

- [x] \`dotnet build\` with no zig-out -> exit 1, error
      \`ghostty.dll missing at ..\..\zig-out\lib\.\` (verified locally
      from a fresh worktree off windows; build halts at csproj line
      151 before any compile step runs).
- [x] After copying a real \`ghostty.dll\` (19,990,016 bytes) into
      \`zig-out/lib/\`, \`dotnet build\` -> exit 0, build succeeds, output
      \`bin\x64\Release\...\native\ghostty.dll\` produced as before.
- [x] No CI impact in this repo: \`test-windows\` is gated on
      \`github.repository == 'ghostty-org/ghostty'\` so it skips on
      forks. \`dispatch-release-bump.yml\` and \`trigger-release.yml\`
      do not run \`dotnet\` directly.
- [x] No regression in the release build: the tier pipeline already
      runs \`zig build\` before \`dotnet build\`, and
      the release build pins a SHA so this change only takes effect
      when the pin advances past this PR.