### PR TITLE
feat(core): add VersionRenderer and BuildInfo for wintty +version

### DIFF
--- a/windows/Ghostty.Core/Ghostty.Core.csproj
+++ b/windows/Ghostty.Core/Ghostty.Core.csproj
@@ -87,4 +87,64 @@
       <LogicalName>Ghostty.Core.Profiles.IconAssets.%(Filename)%(Extension)</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
+
+  <Target Name="GenerateBuildInfo"
+          BeforeTargets="CoreCompile">
+    <PropertyGroup>
+      <_GeneratedBuildInfoFile>$(IntermediateOutputPath)BuildInfo.g.cs</_GeneratedBuildInfoFile>
+      <_WinttyCommit></_WinttyCommit>
+      <_WinttyCommitDirty></_WinttyCommitDirty>
+      <_GitRevExit></_GitRevExit>
+      <_WinttyDirtyOutput></_WinttyDirtyOutput>
+    </PropertyGroup>
+
+    <Exec Command="git rev-parse --short HEAD"
+          ConsoleToMSBuild="true"
+          IgnoreExitCode="true"
+          ContinueOnError="true"
+          WorkingDirectory="$(MSBuildThisFileDirectory)">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_WinttyCommit"/>
+      <Output TaskParameter="ExitCode" PropertyName="_GitRevExit"/>
+    </Exec>
+
+    <Exec Command="git status --porcelain"
+          ConsoleToMSBuild="true"
+          IgnoreExitCode="true"
+          ContinueOnError="true"
+          WorkingDirectory="$(MSBuildThisFileDirectory)">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_WinttyDirtyOutput"/>
+    </Exec>
+
+    <PropertyGroup>
+      <_WinttyCommit Condition="'$(_GitRevExit)' != '0' or '$(_WinttyCommit)' == ''">unknown</_WinttyCommit>
+      <_WinttyCommitDirty Condition="'$(_WinttyDirtyOutput)' != '' and '$(_WinttyCommit)' != 'unknown'">-dirty</_WinttyCommitDirty>
+      <_WinttyVersion>0.0.0</_WinttyVersion>
+      <_WinttyChannel Condition="'$(Channel)' == 'Stable'">stable</_WinttyChannel>
+      <_WinttyChannel Condition="'$(_WinttyChannel)' == ''">tip</_WinttyChannel>
+      <_WinttyVersionString>$(_WinttyVersion)-$(_WinttyChannel)+$(_WinttyCommit)$(_WinttyCommitDirty)</_WinttyVersionString>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_BuildInfoLines Include="// &lt;auto-generated/&gt;"/>
+      <_BuildInfoLines Include="namespace Ghostty.Core.Version%3B"/>
+      <_BuildInfoLines Include="internal static class BuildInfo"/>
+      <_BuildInfoLines Include="{"/>
+      <_BuildInfoLines Include="    public const string WinttyVersion = &quot;$(_WinttyVersion)&quot;%3B"/>
+      <_BuildInfoLines Include="    public const string WinttyVersionString = &quot;$(_WinttyVersionString)&quot;%3B"/>
+      <_BuildInfoLines Include="    public const string WinttyCommit = &quot;$(_WinttyCommit)$(_WinttyCommitDirty)&quot;%3B"/>
+      <_BuildInfoLines Include="    public const string MsbuildConfig = &quot;$(Configuration)&quot;%3B"/>
+      <_BuildInfoLines Include="    public const Edition Edition = Edition.Oss%3B"/>
+      <_BuildInfoLines Include="}"/>
+    </ItemGroup>
+
+    <MakeDir Directories="$(IntermediateOutputPath)"/>
+    <WriteLinesToFile File="$(_GeneratedBuildInfoFile)"
+                      Lines="@(_BuildInfoLines)"
+                      Overwrite="true"
+                      WriteOnlyWhenDifferent="true"/>
+
+    <ItemGroup>
+      <Compile Include="$(_GeneratedBuildInfoFile)" Visible="false"/>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/windows/Ghostty.Core/Ghostty.Core.csproj
+++ b/windows/Ghostty.Core/Ghostty.Core.csproj
@@ -90,6 +90,14 @@
 
   <Target Name="GenerateBuildInfo"
           BeforeTargets="CoreCompile">
