### PR TITLE
windows: stop callbacks landing on a window that has closed

### DIFF
--- a/windows/Ghostty.Tests/Wiring/ShellSource.cs
+++ b/windows/Ghostty.Tests/Wiring/ShellSource.cs
@@ -52,8 +52,35 @@ internal sealed class ShellSource
 
         using var stream = asm.GetManifestResourceStream(matches[0])!;
         using var reader = new StreamReader(stream);
-        var tree = CSharpSyntaxTree.ParseText(reader.ReadToEnd());
-        return new ShellSource((CompilationUnitSyntax)tree.GetRoot());
+        // Conditional regions are invisible with default parse options:
+        // Roslyn keeps them as disabled trivia, so anything inside `#if DEMO`
+        // is simply absent from the tree. That is not a gap a census can live
+        // with, because it reports full coverage of a file it only partly
+        // read, and DEMO is a configuration that ships.
+        //
+        // Defining the symbol reveals that branch. It cannot be the whole
+        // answer, because it hides the other one: an `#else` or `#if !DEMO`
+        // becomes the disabled region instead. So the assertion below refuses
+        // any tree that still has disabled text, which turns adding a new
+        // conditional into a decision someone has to make rather than a
+        // silent widening of the blind spot.
+        var options = new CSharpParseOptions(preprocessorSymbols: new[] { "DEMO" });
+        var tree = CSharpSyntaxTree.ParseText(reader.ReadToEnd(), options);
+        var root = (CompilationUnitSyntax)tree.GetRoot();
+
+        var hidden = root.DescendantTrivia()
+            .Where(t => t.IsKind(SyntaxKind.DisabledTextTrivia))
+            .Select(t => tree.GetLineSpan(t.Span).StartLinePosition.Line + 1)
+            .ToList();
+        Assert.True(
+            hidden.Count == 0,
+            $"{dottedTail} has conditional regions this parse cannot see, at line(s) "
+                + string.Join(", ", hidden)
+                + ". Every scan over this file silently skips them. Either define the "
+                + "symbol that enables them here, or restructure so the code is not "
+                + "hidden from the wiring tests.");
+
+        return new ShellSource(root);
     }
 
     // MSBuild substitutes the host's directory separator into the logical

