### PR TITLE
feat(about): credit Wintty alongside the upstream Ghostty notice

### DIFF
--- a/windows/Ghostty.Core/Version/AboutContent.cs
+++ b/windows/Ghostty.Core/Version/AboutContent.cs
@@ -13,11 +13,12 @@ public static class AboutContent
 
     public const string LicenseNote = "MIT License";
 
-    // Year and holders are pinned to the repo LICENSE file, not the current
-    // date: this is the copyright on the work, so it tracks LICENSE and only
-    // changes when that file does. Wintty (the Windows port + its own features)
-    // gets its own line; the upstream Ghostty notice is retained verbatim, as
-    // MIT requires, on the "Based on Ghostty" line.
+    // Two lines: Wintty's own copyright for the Windows port and its added
+    // features, then the upstream Ghostty notice retained verbatim as MIT
+    // requires. Only the "Based on Ghostty" line is pinned to the repo LICENSE
+    // and changes when that file does; the Wintty line is this port's own copy.
+    // The embedded '\n' is intentional: the About TextBlock renders it as a
+    // line break, keeping this value UI-free and unit-testable here in Core.
     public const string Copyright =
         "Wintty (c) 2026 Alessandro De Blasis\n" +
         "Based on Ghostty (c) 2024 Mitchell Hashimoto, Ghostty contributors";

--- a/windows/Ghostty.Core/Version/AboutContent.cs
+++ b/windows/Ghostty.Core/Version/AboutContent.cs
@@ -15,8 +15,12 @@ public static class AboutContent
 
     // Year and holders are pinned to the repo LICENSE file, not the current
     // date: this is the copyright on the work, so it tracks LICENSE and only
-    // changes when that file does.
-    public const string Copyright = "(c) 2024 Mitchell Hashimoto, Ghostty contributors";
+    // changes when that file does. Wintty (the Windows port + its own features)
+    // gets its own line; the upstream Ghostty notice is retained verbatim, as
+    // MIT requires, on the "Based on Ghostty" line.
+    public const string Copyright =
+        "Wintty (c) 2026 Alessandro De Blasis\n" +
+        "Based on Ghostty (c) 2024 Mitchell Hashimoto, Ghostty contributors";
 
     public const string GitHubUrl = "https://github.com/deblasis/wintty";
     public const string DocsUrl = "https://wintty.io/docs";

--- a/windows/Ghostty.Tests/Version/AboutContentTests.cs
+++ b/windows/Ghostty.Tests/Version/AboutContentTests.cs
@@ -38,4 +38,11 @@ public class AboutContentTests
         Assert.Contains("MIT", AboutContent.LicenseNote);
         Assert.Contains("Ghostty contributors", AboutContent.Copyright);
     }
+
+    [Fact]
+    public void Copyright_CreditsWinttyAlongsideUpstream()
+    {
+        Assert.Contains("Wintty", AboutContent.Copyright);
+        Assert.Contains("Based on Ghostty", AboutContent.Copyright);
+    }
 }

--- a/windows/Ghostty/Dialogs/AboutWindow.xaml
+++ b/windows/Ghostty/Dialogs/AboutWindow.xaml
@@ -112,6 +112,8 @@
                     <TextBlock x:Name="CopyrightText"
                                HorizontalAlignment="Center"
                                TextAlignment="Center"
+                               MaxWidth="340"
+                               TextWrapping="Wrap"
                                IsTextSelectionEnabled="True"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                Style="{StaticResource CaptionTextBlockStyle}" />

--- a/windows/Ghostty/Dialogs/AboutWindow.xaml
+++ b/windows/Ghostty/Dialogs/AboutWindow.xaml
@@ -112,7 +112,7 @@
                     <TextBlock x:Name="CopyrightText"
                                HorizontalAlignment="Center"
                                TextAlignment="Center"
-                               MaxWidth="340"
+                               MaxWidth="320"
                                TextWrapping="Wrap"
                                IsTextSelectionEnabled="True"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"


### PR DESCRIPTION
## What
The About window credited only the upstream (MIT / Mitchell Hashimoto / Ghostty contributors) and never attributed Wintty's own work. Add a **Wintty © 2026 Alessandro De Blasis** copyright line and keep the upstream notice verbatim on a **"Based on Ghostty …"** line, as MIT requires. `CopyrightText` wraps so both lines fit the 420px About panel.

## Why
Wintty is a Ghostty-based Windows port with its own additions — the About should say so, while honoring MIT's requirement to retain the original copyright.

## Test plan
`AboutContentTests` still passes (the required `"Ghostty contributors"` substring is preserved). The same change was verified end-to-end in the Pro tier: builds, Ghostty.Tests green, and the two-line credit renders correctly in the About window.