### PR TITLE
windows: bake the AUMID in per tier and variant

### DIFF
--- a/windows/Ghostty.Core/AppIdentity.cs
+++ b/windows/Ghostty.Core/AppIdentity.cs
@@ -18,8 +18,16 @@ internal static class AppIdentity
     /// already-scheduled toasts from the app, and Windows offers no
     /// migration for that, so treat a change as a one-off break rather
     /// than a rename that follows the brand.
+    ///
+    /// Baked in at build time rather than written here, because every
+    /// tier and variant needs its own: the Shell merges installs that
+    /// share an AUMID into one taskbar button whatever their pack id
+    /// says. The public build gets the default below; wintty-release
+    /// overrides <c>_WinttyAumId</c> per variant. It stays a
+    /// <see langword="const"/> so call sites can keep using it in
+    /// constant contexts and nothing reflects at startup.
     /// </summary>
-    public const string AumId = "com.deblasis.wintty";
+    public const string AumId = Ghostty.Core.Version.BuildInfo.AumId;
 
     /// <summary>
     /// Brand name for what a user reads: window and tab titles, dialog

--- a/windows/Ghostty.Core/Ghostty.Core.csproj
+++ b/windows/Ghostty.Core/Ghostty.Core.csproj
@@ -154,6 +154,21 @@
       <!-- Escape backslash first, then double-quote, so an arbitrary BuildLabel
            stays a valid C# string literal in the generated source. -->
       <_WinttyBuildLabel>$(BuildLabel.Replace('\','\\').Replace('"','\"'))</_WinttyBuildLabel>
+      <!--
+        The Shell's identity key for this build. Windows groups taskbar
+        buttons, jump lists and toasts by AUMID, so two installs sharing
+        one string merge into a single app in the shell no matter how
+        they were packaged. Baking it in here rather than hardcoding it
+        in AppIdentity lets each tier AND each variant carry its own,
+        which is the only way Pro Desktop and Pro Enterprise can differ:
+        they are one tier off one patch series, split only by ProVariant,
+        so nothing patch-shaped can tell them apart.
+
+        Overridable so wintty-release can set it per variant. The default
+        is what the public build ships. Escaped like BuildLabel above.
+      -->
+      <_WinttyAumId Condition="'$(_WinttyAumId)' == ''">com.deblasis.wintty</_WinttyAumId>
+      <_WinttyAumId>$(_WinttyAumId.Replace('\','\\').Replace('"','\"'))</_WinttyAumId>
     </PropertyGroup>
 
     <ItemGroup>
@@ -166,6 +181,7 @@
       <_BuildInfoLines Include="    public const string WinttyCommit = &quot;$(_WinttyCommit)$(_WinttyCommitDirty)&quot;%3B"/>
       <_BuildInfoLines Include="    public const string MsbuildConfig = &quot;$(Configuration)&quot;%3B"/>
       <_BuildInfoLines Include="    public const string BuildLabel = &quot;$(_WinttyBuildLabel)&quot;%3B"/>
+      <_BuildInfoLines Include="    public const string AumId = &quot;$(_WinttyAumId)&quot;%3B"/>
       <_BuildInfoLines Include="    public const Edition Edition = Edition.Oss%3B"/>
       <_BuildInfoLines Include="}"/>
     </ItemGroup>

--- a/windows/Ghostty.Tests/AppIdentityTests.cs
+++ b/windows/Ghostty.Tests/AppIdentityTests.cs
@@ -1,0 +1,53 @@
+using Ghostty.Core;
+using Ghostty.Core.Version;
+using Xunit;
+
+namespace Ghostty.Tests;
+
+/// <summary>
+/// The AUMID is baked in per tier and variant, so these assert the shape
+/// of whatever the build produced rather than one fixed string. Only the
+/// OSS default is pinned to an exact value, guarded on the edition, so a
+/// wintty-release build overriding it does not have to patch this file.
+/// </summary>
+public sealed class AppIdentityTests
+{
+    [Fact]
+    public void AumId_ComesFromTheBuild()
+    {
+        Assert.Equal(BuildInfo.AumId, AppIdentity.AumId);
+    }
+
+    [Fact]
+    public void AumId_IsNotEmpty()
+    {
+        Assert.False(string.IsNullOrWhiteSpace(AppIdentity.AumId));
+    }
+
+    [Fact]
+    public void AumId_HasNoWhitespace()
+    {
+        // SetCurrentProcessExplicitAppUserModelID rejects whitespace, and a
+        // build-time override is the kind of place a stray space arrives.
+        Assert.DoesNotContain(AppIdentity.AumId, char.IsWhiteSpace);
+    }
+
+    [Fact]
+    public void AumId_FitsTheShellLimit()
+    {
+        // Windows caps an AppUserModelID at 128 characters.
+        Assert.True(AppIdentity.AumId.Length <= 128, $"AUMID is {AppIdentity.AumId.Length} chars: {AppIdentity.AumId}");
+    }
+
+    [Fact]
+    public void AumId_DefaultsToTheUnsuffixedIdInAnOssBuild()
+    {
+        // Edition is a compile-time constant, so this folds away rather than
+        // branching. Written as a guarded assert, not an early return, since
+        // the return would be unreachable code in an OSS build (CS0162).
+        if (BuildInfo.Edition == Edition.Oss)
+        {
+            Assert.Equal("com.deblasis.wintty", AppIdentity.AumId);
+        }
+    }
+}


### PR DESCRIPTION
Windows groups taskbar buttons, jump lists and toasts by AppUserModelID. With the AUMID written as a literal in `AppIdentity`, every tier shipped the same one, so installing two flavours side by side collapsed them into a single taskbar button.

The value now comes from `BuildInfo`, next to `Edition` and `BuildLabel`, which is where this tree already puts build-time constants and where the release build already patches per-tier values.

```csharp
public const string AumId = Ghostty.Core.Version.BuildInfo.AumId;
```

Still a `const`, so `App.xaml.cs` keeps using it in a constant context, nothing reflects at startup, and `Ghostty.Core`'s AOT analyzer stays quiet.

## Why MSBuild and not a patch

Pro Desktop and Pro Enterprise are the same tier: one pin, one patch series, separated only by `ProVariant`. Nothing patch-shaped can tell them apart, so a per-tier patch could never give them distinct identities.

## No behaviour change here

The public default is unchanged at `com.deblasis.wintty`. The release build overrides `_WinttyAumId` for the Pro variants once the pin moves. Sponsor ships pack id `Wintty` and inherits the default, so only the three Pro variants need an override.

## Tests

They assert the shape of whatever the build produced, not one fixed string, so a tier build overriding the value does not have to patch them: comes from the build, non-empty, no whitespace, within the 128 character shell limit. Only the exact OSS default is pinned, guarded on `Edition`.

That guard is a wrapped assert rather than an early return, because `Edition` is a compile-time constant and the return would be unreachable (CS0162).

## Verification

1776 passed, 1 skipped. Override confirmed to reach the generated constant:

```
default                                            -> "com.deblasis.wintty"
-p:_WinttyAumId=com.deblasis.wintty.pro.enterprise -> "com.deblasis.wintty.pro.enterprise"
```