### PR TITLE
config: add link-url-style for always-underline link rendering

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1424,6 +1424,25 @@ link: RepeatableLink = .{},
 /// `link`). If you want to customize URL matching, use `link` and disable this.
 @"link-url": bool = true,
 
+/// Controls how OSC 8 hyperlinks and the default URL matcher are visually
+/// highlighted on screen. This only affects the underline rendering; clicking
+/// a link still requires Ctrl (Linux/Windows) or Cmd (macOS) regardless of
+/// this setting, so mouse-aware TUI programs (vim with `mouse=a`, htop, etc.)
+/// keep their normal mouse-button semantics.
+///
+/// Available values:
+///
+///   * `hover-mods` (default): Links are only underlined while the mouse
+///     hovers over them with the modifier held. Matches Ghostty's
+///     minimal-chrome default.
+///
+///   * `always`: Links are always underlined whenever they appear on screen.
+///     Matches the default behavior of most other terminal emulators
+///     (Windows Terminal, iTerm2, WezTerm, Kitty, VS Code).
+///
+/// Available since: 1.3.0
+@"link-url-style": LinkUrlStyle = .@"hover-mods",
+
 /// Show link previews for a matched URL.
 ///
 /// When true, link previews are shown for all matched URLs. When false, link
@@ -4682,6 +4701,18 @@ pub fn finalize(self: *Config) !void {
     if (self.@"window-width" > 0) self.@"window-width" = @max(10, self.@"window-width");
     if (self.@"window-height" > 0) self.@"window-height" = @max(4, self.@"window-height");
 
+    // When link-url-style = always, switch the default URL matcher's
+    // highlight to .always so the URL matcher behaves like the OSC 8
+    // path in always-underline mode. The default link is always at
+    // index 0 (set up in default()). We do this before the link-url
+    // cut below so that disabling link-url still removes the entry
+    // cleanly.
+    if (self.@"link-url" and self.@"link-url-style" == .always and
+        self.link.links.items.len > 0)
+    {
+        self.link.links.items[0].highlight = .{ .always = {} };
+    }
+
     // If URLs are disabled, cut off the first link. The first link is
     // always the URL matcher.
     if (!self.@"link-url") self.link.links.items = self.link.links.items[1..];
@@ -5282,6 +5313,12 @@ pub const LinkPreviews = enum {
     false,
     true,
     osc8,
+};
+
+/// See link-url-style
+pub const LinkUrlStyle = enum {
+    @"hover-mods",
+    always,
 };
 
 /// See working-directory

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -565,6 +565,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             bg_image_fit: configpkg.BackgroundImageFit,
             bg_image_repeat: bool,
             links: link.Set,
+            link_url_style: configpkg.Config.LinkUrlStyle,
             vsync: bool,
             colorspace: configpkg.Config.WindowColorspace,
             blending: configpkg.Config.AlphaBlending,
@@ -639,6 +640,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     .bg_image_fit = config.@"background-image-fit",
                     .bg_image_repeat = config.@"background-image-repeat",
                     .links = links,
+                    .link_url_style = config.@"link-url-style",
                     .vsync = config.@"window-vsync",
                     .colorspace = config.@"window-colorspace",
                     .blending = config.@"alpha-blending",
@@ -1243,23 +1245,39 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     );
                 }
 