+    <!--
+      $(IntermediateOutputPath) is set by Microsoft.NET.Sdk.targets, which
+      imports AFTER the csproj XML evaluates. Both the property assignment
+      and the <Compile Include> live inside this target so the path is
+      fully resolved before WriteLinesToFile and CoreCompile read it. The
+      tradeoff: VS / Rider IntelliSense doesn't see BuildInfo.g.cs until
+      after a CLI build, which is acceptable for this internal generator.
+    -->
     <PropertyGroup>
       <_GeneratedBuildInfoFile>$(IntermediateOutputPath)BuildInfo.g.cs</_GeneratedBuildInfoFile>
       <_WinttyCommit></_WinttyCommit>

--- a/windows/Ghostty.Core/Version/Edition.cs
+++ b/windows/Ghostty.Core/Version/Edition.cs
@@ -1,0 +1,11 @@
+namespace Ghostty.Core.Version;
+
+/// <summary>
+/// Build edition surfaced in the version output. The public repo only
+/// emits <see cref="Oss"/>. The wintty-release overlay extends this enum
+/// with sponsor and pro values.
+/// </summary>
+public enum Edition
+{
+    Oss,
+}

--- a/windows/Ghostty.Core/Version/EditionLabel.cs
+++ b/windows/Ghostty.Core/Version/EditionLabel.cs
@@ -1,0 +1,15 @@
+namespace Ghostty.Core.Version;
+
+/// <summary>
+/// Pure formatter for <see cref="Edition"/>. Public-repo path returns
+/// "oss". Overlay extends the signature to take channel and adds the
+/// channel-aware cases (Sponsor Stable, Pro Tip, etc.).
+/// </summary>
+public static class EditionLabel
+{
+    public static string Format(Edition edition) => edition switch
+    {
+        Edition.Oss => "oss",
+        _ => throw new System.ArgumentOutOfRangeException(nameof(edition), edition, null),
+    };
+}

--- a/windows/Ghostty.Core/Version/EditionLabel.cs
+++ b/windows/Ghostty.Core/Version/EditionLabel.cs
@@ -10,6 +10,6 @@ public static class EditionLabel
     public static string Format(Edition edition) => edition switch
     {
         Edition.Oss => "oss",
-        _ => throw new System.ArgumentOutOfRangeException(nameof(edition), edition, null),
+        _ => throw new ArgumentOutOfRangeException(nameof(edition), edition, null),
     };
 }

