### PR TITLE
input: Ctrl+Up/Down chords for jump-to-prompt (OSC 133)

### DIFF
--- a/windows/Ghostty.Core/Input/PaneAction.cs
+++ b/windows/Ghostty.Core/Input/PaneAction.cs
@@ -59,4 +59,12 @@ public enum PaneAction
     // Open the in-pane scrollback search bar. Routed via event to
     // MainWindow which forwards to the active leaf's TerminalControl.
     OpenSearch = 39,
+
+    // OSC 133 prompt navigation. Router dispatches the upstream
+    // jump_to_prompt:N libghostty binding through the existing
+    // injectable Action<string> delegate. Negative N moves to a
+    // previous prompt, positive N to a following one; we only ship
+    // single-step chords for now.
+    JumpToPreviousPrompt = 40,
+    JumpToNextPrompt = 41,
 }

--- a/windows/Ghostty.Core/Input/PaneAction.cs
+++ b/windows/Ghostty.Core/Input/PaneAction.cs
@@ -60,11 +60,9 @@ public enum PaneAction
     // MainWindow which forwards to the active leaf's TerminalControl.
     OpenSearch = 39,
 
-    // OSC 133 prompt navigation. Router dispatches the upstream
-    // jump_to_prompt:N libghostty binding through the existing
-    // injectable Action<string> delegate. Negative N moves to a
-    // previous prompt, positive N to a following one; we only ship
-    // single-step chords for now.
+    // OSC 133 prompt navigation. Router dispatches the
+    // jump_to_prompt:N libghostty binding. Negative N is previous,
+    // positive N is next.
     JumpToPreviousPrompt = 40,
     JumpToNextPrompt = 41,
 }

--- a/windows/Ghostty/Commands/BuiltInCommandSource.cs
+++ b/windows/Ghostty/Commands/BuiltInCommandSource.cs
@@ -61,6 +61,8 @@ internal sealed class BuiltInCommandSource : ICommandSource
         AddBindingCommand(commands, "clear_screen", "Clear Screen", "Clear the terminal screen and scrollback", CommandCategory.Terminal, "\uE894");
         AddBindingCommand(commands, "scroll_to_top", "Scroll to Top", "Jump to the top of scrollback", CommandCategory.Terminal);
         AddBindingCommand(commands, "scroll_to_bottom", "Scroll to Bottom", "Jump to the bottom of scrollback", CommandCategory.Terminal);
+        AddBindingCommand(commands, "jump_to_prompt:-1", "Jump to Previous Prompt", "Scroll to the previous shell prompt (requires OSC 133)", CommandCategory.Terminal);
+        AddBindingCommand(commands, "jump_to_prompt:1", "Jump to Next Prompt", "Scroll to the next shell prompt (requires OSC 133)", CommandCategory.Terminal);
         AddBindingCommand(commands, "open_config", "Open Config", "Open the Ghostty configuration file", CommandCategory.Config, "\uE713");
         AddBindingCommand(commands, "reload_config", "Reload Config", "Reload configuration from disk", CommandCategory.Config, "\uE72C");
 

--- a/windows/Ghostty/Input/KeyBindings.cs
+++ b/windows/Ghostty/Input/KeyBindings.cs
@@ -158,9 +158,8 @@ internal sealed class KeyBindings
         new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, VirtualKey.End, PaneAction.ScrollToBottom),
 
         // OSC 133 prompt navigation. Ctrl+Up/Down steps between
-        // shell prompts in scrollback when the user's shell emits
-        // OSC 133 marks (every Wintty-shipped integration script
-        // does). No-op otherwise.
+        // shell prompts in scrollback in shells that emit OSC 133
+        // prompt marking. No-op otherwise.
         new KeyBinding(VirtualKeyModifiers.Control, VirtualKey.Up, PaneAction.JumpToPreviousPrompt),
         new KeyBinding(VirtualKeyModifiers.Control, VirtualKey.Down, PaneAction.JumpToNextPrompt),
 

