### PR TITLE
feat(host): wintty +version action and Version palette dialog

### DIFF
--- a/windows/Ghostty/Cli/CliActions.cs
+++ b/windows/Ghostty/Cli/CliActions.cs
@@ -1,0 +1,26 @@
+using System;
+using Ghostty.Core.Version;
+
+namespace Ghostty.Cli;
+
+/// <summary>
+/// Handlers for <c>+</c>-prefixed CLI actions intercepted before the
+/// libghostty CLI dispatcher in <see cref="Program"/>. Console
+/// inheritance is provided by Wintty.exe being a console-subsystem app
+/// (see Program.cs comments) - no AttachConsole plumbing is needed.
+/// </summary>
+internal static class CliActions
+{
+    /// <summary>Render version info to stdout. Returns the process
+    /// exit code the caller should pass to <see cref="Environment.Exit"/>.</summary>
+    public static int PrintVersion()
+    {
+        var info = VersionRenderer.Build();
+        var output = Console.IsOutputRedirected
+            ? VersionRenderer.RenderPlain(info)
+            : VersionRenderer.RenderAnsi(info);
+        Console.Out.Write(output);
+        Console.Out.Flush();
+        return 0;
+    }
+}

--- a/windows/Ghostty/Commands/CommandItem.cs
+++ b/windows/Ghostty/Commands/CommandItem.cs
@@ -11,6 +11,7 @@ internal enum CommandCategory
     Terminal,
     Config,
     Custom,
+    About,
 }
 
 internal record CommandItem

--- a/windows/Ghostty/Commands/VersionCommandSource.cs
+++ b/windows/Ghostty/Commands/VersionCommandSource.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using Ghostty.Dialogs;
+using Microsoft.UI.Xaml;
+
+namespace Ghostty.Commands;
+
+/// <summary>
+/// Single-item command source that opens the Version dialog from the
+/// command palette. <see cref="Refresh"/> is a no-op because version data
+/// is process-static.
+/// </summary>
+internal sealed class VersionCommandSource : ICommandSource
+{
+    private readonly Func<XamlRoot?> _xamlRootProvider;
+    private readonly DialogTracker _dialogs;
+    private readonly IReadOnlyList<CommandItem> _commands;
+
+    public VersionCommandSource(Func<XamlRoot?> xamlRootProvider, DialogTracker dialogs)
+    {
+        _xamlRootProvider = xamlRootProvider;
+        _dialogs = dialogs;
+        _commands = new[]
+        {
+            new CommandItem
+            {
+                Id = "version",
+                Title = "Version",
+                Description = "Show Wintty version, build, and edition",
+                Category = CommandCategory.About,
+                LeadingIcon = "", // Segoe MDL2 Info glyph
+                Execute = _ => OpenDialog(),
+            },
+        };
+    }
+
+    public IReadOnlyList<CommandItem> GetCommands() => _commands;
+
+    public void Refresh() { /* version data is process-static */ }
+
+    private async void OpenDialog()
+    {
+        var xamlRoot = _xamlRootProvider();
+        if (xamlRoot is null) return;
+
+        var dialog = new VersionDialog
+        {
+            XamlRoot = xamlRoot,
+        };
+        using (_dialogs.Track(dialog))
+        {
+            await dialog.ShowAsync();
+        }
+    }
+}

--- a/windows/Ghostty/Commands/VersionCommandSource.cs
+++ b/windows/Ghostty/Commands/VersionCommandSource.cs
@@ -28,7 +28,7 @@ internal sealed class VersionCommandSource : ICommandSource
                 Title = "Version",
                 Description = "Show Wintty version, build, and edition",
                 Category = CommandCategory.About,
-                LeadingIcon = "", // Segoe MDL2 Info glyph
+                LeadingIcon = "\uE946", // Segoe Fluent Info glyph
                 Execute = _ => OpenDialog(),
             },
         };

--- a/windows/Ghostty/Dialogs/VersionDialog.xaml
+++ b/windows/Ghostty/Dialogs/VersionDialog.xaml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ContentDialog
+    x:Class="Ghostty.Dialogs.VersionDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Title="Wintty version"
+    PrimaryButtonText="Copy"
+    CloseButtonText="Close"
+    DefaultButton="Primary">
+    <ScrollViewer>
+        <TextBlock x:Name="VersionText"
+                   FontFamily="Cascadia Mono, Consolas"
+                   IsTextSelectionEnabled="True"
+                   TextWrapping="NoWrap"/>
+    </ScrollViewer>
+</ContentDialog>