--- a/windows/Ghostty.Tests/Wiring/WindowTeardownWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/WindowTeardownWiringTests.cs
@@ -1,0 +1,407 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// Every event MainWindow subscribes to, checked against what its close
+/// takes back.
+///
+/// Four separate callbacks accumulated behind this gap -- an OS colour-scheme
+/// handler calling into libghostty through the app pointer the close is about
+/// to free, and three dispatcher-driven timers nothing stopped -- and each was
+/// found by hand, one at a time, because nothing enumerated the subscriptions
+/// against the unsubscribe list. Sixty-odd `+=` against a handful of `-=` is
+/// not a list anyone re-reads.
+///
+/// The discrimination that matters is who owns the event source:
+///
+///   - A source that outlives the window -- the OS, an app-level service, a
+///     static event, a timer the window created but the dispatcher drives --
+///     keeps calling after Window.Closed, and keeps the closed window alive
+///     while it does. It must be unsubscribed in OnClosedAsync, or its handler
+///     must return early on _isClosed.
+///   - A source the window itself owns and that dies with it -- its own XAML
+///     elements, its per-window services, its pane tree -- needs neither.
+///
+/// There is no semantic model here (see ShellSource), so ownership cannot be
+/// inferred; it has to be declared. <see cref="WindowOwned"/> is that
+/// declaration, and it is an allow-list rather than a list of sources known to
+/// need proof, because the failure mode being defended against is a
+/// subscription NOBODY classified. A deny-list is silent on the receiver
+/// introduced next week, which is precisely how these four arrived. An
+/// allow-list makes the new receiver fail until someone writes down which side
+/// of the line it falls on, and that sentence is the whole product of this
+/// test.
+///
+/// What it cannot see: whether a gated handler's gate covers the turns after
+/// an await, whether an unsubscribe runs on every path through OnClosedAsync,
+/// and every subscription made outside this file. It is a census, not a proof
+/// of safety. The per-case guards below carry the reasoning those need.
+/// </summary>
+public class WindowTeardownWiringTests
+{
+    private static ShellSource Window() => ShellSource.Load("Ghostty.MainWindow.xaml.cs");
+
+    /// <summary>
+    /// Receivers whose events die with the window, and why. Adding a line here
+    /// is meant to cost a decision: the claim is that when this window is gone
+    /// nothing can raise the event again, so neither an unsubscribe nor a gate
+    /// buys anything.
+    /// </summary>
+    private static readonly (string Receiver, string Why)[] WindowOwned =
+    {
+        ("this", "the Window's own events; the window raises them and stops when it does"),
+        ("fe", "this window's XAML content root"),
+        ("CommandPalettePopup", "named element of MainWindow.xaml"),
+        ("TabOverviewHost", "named element of MainWindow.xaml"),
+        ("TabOverviewUI", "named element of MainWindow.xaml"),
+        ("_commandPaletteVm", "per-window view model, constructed and held only by this window"),
+        ("_router", "per-window keybind router, constructed by this window"),
+        // Judged against when the surfaces stop being routed to, not against
+        // Dispose: GhosttyHost.Dispose is the last statement of the close, so
+        // these stay attached across the whole teardown. What makes them safe
+        // is that libghostty routes them from surface input, which a closing
+        // window no longer receives.
+        ("_host", "this window's own GhosttyHost; its events are raised from surface input, "
+                  + "which a closing window no longer receives"),
+        ("_tabManager", "this window's own TabManager"),
+        ("_themeManager", "per-window; OnClosedAsync disposes it before the first await, "
+                          + "and WindowThemeManager.Dispose nulls ThemeChanged"),
+        ("seedHost.ActiveLeaf.Terminal()", "a leaf of this window's pane tree; "
+                                           + "OnLaunchSurfaceFirstRender detaches itself on the first fire"),
+        ("paneHost", "a pane host of this window; RemovePaneHost detaches it"),
+        ("tab.PaneHost", "a pane host of this window; DetachProcessTracking detaches it"),
+        ("((INotifyPropertyChanged)tab)", "a tab model of this window; UnwireTabColor detaches it"),
+        ("newWindow", "another window's Closed, handled by App, holding nothing of this window"),
+        ("aboutWin", "the About window, which OnClosedAsync closes before it tears anything down"),
+        ("window", "the inspector window, which OnClosedAsync closes; its Closed handler "
+                   + "detaches the two subscriptions taken out alongside it"),
+    };
+
+    /// <summary>
+    /// Individual events on sources that DO outlive the window and are still
+    /// left attached, each with the reason detaching or gating would be wrong.
+    /// Spelled as whole events, not receivers, so the rest of the receiver
+    /// stays under the rule.
+    /// </summary>
+    private static readonly (string Event, string Why)[] Exempt =
+    {
+        ("AppWindow.Closing", "runs during the close by design: it is what turns a quake close "
+                              + "into a hide. _isClosed is still false when it fires"),
+        // These two are exempt because a gate is the wrong instrument, not
+        // because they are harmless. The subscription is guarded on seedTab
+        // being null, and only the tab-adoption path passes one, so the
+        // cold-start window, the quake window and every restored or reopened
+        // window all subscribe: the action runs once per window, and each
+        // closure captures this window and keeps it rooted on the bootstrap
+        // host for the life of the process. Detaching on close would leave a
+        // multi-window session with nobody handling the action at all. The fix
+        // is to own these where the bootstrap host lives rather than per
+        // window, which is a behaviour change and is filed separately.
+        ("appHost.OpenConfigRequested", "every non-adopted window subscribes; duplicate execution "
+                                        + "and a per-window leak, fixed by moving ownership to App "
+                                        + "rather than by a gate"),
+        ("appHost.ReloadConfigRequested", "same ownership problem as OpenConfigRequested"),
+    };
+
+    private sealed record Subscription(string Event, string Receiver, string Handler, ExpressionSyntax Rhs);
+
+    /// <summary>All whitespace removed, so an event or handler wrapped across
+    /// lines compares equal to the same one written inline.</summary>
+    private static string Flatten(SyntaxNode node) =>
+        new string(node.ToString().Where(c => !char.IsWhiteSpace(c)).ToArray());
+
+    /// <summary>
+    /// The receiver an event is reached through, as the source spells it, or
+    /// "this" for a bare event name.
+    /// </summary>
+    private static string ReceiverOf(ExpressionSyntax left) =>
+        left is MemberAccessExpressionSyntax member ? Flatten(member.Expression) : "this";
+
+    /// <summary>
+    /// Compound assignment is also arithmetic, so the right-hand side decides:
+    /// a handler is a lambda, a method group, a qualified method group, or an
+    /// explicitly constructed delegate, and nothing else is counted.
+    /// </summary>
+    private static bool IsHandler(ExpressionSyntax rhs) =>
+        rhs is LambdaExpressionSyntax
+            or IdentifierNameSyntax
+            or MemberAccessExpressionSyntax
+            or ObjectCreationExpressionSyntax
+        || (rhs is ParenthesizedExpressionSyntax paren && IsHandler(paren.Expression));
+
+    private static List<Subscription> Assignments(SyntaxNode scope, SyntaxKind kind) =>
+        scope.DescendantNodes()
+            .OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.IsKind(kind) && IsHandler(a.Right))
+            .Select(a => new Subscription(Flatten(a.Left), ReceiverOf(a.Left), Flatten(a.Right), a.Right))
+            .ToList();
+
+    private static List<Subscription> Subscriptions() =>
+        Assignments(Window().Root, SyntaxKind.AddAssignmentExpression);
+
+    private static List<Subscription> Unsubscribes() =>
+        Assignments(Window().Method("OnClosedAsync"), SyntaxKind.SubtractAssignmentExpression);
+
+    /// <summary>
+    /// <c>if (_isClosed) ... return;</c> and nothing that merely mentions the
+    /// field: an inverted or dead condition is a different syntax shape and
+    /// does not match. Deliberately the same shape TabLayoutSwitchWiringTests
+    /// pins on the layout-switch completion -- the two have to agree on what
+    /// counts as a gate, or the file grows two kinds.
+    /// </summary>
+    private static bool IsClosedGuard(StatementSyntax statement) =>
+        statement is IfStatementSyntax { Condition: IdentifierNameSyntax { Identifier.Text: "_isClosed" } } guard
+        && guard.Statement.DescendantNodesAndSelf().OfType<ReturnStatementSyntax>().Any();
+
+    /// <summary>
+    /// Whether the handler bails once teardown has started, looking only at
+    /// the handler's own top-level statements. A gate buried inside another
+    /// branch guards that branch, not the handler, and a gate one call deeper
+    /// is a fact about the callee that this cannot see.
+    /// </summary>
+    private static bool IsGated(Subscription subscription, ShellSource source)
+    {
+        var body = subscription.Rhs switch
+        {
+            // An expression-bodied lambda has no statement to gate on.
+            LambdaExpressionSyntax lambda => lambda.Block,
+            // A method group: read the method it names. Overloaded or absent,
+            // there is no single body to read and nothing is proven.
+            IdentifierNameSyntax name => Bodies(source, name.Identifier.ValueText) is [var only]
+                ? only
+                : null,
+            _ => null,
+        };
+        if (body is null) return false;
+
+        // Position matters, not mere presence: a gate below the work it is
+        // meant to prevent reads as present while the handler still runs
+        // against freed state on every tick, and that shape satisfies an
+        // Any() check.
+        //
+        // Requiring it to be statement zero is too strong, though. Stopping
+        // the timer first, or bailing out because this tick belongs to a
+        // superseded one, are both legitimate and neither can touch anything
+        // the gate protects. So the rule is that the gate must come before
+        // the first statement that does work, where a preceding early-return
+        // guard or a Stop call is not work.
+        var statements = body.Statements;
+        var gate = statements.Select((st, i) => (st, i)).FirstOrDefault(x => IsClosedGuard(x.st));
+        if (gate.st is null) return false;
+
+        var firstWorking = statements.TakeWhile(IsPrelude).Count();
+        return gate.i <= firstWorking;
+    }
+
+    /// <summary>
+    /// A statement that cannot touch what the teardown gate protects: an
+    /// early-return guard, or stopping a timer.
+    /// </summary>
+    private static bool IsPrelude(StatementSyntax statement)
+    {
+        if (statement is IfStatementSyntax guard)
+            return guard.DescendantNodesAndSelf().OfType<ReturnStatementSyntax>().Any();
+
+        return statement is ExpressionStatementSyntax { Expression: InvocationExpressionSyntax call }
+            && call.CalleeText().EndsWith(".Stop", StringComparison.Ordinal);
+    }
+
+    private static List<BlockSyntax?> Bodies(ShellSource source, string method)
+    {
+        return source.Root.DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .Where(m => m.Identifier.ValueText == method)
+            .Select(m => m.Body)
+            .ToList();
+    }
+
+    [Fact]
+    public void EverySubscriptionIsOwnedByTheWindowOrSurvivesItsClose()
+    {
+        var source = Window();
+        var subscriptions = Subscriptions();
+
+        // Load-bearing. Every assertion below is over this list, so a query
+        // that stops matching passes the whole test while reading nothing.
+        Assert.True(
+            subscriptions.Count > 40,
+            $"expected MainWindow's event subscriptions to be found, got {subscriptions.Count}");
+
+        var owned = WindowOwned.Select(x => x.Receiver).ToHashSet(StringComparer.Ordinal);
+        var exempt = Exempt.Select(x => x.Event).ToHashSet(StringComparer.Ordinal);
+        var detached = Unsubscribes()
+            .Select(u => (u.Event, u.Handler))
+            .ToHashSet();
+
+        // The pair, not the event alone: MainWindow attaches two different
+        // handlers to _configService.ConfigChanged, and matching on the event
+        // would let either `-=` answer for both.
+        var mustProve = subscriptions
+            .Where(s => !owned.Contains(s.Receiver) && !exempt.Contains(s.Event))
+            .ToList();
+        var unproven = mustProve
+            .Where(s => !detached.Contains((s.Event, s.Handler)) && !IsGated(s, source))
+            .Select(s => s.Event)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        Assert.True(
+            unproven.Count == 0,
+            "these subscriptions are to sources that outlive the window and are neither "
+            + "unsubscribed in OnClosedAsync nor gated on _isClosed, so they keep firing at, and "
+            + "keep alive, a window that is tearing down: "
+            + string.Join(", ", unproven)
+            + ". Unsubscribe it, gate the handler on _isClosed, or -- if the receiver really does "
+            + "die with the window -- add it to WindowOwned with the reason.");
+
+        // Both ways of satisfying the rule have to be live. Without this, a
+        // regression that classified everything as detached (or everything as
+        // gated) would leave the other branch untested and silently rotten.
+        Assert.Contains(mustProve, s => detached.Contains((s.Event, s.Handler)));
+        Assert.Contains(mustProve, s => IsGated(s, source));
+    }
+
+    /// <summary>
+    /// The allow-list has to stay a description of the file. An entry whose
+    /// receiver no longer subscribes to anything is a claim nobody is checking,
+    /// and the next receiver to be spelled that way inherits an exemption
+    /// nobody granted it.
+    /// </summary>
+    [Fact]
+    public void TheOwnershipDeclarationsStillDescribeTheFile()
+    {
+        var subscriptions = Subscriptions();
+        var receivers = subscriptions.Select(s => s.Receiver).ToHashSet(StringComparer.Ordinal);
+        var events = subscriptions.Select(s => s.Event).ToHashSet(StringComparer.Ordinal);
+
+        var staleOwners = WindowOwned.Where(x => !receivers.Contains(x.Receiver)).Select(x => x.Receiver);
+        var staleExempt = Exempt.Where(x => !events.Contains(x.Event)).Select(x => x.Event);
+        var stale = staleOwners.Concat(staleExempt).ToList();
+
+        Assert.True(
+            stale.Count == 0,
+            "these entries no longer match any subscription in MainWindow and should be removed, "
+            + "so the list keeps meaning what it says: " + string.Join(", ", stale));
+
+        Assert.All(WindowOwned, x => Assert.False(string.IsNullOrWhiteSpace(x.Why)));
+        Assert.All(Exempt, x => Assert.False(string.IsNullOrWhiteSpace(x.Why)));
+    }
+
+    /// <summary>
+    /// The OS colour-scheme handler, pinned on its own because the census above
+    /// is satisfied by either half and this one needs both.
+    ///
+    /// Unsubscribing is what stops UISettings calling and what stops it holding
+    /// the closed window. It is not enough on its own: the handler hops to the
+    /// dispatcher, so a flip that arrives just before the close leaves the real
+    /// work queued for a later turn, and by then _host.Dispose has freed the app
+    /// pointer AppSetColorScheme is handed. The gate inside the enqueued body is
+    /// the only thing that turns that one away.
+    /// </summary>
+    [Fact]
+    public void TheSystemColorSchemeHandlerIsBothDetachedAndGated()
+    {
+        var source = Window();
+        const string Event = "_systemUiSettings.ColorValuesChanged";
+        const string Handler = "OnSystemColorValuesChanged";
+
+        // Named, not inline: an anonymous lambda cannot be unsubscribed at all.
+        var subscribed = Subscriptions().Where(s => s.Event == Event).ToList();
+        Assert.True(
+            subscribed.Count == 1 && subscribed[0].Handler == Handler,
+            $"expected one `{Event} += {Handler}`; a lambda here cannot be detached");
+        Assert.Contains((Event, Handler), Unsubscribes().Select(u => (u.Event, u.Handler)));
+
+        var method = source.Method(Handler);
+        Assert.True(
+            method.Body!.Statements.Any(IsClosedGuard),
+            $"{Handler} must bail on _isClosed before it reads anything");
+
+        // The enqueued body is the half that runs late, and it is a separate
+        // scope: the entry gate above says nothing about the turn it runs on.
+        var enqueued = method.Call("DispatcherQueue.TryEnqueue").ArgumentList.Arguments[0].Expression;
+        var queued = Assert.IsType<ParenthesizedLambdaExpressionSyntax>(enqueued).Block!.Statements;
+
+        var gateIndex = queued.TakeWhile(s => !IsClosedGuard(s)).Count();
+        var callIndex = queued
+            .TakeWhile(s => !s.Calls("Ghostty.Interop.NativeMethods.AppSetColorScheme").Any())
+            .Count();
+
+        // Both have to exist, or TakeWhile silently returns the full count and
+        // the comparison passes while pinning nothing.
+        Assert.True(
+            gateIndex < queued.Count,
+            "the dispatched body must re-check _isClosed; it runs a turn after the handler that "
+            + "queued it, and the close disposes _host in between");
+        Assert.True(callIndex < queued.Count, "expected the dispatched body to set the app colour scheme");
+        Assert.True(gateIndex < callIndex, "the gate must precede the call through _host.App");
+    }
+
+    /// <summary>
+    /// The three dispatcher-driven timers.
+    ///
+    /// Stopping them is what the gates cannot do. A gated tick still arrives
+    /// every 50ms, 500ms or 1200ms for as long as the timer runs, and the timer
+    /// runs against the DispatcherQueue, which outlives the window: the theme
+    /// picker's poll ends only when the picker reports should_quit, which no
+    /// key can ever set once the surfaces are freed, so it would poll for the
+    /// life of the process.
+    ///
+    /// ClosePicker is the one that must also come before the teardown rather
+    /// than merely inside it -- its deinit writes through the picker's surface,
+    /// which DisposeAllLeaves frees -- so its position is pinned too.
+    /// </summary>
+    [Fact]
+    public void TheDispatcherDrivenTimersAreStoppedByTheClose()
+    {
+        var statements = Window().Method("OnClosedAsync").Body!.Statements;
+
+        int IndexOfCall(string call) => statements.TakeWhile(s => !s.Calls(call).Any()).Count();
+
+        var picker = IndexOfCall("ClosePicker");
+        var popup = IndexOfCall("_cyclePopupTimer?.Stop");
+        var detach = IndexOfCall("DetachProcessTracking");
+        var leaves = IndexOfCall("t.PaneHost.DisposeAllLeaves");
+
+        Assert.True(picker < statements.Count, "OnClosedAsync must stop and hand back the theme picker");
+        Assert.True(popup < statements.Count, "OnClosedAsync must stop the Ctrl+Tab popup timer");
+        Assert.True(
+            detach < statements.Count,
+            "OnClosedAsync must detach process tracking for every tab; teardown frees the leaves "
+            + "without removing a tab, so TabRemoved -- the only other caller -- never fires");
+        Assert.True(leaves < statements.Count, "expected OnClosedAsync to free the panes");
+
+        Assert.True(
+            picker < leaves,
+            "ClosePicker must run before the leaves are freed: the deinit restores the surface's "
+            + "input redirects and writes to its pty, and DisposeAllLeaves has freed that surface");
+        Assert.True(
+            detach < leaves,
+            "the shell-pid polls must stop before the leaves they query are freed");
+
+        // Each tick is gated as well, for the one already queued when the stop
+        // lands. Read off the subscriptions rather than by searching the file,
+        // so a tick handler moved elsewhere is still the one being checked.
+        var source = Window();
+        var subscriptions = Subscriptions();
+        // The picker poll subscribes through the local it captures rather than
+        // through the field, so that a tick queued by a previous poll cannot
+        // stop the one that replaced it. That is why this names poll.Tick.
+        foreach (var timer in new[] { "poll.Tick", "_cyclePopupTimer.Tick", "pidPoll.Tick", "startTimer.Tick" })
+        {
+            var ticks = subscriptions.Where(s => s.Event == timer).ToList();
+            Assert.True(ticks.Count == 1, $"expected one {timer} subscription, found {ticks.Count}");
+            Assert.True(
+                IsGated(ticks[0], source),
+                $"{timer}'s handler must return early on _isClosed: Stop does not recall a tick "
+                + "already queued on the dispatcher");
+        }
+    }
+}

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -373,7 +373,12 @@ public sealed partial class MainWindow : Window
             var startTimer = DispatcherQueue.CreateTimer();
             startTimer.Interval = TimeSpan.FromSeconds(3);
             startTimer.IsRepeating = false;
