### PR TITLE
Surface: fix leaks on init error paths

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -523,6 +523,7 @@ pub fn init(
         &derived_config.font,
         font_size,
     );
+    errdefer app.font_grid_set.deref(font_grid_key);
 
     // Build our size struct which has all the sizes we need.
     const size: rendererpkg.Size = size: {
@@ -554,14 +555,24 @@ pub fn init(
 
     // Create our terminal grid with the initial size
     const app_mailbox: App.Mailbox = .{ .rt_app = rt_app, .mailbox = &app.mailbox };
-    var renderer_impl = try Renderer.init(alloc, .{
-        .config = try .init(alloc, config),
-        .font_grid = font_grid,
-        .size = size,
-        .surface_mailbox = .{ .surface = self, .app = app_mailbox },
-        .rt_surface = rt_surface,
-        .thread = &self.renderer_thread,
-    });
+    // The derived config is built inside this block so its errdefer covers
+    // only the window before Renderer.init takes ownership. Renderer.init
+    // does not clean the config up on its own failure paths, so passing an
+    // inline `try .init(...)` would leak the arena; leaving the errdefer at
+    // function scope would instead double free it alongside renderer_impl.
+    var renderer_impl = renderer: {
+        var renderer_config: Renderer.DerivedConfig = try .init(alloc, config);
+        errdefer renderer_config.deinit();
+
+        break :renderer try Renderer.init(alloc, .{
+            .config = renderer_config,
+            .font_grid = font_grid,
+            .size = size,
+            .surface_mailbox = .{ .surface = self, .app = app_mailbox },
+            .rt_surface = rt_surface,
+            .thread = &self.renderer_thread,
+        });
+    };
     errdefer renderer_impl.deinit();
 
     // The mutex used to protect our renderer state.
@@ -674,10 +685,15 @@ pub fn init(
         var io_mailbox = try termio.Mailbox.initSPSC(alloc);
         errdefer io_mailbox.deinit(alloc);
 
+        // Same reasoning as the renderer config above: Termio.init only
+        // takes ownership once it succeeds.
+        var io_config: termio.Termio.DerivedConfig = try .init(alloc, config);
+        errdefer io_config.deinit();
+
         try termio.Termio.init(&self.io, alloc, .{
             .size = size,
             .full_config = config,
-            .config = try termio.Termio.DerivedConfig.init(alloc, config),
+            .config = io_config,
             .backend = .{ .exec = io_exec },
             .mailbox = io_mailbox,
             .renderer_state = &self.renderer_state,


### PR DESCRIPTION
Three allocations in `Surface.init` are not released when a later step fails. Surface creation is recoverable (the apprt reports the error and the app keeps running), so each failure retains memory for the life of the process.

**The font grid reference has no matching deref.** `app.font_grid_set.ref(...)` increments a refcount, and nothing in `init` releases it on the error paths. Any failure after that call leaves the count above zero, so the `SharedGrid` and its atlases are never freed and the map entry is never removed, even after every real surface using that font config has closed. `setFontSize` already registers exactly this errdefer around the same call.

**Two derived configs are built inline as call arguments.** `Renderer.init` and `Termio.init` both receive `.config = try .init(alloc, config)`. Each stores it only on success and neither unwinds it on its own failure paths, so a failure inside either leaks an arena. `Renderer.init` can fail in graphics API, swapchain or shaper setup; `Termio.init` can fail in `Terminal.init`.

Each is now a local guarded by an errdefer scoped to the window before ownership transfers. The scoping matters for the renderer one: at function scope that errdefer would double free the config alongside `renderer_impl`, so it is confined to a block that ends once `Renderer.init` returns. The termio one is already inside a block whose last statement is `Termio.init`.

Reachability is ordinary rather than exotic: a bad `command` in the config, a failing GPU init, or pty spawn failure all take these paths.

## Testing

`zig build test` on macOS: 3349/3365 passed, 16 skipped, no failures. The one failing build step is `xcodebuild test` aborting on `childPID > 0`, which fails identically on the parent commit; that machine has no codesigning certificate.

## Not included

`Surface.init` has a related defect I have deliberately left out. Its errdefers stay live past `std.Thread.spawn` for the renderer and IO threads, so a failure after that point deinits state the running threads are still reading, with no stop-notify or join. `Thread.deinit` documents that the caller must join first. On this branch the only reachable trigger is the IO thread spawn failing while the renderer thread is live, since `set_title` cannot fail on either apprt. The fix needs teardown-ordering judgment rather than an errdefer, so it seemed better raised separately.