--- a/windows/Ghostty.Core/Version/LibGhosttyBuildInfo.cs
+++ b/windows/Ghostty.Core/Version/LibGhosttyBuildInfo.cs
@@ -1,0 +1,55 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Ghostty.Core.Version;
+
+/// <summary>
+/// Build information about the loaded libghostty.dll. Sourced from
+/// the <c>ghostty_build_info</c> FFI export.
+/// </summary>
+public sealed record LibGhosttyBuildInfo(
+    string Version,
+    string VersionString,
+    string Commit,
+    string Channel,
+    string ZigVersion,
+    string BuildMode);
+
+/// <summary>
+/// P/Invoke bridge for the ghostty_build_info FFI. NativeAOT-friendly:
+/// blittable struct of pointers, no delegates, no marshaller attributes
+/// beyond LibraryImport's defaults.
+/// </summary>
+public static partial class LibGhosttyBuildInfoBridge
+{
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Native
+    {
+        public nint Version;
+        public nint VersionString;
+        public nint Commit;
+        public nint Channel;
+        public nint ZigVersion;
+        public nint BuildMode;
+    }
+
+    [LibraryImport("ghostty", EntryPoint = "ghostty_build_info")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
+    private static partial void GhosttyBuildInfo(out Native info);
+
+    /// <summary>
+    /// Read build info from libghostty. The native strings have static
+    /// lifetime so we marshal them into managed copies and return.
+    /// </summary>
+    public static LibGhosttyBuildInfo Read()
+    {
+        GhosttyBuildInfo(out var native);
+        return new LibGhosttyBuildInfo(
+            Version:       Marshal.PtrToStringUTF8(native.Version) ?? string.Empty,
+            VersionString: Marshal.PtrToStringUTF8(native.VersionString) ?? string.Empty,
+            Commit:        Marshal.PtrToStringUTF8(native.Commit) ?? string.Empty,
+            Channel:       Marshal.PtrToStringUTF8(native.Channel) ?? string.Empty,
+            ZigVersion:    Marshal.PtrToStringUTF8(native.ZigVersion) ?? string.Empty,
+            BuildMode:     Marshal.PtrToStringUTF8(native.BuildMode) ?? string.Empty);
+    }
+}

--- a/windows/Ghostty.Core/Version/VersionInfo.cs
+++ b/windows/Ghostty.Core/Version/VersionInfo.cs
@@ -1,0 +1,26 @@
+namespace Ghostty.Core.Version;
+
+/// <summary>
+/// Immutable snapshot of all fields surfaced by <c>wintty +version</c>
+/// and the Version command-palette dialog. Built once via
+/// <see cref="VersionRenderer.Build"/> and rendered to either plain text
+/// or ANSI by the renderer.
+/// </summary>
+public sealed record VersionInfo(
+    // Wintty-side (BuildInfo.g.cs constants)
+    string WinttyVersion,
+    string WinttyVersionString,
+    string WinttyCommit,
+    Edition Edition,
+    // libghostty (FFI)
+    LibGhosttyBuildInfo LibGhostty,
+    // Compile-time C#
+    string DotnetRuntime,
+    string MsbuildConfig,
+    // Constants the host always knows
+    string AppRuntime,
+    string Renderer,
+    string FontEngine,
+    // Runtime probes
+    string WindowsVersion,
+    string Architecture);

--- a/windows/Ghostty.Core/Version/VersionRenderer.cs
+++ b/windows/Ghostty.Core/Version/VersionRenderer.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace Ghostty.Core.Version;
@@ -13,6 +14,29 @@ public static class VersionRenderer
     private const string Osc8Open = "\x1b]8;;";
     private const string Osc8Close = "\x1b]8;;\x1b\\";
     private const string St = "\x1b\\";
+
+    /// <summary>
+    /// Assemble a <see cref="VersionInfo"/> from all sources: the
+    /// MSBuild-generated <see cref="BuildInfo"/> constants, the libghostty
+    /// FFI, the .NET runtime, and the OS.
+    /// </summary>
+    public static VersionInfo Build()
+    {
+        var lib = LibGhosttyBuildInfoBridge.Read();
+        return new VersionInfo(
+            WinttyVersion:       BuildInfo.WinttyVersion,
+            WinttyVersionString: BuildInfo.WinttyVersionString,
+            WinttyCommit:        BuildInfo.WinttyCommit,
+            Edition:             BuildInfo.Edition,
+            LibGhostty:          lib,
+            DotnetRuntime:       Environment.Version.ToString(3),
+            MsbuildConfig:       BuildInfo.MsbuildConfig,
+            AppRuntime:          "WinUI 3",
+            Renderer:            "DX12",
+            FontEngine:          "DirectWrite",
+            WindowsVersion:      Environment.OSVersion.Version.ToString(3),
+            Architecture:        RuntimeInformation.OSArchitecture.ToString().ToLowerInvariant());
+    }
 
     /// <summary>Plain rendering. No escape sequences. Used by the dialog
     /// and by redirected stdout.</summary>

--- a/windows/Ghostty.Core/Version/VersionRenderer.cs
+++ b/windows/Ghostty.Core/Version/VersionRenderer.cs
@@ -14,6 +14,7 @@ public static class VersionRenderer
     private const string Osc8Open = "\x1b]8;;";
     private const string Osc8Close = "\x1b]8;;\x1b\\";
     private const string St = "\x1b\\";
+    private const int FieldValueColumn = 18;
 
     /// <summary>
     /// Assemble a <see cref="VersionInfo"/> from all sources: the
@@ -107,10 +108,9 @@ public static class VersionRenderer
 
     private static void Field(StringBuilder sb, string label, string value)
     {
-        // Two-space indent, label, ":", padded to column 18, then value.
-        const int column = 18;
+        // Two-space indent, label, ":", padded to FieldValueColumn, then value.
         sb.Append("  ").Append(label).Append(':');
-        var padding = column - (2 + label.Length + 1);
+        var padding = FieldValueColumn - (2 + label.Length + 1);
         if (padding > 0) sb.Append(' ', padding);
         sb.Append(value).Append('\n');
     }

--- a/windows/Ghostty.Core/Version/VersionRenderer.cs
+++ b/windows/Ghostty.Core/Version/VersionRenderer.cs
@@ -1,0 +1,93 @@
+using System.Text;
+
+namespace Ghostty.Core.Version;
+
+/// <summary>
+/// Renders <see cref="VersionInfo"/> to either plain text (for the
+/// command-palette dialog and for redirected stdout) or ANSI text (for
+/// interactive stdout, which adds an OSC 8 hyperlink to the header).
+/// </summary>
+public static class VersionRenderer
+{
+    private const string CommitUrlPrefix = "https://github.com/deblasis/wintty/commit/";
+    private const string Osc8Open = "\x1b]8;;";
+    private const string Osc8Close = "\x1b]8;;\x1b\\";
+    private const string St = "\x1b\\";
+
+    /// <summary>Plain rendering. No escape sequences. Used by the dialog
+    /// and by redirected stdout.</summary>
+    public static string RenderPlain(VersionInfo info)
+    {
+        var sb = new StringBuilder();
+        AppendHeader(sb, info, ansi: false);
+        AppendBody(sb, info);
+        return sb.ToString();
+    }
+
+    /// <summary>ANSI rendering. Header is wrapped in an OSC 8 hyperlink
+    /// to the commit on github.com. Used for interactive stdout.</summary>
+    public static string RenderAnsi(VersionInfo info)
+    {
+        var sb = new StringBuilder();
+        AppendHeader(sb, info, ansi: true);
+        AppendBody(sb, info);
+        return sb.ToString();
+    }
+
+    private static void AppendHeader(StringBuilder sb, VersionInfo info, bool ansi)
+    {
+        var hasCommit = !string.IsNullOrEmpty(info.WinttyCommit) && info.WinttyCommit != "unknown";
+        if (ansi && hasCommit)
+        {
+            sb.Append(Osc8Open).Append(CommitUrlPrefix).Append(info.WinttyCommit).Append(St);
+            sb.Append("Wintty ").Append(info.WinttyVersionString);
+            sb.Append(Osc8Close);
+            sb.Append('\n');
+        }
+        else
+        {
+            sb.Append("Wintty ").Append(info.WinttyVersionString).Append('\n');
+        }
+        if (hasCommit)
+        {
+            sb.Append("  ").Append(CommitUrlPrefix).Append(info.WinttyCommit).Append('\n');
+        }
+        sb.Append('\n');
+    }
+
+    private static void AppendBody(StringBuilder sb, VersionInfo info)
+    {
+        sb.Append("Version\n");
+        Field(sb, "version",     info.WinttyVersion);
+        Field(sb, "channel",     info.LibGhostty.Channel);
+        Field(sb, "edition",     EditionLabel.Format(info.Edition));
+        sb.Append('\n');
+
+        sb.Append("Build Config\n");
+        Field(sb, "Zig version",  info.LibGhostty.ZigVersion);
+        Field(sb, ".NET runtime", info.DotnetRuntime);
+        Field(sb, "app runtime",  info.AppRuntime);
+        Field(sb, "renderer",     info.Renderer);
+        Field(sb, "font engine",  info.FontEngine);
+        Field(sb, "libghostty",   FormatLibghosttyVersion(info.LibGhostty));
+        Field(sb, "windows",      info.WindowsVersion);
+        Field(sb, "arch",         info.Architecture);
+        Field(sb, "build mode",   info.MsbuildConfig);
+    }
+
+    private static string FormatLibghosttyVersion(LibGhosttyBuildInfo lib)
+    {
+        if (string.IsNullOrEmpty(lib.Commit)) return lib.Version;
+        return $"{lib.Version}+{lib.Commit}";
+    }
+
+    private static void Field(StringBuilder sb, string label, string value)
+    {
+        // Two-space indent, label, ":", padded to column 18, then value.
+        const int column = 18;
+        sb.Append("  ").Append(label).Append(':');
+        var padding = column - (2 + label.Length + 1);
+        if (padding > 0) sb.Append(' ', padding);
+        sb.Append(value).Append('\n');
+    }
+}

--- a/windows/Ghostty.Tests/Version/EditionLabelTests.cs
+++ b/windows/Ghostty.Tests/Version/EditionLabelTests.cs
@@ -1,0 +1,13 @@
+using Ghostty.Core.Version;
+using Xunit;
+
+namespace Ghostty.Tests.Version;
+
+public sealed class EditionLabelTests
+{
+    [Fact]
+    public void Format_Oss_ReturnsLowercaseOss()
+    {
+        Assert.Equal("oss", EditionLabel.Format(Edition.Oss));
+    }
+}

--- a/windows/Ghostty.Tests/Version/VersionRendererTests.cs
+++ b/windows/Ghostty.Tests/Version/VersionRendererTests.cs
@@ -1,0 +1,84 @@
+using Ghostty.Core.Version;
+using Xunit;
+
+namespace Ghostty.Tests.Version;
+
+public sealed class VersionRendererTests
+{
+    private static VersionInfo Sample() => new(
+        WinttyVersion:       "1.2.0",
+        WinttyVersionString: "1.2.0-tip+abc1234",
+        WinttyCommit:        "abc1234",
+        Edition:             Edition.Oss,
+        LibGhostty: new LibGhosttyBuildInfo(
+            Version:       "1.2.0",
+            VersionString: "1.2.0-tip+abc1234",
+            Commit:        "abc1234",
+            Channel:       "tip",
+            ZigVersion:    "0.14.0",
+            BuildMode:     "ReleaseFast"),
+        DotnetRuntime:   "10.0.0",
+        MsbuildConfig:   "Release",
+        AppRuntime:      "WinUI 3",
+        Renderer:        "DX12",
+        FontEngine:      "DirectWrite",
+        WindowsVersion:  "11.0.26200",
+        Architecture:    "x64");
+
+    [Fact]
+    public void RenderPlain_OssFixture_MatchesExpected()
+    {
+        var expected =
+            "Wintty 1.2.0-tip+abc1234\n" +
+            "  https://github.com/deblasis/wintty/commit/abc1234\n" +
+            "\n" +
+            "Version\n" +
+            "  version:        1.2.0\n" +
+            "  channel:        tip\n" +
+            "  edition:        oss\n" +
+            "\n" +
+            "Build Config\n" +
+            "  Zig version:    0.14.0\n" +
+            "  .NET runtime:   10.0.0\n" +
+            "  app runtime:    WinUI 3\n" +
+            "  renderer:       DX12\n" +
+            "  font engine:    DirectWrite\n" +
+            "  libghostty:     1.2.0+abc1234\n" +
+            "  windows:        11.0.26200\n" +
+            "  arch:           x64\n" +
+            "  build mode:     Release\n";
+
+        Assert.Equal(expected, VersionRenderer.RenderPlain(Sample()));
+    }
+
+    [Fact]
+    public void RenderPlain_NoCommit_OmitsHeaderUrl()
+    {
+        var info = Sample() with
+        {
+            WinttyVersionString = "1.2.0-tip+unknown",
+            WinttyCommit = "unknown",
+        };
+
+        var output = VersionRenderer.RenderPlain(info);
+        Assert.StartsWith("Wintty 1.2.0-tip+unknown\n\n", output);
+        Assert.DoesNotContain("github.com/deblasis/wintty/commit", output);
+    }
+
+    [Fact]
+    public void RenderAnsi_TtyFixture_HasOsc8HeaderHyperlink()
+    {
+        var output = VersionRenderer.RenderAnsi(Sample());
+        Assert.Contains(
+            "\x1b]8;;https://github.com/deblasis/wintty/commit/abc1234\x1b\\Wintty 1.2.0-tip+abc1234\x1b]8;;\x1b\\",
+            output);
+    }
+
+    [Fact]
+    public void RenderAnsi_NoCommit_OmitsOsc8()
+    {
+        var info = Sample() with { WinttyCommit = "unknown" };
+        var output = VersionRenderer.RenderAnsi(info);
+        Assert.DoesNotContain("\x1b]8", output);
+    }
+}


### PR DESCRIPTION
> [!IMPORTANT]
> Stack order:
> - PR A (#362) -> ghostty_build_info FFI export
> - **PR B (this)** -> Ghostty.Core: VersionInfo, VersionRenderer, BuildInfo.g.cs generator
> - PR C -> Wintty.exe: \`+version\` action and Version palette dialog
>
> Targets PR A's branch. GitHub will auto-retarget to \`windows\` when PR A merges.

## Summary

Adds the C# side of the version-rendering pipeline in \`Ghostty.Core/Version/\`. One renderer feeds both surfaces (CLI output and the Version palette dialog in PR C). All types are pure logic so \`Ghostty.Tests\` covers them without compile-source-with-stubs.

## What's in here

- \`Edition\` enum (Oss only on this branch; the release overlay extends with sponsor/pro).
- \`EditionLabel.Format(Edition)\` pure formatter.
- \`LibGhosttyBuildInfo\` record + \`LibGhosttyBuildInfoBridge\` static partial class. P/Invokes \`ghostty_build_info\` from PR A; blittable struct of \`nint\`, \`Marshal.PtrToStringUTF8\`, NativeAOT-friendly.
- \`VersionInfo\` record - the full immutable shape for one \`+version\` rendering.
- \`VersionRenderer.RenderPlain\` and \`RenderAnsi\` - StringBuilder, OSC 8 hyperlink on the header for ANSI.
- \`VersionRenderer.Build()\` - assembles \`VersionInfo\` from the FFI, MSBuild constants, \`Environment.OSVersion\`, and \`RuntimeInformation\`.
- MSBuild \`<Target Name=\"GenerateBuildInfo\">\` in \`Ghostty.Core.csproj\` that emits \`obj/.../BuildInfo.g.cs\` with Wintty version, commit (with \`-dirty\` suffix), MSBuild config, and \`Edition.Oss\`. Falls back to \`commit=\"unknown\"\` when git isn't available.

## Tests

- \`EditionLabelTests\` - 1 test
- \`VersionRendererTests\` - 4 tests (plain fixture, no-commit fallback, ANSI OSC 8 presence, ANSI no-OSC-when-no-commit)

## Test plan

- [x] \`dotnet build windows/Ghostty.Core/Ghostty.Core.csproj\` succeeds
- [x] \`dotnet test windows/Ghostty.Tests/Ghostty.Tests.csproj\` passes 795+1 (5 new)
- [x] Generated \`BuildInfo.g.cs\` has correct constants and no escape leakage (\`&quot;\`, \`%3B\`)
- [ ] Wired up to the host in PR C