--- a/windows/Ghostty/Dialogs/VersionDialog.xaml.cs
+++ b/windows/Ghostty/Dialogs/VersionDialog.xaml.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Threading.Tasks;
+using Ghostty.Core.Version;
+using Microsoft.UI.Xaml.Controls;
+using Windows.ApplicationModel.DataTransfer;
+using WinClipboard = Windows.ApplicationModel.DataTransfer.Clipboard;
+
+namespace Ghostty.Dialogs;
+
+internal sealed partial class VersionDialog : ContentDialog
+{
+    private readonly string _output;
+
+    public VersionDialog()
+    {
+        InitializeComponent();
+
+        var info = VersionRenderer.Build();
+        _output = VersionRenderer.RenderPlain(info);
+        VersionText.Text = _output;
+        Title = $"Wintty {info.WinttyVersionString}";
+
+        PrimaryButtonClick += OnCopy;
+    }
+
+    private async void OnCopy(ContentDialog sender, ContentDialogButtonClickEventArgs args)
+    {
+        // Don't dismiss the dialog when Copy is clicked.
+        args.Cancel = true;
+
+        var data = new DataPackage();
+        data.SetText(_output);
+        WinClipboard.SetContent(data);
+
+        var originalText = PrimaryButtonText;
+        PrimaryButtonText = "Copied";
+        try
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(1500));
+        }
+        finally
+        {
+            PrimaryButtonText = originalText;
+        }
+    }
+}

--- a/windows/Ghostty/Dialogs/VersionDialog.xaml.cs
+++ b/windows/Ghostty/Dialogs/VersionDialog.xaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Ghostty.Core.Version;
 using Microsoft.UI.Xaml.Controls;
@@ -10,6 +11,8 @@ namespace Ghostty.Dialogs;
 internal sealed partial class VersionDialog : ContentDialog
 {
     private readonly string _output;
+    private readonly string _copyButtonRest;
+    private bool _copyInProgress;
 
     public VersionDialog()
     {
@@ -20,6 +23,9 @@ internal sealed partial class VersionDialog : ContentDialog
         VersionText.Text = _output;
         Title = $"Wintty {info.WinttyVersionString}";
 
+        // Capture the original button label once so re-entrancy (rapid
+        // double-click) can't leave the button stuck on "Copied".
+        _copyButtonRest = PrimaryButtonText;
         PrimaryButtonClick += OnCopy;
     }
 
@@ -28,11 +34,24 @@ internal sealed partial class VersionDialog : ContentDialog
         // Don't dismiss the dialog when Copy is clicked.
         args.Cancel = true;
 
+        // Drop double-clicks while a previous Copy is still mid-revert.
+        if (_copyInProgress) return;
+        _copyInProgress = true;
+
         var data = new DataPackage();
         data.SetText(_output);
-        WinClipboard.SetContent(data);
+        try
+        {
+            // SetContent races WinUI startup and can throw CO_E_NOTINITIALIZED /
+            // CLIPBRD_E_CANT_OPEN -- same hazard handled in WinUiClipboardBackend.
+            WinClipboard.SetContent(data);
+        }
+        catch (COMException)
+        {
+            _copyInProgress = false;
+            return;
+        }
 
-        var originalText = PrimaryButtonText;
         PrimaryButtonText = "Copied";
         try
         {
@@ -40,7 +59,8 @@ internal sealed partial class VersionDialog : ContentDialog
         }
         finally
         {
-            PrimaryButtonText = originalText;
+            PrimaryButtonText = _copyButtonRest;
+            _copyInProgress = false;
         }
     }
 }

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1686,7 +1686,9 @@ public sealed partial class MainWindow : Window
 
         var config = new ConfigCommandSource();
 
-        var sources = new List<ICommandSource> { builtIn, jump, config };
+        var version = new VersionCommandSource(() => this.Content?.XamlRoot, _dialogs);
+
+        var sources = new List<ICommandSource> { builtIn, jump, config, version };
 
         // Null-check App services as a defensive belt (cold-start where App.ProfileRegistry
         // isn't wired yet would skip the source entirely; ProfileCommandSource itself

--- a/windows/Ghostty/Program.cs
+++ b/windows/Ghostty/Program.cs
@@ -146,6 +146,16 @@ public static partial class Program
         // survives reboot and tells us exactly what went wrong.
         RedirectStderrToFile();
 
+        // +version is intercepted here, before the libghostty CLI
+        // dispatcher. The renderer lives in C# so it can also drive the
+        // Version palette dialog with the same output.
+        if (args.Length > 0 &&
+            (args[0] == "+version" || args[0] == "--version" || args[0] == "-v"))
+        {
+            RegisterNativeResolver();
+            Environment.Exit(Cli.CliActions.PrintVersion());
+        }
+
         // CLI actions are delegated to libghostty, matching the macOS
         // architecture: ghostty_init parses argv, ghostty_cli_run_action
         // runs the action (if any). If no action, we start the WinUI app.
@@ -336,18 +346,21 @@ public static partial class Program
     /// Register the native DLL resolver so LibraryImport("ghostty") finds
     /// native/ghostty.dll. Mirrors the resolver in App.xaml.cs but runs
     /// before WinUI is initialized, enabling CLI-path P/Invoke calls.