-            startTimer.Tick += (_, _) => { startTimer.Stop(); StartDemo(mode); };
+            startTimer.Tick += (_, _) =>
+            {
+                startTimer.Stop();
+                if (_isClosed) return;
+                StartDemo(mode);
+            };
             startTimer.Start();
         }
 #endif
@@ -462,34 +467,11 @@ public sealed partial class MainWindow : Window
         // app-level scheme when it initializes. The runtime handler below
         // covers post-init OS theme changes.
 
-        // Subscribe to runtime theme changes. ColorValuesChanged fires on a
-        // background thread, so dispatch back to the UI thread before calling
-        // into libghostty (which expects UI-thread callers for App-level ops).
-        _systemUiSettings.ColorValuesChanged += (s, _) =>
-        {
-            // Classify the event's own sender rather than activating a
-            // second UISettings, which could answer for a later moment.
-            var dark = Ghostty.Services.OsTheme.IsDark(s);
-            DispatcherQueue.TryEnqueue(() =>
-            {
-                var scheme = dark
-                    ? Ghostty.Core.Interop.GhosttyColorScheme.Dark
-                    : Ghostty.Core.Interop.GhosttyColorScheme.Light;
-                Ghostty.Interop.NativeMethods.AppSetColorScheme(_host.App, scheme);
-                _host.NotifyColorSchemeChanged(scheme);
-
-                // The two calls above move libghostty onto the new scheme,
-                // so the surfaces repaint. Anything the C# chrome derives
-                // from a conditional theme is still resolved against the
-                // outgoing one until this runs, which is what would leave
-                // window chrome on the old palette beside a repainted
-                // terminal. Self-guarding, so the per-window duplicates of
-                // this handler collapse to one refresh. Handed the same
-                // `dark` that drove the two calls above, so libghostty and
-                // the config caches cannot describe different schemes.
-                _configService.RefreshForOsColorScheme(dark);
-            });
-        };
+        // Subscribe to runtime theme changes. Named rather than inline so
+        // OnClosedAsync can take it back off: UISettings is an OS object that
+        // outlives the window, and a live subscription both keeps the closed
+        // window alive and points an OS callback at a freed libghostty app.
+        _systemUiSettings.ColorValuesChanged += OnSystemColorValuesChanged;
 
         // Apply initial backdrop (Mica when opaque, transparent when
         // background-opacity < 1). Also sets the Win32 class brush