-                // Get our OSC8 links we're hovering if we have a mouse.
-                // This requires terminal state because of URLs.
+                // Determine which OSC 8 hyperlink cells should be
+                // underlined this frame. With link-url-style = .always,
+                // every hyperlink cell in the viewport is underlined
+                // regardless of hover/mods state — matches the default
+                // behavior of most other terminal emulators.
+                // With link-url-style = .@"hover-mods" (default), only
+                // the hyperlink under the mouse is highlighted, and
+                // only while Ctrl/Cmd is held.
                 const links: terminal.RenderState.CellSet = osc8: {
-                    // If our mouse isn't hovering, we have no links.
-                    const vp = state.mouse.point orelse break :osc8 .empty;
+                    switch (self.config.link_url_style) {
+                        .always => break :osc8 self.terminal_state.allHyperlinkCells(
+                            arena_alloc,
+                        ) catch |err| {
+                            log.warn("error collecting OSC8 hyperlinks err={}", .{err});
+                            break :osc8 .empty;
+                        },
+                        .@"hover-mods" => {
+                            // If our mouse isn't hovering, we have no links.
+                            const vp = state.mouse.point orelse break :osc8 .empty;
 
-                    // If the right mods aren't pressed, then we can't match.
-                    if (!state.mouse.mods.equal(inputpkg.ctrlOrSuper(.{})))
-                        break :osc8 .empty;
+                            // If the right mods aren't pressed, then we can't match.
+                            if (!state.mouse.mods.equal(inputpkg.ctrlOrSuper(.{})))
+                                break :osc8 .empty;
 
-                    break :osc8 self.terminal_state.linkCells(
-                        arena_alloc,
-                        vp,
-                    ) catch |err| {
-                        log.warn("error searching for OSC8 links err={}", .{err});
-                        break :osc8 .empty;
-                    };
+                            break :osc8 self.terminal_state.linkCells(
+                                arena_alloc,
+                                vp,
+                            ) catch |err| {
+                                log.warn("error searching for OSC8 links err={}", .{err});
+                                break :osc8 .empty;
+                            };
+                        },
+                    }
                 };
 
                 const overlay_features: []const Overlay.Feature = overlay: {

--- a/src/terminal/render.zig
+++ b/src/terminal/render.zig
@@ -877,6 +877,41 @@ pub const RenderState = struct {
 
         return result;
     }
+
+    /// Returns the set of all OSC 8 hyperlink cells in the current
+    /// viewport, regardless of mouse position or any specific link ID.
+    /// Used by renderers in always-underline mode (config
+    /// `link-url-style = always`).
+    ///
+    /// IMPORTANT: The terminal must not have updated since the last call to
+    /// `update`. If there is any chance the terminal has updated, the caller
+    /// must first call `update` again to refresh the render state.
+    pub fn allHyperlinkCells(
+        self: *const RenderState,
+        alloc: Allocator,
+    ) Allocator.Error!CellSet {
+        var result: CellSet = .empty;
+        errdefer result.deinit(alloc);
+
+        const row_slice = self.row_data.slice();
+        const row_raw = row_slice.items(.raw);
+        const row_cells = row_slice.items(.cells);
+
+        for (row_raw, row_cells, 0..) |row, cells, y| {
+            // Row-level shortcut: skip whole rows with no hyperlink cells.
+            if (!row.hyperlink) continue;
+
+            for (0.., cells.items(.raw)) |x, cell| {
+                if (!cell.hyperlink) continue;
+                try result.put(alloc, .{
+                    .y = @intCast(y),
+                    .x = @intCast(x),
+                }, {});
+            }
+        }
+
+        return result;
+    }
 };
 
 test "styled" {
@@ -1293,6 +1328,67 @@ test "linkCells" {
     var cells2 = try state.linkCells(alloc, .{ .x = 4, .y = 0 });
     defer cells2.deinit(alloc);
     try testing.expectEqual(0, cells2.count());
+}
+
+test "allHyperlinkCells empty viewport" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var t = try Terminal.init(alloc, .{
+        .cols = 5,
+        .rows = 2,
+    });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    s.nextSlice("hello");
+
+    var state: RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var cells = try state.allHyperlinkCells(alloc);
+    defer cells.deinit(alloc);
+
+    try testing.expectEqual(0, cells.count());
+}
+
+test "allHyperlinkCells multiple hyperlinks" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var t = try Terminal.init(alloc, .{
+        .cols = 20,
+        .rows = 3,
+    });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+
+    // Three OSC 8 hyperlinks: two on row 0, one on row 1.
+    s.nextSlice("\x1b]8;;http://a\x1b\\AAAA\x1b]8;;\x1b\\ \x1b]8;;http://b\x1b\\BB\x1b]8;;\x1b\\\r\n");
+    s.nextSlice("\x1b]8;;http://c\x1b\\CCC\x1b]8;;\x1b\\");
+
+    var state: RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var cells = try state.allHyperlinkCells(alloc);
+    defer cells.deinit(alloc);
+
+    // 4 (AAAA) + 2 (BB) + 3 (CCC) = 9 hyperlink cells, regardless of URL.
+    try testing.expectEqual(9, cells.count());
+    try testing.expect(cells.contains(.{ .x = 0, .y = 0 }));
+    try testing.expect(cells.contains(.{ .x = 3, .y = 0 }));
+    try testing.expect(cells.contains(.{ .x = 5, .y = 0 }));
+    try testing.expect(cells.contains(.{ .x = 6, .y = 0 }));
+    try testing.expect(cells.contains(.{ .x = 0, .y = 1 }));
+    try testing.expect(cells.contains(.{ .x = 2, .y = 1 }));
+
+    // The space between the two links on row 0 has no hyperlink.
+    try testing.expect(!cells.contains(.{ .x = 4, .y = 0 }));
 }
 
 test "string" {


### PR DESCRIPTION
Staging draft for a planned ghostty-org/ghostty PR.

This branch is `upstream/main` plus the #394 cherry-pick (`79550b8c2`). The "Files changed" view here previews exactly what the upstream submission will look like.

Validated:
- Mac: `zig build test-lib-vt` — 4177/4195 passed, 18 skipped, 0 failed
- Windows: `zig build test-lib-vt` + `dotnet build Ghostty.csproj -p:Platform=x64` clean

See the pinned comment for the do-not-merge / do-not-Update-branch reminder.