+    /// Registered for both the host assembly (Interop.NativeMethods) and
+    /// Ghostty.Core, since LibGhosttyBuildInfoBridge lives in the latter.
     /// </summary>
     private static void RegisterNativeResolver()
     {
-        NativeLibrary.SetDllImportResolver(
-            typeof(Interop.NativeMethods).Assembly,
-            (name, assembly, path) =>
-            {
-                if (!string.Equals(name, "ghostty", StringComparison.OrdinalIgnoreCase))
-                    return IntPtr.Zero;
-                var candidate = Path.Combine(AppContext.BaseDirectory, "native", "ghostty.dll");
-                return NativeLibrary.Load(candidate);
-            });
+        static IntPtr Resolve(string name, System.Reflection.Assembly assembly, DllImportSearchPath? path)
+        {
+            if (!string.Equals(name, "ghostty", StringComparison.OrdinalIgnoreCase))
+                return IntPtr.Zero;
+            var candidate = Path.Combine(AppContext.BaseDirectory, "native", "ghostty.dll");
+            return NativeLibrary.Load(candidate);
+        }
+
+        NativeLibrary.SetDllImportResolver(typeof(Interop.NativeMethods).Assembly, Resolve);
+        NativeLibrary.SetDllImportResolver(typeof(Ghostty.Core.Version.LibGhosttyBuildInfoBridge).Assembly, Resolve);
     }
 
     private static int StartGui()


### PR DESCRIPTION
> [!IMPORTANT]
> Stack order:
> - PR A (#362) -> ghostty_build_info FFI export
> - PR B (#364) -> Ghostty.Core: VersionInfo, VersionRenderer, BuildInfo.g.cs generator
> - **PR C (this)** -> Wintty.exe: \`+version\` action and Version palette dialog
>
> Targets PR B's branch. GitHub will auto-retarget when PRs A and B merge.

## Summary

Wires up the host side of \`wintty +version\`: a CLI intercept in \`Program.MainImpl\` that prints from a single C# renderer (PR B), plus a Version command-palette entry that opens a ContentDialog rendering the same text. Both surfaces use the OSS-only output (header, Version block, Build Config block; the release overlay extends with sponsor / pro tier and the thank-you line).

## What's in here

- New \`+version\` / \`--version\` / \`-v\` branch in \`Program.MainImpl\` runs BEFORE the existing libghostty CLI dispatcher, calls the new \`Cli.CliActions.PrintVersion()\`, and exits. Wintty.exe is a console-subsystem app so \`Console.Out\` works natively without AttachConsole; \`Console.IsOutputRedirected\` picks ANSI vs Plain rendering.
- \`Cli.CliActions.PrintVersion()\` - one-shot renderer, no \`ghostty_init\` needed (the FFI is callable without it, see PR A).
- \`Commands.VersionCommandSource\` - single-item \`ICommandSource\` under the new \`CommandCategory.About\` value, with a \`Func<XamlRoot?>\` lookup and the existing \`DialogTracker\` integration so the Version dialog participates in the window-teardown drain (same pattern as RenameTabDialog).
- \`Dialogs.VersionDialog\` - \`ContentDialog\` with monospace body, Copy primary button (no dismiss; brief \`Copied\` confirm for ~1.5s), Close. \`SetContent\` wrapped in \`try/catch (COMException)\` matching \`WinUiClipboardBackend\`'s startup-race handling. \`_copyInProgress\` guard prevents rapid-double-click from leaving the button stuck on \`Copied\`.
- \`MainWindow\` registration: \`new VersionCommandSource(() => this.Content?.XamlRoot, _dialogs)\` added to the palette source list.
- \`RegisterNativeResolver\` extended to register against both \`Interop.NativeMethods\` and \`Ghostty.Core.Version.LibGhosttyBuildInfoBridge\` assemblies (\`LibraryImport\` resolves per-assembly), with the lambda refactored to a static local function to avoid closure allocation.

## End-to-end smoke

\`Wintty.exe +version\` was tested mid-implementation:
- Output renders correctly with the spec format (header, Version, Build Config).
- OSC 8 hyperlink wraps the header URL on TTY.
- Exit code 0.

Full smoke spec lives in \`docs/superpowers/smoke/2026-04-28-wintty-version-smoke.md\` (worktree-local; not committed per the project's superpowers exclude).

## Test plan

- [x] \`dotnet build windows/Ghostty/Ghostty.csproj\` succeeds
- [x] \`dotnet test windows/Ghostty.Tests/Ghostty.Tests.csproj\` 795 + 1 skipped (no host-side tests added; CLI and dialog are end-to-end territory)
- [x] \`Wintty.exe +version\` from terminal renders as expected with OSC 8
- [ ] \`Wintty.exe +version | Out-File\` plain-only (no ANSI) - manual smoke
- [ ] Palette -> Version -> Copy round-trips via clipboard - manual smoke
- [ ] Rapid double-click on Copy doesn't leave button stuck - manual smoke