### PR TITLE
a11y: fix what the UIA acceptance harness caught

### DIFF
--- a/windows/Ghostty/Accessibility/TerminalAutomationPeer.cs
+++ b/windows/Ghostty/Accessibility/TerminalAutomationPeer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.InteropServices;
 using Ghostty.Controls;
 using Ghostty.Core.Accessibility;
 using Microsoft.UI.Xaml;
@@ -62,10 +63,22 @@ internal sealed partial class TerminalAutomationPeer
 
     private void OnOwnerUnloaded(object sender, RoutedEventArgs e) => _announceTimer.Stop();
 
+    /// <summary>
+    /// Whether anything is listening. A screen reader sets SPI_GETSCREENREADER,
+    /// but plenty of assistive and automation clients subscribe to UIA events
+    /// without claiming to be one - gating on the flag alone meant those
+    /// clients advised for TextChanged and then never received a single event.
+    /// ListenerExists is the UIA-native answer to "did anyone advise", and it
+    /// is a cheap field read when nobody did.
+    /// </summary>
+    private static bool AnyoneListening() =>
+        ScreenReaderDetector.IsRunning()
+        || AutomationPeer.ListenerExists(AutomationEvents.TextPatternOnTextChanged)
+        || AutomationPeer.ListenerExists(AutomationEvents.TextPatternOnTextSelectionChanged);
+
     private void OnAnnounceTick(object? sender, object e)
     {
-        // Inert unless a screen reader is attached and this surface is active.
-        if (!ScreenReaderDetector.IsRunning() || !_owner.IsActive)
+        if (!AnyoneListening() || !_owner.IsActive)
         {
             _announcer.Reseed(Document.Text);
             // Drop the remembered caret too, so returning to this surface
@@ -169,6 +182,45 @@ internal sealed partial class TerminalAutomationPeer
     /// line of build output.
     /// </summary>
     protected override AutomationLiveSetting GetLiveSettingCore() => AutomationLiveSetting.Polite;
+
+    /// <summary>
+    /// True when this pane is not actually on screen. The default only knows
+    /// about Visibility and clipping, but split zoom parks the non-zoomed panes
+    /// with a Composition Translation rather than collapsing them - a
+    /// SwapChainPanel keeps compositing when collapsed, so zoom moves the tree
+    /// instead. XAML layout cannot see that facade, so without this a parked
+    /// pane reports itself on screen and hands out bounding rectangles for
+    /// pixels the user cannot see.
+    /// </summary>
+    protected override bool IsOffscreenCore()
+    {
+        if (base.IsOffscreenCore()) return true;
+
+        DependencyObject? node = _owner;
+        while (node is not null)
+        {
+            if (node is UIElement e && IsTranslatedAway(e)) return true;
+            node = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(node);
+        }
+        return false;
+    }
+
+    private static bool IsTranslatedAway(UIElement e)
+    {
+        try
+        {
+            var visual = Microsoft.UI.Xaml.Hosting.ElementCompositionPreview.GetElementVisual(e);
+            return visual.Properties.TryGetVector3("Translation", out var t)
+                       == Microsoft.UI.Composition.CompositionGetValueStatus.Succeeded
+                   && (Math.Abs(t.X) > 0.5f || Math.Abs(t.Y) > 0.5f);
+        }
+        catch (COMException)
+        {
+            // The visual is gone mid-teardown; treat that as "not parked" and
+            // let the ordinary offscreen rules decide.
+            return false;
+        }
+    }
 
     protected override object GetPatternCore(PatternInterface patternInterface)
         => patternInterface is PatternInterface.Text or PatternInterface.Text2 or PatternInterface.Value

--- a/windows/Ghostty/Accessibility/TerminalAutomationPeer.cs
+++ b/windows/Ghostty/Accessibility/TerminalAutomationPeer.cs
@@ -282,6 +282,12 @@ internal sealed partial class TerminalAutomationPeer
     /// element holding this caret has keyboard focus": reporting a constant
     /// true would tell a screen reader that a background pane's caret is the
     /// live one.
+    ///
+    /// Note that WinUI does NOT carry this out-parameter across to a native UIA
+    /// client - proven by forcing it to false unconditionally and watching a
+    /// real client still read 1, with S_OK, for a backgrounded window. We keep
+    /// computing it honestly so the value is right the day the projection
+    /// starts honouring it, but nothing downstream can rely on it today.
     /// </summary>
     public ITextRangeProvider GetCaretRange(out bool isActive)
     {

--- a/windows/Ghostty/Accessibility/TerminalTextRangeProvider.cs
+++ b/windows/Ghostty/Accessibility/TerminalTextRangeProvider.cs
@@ -69,6 +69,11 @@ internal sealed partial class TerminalTextRangeProvider : ITextRangeProvider
             return ColorAttribute(fg: true);
         if (attributeId == (int)AutomationTextAttributesEnum.BackgroundColorAttribute)
             return ColorAttribute(fg: false);
+        // The grid is not editable through UIA. Answering NotSupported let a
+        // client assume the text might be typeable and offer editing affordances
+        // over a surface that only accepts keystrokes through the shell.
+        if (attributeId == (int)AutomationTextAttributesEnum.IsReadOnlyAttribute)
+            return true;
         return UiaReservedValues.NotSupported()!;
     }
 
@@ -107,9 +112,15 @@ internal sealed partial class TerminalTextRangeProvider : ITextRangeProvider
 
     public int Move(WinTextUnit unit, int count)
     {
-        // Collapse to the start, move that endpoint, then expand by one unit.
+        var wasDegenerate = _span.IsDegenerate;
+        // Collapse to the start, move that endpoint, then expand by one unit -
+        // unless the range was already empty. UIA requires a degenerate range
+        // to stay degenerate across Move: it is a caret, and expanding it would
+        // turn every caret step into a one-unit selection.
         var (offset, moved) = TextRangeNavigator.MoveEndpointByUnit(Doc, _span.Start, MapUnit(unit), count);
-        _span = TextRangeNavigator.ExpandToEnclosingUnit(Doc, new TextSpan(offset, offset), MapUnit(unit));
+        _span = wasDegenerate
+            ? new TextSpan(offset, offset)
+            : TextRangeNavigator.ExpandToEnclosingUnit(Doc, new TextSpan(offset, offset), MapUnit(unit));
         return moved;
     }
 

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -1010,7 +1010,14 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         var env = XamlRoot?.ContentIslandEnvironment;
         if (env is null) return false;
         nint mine = Microsoft.UI.Win32Interop.GetWindowFromWindowId(env.AppWindowId);
-        return mine != 0 && mine == PInvoke.GetForegroundWindow();
+        if (mine == 0 || mine != PInvoke.GetForegroundWindow()) return false;
+        // Foreground is not enough. Windows does not hand the foreground to
+        // anyone else when a window is minimised and nothing else activates, so
+        // GetForegroundWindow keeps naming a window the user cannot see -
+        // measured: minimise, and it still reports itself foreground several
+        // seconds later. A minimised surface is not one the user is looking at,
+        // which is the whole claim this property makes.
+        return !PInvoke.IsIconic(new Windows.Win32.Foundation.HWND(mine));
     }
 
     // Stable per-surface key for the toast Group (dedupe + focus-regain

--- a/windows/Ghostty/NativeMethods.txt
+++ b/windows/Ghostty/NativeMethods.txt
@@ -16,6 +16,7 @@ FLASHWINFO_FLAGS
 GetCursorPos
 GetDpiForWindow
 GetForegroundWindow
+IsIconic
 GetKeyState
 GetMonitorInfo
 GetSystemMenu


### PR DESCRIPTION
`uiatest` ran end to end for the first time (it needs an unlocked interactive desktop, which is why it never had). It scored **60 passed / 8 failed** against # 569, and six of those eight were real defects in the peer.

**68 passed, 0 failed** after this branch. For context, the harness was **12/18 on `main`** and 39/17 after the pin advance - it has not been a working gate for some time.

## Peer defects

- **Events reached only screen readers.** The announce tick was gated on `SPI_GETSCREENREADER` alone, so a UIA client could advise for `TextChanged` and never receive a single event. Now gated on that flag *or* `ListenerExists`, which is the UIA-native answer to "did anyone advise".
- **`Move` broke the caret.** It expanded a degenerate range by one unit, so a caret stopped being a caret the moment a client moved it. UIA requires an empty range to stay empty across `Move`.
- **`IsReadOnly` answered NotSupported.** The grid is not editable through UIA; saying so lets a client stop offering editing affordances.
- **Zoom-parked panes reported themselves visible.** Split zoom moves the non-zoomed tree with a Composition Translation rather than collapsing it (a SwapChainPanel keeps compositing when collapsed), and XAML layout cannot see that facade - so the peer handed out bounding rectangles for pixels nobody can see. `IsOffscreenCore` now walks for it.
- **A minimised window still reported itself active.** `GetForegroundWindow` keeps naming a minimised window when nothing else activates - measured from the announce tick, `fgMatch` stayed true indefinitely. `IsIconic` closes it.

## A framework limitation, proven

**WinUI does not propagate `GetCaretRange`'s `isActive` out-parameter to a native UIA client.** Forced the provider to write `false` unconditionally; a real client still read `1`, `hr=S_OK`, for both a focused and a backgrounded window. The satellite could honour it because it wrote the `BOOL` into the caller's buffer itself - a projected peer hands its `bool` to the framework and the framework drops it.

The peer keeps computing it honestly so the value is right the day the projection starts honouring it, but the code now says plainly that nothing downstream can rely on it. **This also means the `isActive=1` line I quoted as verification in # 569 was meaningless** - it reads 1 regardless.

## Two harness bugs, not product bugs

- **`IsRowOfToken` assumed padded rows.** It divided a flat index by a fixed column count; its own comment warned it "leans on rows being exactly Cols chars" and would "fail loudly rather than decay into a substring test that always passes". That held for the satellite, which padded every row - `read_text` trims trailing blanks. It now walks the rows' real lengths, which still spans a wrapped line.
- **`Minimize` asserted before its precondition held.** `ShowWindow(SW_MINIMIZE)` returns long before another process can observe it - measured at 1-2s here against a fixed 1000ms sleep. It now polls until the window really is iconic and no longer foreground.

Harness changes live in the release repo.

1724 tests pass.