@@ -765,6 +747,13 @@ public sealed partial class MainWindow : Window
 
         AppWindow.Changed += (_, args) =>
         {
+            // Cheap insurance rather than a known crash: no case has been
+            // constructed where AppWindow raises Changed after Window.Closed.
+            // But the body reaches _taskbar and _titleBar, and _taskbar is
+            // disposed in OnClosedAsync after an await, so if one ever does
+            // arrive in that gap it lands on disposed state. The gate is one
+            // comparison; proving the negative is not.
+            if (_isClosed) return;
             _taskbar.OnAppWindowChanged(AppWindow);
             _titleBar.SyncCaptionInset();
             if (IsQuickTerminal && args.DidSizeChange && !_movingQuake && AppWindow.IsVisible)
@@ -837,8 +826,12 @@ public sealed partial class MainWindow : Window
         // App-targeted actions (OpenConfig, ReloadConfig) fire on the
         // bootstrap host because libghostty sends them with target=app,
         // not target=surface. The per-window _host never receives them.
-        // Only the primary window subscribes; adopted windows (tab detach)
-        // skip this to avoid stacking duplicate handlers.
+        // Every window except an adopted one subscribes, because that is the
+        // only path that passes a seed tab. So the cold-start window, the
+        // quake window and each restored window all handle these, the action
+        // runs once per window, and each closure keeps its window rooted on
+        // the bootstrap host. Owning them on App instead is the fix; it is a
+        // behaviour change and is tracked separately.
         if (seedTab is null)
         {
             var appHost = Ghostty.App.BootstrapHost!;
@@ -1433,6 +1426,24 @@ public sealed partial class MainWindow : Window
         _layout.CancelSwitch();
         _themeManager.Dispose();
 
+        // Stop the dispatcher-driven timers this window started. None of them
+        // is owned by the visual tree, so nothing else in this method reaches
+        // them, and each keeps the closed window alive for as long as it runs:
+        // the picker poll forever, the Ctrl+Tab popup for 1.2s, the shell-pid
+        // poll for the rest of its 10s budget. Their handlers are gated on
+        // _isClosed as well, for the tick already queued when the stop lands.
+        //
+        // ClosePicker also hands the picker back to libghostty, which reads
+        // and writes through the picker's surface -- so it has to run here,
+        // above DisposeAllLeaves, not after it.
+        ClosePicker();
+        _cyclePopupTimer?.Stop();
+        // The detach also unregisters the tab from App's process tracker,
+        // which is process-global. Teardown frees the leaves without ever
+        // removing a tab, so TabRemoved -- the only other caller -- never
+        // fires here and every tab would stay in that registry.
+        foreach (var t in _tabManager.Tabs) DetachProcessTracking(t);
+
         // Close the inspector window before any surface/host teardown below.
         // Its present timer drives libghostty against the bound surface every
         // frame; closing it now runs its shutdown (stop timer + tear down the
@@ -1468,6 +1479,17 @@ public sealed partial class MainWindow : Window
         _configService.ConfigChanged -= OnConfigReloaded;
         _configService.ConfigChanged -= OnConfigReloadedChrome;
         _shellTheme.ThemeChanged -= OnShellThemeChanged;
+        // UISettings is an OS object and calls back on a thread-pool thread.
+        // Left attached, an OS light/dark flip, accent change or high-contrast
+        // toggle during teardown puts AppSetColorScheme through the app
+        // pointer _host.Dispose is about to free at the end of this method.
+        _systemUiSettings.ColorValuesChanged -= OnSystemColorValuesChanged;
+        // The preview service owns a named-pipe server on a background task,
+        // so it raises this from outside the window's own lifetime. The task
+        // itself outlives this window either way -- nothing disposes the
+        // service -- but detaching keeps a LIST_THEMES arriving afterwards
+        // from starting a picker on a window whose surfaces are gone.
+        _themePreview.ListThemesRequested -= OnListThemesRequested;
 
         // CompositionTarget.Rendering is static, so a window closed before
         // its first composed frame would otherwise stay subscribed.
@@ -1664,6 +1686,18 @@ public sealed partial class MainWindow : Window
             pidPoll.Interval = ShellPidPollInterval;
             pidPoll.Tick += (_, _) =>
             {
+                // The dispatcher drives this timer, not the window, so the
+                // ticks keep arriving through teardown. OnClosedAsync detaches
+                // every tab, which stops the timer; this turns away a tick
+                // already queued when it did. Stopping here too, because a
+                // detach that ever stopped reaching this timer would otherwise
+                // leave it running for the rest of the budget.
+                if (_isClosed)
+                {
+                    pidPoll?.Stop();
+                    pidPoll = null;
+                    return;
+                }
                 pollTicks++;
                 TryAssignPid(leaf);
                 if (tab.ShellPid is not null)
@@ -1887,6 +1921,10 @@ public sealed partial class MainWindow : Window
         _cyclePopupTimer.Tick += (_, _) =>
         {
             _cyclePopupTimer!.Stop();
+            // OnClosedAsync stops the timer, but a tick queued in the same
+            // dispatcher turn still arrives, and the popup host is part of the
+            // tree the close is taking down.
+            if (_isClosed) return;
             TabSwitcherPopupHost.IsOpen = false;
         };
 
@@ -2667,6 +2705,50 @@ public sealed partial class MainWindow : Window
     /// </summary>
     private void OnWindowThemeChanged(bool isDark) => ApplyTheme();
 
+    /// <summary>
+    /// UISettings.ColorValuesChanged handler: an OS light/dark flip, accent
+    /// change or high-contrast toggle. Fires on a thread-pool thread, so the
+    /// work hops to the dispatcher before touching libghostty (which expects
+    /// UI-thread callers for App-level ops).
+    ///
+    /// That hop is why the unsubscribe in OnClosedAsync is not the whole
+    /// defence. The enqueued body runs on a later dispatcher turn, and by
+    /// then _host may already have been disposed at the end of the teardown,
+    /// which would put AppSetColorScheme through a freed app pointer -- the
+    /// same shape as the config-reload race the other teardown gates in this
+    /// file exist for. OnClosedAsync unsubscribes so the OS stops calling and
+    /// stops retaining the window; the gate below turns away the one call
+    /// already in the air.
+    /// </summary>
+    private void OnSystemColorValuesChanged(
+        Windows.UI.ViewManagement.UISettings sender, object args)
+    {
+        if (_isClosed) return;
+        // Classify the event's own sender rather than activating a
+        // second UISettings, which could answer for a later moment.
+        var dark = Ghostty.Services.OsTheme.IsDark(sender);
+        DispatcherQueue.TryEnqueue(() =>
+        {
+            if (_isClosed) return;
+            var scheme = dark
+                ? Ghostty.Core.Interop.GhosttyColorScheme.Dark
+                : Ghostty.Core.Interop.GhosttyColorScheme.Light;
+            Ghostty.Interop.NativeMethods.AppSetColorScheme(_host.App, scheme);
+            _host.NotifyColorSchemeChanged(scheme);
+
+            // The two calls above move libghostty onto the new scheme,
+            // so the surfaces repaint. Anything the C# chrome derives
+            // from a conditional theme is still resolved against the
+            // outgoing one until this runs, which is what would leave
+            // window chrome on the old palette beside a repainted
+            // terminal. Self-guarding, so the per-window duplicates of
+            // this handler collapse to one refresh. Handed the same
+            // `dark` that drove the two calls above, so libghostty and
+            // the config caches cannot describe different schemes.
+            _configService.RefreshForOsColorScheme(dark);
+        });
+    }
+
     private void OnShellThemeChanged()
     {
         // Same teardown race as ApplyTheme: ShellThemeService routes its
@@ -2877,6 +2959,12 @@ public sealed partial class MainWindow : Window
     /// </summary>
     private void UpdateQuakeStripVisibility()
     {
+        // Reached from TabAdded/TabRemoved, and SetStripHidden walks the tab
+        // hosts and the pane host -- the tree a close is taking down. Teardown
+        // happens not to raise TabRemoved today (it frees the leaves and never
+        // removes a tab), so this is currently unreachable on close. That is an
+        // ordering accident in another method, not a guard here.
+        if (_isClosed) return;
         if (!IsQuickTerminal) return;
         _layout.SetStripHidden(_tabManager.Tabs.Count <= 1, _verticalTabsVisible);
     }
@@ -3813,6 +3901,18 @@ public sealed partial class MainWindow : Window
     private GhosttySurface _pickerSurface;
     private IntPtr _pickerHandle;
 
+    /// <summary>
+    /// The control and tab the picker's surface belongs to.
+    /// <see cref="_pickerSurface"/> is a copy of a raw pointer and nothing
+    /// zeroes it when that surface is freed, so these are what make the
+    /// liveness check in <see cref="ClosePicker"/> possible.
+    /// </summary>
+    private Ghostty.Controls.TerminalControl? _pickerTerminal;
+    private Ghostty.Core.Tabs.TabModel? _pickerTab;
+    // Held rather than left local to StartPickerPoll: the dispatcher drives
+    // the poll, so the window's teardown has no other way to reach it.
+    private Microsoft.UI.Dispatching.DispatcherQueueTimer? _pickerPoll;
+
     private void OnListThemesRequested(object? sender, EventArgs e)
     {
         var leaf = _tabManager.ActiveTab?.PaneHost?.ActiveLeaf;
@@ -3822,7 +3922,16 @@ public sealed partial class MainWindow : Window
         var surfaceHandle = terminal.SurfaceHandle;
         if (surfaceHandle == IntPtr.Zero) return;
 
+        // A second request while one is open would otherwise overwrite the
+        // handle, stranding the first picker's allocation with nothing left
+        // able to free it, and reassign the callback field, dropping the GC
+        // root for a delegate whose function pointer the first picker still
+        // holds.
+        ClosePicker();
+
         _pickerSurface = new GhosttySurface(surfaceHandle);
+        _pickerTerminal = terminal;
+        _pickerTab = _tabManager.ActiveTab;
 
         // Theme callback: apply preview/confirm colors on the UI thread.
         _inlineThemeCb = (namePtr, confirmed) =>
@@ -3857,19 +3966,96 @@ public sealed partial class MainWindow : Window
     {
         // Use a DispatcherQueue timer so cleanup runs on the UI thread
         // with no race against the apprt thread's input redirect.
-        var timer = DispatcherQueue.CreateTimer();
-        timer.Interval = TimeSpan.FromMilliseconds(50);
-        timer.Tick += (_, _) =>
+        //
+        // One poll at a time: a second picker replaces _pickerHandle, and a
+        // leftover timer would then be polling the new picker and could run
+        // the cleanup out from under it.
+        _pickerPoll?.Stop();
+        var poll = DispatcherQueue.CreateTimer();
+        _pickerPoll = poll;
+        poll.Interval = TimeSpan.FromMilliseconds(50);
+        poll.Tick += (_, _) =>
         {
+            // Act on this timer, never on whatever the field holds now.
+            // Stopping a timer does not recall a tick already queued on the
+            // dispatcher, so a tick from the previous poll can still arrive
+            // after a second picker has installed its own; reading the field
+            // would let it stop and deinit the newer one.
+            if (!ReferenceEquals(_pickerPoll, poll))
+            {
+                poll.Stop();
+                return;
+            }
+
+            // ClosePicker has already run the deinit against a surface that
+            // was still valid; the surface this tick would hand it is not.
+            // A tick queued in the same dispatcher turn as that stop still
+            // arrives, which is what this turns away.
+            if (_isClosed)
+            {
+                poll.Stop();
+                _pickerPoll = null;
+                return;
+            }
+
             if (!NativeMethods.SurfaceListThemesShouldQuit(_pickerHandle))
                 return;
 
-            timer.Stop();
-            NativeMethods.SurfaceListThemesDeinit(_pickerSurface, _pickerHandle);
-            _pickerHandle = IntPtr.Zero;
-            _inlineThemeCb = null;
+            ClosePicker();
         };
-        timer.Start();
+        poll.Start();
+    }
+
+    /// <summary>
+    /// Stop the picker poll and hand the picker back to libghostty.
+    ///
+    /// Nothing else ends the poll. It runs until the picker reports
+    /// should_quit, and once the window's leaves are freed no key can reach
+    /// the picker to set it, so the timer would hold the closed window for the
+    /// life of the process and the picker allocation would never be returned.
+    /// The sharper half is the other order: should_quit can already be true
+    /// with the tick still queued, and the deinit it then runs writes through
+    /// <see cref="_pickerSurface"/> -- restoring the redirects and nudging the
+    /// shell -- which <c>DisposeAllLeaves</c> has freed by that point.
+    ///
+    /// So the close calls this before any teardown, for the same reason it
+    /// closes the inspector there. Safe to call with no picker running: the
+    /// timer is null and the handle is zero, and the native deinit ignores a
+    /// null picker in any case.
+    /// </summary>
+    private void ClosePicker()
+    {
+        _pickerPoll?.Stop();
+        _pickerPoll = null;
+        if (_pickerHandle == IntPtr.Zero) return;
+
+        // A non-zero handle does not mean the surface behind it is still
+        // there. Deinit writes through that pointer -- it clears three
+        // redirects and pushes pty input -- so running it against a freed
+        // surface is a write into freed memory, and closing the picker's tab
+        // frees the surface without touching anything here.
+        //
+        // The control zeroes its own handle when it disposes the surface, so
+        // a mismatch means the surface is gone. The tab check answers the
+        // other direction: a detached tab carries its live surface to another
+        // window, and deiniting from here would strip the redirects of a
+        // window that never closed.
+        //
+        // When neither holds, the picker allocation is stranded, which is
+        // what happened before this path existed at all. Leaking it is the
+        // right trade against writing through a dangling pointer.
+        var live = _pickerTerminal is { } terminal
+            && terminal.SurfaceHandle == _pickerSurface.Handle
+            && _pickerTab is { } tab
+            && _tabManager.Tabs.Contains(tab);
+        if (live)
+            NativeMethods.SurfaceListThemesDeinit(_pickerSurface, _pickerHandle);
+
+        _pickerHandle = IntPtr.Zero;
+        _pickerSurface = default;
+        _pickerTerminal = null;
+        _pickerTab = null;
+        _inlineThemeCb = null;
     }
 }
 


### PR DESCRIPTION
Closes #689.

`OnClosedAsync` sets the gate, cancels a couple of things, disposes the theme manager, then after an await frees the panes and the host. Several callbacks could still fire across that and were neither unsubscribed nor gated. There are around seventy subscription sites in this file and were five detaches, which is how they accumulated.

**The system colour subscription was the serious one.** It fires on a threadpool thread, enqueues to the dispatcher, and the enqueued body calls into libghostty through the app pointer the last statements of teardown free. An OS light/dark flip, accent change or high-contrast toggle during a close was a call through freed memory, the same class as #208. It is now both detached and gated, because those cover different things: detaching stops the OS calling and stops it retaining the window, but cannot recall a body already queued for a later turn, and that later turn is exactly when the host is gone.

**The theme picker poll was the other real one, and worse than the issue described.** Its handle stays non-zero for the whole hazard window, so the native null checks do not help: a tick landing after the leaves are freed calls deinit, which writes through the surface and pushes pty input to it. The picker is also a separate allocation nothing frees and no key can reach once the window is gone, so the 50ms poll would have run for the life of the process.

**The shell-pid poll turned out not to be a use-after-free**, which the issue flagged as needing confirmation rather than assuming. `TerminalControl.TryGetShellPid` checks for a zeroed handle and `DisposeSurface` zeroes it synchronously before any later tick. It was still holding every closed window alive for ten seconds a tab, and leaving every tab in a process-global registry, because the only detach ran from tab removal and teardown never removes tabs.

`AppWindow.Changed` is gated as insurance rather than as a known bug: no case was found where it fires after close, and that is said in the comment rather than dressed up.

Also found while censusing: `_themePreview.ListThemesRequested` is raised from a named-pipe server on a background task, so it outlives the window outright, and a request after close would have started a picker against freed surfaces.

**The census test is the point of this, more than any individual fix.** Every subscription in the file is now classified: either its source dies with the window, or it must be detached on close or its handler gated. Ownership is declared rather than inferred, since there is no semantic model to infer it from, and a receiver nobody has classified fails until someone writes down which side of the line it falls on.

## What review then found, all in my own work

**The first version turned a leak into a write through freed memory.** `ClosePicker` ran the native deinit from the close path, but the picker handle is not evidence that the surface behind it still exists: it is a copy of a raw pointer, and closing the picker's tab frees the surface without touching it. Deinit writes through that pointer, clearing three redirects and pushing pty input. Before this PR the same call only ever ran from a tick needing key input a freed surface cannot deliver, so it leaked instead. It now establishes liveness first, from the control zeroing its own handle on disposal and from the tab still belonging to this window. When neither holds it strands the allocation, which is the pre-existing behaviour and the right trade against a dangling write.

**The census could not see conditional regions at all.** Roslyn keeps them as disabled trivia, so everything inside a `#if DEMO` block was absent from the tree and the census reported full coverage of a file it had only partly read, with a live dispatcher timer inside. It parses those regions now and refuses any tree that still has hidden ones, so a new conditional forces a decision rather than silently widening the blind spot. With the fix reverted the census names seven subscriptions, not six.

**Gate position is checked, not just presence.** A gate below the work it prevents reads as present while the handler still runs every tick. Stopping a timer or bailing out of a superseded tick may precede it, since neither touches what the gate protects. Verified by moving a gate below real work and watching the census fail.

**The poll tick acted on the field rather than its own timer**, so a tick queued by a previous poll could stop the one that replaced it. It captures the timer now, the same identity idiom `LayoutCoordinator` uses for its switch storyboard.

**One exemption said something untrue.** The bootstrap host subscriptions are guarded on a seed tab, and only tab adoption passes one, so the cold-start window, the quake window and every restored window all subscribe: the action runs once per window and each closure keeps its window rooted for the process lifetime. The reason now says that. Owning them on `App` is the actual fix and is filed as #704, since it changes how many times an action runs.

Full suite 2234 + 44 passing, solution builds clean.

Not fixed, worth a follow-up: nothing ever disposes `ThemePreviewService`, so its pipe server and CTS leak one per window regardless of this change.