--- a/windows/Ghostty/Input/KeyBindings.cs
+++ b/windows/Ghostty/Input/KeyBindings.cs
@@ -157,6 +157,13 @@ internal sealed class KeyBindings
         new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, VirtualKey.Home, PaneAction.ScrollToTop),
         new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, VirtualKey.End, PaneAction.ScrollToBottom),
 
+        // OSC 133 prompt navigation. Ctrl+Up/Down steps between
+        // shell prompts in scrollback when the user's shell emits
+        // OSC 133 marks (every Wintty-shipped integration script
+        // does). No-op otherwise.
+        new KeyBinding(VirtualKeyModifiers.Control, VirtualKey.Up, PaneAction.JumpToPreviousPrompt),
+        new KeyBinding(VirtualKeyModifiers.Control, VirtualKey.Down, PaneAction.JumpToNextPrompt),
+
         // Scrollback search. Ctrl+Shift+F matches Windows Terminal
         // muscle memory; plain Ctrl+F is reserved for in-find inside
         // the Settings raw editor.

--- a/windows/Ghostty/Input/PaneActionRouter.cs
+++ b/windows/Ghostty/Input/PaneActionRouter.cs
@@ -124,6 +124,12 @@ internal sealed class PaneActionRouter
             case PaneAction.ScrollToBottom:
                 _bindingAction?.Invoke("scroll_to_bottom");
                 return;
+            case PaneAction.JumpToPreviousPrompt:
+                _bindingAction?.Invoke("jump_to_prompt:-1");
+                return;
+            case PaneAction.JumpToNextPrompt:
+                _bindingAction?.Invoke("jump_to_prompt:1");
+                return;
 
             // Profile slot chords resolve via the live registry; out-of-range
             // and missing-delegate are silent no-ops.

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1857,6 +1857,7 @@ public sealed partial class MainWindow : Window
             ["clear_screen"] = new() { Name = "clear_screen", Description = "Clear screen and scrollback", RequiresParameter = false },
             ["scroll_to_top"] = new() { Name = "scroll_to_top", Description = "Scroll to top of scrollback", RequiresParameter = false },
             ["scroll_to_bottom"] = new() { Name = "scroll_to_bottom", Description = "Scroll to bottom", RequiresParameter = false },
+            ["jump_to_prompt"] = new() { Name = "jump_to_prompt", Description = "Jump to previous/next shell prompt (OSC 133)", RequiresParameter = true, Parameters = ["-1", "1"] },
             ["open_config"] = new() { Name = "open_config", Description = "Open configuration file", RequiresParameter = false },
             ["reload_config"] = new() { Name = "reload_config", Description = "Reload configuration", RequiresParameter = false },
             ["toggle_fullscreen"] = new() { Name = "toggle_fullscreen", Description = "Toggle fullscreen mode", RequiresParameter = false },


### PR DESCRIPTION
OSS half of OSS roadmap section 4.2. Mainline Ghostty exposes `jump_to_prompt:N` as a binding action (positive N forward, negative N back); this binds it to chords on the Windows side.

### What lands

- `PaneAction.JumpToPreviousPrompt` + `JumpToNextPrompt`
- `PaneActionRouter` cases dispatching `jump_to_prompt:-1` / `jump_to_prompt:1` via the existing injectable `Action<string>` delegate landed in the warmup batch — no new dispatch path
- `Ctrl+Up` → previous prompt, `Ctrl+Down` → next prompt
- Two `BuiltInCommandSource` entries for command palette discoverability

### Behavior

No-op when the shell does not emit OSC 133 marks. With the PowerShell integration that just shipped in # 432 (and the existing bash/zsh/fish scripts), Ctrl+Up walks back through previous shell prompts in scrollback.

### Re-scope note

The WT-style left-margin gutter (visible mark dots, click-to-jump, hover-to-preview) goes beyond Ghostty mainline and was moved to the Pro tier (tracked on the release side).