### PR TITLE
settings: shader gallery picker window, three-state shader setting, gallery additions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ windows/scripts/shader-notice-fuzz/
 windows/scripts/vtabs-layout-switch/
 windows/scripts/vtabs-morph/
 windows/scripts/vtabs-switcher/
+
+# Gallery tooling scratch renders (WARP PPMs and PNGs diffed during
+# shader bring-up; never something we want committed).
+tools/gallery/previews/

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -95,8 +95,8 @@
         // between zioshade versions on unchanged input (lowering and
         // identifier fixes); regenerate any golden outputs.
         .zioshade = .{
-            .url = "https://github.com/zioShade/zioshade/archive/refs/tags/v0.8.1.tar.gz",
-            .hash = "zioshade-0.8.1-8s3a2uqzUQDg5MmjBeS40zPLB7wnhTY7mi70tt3a5smR",
+            .url = "https://github.com/zioShade/zioshade/archive/refs/tags/v0.8.2.tar.gz",
+            .hash = "zioshade-0.8.2-8s3a2s7QUQAEWvH3AJKcrOm1imGnTcuKO-lLTj8tLIKZ",
             .lazy = true,
         },
 

--- a/src/Command.zig
+++ b/src/Command.zig
@@ -20,6 +20,7 @@
 const Command = @This();
 
 const std = @import("std");
+const log = std.log.scoped(.command);
 const builtin = @import("builtin");
 const configpkg = @import("config.zig");
 const global = @import("global.zig");
@@ -302,6 +303,78 @@ fn fork() !posix.pid_t {
     }
 }
 
+/// Resolve a bare program name (no directory component) to an absolute
+/// path so CreateProcessW gets an explicit lpApplicationName.
+///
+/// With lpApplicationName null, CreateProcessW searches using THIS
+/// process's PATH -- inherited verbatim from whoever launched us. A GUI
+/// app started from a terminal whose session predates a PATH edit (or
+/// that sanitizes the environment) fails to find shells that plainly
+/// exist, surfacing as error.FileNotFound mapped up to an opaque
+/// error.Unexpected on the "error starting IO thread" screen (live
+/// incident 2026-08-23: `command = pwsh.exe` from a Warp session whose
+/// PATH lacked PowerShell 7).
+///
+/// Search order: SearchPathW first (the exact search CreateProcessW
+/// would have done, honoring the caller's PATH ordering), then a few
+/// well-known shell homes PATH misses when stale. Returns null when
+/// nothing resolves; the caller then falls back to the legacy
+/// CreateProcessW search unchanged.
+fn resolveWindowsProgram(arena: Allocator, path: [:0]const u8) !?[:0]const u8 {
+    if (std.fs.path.dirname(path) != null) return null;
+
+    const name_w = try std.unicode.utf8ToUtf16LeAllocZ(arena, path);
+    var buf: [32768]u16 = undefined;
+
+    // 1) The PATH-aware search CreateProcessW itself would run.
+    const dot_exe = std.unicode.utf8ToUtf16LeStringLiteral(".exe");
+    const ext: ?windows.LPCWSTR = if (std.fs.path.extension(path).len == 0) dot_exe.ptr else null;
+    const len = windows.exp.kernel32.SearchPathW(null, name_w.ptr, ext, buf.len, @ptrCast(&buf), null);
+    if (len > 0 and len < buf.len) {
+        return try std.unicode.utf16LeToUtf8AllocZ(arena, buf[0..len]);
+    }
+
+    // 2) Well-known homes. Cheap existence probes; covers the default
+    // shells when the caller's PATH is stale.
+    const sys32 = std.unicode.utf8ToUtf16LeStringLiteral("\\System32\\");
+    const pwsh7 = std.unicode.utf8ToUtf16LeStringLiteral("\\PowerShell\\7\\");
+    const winps = std.unicode.utf8ToUtf16LeStringLiteral("\\System32\\WindowsPowerShell\\v1.0\\");
+    const dirs = [_][]const u16{
+        winJoinEnv(arena, "SystemRoot", sys32) catch return null,
+        winJoinEnv(arena, "ProgramFiles", pwsh7) catch return null,
+        winJoinEnv(arena, "SystemRoot", winps) catch return null,
+    };
+    for (dirs) |dir| {
+        var candidate: [32768 + 16]u16 = undefined;
+        if (dir.len + name_w.len > candidate.len) continue;
+        @memcpy(candidate[0..dir.len], dir);
+        @memcpy(candidate[dir.len..][0..name_w.len], name_w[0..name_w.len :0]);
+        candidate[dir.len + name_w.len] = 0;
+        const full = candidate[0 .. dir.len + name_w.len :0];
+        const attrs = windows.exp.kernel32.GetFileAttributesW(full.ptr);
+        if (attrs != windows.INVALID_FILE_ATTRIBUTES) {
+            return try std.unicode.utf16LeToUtf8AllocZ(arena, full);
+        }
+    }
+
+    return null;
+}
+
+/// dir-from-env helper: `<env var value><literal suffix>` as UTF-16, or
+/// null when the variable is unset. Errors are swallowed by the caller
+/// (the resolver treats a missing env as a dead probe, never a spawn
+/// failure).
+fn winJoinEnv(arena: Allocator, name: []const u8, suffix: []const u16) ![]u16 {
+    const name_w = try std.unicode.utf8ToUtf16LeAllocZ(arena, name);
+    var vbuf: [32768]u16 = undefined;
+    const vlen = windows.exp.kernel32.GetEnvironmentVariableW(name_w.ptr, @ptrCast(&vbuf), vbuf.len);
+    if (vlen == 0 or vlen >= vbuf.len) return error.EnvironmentVariableMissing;
+    const out = try arena.alloc(u16, vlen + suffix.len);
+    @memcpy(out[0..vlen], vbuf[0..vlen]);
+    @memcpy(out[vlen..], suffix);
+    return out;
+}
+
 fn startWindows(self: *Command, arena: Allocator) !void {
     const cwd_w = if (self.cwd) |cwd| try std.unicode.utf8ToUtf16LeAllocZ(arena, cwd) else null;
 
@@ -317,6 +390,15 @@ fn startWindows(self: *Command, arena: Allocator) !void {
     else
         try windowsCreateCommandLine(arena, &.{self.path});
     const command_line_w = try std.unicode.utf8ToUtf16LeAllocZ(arena, command_line);
+
+    // Bare program names get an explicit lpApplicationName so the spawn
+    // does not depend on this process's (possibly stale) PATH. argv[0]
+    // in the command line stays as the caller wrote it; only the module
+    // to load comes from the resolved absolute path.
+    const app_name_w: ?[:0]u16 = if (try resolveWindowsProgram(arena, self.path)) |abs|
+        try std.unicode.utf8ToUtf16LeAllocZ(arena, abs)
+    else
+        null;
     const env_w = if (self.env) |env_map| try createWindowsEnvBlock(arena, env_map) else null;
 
     const any_null_fd = self.stdin == null or self.stdout == null or self.stderr == null;
@@ -497,7 +579,7 @@ fn startWindows(self: *Command, arena: Allocator) !void {
 
     var process_information: windows.PROCESS_INFORMATION = undefined;
     if (windows.exp.kernel32.CreateProcessW(
-        null,
+        if (app_name_w) |w| w.ptr else null,
         command_line_w.ptr,
         null,
         null,
@@ -507,7 +589,15 @@ fn startWindows(self: *Command, arena: Allocator) !void {
         if (cwd_w) |w| w.ptr else null,
         @ptrCast(&startup_info_ex.StartupInfo),
         &process_information,
-    ) == windows.FALSE) return windows.unexpectedError(windows.GetLastError());
+    ) == windows.FALSE) {
+        const failed_rc = windows.GetLastError();
+        log.warn("CreateProcessW failed rc={d} app={s} cmd={s}", .{
+            failed_rc,
+            if (app_name_w) |w| std.unicode.utf16LeToUtf8Alloc(arena, w) catch "<utf16>" else "<path-search>",
+            command_line,
+        });
+        return windows.unexpectedError(failed_rc);
+    }
 
     self.pid = process_information.hProcess;
 }

--- a/src/Command.zig
+++ b/src/Command.zig
@@ -304,7 +304,9 @@ fn fork() !posix.pid_t {
 }
 
 /// Resolve a bare program name (no directory component) to an absolute
-/// path so CreateProcessW gets an explicit lpApplicationName.
+/// path so CreateProcessW gets an explicit lpApplicationName. Returned
+/// as UTF-16 straight through; the caller hands it to CreateProcessW
+/// without re-encoding.
 ///
 /// With lpApplicationName null, CreateProcessW searches using THIS
 /// process's PATH -- inherited verbatim from whoever launched us. A GUI
@@ -320,40 +322,49 @@ fn fork() !posix.pid_t {
 /// well-known shell homes PATH misses when stale. Returns null when
 /// nothing resolves; the caller then falls back to the legacy
 /// CreateProcessW search unchanged.
-fn resolveWindowsProgram(arena: Allocator, path: [:0]const u8) !?[:0]const u8 {
+fn resolveWindowsProgram(arena: Allocator, path: [:0]const u8) !?[:0]u16 {
     if (std.fs.path.dirname(path) != null) return null;
 
-    const name_w = try std.unicode.utf8ToUtf16LeAllocZ(arena, path);
+    // Probe name: the program as written plus .exe when it carries no
+    // extension. SearchPathW would append the extension itself, but
+    // GetFileAttributesW below appends nothing, so a bare `pwsh` only
+    // resolves with the suffix baked in.
+    const probe_u8 = if (std.fs.path.extension(path).len != 0)
+        path
+    else
+        try std.fmt.allocPrintSentinel(arena, "{s}.exe", .{path}, 0);
+    const probe_w = try std.unicode.utf8ToUtf16LeAllocZ(arena, probe_u8);
     var buf: [32768]u16 = undefined;
 
     // 1) The PATH-aware search CreateProcessW itself would run.
-    const dot_exe = std.unicode.utf8ToUtf16LeStringLiteral(".exe");
-    const ext: ?windows.LPCWSTR = if (std.fs.path.extension(path).len == 0) dot_exe.ptr else null;
-    const len = windows.exp.kernel32.SearchPathW(null, name_w.ptr, ext, buf.len, @ptrCast(&buf), null);
+    const len = windows.exp.kernel32.SearchPathW(null, probe_w.ptr, null, buf.len, @ptrCast(&buf), null);
     if (len > 0 and len < buf.len) {
-        return try std.unicode.utf16LeToUtf8AllocZ(arena, buf[0..len]);
+        return try arena.dupeZ(u16, buf[0..len]);
     }
 
     // 2) Well-known homes. Cheap existence probes; covers the default
     // shells when the caller's PATH is stale.
     const sys32 = std.unicode.utf8ToUtf16LeStringLiteral("\\System32\\");
     const pwsh7 = std.unicode.utf8ToUtf16LeStringLiteral("\\PowerShell\\7\\");
+    const ps7_user = std.unicode.utf8ToUtf16LeStringLiteral("\\Programs\\PowerShell\\7\\");
     const winps = std.unicode.utf8ToUtf16LeStringLiteral("\\System32\\WindowsPowerShell\\v1.0\\");
+    // A missing env var kills only its own probe, never the rest.
     const dirs = [_][]const u16{
-        winJoinEnv(arena, "SystemRoot", sys32) catch return null,
-        winJoinEnv(arena, "ProgramFiles", pwsh7) catch return null,
-        winJoinEnv(arena, "SystemRoot", winps) catch return null,
+        winJoinEnv(arena, "SystemRoot", sys32) catch &.{},
+        winJoinEnv(arena, "ProgramFiles", pwsh7) catch &.{},
+        winJoinEnv(arena, "LOCALAPPDATA", ps7_user) catch &.{},
+        winJoinEnv(arena, "SystemRoot", winps) catch &.{},
     };
     for (dirs) |dir| {
         var candidate: [32768 + 16]u16 = undefined;
-        if (dir.len + name_w.len > candidate.len) continue;
+        if (dir.len + probe_w.len > candidate.len) continue;
         @memcpy(candidate[0..dir.len], dir);
-        @memcpy(candidate[dir.len..][0..name_w.len], name_w[0..name_w.len :0]);
-        candidate[dir.len + name_w.len] = 0;
-        const full = candidate[0 .. dir.len + name_w.len :0];
+        @memcpy(candidate[dir.len..][0..probe_w.len], probe_w[0..probe_w.len :0]);
+        candidate[dir.len + probe_w.len] = 0;
+        const full = candidate[0 .. dir.len + probe_w.len :0];
         const attrs = windows.exp.kernel32.GetFileAttributesW(full.ptr);
         if (attrs != windows.INVALID_FILE_ATTRIBUTES) {
-            return try std.unicode.utf16LeToUtf8AllocZ(arena, full);
+            return try arena.dupeZ(u16, full);
         }
     }
 
@@ -395,10 +406,7 @@ fn startWindows(self: *Command, arena: Allocator) !void {
     // does not depend on this process's (possibly stale) PATH. argv[0]
     // in the command line stays as the caller wrote it; only the module
     // to load comes from the resolved absolute path.
-    const app_name_w: ?[:0]u16 = if (try resolveWindowsProgram(arena, self.path)) |abs|
-        try std.unicode.utf8ToUtf16LeAllocZ(arena, abs)
-    else
-        null;
+    const app_name_w: ?[:0]u16 = try resolveWindowsProgram(arena, self.path);
     const env_w = if (self.env) |env_map| try createWindowsEnvBlock(arena, env_map) else null;
 
     const any_null_fd = self.stdin == null or self.stdout == null or self.stderr == null;
@@ -591,7 +599,7 @@ fn startWindows(self: *Command, arena: Allocator) !void {
         &process_information,
     ) == windows.FALSE) {
         const failed_rc = windows.GetLastError();
-        log.warn("CreateProcessW failed rc={d} app={s} cmd={s}", .{
+        log.warn("CreateProcessW failed rc=0x{x} app={s} cmd={s}", .{
             failed_rc,
             if (app_name_w) |w| std.unicode.utf16LeToUtf8Alloc(arena, w) catch "<utf16>" else "<path-search>",
             command_line,

--- a/src/os/windows.zig
+++ b/src/os/windows.zig
@@ -58,6 +58,8 @@ pub const LPCWSTR = windows.LPCWSTR;
 pub const LPSTR = windows.LPSTR;
 pub const LPVOID = windows.LPVOID;
 pub const LPWSTR = windows.LPWSTR;
+/// Win32 INVALID_FILE_ATTRIBUTES sentinel (GetFileAttributesW failure).
+pub const INVALID_FILE_ATTRIBUTES: DWORD = 0xFFFFFFFF;
 pub const PVOID = windows.PVOID;
 pub const SIZE_T = windows.SIZE_T;
 pub const UINT = windows.UINT;
@@ -216,6 +218,20 @@ pub const exp = struct {
         // conpty.dll loader in pty.zig resolves its entry points with them.
         // Zig 0.16 also dropped DuplicateHandle. The child-exit watcher in
         // termio/Exec.zig dups the process handle with it.
+        pub extern "kernel32" fn SearchPathW(
+            lpPath: ?LPCWSTR,
+            lpFileName: LPCWSTR,
+            lpExtension: ?LPCWSTR,
+            nBufferLength: DWORD,
+            lpBuffer: LPWSTR,
+            lpFilePart: ?*?LPWSTR,
+        ) callconv(.winapi) DWORD;
+        pub extern "kernel32" fn GetFileAttributesW(lpFileName: LPCWSTR) callconv(.winapi) DWORD;
+        pub extern "kernel32" fn GetEnvironmentVariableW(
+            lpName: LPCWSTR,
+            lpBuffer: LPWSTR,
+            nSize: DWORD,
+        ) callconv(.winapi) DWORD;
         pub extern "kernel32" fn DuplicateHandle(
             hSourceProcessHandle: HANDLE,
             hSourceHandle: HANDLE,

--- a/src/pty.zig
+++ b/src/pty.zig
@@ -615,7 +615,14 @@ const WindowsPty = struct {
             0,
             &hpcon,
         );
-        if (result != windows.S_OK) return error.Unexpected;
+        if (result != windows.S_OK) {
+            log.warn("CreatePseudoConsole failed hr=0x{x} size={d}x{d}", .{
+                @as(u32, @bitCast(result)),
+                size.ws_col,
+                size.ws_row,
+            });
+            return error.Unexpected;
+        }
         pty.pseudo_console = hpcon;
 
         return pty;

--- a/src/renderer/directx12/gpu_test.zig
+++ b/src/renderer/directx12/gpu_test.zig
@@ -21,7 +21,8 @@ const Pipeline = @import("Pipeline.zig");
 const Frame = @import("Frame.zig");
 const Device = @import("device.zig").Device;
 const Surface = @import("surface.zig").Surface;
-const Shaders = @import("shaders.zig").Shaders;
+const shaders_mod = @import("shaders.zig");
+const Shaders = shaders_mod.Shaders;
 
 const Buffer = buffer_mod.Buffer;
 
@@ -29,6 +30,38 @@ const Buffer = buffer_mod.Buffer;
 
 /// Bundles a device, command queue, command list, and fence so tests
 /// can create resources and record/execute commands.
+// Minimal debug-layer info queue: the debug layer is enabled by
+// Device.init in Debug builds, so any validation error from the post
+// pass lands here. Layout follows d3d12.h's ID3D12InfoQueue.
+const InfoQueue = extern struct {
+    vtable: *const VTable,
+    pub const IID = com.GUID{
+        .data1 = 0x0742a90b,
+        .data2 = 0x426e,
+        .data3 = 0x479e,
+        .data4 = .{ 0x8d, 0xe5, 0x30, 0x10, 0xf7, 0x63, 0x63, 0x94 },
+    };
+    pub const Message = extern struct {
+        Category: u32,
+        Severity: u32,
+        ID: u32,
+        pDescription: ?[*:0]const u8,
+        DescriptionByteLength: usize,
+    };
+    pub const VTable = extern struct {
+        QueryInterface: *const fn (*InfoQueue, *const com.GUID, *?*anyopaque) callconv(.winapi) com.HRESULT,
+        AddRef: *const fn (*InfoQueue) callconv(.winapi) u32,
+        Release: *const fn (*InfoQueue) callconv(.winapi) u32,
+        SetMuteDebugOutput: *const fn (*InfoQueue, i32) callconv(.winapi) void,
+        GetMuteDebugOutput: *const fn (*InfoQueue) callconv(.winapi) i32,
+        GetNumStoredMessages: *const fn (*InfoQueue) callconv(.winapi) u64,
+        GetNumStoredMessagesAllowedByRetrievalFilter: *const fn (*InfoQueue) callconv(.winapi) u64,
+        GetNumMessagesDeniedByRetrievalFilter: *const fn (*InfoQueue) callconv(.winapi) u64,
+        GetNumMessagesDiscardedByMessageFilter: *const fn (*InfoQueue) callconv(.winapi) u64,
+        GetMessage: *const fn (*InfoQueue, u64, ?*Message, *usize) callconv(.winapi) com.HRESULT,
+    };
+};
+
 const TestDevice = struct {
     device: *d3d12.ID3D12Device,
     command_queue: *d3d12.ID3D12CommandQueue,
@@ -856,6 +889,10 @@ test "post pipeline: scanline shader leaves row periodicity" {
 
     // The scanline body from the gallery's CRT v5: hard-edged dark lines
     // every 4 px in fragCoord space over the sampled content.
+    // MICRO-BISECT stage: solid red, no uniforms, no texture. If the app
+    // path still renders black with THIS, the draw itself is producing
+    // nothing and the plumbing (PSO/viewport/RT/binding) is the bug, not
+    // anything about the shadertoy contract.
     const scanline_body =
         \\void mainImage( out vec4 fragColor, in vec2 fragCoord )
         \\{
@@ -886,6 +923,18 @@ test "post pipeline: scanline shader leaves row periodicity" {
         return err;
     };
     defer alloc.free(hlsl);
+
+    // Dump the app-path HLSL for offline inspection (zioshade-4ne).
+    {
+        const cwd = std.Io.Dir.cwd();
+        if (cwd.createFile(global.io(), "debug_post.hlsl", .{ .truncate = true })) |f| {
+            defer f.close(global.io());
+            var wbuf: [4096]u8 = undefined;
+            var fw = f.writer(global.io(), &wbuf);
+            fw.interface.writeAll(hlsl) catch {};
+            fw.interface.flush() catch {};
+        } else |_| {}
+    }
 
     // Real device in shared-texture (offscreen, headless-safe) mode.
     var device = Device.init(.{ .shared_texture = .{
@@ -976,12 +1025,11 @@ test "post pipeline: scanline shader leaves row periodicity" {
         .render_target = true,
     };
 
-    // Content texture: flat mid gray (BGRA), uploaded through the real path.
-    const pixels = try alloc.alloc(u8, W * H * 4);
-    defer alloc.free(pixels);
-    @memset(pixels, 0x80);
-    for (0..W * H) |i| pixels[i * 4 + 3] = 0xFF;
-    var back = try Texture.init(tex_opts, W, H, pixels);
+    // Content texture: render-target pair, filled the way production fills
+    // it -- by a render pass targeting it (Texture.init only uploads initial
+    // data for non-RT textures, so passing pixels here would be silently
+    // ignored). A clear-to-gray stands in for the terminal content pass.
+    var back = try Texture.init(tex_opts, W, H, null);
     defer back.deinit();
 
     // Output texture (the "front" the post pass writes).
@@ -1000,8 +1048,21 @@ test "post pipeline: scanline shader leaves row periodicity" {
     var sampler = try Sampler.init(.{ .device = dev, .sampler_heap = &sampler_heap });
     defer sampler.deinit();
 
-    // The post pass, shaped like generic.zig's loop for the single-shader
-    // case: sample back, write the output target.
+    // Fill back with mid gray via a real render pass (the production shape).
+    {
+        var pass = RenderPassMod.begin(.{
+            .command_list = command_list.?,
+            .srv_heap = &srv_heap,
+            .sampler_heap = &sampler_heap,
+            .attachments = &.{.{
+                .target = .{ .texture = back },
+                .clear_color = .{ 0.5, 0.5, 0.5, 1.0 },
+            }},
+        });
+        pass.complete();
+    }
+
+    // BISECT ARM A: the app's post pipeline verbatim (bg_color_vs).
     {
         var pass = RenderPassMod.begin(.{
             .command_list = command_list.?,
@@ -1014,6 +1075,71 @@ test "post pipeline: scanline shader leaves row periodicity" {
         });
         pass.step(.{
             .pipeline = shaders.post_pipelines[0],
+            .uniforms = ubuf.buffer,
+            .textures = &.{back},
+            .samplers = &.{sampler},
+            .draw = .{ .type = .triangle, .vertex_count = 3 },
+        });
+        pass.complete();
+    }
+    // Note: single command-list recording; the readback below reads `front`.
+
+    // BISECT ARM B: same PS bytecode + same post root signature, but a
+    // hand-written fullscreen vertex stage. Renders over arm A's output; if
+    // the readback then shows scanlines where arm A left black, the app's
+    // bg_color_vs vertex stage is the culprit.
+    {
+        const vs_src =
+            \\float4 VSMain(uint vid : SV_VertexID) : SV_Position
+            \\{
+            \\    float2 p = float2((vid == 2) ? 3.0 : -1.0, (vid == 0) ? -3.0 : 1.0);
+            \\    return float4(p, 0.0, 1.0);
+            \\}
+        ;
+        const vs_z = try alloc.dupeZ(u8, vs_src);
+        defer alloc.free(vs_z);
+        const vs_entry_w = try std.unicode.utf8ToUtf16LeAllocZ(alloc, "VSMain");
+        defer alloc.free(vs_entry_w);
+        const ps_entry_w = try std.unicode.utf8ToUtf16LeAllocZ(alloc, "main");
+        defer alloc.free(ps_entry_w);
+
+        const vs_dxil = (try shaders_mod.compileHlslToDxilProfile(alloc, vs_z, vs_entry_w, std.unicode.utf8ToUtf16LeStringLiteral("vs_6_0"))) orelse return error.VsCompileFailed;
+        defer alloc.free(vs_dxil);
+        const ps_dxil = (try shaders_mod.compileHlslToDxil(alloc, hlsl, ps_entry_w)) orelse return error.PsCompileFailed;
+        defer alloc.free(ps_dxil);
+
+        // Dump the COM-compiled DXIL for disassembly (zioshade-4ne).
+        {
+            const cwd = std.Io.Dir.cwd();
+            if (cwd.createFile(global.io(), "debug_post.cso", .{ .truncate = true })) |f| {
+                defer f.close(global.io());
+                var wbuf: [65536]u8 = undefined;
+                var fw = f.writer(global.io(), &wbuf);
+                fw.interface.writeAll(ps_dxil) catch {};
+                fw.interface.flush() catch {};
+            } else |_| {}
+        }
+
+        const arm_b = Pipeline.init(.{
+            .device = dev,
+            .root_signature = shaders.post_root_signature.?,
+            .vs_bytecode = vs_dxil,
+            .ps_bytecode = ps_dxil,
+            .blend = .none,
+        }) catch return error.ArmBPipelineFailed;
+        defer arm_b.deinit();
+
+        var pass = RenderPassMod.begin(.{
+            .command_list = command_list.?,
+            .srv_heap = &srv_heap,
+            .sampler_heap = &sampler_heap,
+            .attachments = &.{.{
+                .target = .{ .texture = front },
+                .clear_color = .{ 0.0, 0.0, 0.0, 1.0 },
+            }},
+        });
+        pass.step(.{
+            .pipeline = arm_b,
             .uniforms = ubuf.buffer,
             .textures = &.{back},
             .samplers = &.{sampler},
@@ -1071,16 +1197,109 @@ test "post pipeline: scanline shader leaves row periodicity" {
         if (d3d12.WaitForSingleObject(fence_event, d3d12.INFINITE) != 0) return error.WaitFailed;
     }
 
+    // Drain the debug-layer info queue: the runtime's own complaints about
+    // the post pass (binding, state, viewport) name the defect directly.
+    {
+        var iq: ?*InfoQueue = null;
+        const hr = dev.vtable.QueryInterface(dev, &InfoQueue.IID, @ptrCast(&iq));
+        if (!com.FAILED(hr) and iq != null) {
+            defer _ = iq.?.vtable.Release(iq.?);
+            const n = iq.?.vtable.GetNumStoredMessages(iq.?);
+            std.debug.print("D3D12 debug layer: {d} stored message(s)\n", .{n});
+            var i: u64 = 0;
+            while (i < n and i < 20) : (i += 1) {
+                var len: usize = 0;
+                _ = iq.?.vtable.GetMessage(iq.?, i, null, &len);
+                const buf = alloc.alloc(u8, len) catch break;
+                defer alloc.free(buf);
+                const msg: *InfoQueue.Message = @ptrCast(@alignCast(buf.ptr));
+                if (iq.?.vtable.GetMessage(iq.?, i, msg, &len) == 0) {
+                    const desc = if (msg.pDescription) |d| std.mem.sliceTo(d, 0) else "";
+                    std.debug.print("  [sev={d} id={d}] {s}\n", .{ msg.Severity, msg.ID, desc });
+                }
+            }
+        } else {
+            std.debug.print("D3D12 debug layer unavailable (hr=0x{x})\n", .{@as(u32, @bitCast(hr))});
+        }
+    }
+
     var mapped: ?*anyopaque = null;
     {
         const rr = d3d12.D3D12_RANGE{ .Begin = 0, .End = W * H * 4 };
         _ = readback.?.Map(0, &rr, &mapped);
     }
-    const px: [*]const u8 = @ptrCast(mapped.?);
+    // Snapshot front's bytes NOW: the back-texture probe below reuses this
+    // same readback resource, which silently replaced everything analyzed
+    // after it (the entire "fragCoord.y is constant" trail was this race).
+    const front_bytes = alloc.dupe(u8, @as([*]const u8, @ptrCast(mapped.?))[0 .. W * H * 4]) catch return error.OutOfMemory;
+    defer alloc.free(front_bytes);
+    const px: [*]const u8 = front_bytes.ptr;
 
     // Row analysis: the scanline pattern darkens roughly 1.4px of every 4
     // by ~45% over a mid-gray input, so adjacent row means must differ
     // strongly and periodically.
+    // DISCRIMINATOR: read the back texture itself. Gray => the upload landed
+    // and the SRV/table binding is the bug; black => the upload is the bug.
+    {
+        _ = cmd_allocator.?.Reset();
+        _ = command_list.?.Reset(cmd_allocator.?, null);
+        back.transitionBarrier(command_list.?, d3d12.D3D12_RESOURCE_STATES.PIXEL_SHADER_RESOURCE, d3d12.D3D12_RESOURCE_STATES.COPY_SOURCE);
+        {
+            var dst: d3d12.D3D12_TEXTURE_COPY_LOCATION = std.mem.zeroes(d3d12.D3D12_TEXTURE_COPY_LOCATION);
+            dst.pResource = readback.?;
+            dst.Type = .PLACED_FOOTPRINT;
+            dst.u.PlacedFootprint.Footprint.Format = .B8G8R8A8_UNORM;
+            dst.u.PlacedFootprint.Footprint.Width = W;
+            dst.u.PlacedFootprint.Footprint.Height = H;
+            dst.u.PlacedFootprint.Footprint.Depth = 1;
+            dst.u.PlacedFootprint.Footprint.RowPitch = W * 4;
+            var src: d3d12.D3D12_TEXTURE_COPY_LOCATION = std.mem.zeroes(d3d12.D3D12_TEXTURE_COPY_LOCATION);
+            src.pResource = back.resource.?;
+            src.Type = .SUBRESOURCE_INDEX;
+            src.u.SubresourceIndex = 0;
+            command_list.?.CopyTextureRegion(&dst, 0, 0, 0, &src, null);
+        }
+        _ = command_list.?.Close();
+        const lists2 = [_]*d3d12.ID3D12GraphicsCommandList{command_list.?};
+        queue.?.ExecuteCommandLists(1, @ptrCast(&lists2));
+        _ = queue.?.Signal(fence.?, 2);
+        if (fence.?.GetCompletedValue() < 2) {
+            _ = fence.?.SetEventOnCompletion(2, fence_event);
+            if (d3d12.WaitForSingleObject(fence_event, d3d12.INFINITE) != 0) return error.WaitFailed;
+        }
+        var mapped2: ?*anyopaque = null;
+        const rr2 = d3d12.D3D12_RANGE{ .Begin = 0, .End = W * H * 4 };
+        _ = readback.?.Map(0, &rr2, &mapped2);
+        const bpx: [*]const u8 = @ptrCast(mapped2.?);
+        var bsum: u64 = 0;
+        for (0..W * H) |i| bsum += bpx[i * 4];
+        std.debug.print("BACK TEXTURE avg byte0 = {d:.1} (~128 = upload landed)\n", .{@as(f64, @floatFromInt(bsum)) / @as(f64, @floatFromInt(W * H))});
+        const nrw2 = d3d12.D3D12_RANGE{ .Begin = 0, .End = 0 };
+        readback.?.Unmap(0, &nrw2);
+    }
+
+    // Dump front as PPM for direct inspection (zioshade-4ne).
+    {
+        const cwd = std.Io.Dir.cwd();
+        if (cwd.createFile(global.io(), "debug_front.ppm", .{ .truncate = true })) |f| {
+            defer f.close(global.io());
+            var wbuf: [4096]u8 = undefined;
+            var fw = f.writer(global.io(), &wbuf);
+            const w = &fw.interface;
+            w.print("P6\n{d} {d}\n255\n", .{ W, H }) catch {};
+            var y2: usize = 0;
+            while (y2 < H) : (y2 += 1) {
+                var x2: usize = 0;
+                while (x2 < W) : (x2 += 1) {
+                    const i = y2 * W * 4 + x2 * 4;
+                    const rgb = [3]u8{ px[i + 2], px[i + 1], px[i] }; // BGRA -> RGB
+                    w.writeAll(&rgb) catch {};
+                }
+            }
+            w.flush() catch {};
+        } else |_| {}
+    }
+
     var row_means: [H]f64 = undefined;
     for (0..H) |y| {
         var sum: u64 = 0;
@@ -1108,9 +1327,23 @@ test "post pipeline: scanline shader leaves row periodicity" {
         readback.?.Unmap(0, &nrw);
     }
 
-    // With scanlines, max adjacent-row difference is ~45% of the gray level
-    // (~28.8/255) and dark rows cover roughly a third of the height. A flat
-    // output (the bug) gives a max diff near 0.
+    // Solid red expectation: row means near 255 (red channel read here is
+    // the FIRST byte = B in BGRA... red = BGR(0,0,255) so byte0=0? No:
+    // B8G8R8A8 = bytes [B,G,R,A]; a red pixel = [0,0,255,255]. The analysis
+    // reads byte0 = blue = 0. So for the red probe, assert the RED channel
+    // instead: rebuild row means from byte2.
+    var red_means: [H]f64 = undefined;
+    for (0..H) |y| {
+        var sum: u64 = 0;
+        for (0..W) |x| sum += px[y * W * 4 + x * 4 + 2];
+        red_means[y] = @as(f64, @floatFromInt(sum)) / @as(f64, @floatFromInt(W));
+    }
+    var red_total: f64 = 0;
+    for (red_means) |v| red_total += v;
+    const red_avg = red_total / @as(f64, @floatFromInt(H));
+    std.debug.print("red-channel average = {d:.1} (255 = solid red)\n", .{red_avg});
+        // Scanlines over mid gray: bright rows ~128, dark rows ~70; strong
+    // row-to-row differences and roughly a third of rows dark.
     try std.testing.expect(max_diff > 10.0);
     try std.testing.expect(dark_rows > H / 8);
 }

--- a/src/renderer/directx12/gpu_test.zig
+++ b/src/renderer/directx12/gpu_test.zig
@@ -28,11 +28,9 @@ const Buffer = buffer_mod.Buffer;
 
 // ---- Test device helper ----
 
-/// Bundles a device, command queue, command list, and fence so tests
-/// can create resources and record/execute commands.
-// Minimal debug-layer info queue: the debug layer is enabled by
-// Device.init in Debug builds, so any validation error from the post
-// pass lands here. Layout follows d3d12.h's ID3D12InfoQueue.
+/// Minimal debug-layer info queue: the debug layer is enabled by
+/// Device.init in Debug builds, so any validation error from the post
+/// pass lands here. Layout follows d3d12.h's ID3D12InfoQueue.
 const InfoQueue = extern struct {
     vtable: *const VTable,
     pub const IID = com.GUID{
@@ -62,6 +60,8 @@ const InfoQueue = extern struct {
     };
 };
 
+/// Bundles a device, command queue, command list, and fence so tests
+/// can create resources and record/execute commands.
 const TestDevice = struct {
     device: *d3d12.ID3D12Device,
     command_queue: *d3d12.ID3D12CommandQueue,
@@ -879,6 +879,11 @@ test "Device: GetDeviceRemovedReason returns S_OK on healthy device" {
 // exactly like generic.zig's post loop -- then reads the target back and
 // looks for the scanline row pattern. If the app path drops the pattern,
 // this test reproduces it in-repo.
+//
+// The app path is the ONLY thing exercised: the draw goes through the
+// app's own post pipeline (bg_color_vs vertex stage), so a regression in
+// that vertex stage fails the assertions below rather than being masked
+// by a hand-written replacement stage.
 test "post pipeline: scanline shader leaves row periodicity" {
     if (comptime builtin.os.tag != .windows) return;
 
@@ -887,12 +892,9 @@ test "post pipeline: scanline shader leaves row periodicity" {
 
     const alloc = std.heap.c_allocator;
 
-    // The scanline body from the gallery's CRT v5: hard-edged dark lines
-    // every 4 px in fragCoord space over the sampled content.
-    // MICRO-BISECT stage: solid red, no uniforms, no texture. If the app
-    // path still renders black with THIS, the draw itself is producing
-    // nothing and the plumbing (PSO/viewport/RT/binding) is the bug, not
-    // anything about the shadertoy contract.
+    // A scanline body in the gallery CRT's shape: a smooth sine darkening
+    // every 4 px in fragCoord space over the sampled content, so the
+    // expected output is periodic row means over mid gray.
     const scanline_body =
         \\void mainImage( out vec4 fragColor, in vec2 fragCoord )
         \\{
@@ -923,18 +925,6 @@ test "post pipeline: scanline shader leaves row periodicity" {
         return err;
     };
     defer alloc.free(hlsl);
-
-    // Dump the app-path HLSL for offline inspection (zioshade-4ne).
-    {
-        const cwd = std.Io.Dir.cwd();
-        if (cwd.createFile(global.io(), "debug_post.hlsl", .{ .truncate = true })) |f| {
-            defer f.close(global.io());
-            var wbuf: [4096]u8 = undefined;
-            var fw = f.writer(global.io(), &wbuf);
-            fw.interface.writeAll(hlsl) catch {};
-            fw.interface.flush() catch {};
-        } else |_| {}
-    }
 
     // Real device in shared-texture (offscreen, headless-safe) mode.
     var device = Device.init(.{ .shared_texture = .{
@@ -971,13 +961,17 @@ test "post pipeline: scanline shader leaves row periodicity" {
         const hr = dev.CreateCommandAllocator(.DIRECT, &d3d12.ID3D12CommandAllocator.IID, @ptrCast(&cmd_allocator));
         if (com.FAILED(hr) or cmd_allocator == null) return error.CommandAllocatorCreationFailed;
     }
-    defer if (cmd_allocator) |a| { _ = a.Release(); };
+    defer if (cmd_allocator) |a| {
+        _ = a.Release();
+    };
     var command_list: ?*d3d12.ID3D12GraphicsCommandList = null;
     {
         const hr = dev.CreateCommandList(0, .DIRECT, cmd_allocator.?, null, &d3d12.ID3D12GraphicsCommandList.IID, @ptrCast(&command_list));
         if (com.FAILED(hr) or command_list == null) return error.CommandListCreationFailed;
     }
-    defer if (command_list) |l| { _ = l.Release(); };
+    defer if (command_list) |l| {
+        _ = l.Release();
+    };
     var queue: ?*d3d12.ID3D12CommandQueue = null;
     {
         const qd = d3d12.D3D12_COMMAND_QUEUE_DESC{
@@ -993,7 +987,9 @@ test "post pipeline: scanline shader leaves row periodicity" {
         );
         if (com.FAILED(hr) or queue == null) return error.CommandQueueCreationFailed;
     }
-    defer if (queue) |q| { _ = q.Release(); };
+    defer if (queue) |q| {
+        _ = q.Release();
+    };
 
     var fence: ?*d3d12.ID3D12Fence = null;
     {
@@ -1005,7 +1001,9 @@ test "post pipeline: scanline shader leaves row periodicity" {
         );
         if (com.FAILED(hr) or fence == null) return error.FenceCreationFailed;
     }
-    defer if (fence) |f| { _ = f.Release(); };
+    defer if (fence) |f| {
+        _ = f.Release();
+    };
 
     const fence_event = d3d12.CreateEventW(null, .FALSE, .FALSE, null) orelse
         return error.FenceEventCreationFailed;
@@ -1062,7 +1060,8 @@ test "post pipeline: scanline shader leaves row periodicity" {
         pass.complete();
     }
 
-    // BISECT ARM A: the app's post pipeline verbatim (bg_color_vs).
+    // The app's post pipeline verbatim (bg_color_vs). The readback below
+    // asserts on what this draw alone leaves in `front`.
     {
         var pass = RenderPassMod.begin(.{
             .command_list = command_list.?,
@@ -1075,71 +1074,6 @@ test "post pipeline: scanline shader leaves row periodicity" {
         });
         pass.step(.{
             .pipeline = shaders.post_pipelines[0],
-            .uniforms = ubuf.buffer,
-            .textures = &.{back},
-            .samplers = &.{sampler},
-            .draw = .{ .type = .triangle, .vertex_count = 3 },
-        });
-        pass.complete();
-    }
-    // Note: single command-list recording; the readback below reads `front`.
-
-    // BISECT ARM B: same PS bytecode + same post root signature, but a
-    // hand-written fullscreen vertex stage. Renders over arm A's output; if
-    // the readback then shows scanlines where arm A left black, the app's
-    // bg_color_vs vertex stage is the culprit.
-    {
-        const vs_src =
-            \\float4 VSMain(uint vid : SV_VertexID) : SV_Position
-            \\{
-            \\    float2 p = float2((vid == 2) ? 3.0 : -1.0, (vid == 0) ? -3.0 : 1.0);
-            \\    return float4(p, 0.0, 1.0);
-            \\}
-        ;
-        const vs_z = try alloc.dupeZ(u8, vs_src);
-        defer alloc.free(vs_z);
-        const vs_entry_w = try std.unicode.utf8ToUtf16LeAllocZ(alloc, "VSMain");
-        defer alloc.free(vs_entry_w);
-        const ps_entry_w = try std.unicode.utf8ToUtf16LeAllocZ(alloc, "main");
-        defer alloc.free(ps_entry_w);
-
-        const vs_dxil = (try shaders_mod.compileHlslToDxilProfile(alloc, vs_z, vs_entry_w, std.unicode.utf8ToUtf16LeStringLiteral("vs_6_0"))) orelse return error.VsCompileFailed;
-        defer alloc.free(vs_dxil);
-        const ps_dxil = (try shaders_mod.compileHlslToDxil(alloc, hlsl, ps_entry_w)) orelse return error.PsCompileFailed;
-        defer alloc.free(ps_dxil);
-
-        // Dump the COM-compiled DXIL for disassembly (zioshade-4ne).
-        {
-            const cwd = std.Io.Dir.cwd();
-            if (cwd.createFile(global.io(), "debug_post.cso", .{ .truncate = true })) |f| {
-                defer f.close(global.io());
-                var wbuf: [65536]u8 = undefined;
-                var fw = f.writer(global.io(), &wbuf);
-                fw.interface.writeAll(ps_dxil) catch {};
-                fw.interface.flush() catch {};
-            } else |_| {}
-        }
-
-        const arm_b = Pipeline.init(.{
-            .device = dev,
-            .root_signature = shaders.post_root_signature.?,
-            .vs_bytecode = vs_dxil,
-            .ps_bytecode = ps_dxil,
-            .blend = .none,
-        }) catch return error.ArmBPipelineFailed;
-        defer arm_b.deinit();
-
-        var pass = RenderPassMod.begin(.{
-            .command_list = command_list.?,
-            .srv_heap = &srv_heap,
-            .sampler_heap = &sampler_heap,
-            .attachments = &.{.{
-                .target = .{ .texture = front },
-                .clear_color = .{ 0.0, 0.0, 0.0, 1.0 },
-            }},
-        });
-        pass.step(.{
-            .pipeline = arm_b,
             .uniforms = ubuf.buffer,
             .textures = &.{back},
             .samplers = &.{sampler},
@@ -1173,7 +1107,9 @@ test "post pipeline: scanline shader leaves row periodicity" {
         };
         _ = dev.CreateCommittedResource(&hp, 0, &rd, d3d12.D3D12_RESOURCE_STATES.COPY_DEST, null, &d3d12.ID3D12Resource.IID, @ptrCast(&readback));
     }
-    defer if (readback) |r| { _ = r.Release(); };
+    defer if (readback) |r| {
+        _ = r.Release();
+    };
     {
         var dst: d3d12.D3D12_TEXTURE_COPY_LOCATION = std.mem.zeroes(d3d12.D3D12_TEXTURE_COPY_LOCATION);
         dst.pResource = readback.?;
@@ -1278,28 +1214,6 @@ test "post pipeline: scanline shader leaves row periodicity" {
         readback.?.Unmap(0, &nrw2);
     }
 
-    // Dump front as PPM for direct inspection (zioshade-4ne).
-    {
-        const cwd = std.Io.Dir.cwd();
-        if (cwd.createFile(global.io(), "debug_front.ppm", .{ .truncate = true })) |f| {
-            defer f.close(global.io());
-            var wbuf: [4096]u8 = undefined;
-            var fw = f.writer(global.io(), &wbuf);
-            const w = &fw.interface;
-            w.print("P6\n{d} {d}\n255\n", .{ W, H }) catch {};
-            var y2: usize = 0;
-            while (y2 < H) : (y2 += 1) {
-                var x2: usize = 0;
-                while (x2 < W) : (x2 += 1) {
-                    const i = y2 * W * 4 + x2 * 4;
-                    const rgb = [3]u8{ px[i + 2], px[i + 1], px[i] }; // BGRA -> RGB
-                    w.writeAll(&rgb) catch {};
-                }
-            }
-            w.flush() catch {};
-        } else |_| {}
-    }
-
     var row_means: [H]f64 = undefined;
     for (0..H) |y| {
         var sum: u64 = 0;
@@ -1327,22 +1241,7 @@ test "post pipeline: scanline shader leaves row periodicity" {
         readback.?.Unmap(0, &nrw);
     }
 
-    // Solid red expectation: row means near 255 (red channel read here is
-    // the FIRST byte = B in BGRA... red = BGR(0,0,255) so byte0=0? No:
-    // B8G8R8A8 = bytes [B,G,R,A]; a red pixel = [0,0,255,255]. The analysis
-    // reads byte0 = blue = 0. So for the red probe, assert the RED channel
-    // instead: rebuild row means from byte2.
-    var red_means: [H]f64 = undefined;
-    for (0..H) |y| {
-        var sum: u64 = 0;
-        for (0..W) |x| sum += px[y * W * 4 + x * 4 + 2];
-        red_means[y] = @as(f64, @floatFromInt(sum)) / @as(f64, @floatFromInt(W));
-    }
-    var red_total: f64 = 0;
-    for (red_means) |v| red_total += v;
-    const red_avg = red_total / @as(f64, @floatFromInt(H));
-    std.debug.print("red-channel average = {d:.1} (255 = solid red)\n", .{red_avg});
-        // Scanlines over mid gray: bright rows ~128, dark rows ~70; strong
+    // Scanlines over mid gray: bright rows ~128, dark rows ~70; strong
     // row-to-row differences and roughly a third of rows dark.
     try std.testing.expect(max_diff > 10.0);
     try std.testing.expect(dark_rows > H / 8);

--- a/src/renderer/directx12/shaders.zig
+++ b/src/renderer/directx12/shaders.zig
@@ -43,9 +43,20 @@ const shader_bytecode = if (builtin.os.tag == .windows) struct {
     const bg_image_ps: []const u8 = &.{};
 };
 
-/// Compile HLSL source to DXIL bytecode using DXC.
+/// Compile HLSL source to DXIL bytecode using DXC (pixel profile).
 /// Returns null on failure. Caller owns returned memory.
-fn compileHlslToDxil(alloc: std.mem.Allocator, source: [:0]const u8, entry_point: [*:0]const u16) error{OutOfMemory}!?[]const u8 {
+pub fn compileHlslToDxil(alloc: std.mem.Allocator, source: [:0]const u8, entry_point: [*:0]const u16) error{OutOfMemory}!?[]const u8 {
+    return compileHlslToDxilProfile(alloc, source, entry_point, std.unicode.utf8ToUtf16LeStringLiteral("ps_6_0"));
+}
+
+/// Compile HLSL source to DXIL bytecode using DXC (explicit profile).
+/// Returns null on failure. Caller owns returned memory.
+pub fn compileHlslToDxilProfile(
+    alloc: std.mem.Allocator,
+    source: [:0]const u8,
+    entry_point: [*:0]const u16,
+    profile: [*:0]const u16,
+) error{OutOfMemory}!?[]const u8 {
     const dxc_lib = d3d12.DxcLibrary.load() orelse {
         log.warn("dxcompiler.dll not found, cannot compile custom shader", .{});
         return null;
@@ -90,16 +101,15 @@ fn compileHlslToDxil(alloc: std.mem.Allocator, source: [:0]const u8, entry_point
         .Encoding = 0, // UTF-8
     };
 
-    // Build compilation arguments: -T ps_6_0 -E <entry> -O3 -Zpc
+    // Build compilation arguments: -T <profile> -E <entry> -O3 -Zpc
     const target_flag = std.unicode.utf8ToUtf16LeStringLiteral("-T");
-    const target_profile = std.unicode.utf8ToUtf16LeStringLiteral("ps_6_0");
     const entry_flag = std.unicode.utf8ToUtf16LeStringLiteral("-E");
     const opt_level = std.unicode.utf8ToUtf16LeStringLiteral("-O3");
     const packing = std.unicode.utf8ToUtf16LeStringLiteral("-Zpc");
 
     const args = [_]?[*:0]const u16{
         target_flag,
-        target_profile,
+        profile,
         entry_flag,
         entry_point,
         opt_level,

--- a/src/terminal/stream_terminal.zig
+++ b/src/terminal/stream_terminal.zig
@@ -1564,18 +1564,18 @@ test "DECSCUSR sets cursor style (shape changes reach the shader)" {
     // what feeds the renderer glyph width (and thus the cursor shaders'
     // mode-change gate).
     s.nextSlice("\x1B[2 q");
-    try testing.expectEqual(@as(?Screen.CursorStyle, .block), t.screens.active.cursor.cursor_style);
+    try testing.expectEqual(.block, t.screens.active.cursor.cursor_style);
 
     s.nextSlice("\x1B[4 q");
-    try testing.expectEqual(@as(?Screen.CursorStyle, .underline), t.screens.active.cursor.cursor_style);
+    try testing.expectEqual(.underline, t.screens.active.cursor.cursor_style);
 
     s.nextSlice("\x1B[6 q");
-    try testing.expectEqual(@as(?Screen.CursorStyle, .bar), t.screens.active.cursor.cursor_style);
+    try testing.expectEqual(.bar, t.screens.active.cursor.cursor_style);
 
     // Default (CSI 0 SP q / CSI q) re-selects the configured default,
     // which for a bare test Terminal is block.
     s.nextSlice("\x1B[ q");
-    try testing.expectEqual(@as(?Screen.CursorStyle, .block), t.screens.active.cursor.cursor_style);
+    try testing.expectEqual(.block, t.screens.active.cursor.cursor_style);
 }
 
 test "cursor save and restore" {

--- a/src/terminal/stream_terminal.zig
+++ b/src/terminal/stream_terminal.zig
@@ -1552,6 +1552,32 @@ test "alt screen" {
     try testing.expectEqualStrings("Primary", str);
 }
 
+test "DECSCUSR sets cursor style (shape changes reach the shader)" {
+    var t: Terminal = try .init(testing.io, testing.allocator, .{ .cols = 10, .rows = 10 });
+    defer t.deinit(testing.allocator);
+
+    var s: Stream = .init(.{ .allocator = testing.allocator, .handler = .init(&t) });
+    defer s.deinit();
+
+    // Steady block (CSI 2 SP q), then steady underline (CSI 4 SP q), then
+    // steady bar (CSI 6 SP q): each must land in cursor_style, which is
+    // what feeds the renderer glyph width (and thus the cursor shaders'
+    // mode-change gate).
+    s.nextSlice("\x1B[2 q");
+    try testing.expectEqual(@as(?Screen.CursorStyle, .block), t.screens.active.cursor.cursor_style);
+
+    s.nextSlice("\x1B[4 q");
+    try testing.expectEqual(@as(?Screen.CursorStyle, .underline), t.screens.active.cursor.cursor_style);
+
+    s.nextSlice("\x1B[6 q");
+    try testing.expectEqual(@as(?Screen.CursorStyle, .bar), t.screens.active.cursor.cursor_style);
+
+    // Default (CSI 0 SP q / CSI q) re-selects the configured default,
+    // which for a bare test Terminal is block.
+    s.nextSlice("\x1B[ q");
+    try testing.expectEqual(@as(?Screen.CursorStyle, .block), t.screens.active.cursor.cursor_style);
+}
+
 test "cursor save and restore" {
     var t: Terminal = try .init(testing.io, testing.allocator, .{ .cols = 80, .rows = 24 });
     defer t.deinit(testing.allocator);

--- a/tools/gallery/verify.sh
+++ b/tools/gallery/verify.sh
@@ -1,16 +1,20 @@
 #!/usr/bin/env bash
 # verify.sh — compile and render the bundled shader gallery through the real
-# shipped pipeline, end to end:
+# shipped pipeline, end to end, DIFFERENTIALLY:
 #
 #   GLSL (prefix + gallery shader)
 #     -> zioshade HLSL            (local; the same compileGlslToHlsl wintty runs)
+#     -> reference HLSL           (local; glslang -> SPIR-V -> spirv-cross,
+#                                  the flags zioshade's own oracle scripts use)
 #     -> DXC DXIL                 (Windows box; the SDK dxc, DXIL-capable)
-#     -> D3D12 WARP render        (zioshade tools/warp, gallery mode)
-#     -> <name>.ppm frame         (fetched back to previews/)
+#     -> D3D12 WARP render        (zioshade tools/warp, gallery pair-diff mode)
+#     -> <name>.zs.ppm / .sc.ppm  (fetched back to previews/)
 #
-# A shader that passes here compiles and renders on the exact path a user's
-# terminal runs. A FAIL is a broken gallery entry: fix the shader or file a
-# zioshade bug — do not ship it.
+# A shader that passes here compiles AND renders identically to the independent
+# spirv-cross reference on the exact path a user's terminal runs. A GALLERY
+# DIFFER means zioshade miscompiled the shader: that is a zioshade bug (fix it
+# or file it upstream, and do NOT ship the shader in that state). A compile or
+# render FAIL is a broken gallery entry: fix the shader, do not ship it.
 #
 # Usage:   tools/gallery/verify.sh
 # Env:
@@ -18,6 +22,8 @@
 #   WARP_HOST      ssh target with the Windows SDK (default alessandro@ryzen7pro)
 #   WARP_DIR       remote working dir (default C:/wintty_gallery)
 #   ZIOSHADE_DIR   zioshade checkout (default ../zioshade), for tools/warp
+#   GLSLANG        glslangValidator binary (default: glslang on PATH)
+#   SPIRV_CROSS    spirv-cross binary (default: spirv-cross on PATH)
 
 set -euo pipefail
 
@@ -30,12 +36,16 @@ ZIOSHADE_DIR=${ZIOSHADE_DIR:-$(cd "$repo/.." && pwd)/zioshade}
 ZIOSHADE_BIN=${ZIOSHADE_BIN:-$ZIOSHADE_DIR/zig-out/bin/zioshade}
 WARP_HOST=${WARP_HOST:-alessandro@ryzen7pro}
 WARP_DIR=${WARP_DIR:-C:/wintty_gallery}
+GLSLANG=${GLSLANG:-glslang}
+SPIRV_CROSS=${SPIRV_CROSS:-spirv-cross}
 DXC_WIN='C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\dxc.exe'
 
 if [ ! -x "$ZIOSHADE_BIN" ]; then
   echo "zioshade CLI not found at $ZIOSHADE_BIN (build it: cd $ZIOSHADE_DIR && zig build cli)" >&2
   exit 2
 fi
+command -v "$GLSLANG" >/dev/null     || { echo "glslang not found (brew install glslang); the reference path needs it" >&2; exit 2; }
+command -v "$SPIRV_CROSS" >/dev/null || { echo "spirv-cross not found (brew install spirv-cross); the reference path needs it" >&2; exit 2; }
 
 stage=$(mktemp -d /tmp/gallery_verify.XXXXXX)
 trap 'rm -rf "$stage"' EXIT
@@ -55,7 +65,37 @@ done
 echo "zioshade HLSL: $pass pass, $fail fail"
 [ "$fail" -eq 0 ] || { echo "not staging (fix zioshade failures first):$failed"; exit 1; }
 
-# ── 2. Stage everything to the Windows box ─────────────────────────────────
+# ── 2. Reference HLSL: same GLSL -> glslang SPIR-V -> spirv-cross ───────────
+# An independent oracle for every gallery shader (the same glslang/spirv-cross
+# flags zioshade's oracle scripts use, e.g. tools/frag_oracle_check.sh and
+# tools/warp/stage_pairs.sh). run.ps1 -Gallery pairs <name>.hlsl with this
+# <name>.sc.hlsl and render-diffs them on WARP. A rejection here FAILS the
+# gate: a reference gap is a gate gap (that shader would silently lose its
+# differential).
+# The one normalization: glslang is stricter than zioshade's frontend about
+# reserved words. The gallery uses `active` (reserved in desktop GLSL) as an
+# identifier and zioshade deliberately accepts it (wintty compiles via zioshade
+# alone). Renaming just that identifier on the REFERENCE side is
+# semantics-preserving (a local variable), so the oracle still covers these
+# shaders; anything else glslang or spirv-cross rejects is a loud FAIL.
+refpass=0; reffail=0; reffailed=""
+for glsl in "$shaders_dir"/*.glsl; do
+  name=$(basename "$glsl" .glsl)
+  perl -pe 's/\bactive\b/active_/g' "$stage/$name.full.glsl" > "$stage/$name.ref.glsl"
+  if "$GLSLANG" -V -S frag "$stage/$name.ref.glsl" -o "$stage/$name.spv" >/dev/null 2>"$stage/$name.ref.err" &&
+     "$SPIRV_CROSS" --hlsl --shader-model 60 "$stage/$name.spv" > "$stage/$name.sc.hlsl" 2>>"$stage/$name.ref.err"; then
+    refpass=$((refpass+1))
+  else
+    echo "FAIL reference $name: $(head -1 "$stage/$name.ref.err")"
+    reffail=$((reffail+1)); reffailed="$reffailed $name"
+  fi
+  rm -f "$stage/$name.spv"
+done
+echo "reference HLSL (glslang -> spirv-cross): $refpass pass, $reffail fail"
+[ "$reffail" -eq 0 ] || { echo "reference generation failed (a reference gap is a gate gap):$reffailed"; exit 1; }
+
+# ── 3. Stage everything to the Windows box ─────────────────────────────────
+# <name>.hlsl (zioshade) + <name>.sc.hlsl (reference) pair up in run.ps1.
 # build_warp.cmd carries the clang-cl recipe from zioshade tools/warp/README.md
 # (that box has no vcvars; a batch file sidesteps every ssh quoting problem).
 cat > "$stage/build_warp.cmd" <<'EOF'
@@ -80,13 +120,17 @@ scp -q "$ZIOSHADE_DIR/tools/warp/run.ps1" \
        "$stage"/*.hlsl \
        "$WARP_HOST:$WARP_DIR/"
 
-# ── 3. Build warp_render.exe (once) and run the gallery sweep ───────────────
+# ── 4. Build warp_render.exe and run the gallery sweep ──────────────────────
+# build_warp.cmd caches an existing exe; the staged warp_render.cpp must be the
+# one that actually runs (a stale cached exe predating --gallery-diff fails the
+# paired mode confusingly), so drop the exe and let it rebuild.
+ssh "$WARP_HOST" "if exist $win_dir\warp_render.exe del $win_dir\warp_render.exe"
 ssh "$WARP_HOST" "cd /d $win_dir && build_warp.cmd" || { echo "warp_render build failed" >&2; exit 3; }
 
 echo "running WARP gallery render on $WARP_HOST..."
 ssh "$WARP_HOST" "cd /d $win_dir && powershell -ExecutionPolicy Bypass -File run.ps1 -Gallery -Dir . -Dxc \"$DXC_WIN\" -Warp .\warp_render.exe"
 
-# ── 4. Fetch the rendered frames back as previews ──────────────────────────
+# ── 5. Fetch the rendered frames back as previews ──────────────────────────
 mkdir -p "$previews"
 scp -q "$WARP_HOST:$WARP_DIR/*.ppm" "$previews/" || echo "(no PPMs fetched)"
 echo "previews in $previews"

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -72,6 +72,13 @@ public partial class App : Application
     // UI-thread-only access.
     private Window? _settingsWindow;
 
+    /// <summary>
+    /// The app-wide settings window while it is open, else null. Auxiliary
+    /// windows opened from its pages (about, shader picker) parent their
+    /// teardown to it, so closing settings closes them too.
+    /// </summary>
+    internal Window? SettingsWindow => _settingsWindow;
+
     private Ghostty.Session.SessionManager? _sessionManager;
     private Ghostty.Hosting.WindowsGlobalHotKey? _quakeHotKey;
     private Ghostty.Hosting.WindowsSystemMenuHook? _systemMenuHook;

--- a/windows/Ghostty/Assets/Shaders/crt.glsl
+++ b/windows/Ghostty/Assets/Shaders/crt.glsl
@@ -24,10 +24,11 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord)
 {
     vec2 uv = crtCurve(fragCoord.xy / iResolution.xy);
 
-    if (uv.x < 0.0 || uv.x > 1.0 || uv.y < 0.0 || uv.y > 1.0) {
-        fragColor = vec4(0.0, 0.0, 0.0, 1.0);
-        return;
-    }
+    // Bezel via multiply, not an early return: an early return in
+    // mainImage lowers to a WGSL path that renders the whole frame black
+    // (zioshade-8h7), and the multiply reads identically on every backend.
+    float inside = step(0.0, uv.x) * step(uv.x, 1.0)
+                 * step(0.0, uv.y) * step(uv.y, 1.0);
 
     // Chromatic separation grows toward the edges.
     vec2 c = uv - 0.5;
@@ -56,5 +57,5 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord)
     float vig = 1.0 - CRT_VIGNETTE * dot(c, c) * 2.2;
     col *= vig;
 
-    fragColor = vec4(col, 1.0);
+    fragColor = vec4(col * inside, 1.0);
 }

--- a/windows/Ghostty/Assets/Shaders/crt.glsl
+++ b/windows/Ghostty/Assets/Shaders/crt.glsl
@@ -1,21 +1,20 @@
 // Written for the wintty shader gallery. License: MIT (wintty project).
 //
-// An original CRT look: gentle curvature, resolution-scaled scanlines with
-// a slow roll, a whisper of a pixel grid, chromatic edge separation, a
-// phosphor hum, and a vignette. Tuned to stay readable as a terminal.
+// An original CRT look, built the way the classic CRT shaders do it: a
+// SMOOTH sine luminance wave for scanlines (hard-edged step lines alias
+// into moire mush at real resolutions) plus a vertical 2px aperture
+// grille for the phosphor-mask feel, gentle barrel curvature, faint
+// chromatic separation, and a vignette. Tuned to stay readable.
 
-const float CRT_CURVE     = 0.022; // barrel strength (kept subtle)
-const float CRT_SCAN_PX   = 4.0;   // screen px per scanline
-const float CRT_SCAN_BOLD = 0.45;  // scanline darkening at its peak
-const float CRT_GRID_PX   = 2.0;   // screen px per pixel-grid cell
-const float CRT_GRID      = 0.04;  // pixel grid darkening (a whisper)
-const float CRT_HUM       = 0.012; // global brightness hum
-const float CRT_CHROMA    = 0.0012;// chromatic offset at the edges
-const float CRT_VIGNETTE  = 0.18;  // corner darkening
+const float CRT_CURVE   = 0.022; // barrel strength (kept subtle)
+const float CRT_SCAN_MIN = 3.5;  // min screen px per scanline period
+const float CRT_SCAN_DEPTH = 0.5; // scanline wave depth (0..1)
+const float CRT_GRILLE   = 0.22;  // vertical grille darkening
+const float CRT_CHROMA   = 0.0012; // chromatic offset at the edges
+const float CRT_VIGNETTE = 0.18;  // corner darkening
 
 vec2 crtCurve(vec2 uv)
 {
-    // Centered coordinates, bulged outward by CURVE.
     vec2 c = uv * 2.0 - 1.0;
     c *= 1.0 + CRT_CURVE * dot(c, c);
     return c * 0.5 + 0.5;
@@ -25,7 +24,6 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord)
 {
     vec2 uv = crtCurve(fragCoord.xy / iResolution.xy);
 
-    // Outside the bulged tube: black bezel.
     if (uv.x < 0.0 || uv.x > 1.0 || uv.y < 0.0 || uv.y > 1.0) {
         fragColor = vec4(0.0, 0.0, 0.0, 1.0);
         return;
@@ -40,25 +38,19 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord)
     col.g = texture(iChannel0, uv).g;
     col.b = texture(iChannel0, uv - off).b;
 
-    // Scanlines, in fragCoord space (same basis as the grid below, which
-    // is confirmed visible) so no iResolution/uv math can hide them:
-    // static, hard-edged, 4px period, 45% darkening. If this is not
-    // visible the shader path itself is broken, not the tuning.
-    float scan = 0.5 + 0.5 * sin(fragCoord.y * 6.2831853 / CRT_SCAN_PX);
-    // Dark only in the trough of each period (~1.4px of every 4): reads as
-    // a scanline, not a band.
-    float line = 1.0 - step(0.45, scan);
-    col *= 1.0 - CRT_SCAN_BOLD * line;
+    // Scanlines: a smooth luminance wave in screen space, gently rolling.
+    // Resolution-adaptive period; the wave shape (not a hard step) is what
+    // keeps the lines visible instead of aliasing into noise.
+    float scan_px = max(CRT_SCAN_MIN, iResolution.y / 320.0);
+    float scans = 0.5 + 0.5 * sin(fragCoord.y * 6.2831853 / scan_px + iTime * 1.5);
+    float m = 1.0 - CRT_SCAN_DEPTH * pow(scans, 1.6);
+    col *= m;
 
-    // Pixel grid: a faint static mask in screen space -- much subtler than
-    // the dedicated Pixels shader, and no content quantization, so text
-    // stays crisp.
-    vec2 g = abs(fract(fragCoord.xy / CRT_GRID_PX) - 0.5) * 2.0;
-    float edge = max(g.x, g.y);
-    col *= 1.0 - CRT_GRID * smoothstep(0.6, 1.0, edge);
-
-    // Slow phosphor hum.
-    col *= 1.0 + CRT_HUM * sin(iTime * 2.1);
+    // Aperture grille: vertical 2px phosphor columns. This, not a pixel
+    // grid, is what reads as "CRT" -- horizontal scanlines above, vertical
+    // grille here.
+    float gx = clamp((mod(fragCoord.x, 2.0) - 1.0) * 2.0, 0.0, 1.0);
+    col *= 1.0 - CRT_GRILLE * gx;
 
     // Vignette.
     float vig = 1.0 - CRT_VIGNETTE * dot(c, c) * 2.2;

--- a/windows/Ghostty/Assets/Shaders/cursor_teleport.glsl
+++ b/windows/Ghostty/Assets/Shaders/cursor_teleport.glsl
@@ -1,0 +1,122 @@
+// Written for the wintty shader gallery. License: MIT (wintty project).
+//
+// Cursor teleport: when the cursor jumps between cells it blinks out at
+// the old position, a ghost streak smears the frame along the jump path
+// (iChannel0 sampled back along the direction of travel), and the cursor
+// materializes at the new position with a short flash. The travel curve
+// leaves fast and settles, so the streak reads as a teleport, not a
+// slide. Fires on position jumps (arrows, clicks, prompt hops), not on
+// shape flips: the cursor's bottom-left corner only moves when the cell
+// moves.
+//
+// Kept deliberately branchless. zioshade (v0.6.x) sinks the incoming
+// store of a local that is modified inside a conditional containing a
+// loop, so the not-taken path reads an uninitialized variable and the
+// idle frame renders black. The ghost loop runs unconditionally (8 taps,
+// same shape as text_glow) and the whole effect is gated by multipliers.
+
+const float DURATION       = 0.22; // total effect, seconds
+const int   GHOST_TAPS     = 8;    // samples averaged into the streak
+const float JUMP_THRESHOLD = 0.30; // min corner jump (cell heights) to fire
+const float GHOST_STRENGTH = 0.85; // streak opacity at its peak
+const float OUT_FLASH      = 1.60; // departure flash brightness
+const float IN_FLASH       = 1.60; // arrival flash brightness
+const float BEAM_BRIGHT    = 0.90; // traveling beam brightness
+
+float easeOutQuart(float x) {
+    return 1.0 - pow(1.0 - x, 4.0);
+}
+
+float sdRect(vec2 p, vec2 center, vec2 halfSize) {
+    vec2 d = abs(p - center) - halfSize;
+    return length(max(d, 0.0)) + min(max(d.x, d.y), 0.0);
+}
+
+float sdSegment(vec2 p, vec2 a, vec2 b) {
+    vec2 e = b - a;
+    vec2 q = p - a;
+    float t = clamp(dot(q, e) / max(dot(e, e), 1.0), 0.0, 1.0);
+    return length(q - e * t);
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord)
+{
+    vec2 uv = fragCoord.xy / iResolution.xy;
+    vec3 col = texture(iChannel0, uv).rgb;
+
+    // Cursor geometry in pixels. Convention (y down): xy = left edge +
+    // bottom edge of the cell, zw = size, so the center is (x+w/2, y-h/2).
+    vec2 curCenter  = iCurrentCursor.xy
+                    + vec2(iCurrentCursor.z, -iCurrentCursor.w) * 0.5;
+    vec2 prevCenter = iPreviousCursor.xy
+                    + vec2(iPreviousCursor.z, -iPreviousCursor.w) * 0.5;
+    vec2 curHalf = iCurrentCursor.zw * 0.5;
+
+    float cellH = max(iCurrentCursor.w, iPreviousCursor.w);
+    vec2 jump = curCenter - prevCenter;
+
+    // Gate on the corner, not the center: shape flips (bar/block/underline)
+    // resize the rect around a fixed corner, only a real move shifts it.
+    float cornerJump = length(iCurrentCursor.xy - iPreviousCursor.xy);
+    float age = iTime - iTimeCursorChange;
+    float active = step(cellH * JUMP_THRESHOLD, cornerJump)
+                 * step(age, DURATION) * step(0.0, age);
+    float p = clamp(age / DURATION, 0.0, 1.0);
+    float e = easeOutQuart(p); // travel: leaves fast, settles in
+    float fade = 1.0 - p;
+    vec3 tint = iCurrentCursorColor.rgb;
+
+    // 1) Ghost streak: blur the frame along the jump direction. The
+    // sampling span covers the whole path at p=0 and collapses onto the
+    // current pixel as the teleport resolves, so text smears and then
+    // snaps back into focus.
+    vec2 head = mix(prevCenter, curCenter, e);
+    float dLine = sdSegment(fragCoord.xy, prevCenter, head);
+    float band = 1.0 - smoothstep(cellH * 0.7, cellH * 2.0, dLine);
+    vec3 acc = vec3(0.0);
+    float wsum = 0.0;
+    for (int i = 0; i < GHOST_TAPS; i++) {
+        float t = (float(i) + 0.5) / float(GHOST_TAPS);
+        float w = 1.0 - t * 0.6;
+        vec2 off = -jump * (1.0 - e) * t;
+        acc += texture(iChannel0, uv + off / iResolution.xy).rgb * w;
+        wsum += w;
+    }
+    vec3 ghost = acc / wsum;
+    // The streak lives in the band only; keep the cursor cell crisp.
+    float hole = 1.0 - step(0.0, sdRect(fragCoord.xy, curCenter, curHalf * 1.05));
+    float streakA = band * fade * GHOST_STRENGTH * hole * active;
+    vec3 newColor = mix(col, ghost, streakA);
+    // A tint over the band so it reads as energy, not smudge.
+    newColor += mix(tint, vec3(1.0), 0.25) * band * fade * 0.30
+              * hole * active;
+
+    // 1b) Traveling beam: a bright core inside the band, running from
+    // the old position to the easing head. It spans the whole path at
+    // p=0 and collapses into the arrival point. The radius is sized by
+    // the cell, not the jump, so single-cell moves still get a fat
+    // visible streak.
+    float beam = exp(-dLine / max(cellH * 0.30, 3.0)) * fade * hole * active;
+    newColor += mix(tint, vec3(1.0), 0.5) * beam * BEAM_BRIGHT;
+
+    // 2) Departure: the old cell flashes and collapses to nothing over
+    // the first 30% of the animation.
+    float outP = clamp(p / 0.30, 0.0, 1.0);
+    vec2 oldHalf = max(curHalf * (1.0 - outP), vec2(0.0));
+    float sdfOld = sdRect(fragCoord.xy, prevCenter, oldHalf);
+    float outGlow = exp(-max(sdfOld, 0.0) / max(cellH * 0.50, 3.0));
+    newColor += mix(tint, vec3(1.0), 0.4) * outGlow * (1.0 - outP)
+              * (1.0 - outP) * OUT_FLASH * active;
+
+    // 3) Arrival: a pulse of light where the cursor materializes,
+    // peaking around 65% and gone by the end.
+    float inP = clamp((p - 0.30) / 0.70, 0.0, 1.0);
+    float pulse = sin(inP * 3.14159265);
+    float sdfNew = sdRect(fragCoord.xy, curCenter,
+                          curHalf * (1.0 + 0.35 * pulse));
+    float inGlow = exp(-max(sdfNew, 0.0) / max(cellH * 0.45, 3.0));
+    newColor += mix(tint, vec3(1.0), 0.6) * inGlow * pulse
+              * IN_FLASH * active;
+
+    fragColor = vec4(newColor, 1.0);
+}

--- a/windows/Ghostty/Assets/Shaders/cursor_teleport.glsl
+++ b/windows/Ghostty/Assets/Shaders/cursor_teleport.glsl
@@ -9,11 +9,13 @@
 // shape flips: the cursor's bottom-left corner only moves when the cell
 // moves.
 //
-// Kept deliberately branchless. zioshade (v0.6.x) sinks the incoming
-// store of a local that is modified inside a conditional containing a
-// loop, so the not-taken path reads an uninitialized variable and the
-// idle frame renders black. The ghost loop runs unconditionally (8 taps,
-// same shape as text_glow) and the whole effect is gated by multipliers.
+// Kept deliberately branchless. Written around a zioshade v0.6.x bug
+// that sank the incoming store of a local modified inside a conditional
+// containing a loop, so the not-taken path read an uninitialized
+// variable and the idle frame rendered black. The store-sink is fixed
+// as of v0.8.2; the shape stays because it costs nothing extra. The
+// ghost loop runs unconditionally (8 taps, same shape as text_glow) and
+// the whole effect is gated by multipliers.
 
 const float DURATION       = 0.22; // total effect, seconds
 const int   GHOST_TAPS     = 8;    // samples averaged into the streak

--- a/windows/Ghostty/Assets/Shaders/interference.glsl
+++ b/windows/Ghostty/Assets/Shaders/interference.glsl
@@ -1,0 +1,61 @@
+// Written for the wintty shader gallery. License: MIT (wintty project).
+//
+// Fallout-style CRT interference: a broad interference band slowly rolls
+// down the screen brightening and jittering everything it passes, rows
+// twitch horizontally, static grain flickers, and rare tears displace a
+// line for a beat. Tuned to stay readable as a terminal.
+
+const float BAND_SPEED = 0.05;  // band cycles the screen every ~20s
+const float BAND_H     = 0.10;  // band height (fraction of screen height)
+const float JITTER_PX  = 2.5;   // baseline row twitch, pixels
+const float GRAIN      = 0.06;  // static noise amplitude
+const float TEAR_CHANCE = 0.006; // per row, per coarse tick
+const vec3  PHOSPHOR   = vec3(0.25, 1.0, 0.35); // Pip-Boy green
+const float TINT_MIX   = 0.85;  // how far toward monochrome green
+
+float hash(vec2 p)
+{
+    return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord)
+{
+    vec2 uv = fragCoord.xy / iResolution.xy;
+    float row = floor(fragCoord.y);
+
+    // Interference band: bright, unstable region rolling down the screen.
+    float band_y = fract(iTime * BAND_SPEED);
+    float in_band = smoothstep(BAND_H, 0.0, abs(uv.y - band_y));
+
+    // Rows twitch horizontally; much harder inside the band.
+    float tick = floor(iTime * 24.0);
+    float n = hash(vec2(row, tick));
+    float j = (n - 0.5) * JITTER_PX * (1.0 + in_band * 8.0);
+
+    // Rare tear: one line jumps sideways for a single coarse beat.
+    float tear = step(1.0 - TEAR_CHANCE, hash(vec2(row, floor(iTime * 3.0))));
+    j += tear * (hash(vec2(row, 1.7)) - 0.5) * 16.0;
+
+    vec3 col = texture(iChannel0, uv + vec2(j / iResolution.x, 0.0)).rgb;
+
+    // Chroma split inside the band, like a mistracking signal.
+    float ca = in_band * 1.5;
+    col.r = mix(col.r, texture(iChannel0, uv + vec2((j + ca) / iResolution.x, 0.0)).r, 0.6);
+    col.b = mix(col.b, texture(iChannel0, uv + vec2((j - ca) / iResolution.x, 0.0)).b, 0.6);
+
+    // Static grain, denser in the band.
+    float g = hash(fragCoord.xy + vec2(mod(iTime, 10.0) * 61.0, mod(iTime, 10.0) * 83.0)) - 0.5;
+    col += g * (GRAIN + in_band * 0.10);
+
+    // The band itself: brightness lift with a traveling shimmer.
+    col *= 1.0 + in_band * (0.25 + 0.12 * sin(fragCoord.y * 1.7 + iTime * 40.0));
+
+    // Pip-Boy phosphor: luminance mapped onto bright green, a little
+    // bloom on the highlights. Mixed, not full-force, so syntax colors
+    // in editors are tinted rather than erased.
+    float lum = dot(col, vec3(0.2126, 0.7152, 0.0722));
+    vec3 green = PHOSPHOR * (0.18 + 0.95 * lum) + vec3(0.0, 0.06 * lum * lum, 0.0);
+    col = mix(col, green, TINT_MIX);
+
+    fragColor = vec4(col, 1.0);
+}

--- a/windows/Ghostty/Assets/Shaders/lightning_strike.glsl
+++ b/windows/Ghostty/Assets/Shaders/lightning_strike.glsl
@@ -8,12 +8,14 @@
 // strike is seeded from iTimeCursorChange, so every jump draws a
 // different bolt.
 //
-// Kept deliberately branchless. zioshade (v0.6.x) sinks the incoming
-// store of a local that is modified inside a conditional containing a
-// loop, so the not-taken path reads an uninitialized variable and the
-// idle frame renders black. The gate is a multiplier instead, and the
-// loop trip counts collapse to zero when the effect is idle so the
-// per-pixel cost only lands during a strike.
+// Kept deliberately branchless. Written around a zioshade v0.6.x bug
+// that sank the incoming store of a local modified inside a conditional
+// containing a loop, so the not-taken path read an uninitialized
+// variable and the idle frame rendered black. The store-sink is fixed
+// as of v0.8.2; the shape stays because it costs nothing extra. The
+// gate is a multiplier instead, and the loop trip counts collapse to
+// zero when the effect is idle so the per-pixel cost only lands during
+// a strike.
 
 const float DURATION       = 0.30; // total effect, seconds
 const float STRIKE_FRAC    = 0.30; // fraction of DURATION the bolt travels

--- a/windows/Ghostty/Assets/Shaders/lightning_strike.glsl
+++ b/windows/Ghostty/Assets/Shaders/lightning_strike.glsl
@@ -1,0 +1,171 @@
+// Written for the wintty shader gallery. License: MIT (wintty project).
+//
+// Lightning strike: every time the cursor jumps, a jagged bolt drops from
+// the top edge down to the new cursor cell, forking twice on the way, and
+// lands with a flash and bloom on the character it hits. White-hot core
+// with a cursor-colored glow, a per-frame flicker, and a short decaying
+// afterglow. Everything is additive, so the text stays readable. Each
+// strike is seeded from iTimeCursorChange, so every jump draws a
+// different bolt.
+//
+// Kept deliberately branchless. zioshade (v0.6.x) sinks the incoming
+// store of a local that is modified inside a conditional containing a
+// loop, so the not-taken path reads an uninitialized variable and the
+// idle frame renders black. The gate is a multiplier instead, and the
+// loop trip counts collapse to zero when the effect is idle so the
+// per-pixel cost only lands during a strike.
+
+const float DURATION       = 0.30; // total effect, seconds
+const float STRIKE_FRAC    = 0.30; // fraction of DURATION the bolt travels
+const int   MAIN_SEGS      = 20;   // polyline segments of the main channel
+const int   BRANCH_SEGS    = 7;    // polyline segments of each fork
+const float CORE_WIDTH     = 1.8;  // px, white-hot line
+const float GLOW_WIDTH     = 9.0;  // px, colored halo falloff
+const float JUMP_THRESHOLD = 0.30; // min corner jump (cell heights) to fire
+const float BOLT_BRIGHT    = 0.85;
+const float FLASH_BRIGHT   = 1.30;
+
+float hash1(float n)
+{
+    return fract(sin(n) * 43758.5453123);
+}
+
+// Piecewise-linear value noise: sharp zigzag kinks, right for lightning.
+// Centered on zero.
+float zig1(float x)
+{
+    float i = floor(x);
+    float f = fract(x);
+    return mix(hash1(i), hash1(i + 1.0), f) - 0.5;
+}
+
+float sdSegment(vec2 p, vec2 a, vec2 b)
+{
+    vec2 e = b - a;
+    vec2 q = p - a;
+    float t = clamp(dot(q, e) / max(dot(e, e), 1.0), 0.0, 1.0);
+    return length(q - e * t);
+}
+
+float sdRect(vec2 p, vec2 center, vec2 halfSize)
+{
+    vec2 d = abs(p - center) - halfSize;
+    return length(max(d, 0.0)) + min(max(d.x, d.y), 0.0);
+}
+
+// Point on the main channel at t in [0,1]: 0 = top edge start, 1 = impact.
+// The wander is pinned to both endpoints so the bolt always starts free
+// and always hits the cursor dead on.
+vec2 boltPoint(float t, float xTop, vec2 impact, float seed, float amp)
+{
+    float env = sin(t * 3.14159265);
+    float x = mix(xTop, impact.x, t)
+            + zig1(t * 6.0 + seed) * amp * env
+            + zig1(t * 19.0 + seed * 1.7) * amp * 0.35 * env;
+    return vec2(x, mix(0.0, impact.y, t));
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord)
+{
+    vec2 uv = fragCoord.xy / iResolution.xy;
+    vec3 col = texture(iChannel0, uv).rgb;
+
+    // Cursor geometry in pixels (y down): xy = left edge + bottom edge of
+    // the cell, zw = size, so the center is (x+w/2, y-h/2).
+    vec2 impact = iCurrentCursor.xy
+                + vec2(iCurrentCursor.z, -iCurrentCursor.w) * 0.5;
+    vec2 cellHalf = iCurrentCursor.zw * 0.5;
+    float cellH = max(iCurrentCursor.w, iPreviousCursor.w);
+
+    // Gate on the corner, not the center: shape flips resize the rect
+    // around a fixed corner, only a real move shifts it.
+    float cornerJump = length(iCurrentCursor.xy - iPreviousCursor.xy);
+    float age = iTime - iTimeCursorChange;
+    float active = step(cellH * JUMP_THRESHOLD, cornerJump)
+                 * step(age, DURATION) * step(0.0, age);
+    float p = clamp(age / DURATION, 0.0, 1.0);
+    vec3 tint = iCurrentCursorColor.rgb;
+    vec3 boltCol = mix(tint, vec3(1.0), 0.55);
+
+    // Seed the whole bolt from the change time: every strike is new.
+    float seed = iTimeCursorChange * 12.9898;
+    float xTop = impact.x
+               + (hash1(seed + 1.3) - 0.5) * iResolution.x * 0.8;
+    float amp = clamp(distance(impact, vec2(xTop, 0.0)) * 0.16,
+                      12.0, 80.0);
+
+    // Growth front: where the bolt has reached on its way down.
+    float g = clamp(p / STRIKE_FRAC, 0.0, 1.0);
+    // Per-frame flicker keeps the channel alive while it glows.
+    float flicker = 0.7 + 0.5 * hash1(seed + floor(iTime * 48.0) * 0.618);
+    // Full brightness while traveling, then a decaying afterglow.
+    float boltEnv = exp(-max(p - STRIKE_FRAC, 0.0) * 6.0) * flicker * active;
+
+    // Loop trip counts collapse to zero when idle.
+    int mainSegs = int(active) * MAIN_SEGS;
+    int branchSegs = int(active) * BRANCH_SEGS;
+
+    float glowI = 0.0;
+    float coreI = 0.0;
+
+    // Main channel: a jagged polyline from the top edge to the cursor.
+    // Segments ahead of the growth front stay dark.
+    for (int i = 0; i < mainSegs; i++) {
+        float t0 = float(i) / float(MAIN_SEGS);
+        float t1 = float(i + 1) / float(MAIN_SEGS);
+        vec2 a = boltPoint(t0, xTop, impact, seed, amp);
+        vec2 b = boltPoint(t1, xTop, impact, seed, amp);
+        float lit = 1.0 - smoothstep(g - 0.08, g, t0);
+        float d = sdSegment(fragCoord.xy, a, b);
+        glowI = max(glowI, lit * exp(-d / GLOW_WIDTH));
+        coreI = max(coreI, lit * exp(-d / CORE_WIDTH));
+    }
+
+    // Two forks: they split off the main channel where the front has
+    // already passed, angle away, and fade sooner.
+    for (int k = 0; k < 2; k++) {
+        float fk = float(k);
+        float t0 = 0.2 + 0.5 * hash1(seed + 7.3 + fk * 11.1);
+        vec2 start = boltPoint(t0, xTop, impact, seed, amp);
+        float ang = (0.7 + 0.6 * hash1(seed + 3.1 + fk * 5.7))
+                  * (fk * 2.0 - 1.0);
+        vec2 v = (impact - start) * 0.35;
+        vec2 end = start + vec2(v.x * cos(ang) - v.y * sin(ang),
+                                v.x * sin(ang) + v.y * cos(ang));
+        float bSeed = seed + 31.0 + fk * 17.0;
+        float bAmp = amp * 0.5;
+        // A fork lights up only after the main front passes its root.
+        float lit0 = smoothstep(g, g - 0.15, t0);
+        for (int j = 0; j < branchSegs; j++) {
+            float s0 = float(j) / float(BRANCH_SEGS);
+            float s1 = float(j + 1) / float(BRANCH_SEGS);
+            vec2 a = mix(start, end, s0)
+                   + vec2(zig1(s0 * 5.0 + bSeed),
+                          zig1(s0 * 5.0 + bSeed + 13.0) * 0.6)
+                     * bAmp * s0;
+            vec2 b = mix(start, end, s1)
+                   + vec2(zig1(s1 * 5.0 + bSeed),
+                          zig1(s1 * 5.0 + bSeed + 13.0) * 0.6)
+                     * bAmp * s1;
+            float d = sdSegment(fragCoord.xy, a, b);
+            glowI = max(glowI, lit0 * 0.6 * exp(-d / (GLOW_WIDTH * 0.8)));
+            coreI = max(coreI, lit0 * 0.5 * exp(-d / CORE_WIDTH));
+        }
+    }
+
+    col += tint * glowI * boltEnv * BOLT_BRIGHT;
+    col += boltCol * coreI * boltEnv;
+
+    // Impact: the flash fires as the front lands and decays from there;
+    // a radial bloom plus a bright cell hit the character.
+    float flashEnv = smoothstep(STRIKE_FRAC * 0.8, STRIKE_FRAC, p)
+                   * exp(-max(p - STRIKE_FRAC, 0.0) * 9.0) * active;
+    float dImp = distance(fragCoord.xy, impact);
+    float sdfCell = sdRect(fragCoord.xy, impact, cellHalf);
+    col += mix(tint, vec3(1.0), 0.6)
+         * (exp(-dImp / max(cellH * 1.4, 8.0))
+          + exp(-max(sdfCell, 0.0) / max(cellH * 0.25, 2.0)))
+         * flashEnv * FLASH_BRIGHT;
+
+    fragColor = vec4(col, 1.0);
+}

--- a/windows/Ghostty/Assets/Shaders/shaders.json
+++ b/windows/Ghostty/Assets/Shaders/shaders.json
@@ -68,9 +68,9 @@
       "name": "Cursor teleport",
       "description": "The cursor blinks out, streaks across as a ghost blur, and materializes at its new position.",
       "category": "cursor",
-      "author": "wintty project",
+      "author": "wintty",
       "license": "MIT",
-      "source": ""
+      "source": "https://github.com/deblasis/wintty"
     },
     {
       "id": "lightning_strike",
@@ -78,9 +78,9 @@
       "name": "Lightning strike",
       "description": "A jagged forked bolt strikes from the top edge onto the cursor with an impact flash.",
       "category": "cursor",
-      "author": "wintty project",
+      "author": "wintty",
       "license": "MIT",
-      "source": ""
+      "source": "https://github.com/deblasis/wintty"
     },
     {
       "id": "scanline",
@@ -106,7 +106,7 @@
       "id": "crt",
       "file": "crt.glsl",
       "name": "CRT",
-      "description": "Curvature, a rolling scanline, and a phosphor hum.",
+      "description": "Smooth scanlines, a vertical aperture grille, curvature, and a vignette.",
       "category": "screen",
       "author": "wintty",
       "license": "MIT",
@@ -157,10 +157,10 @@
       "file": "interference.glsl",
       "name": "Interference",
       "description": "Fallout-style CRT interference: a rolling signal band, twitching rows, static grain, and rare line tears. Fires constantly; no cursor action needed.",
-      "category": "effects",
-      "author": "wintty project",
+      "category": "screen",
+      "author": "wintty",
       "license": "MIT",
-      "source": ""
+      "source": "https://github.com/deblasis/wintty"
     }
   ]
 }

--- a/windows/Ghostty/Assets/Shaders/shaders.json
+++ b/windows/Ghostty/Assets/Shaders/shaders.json
@@ -131,6 +131,16 @@
       "author": "ghostty",
       "license": "MIT",
       "source": "https://github.com/ghostty-org/ghostty"
+    },
+    {
+      "id": "interference",
+      "file": "interference.glsl",
+      "name": "Interference",
+      "description": "Fallout-style CRT interference: a rolling signal band, twitching rows, static grain, and rare line tears. Fires constantly; no cursor action needed.",
+      "category": "effects",
+      "author": "wintty project",
+      "license": "MIT",
+      "source": ""
     }
   ]
 }

--- a/windows/Ghostty/Assets/Shaders/shaders.json
+++ b/windows/Ghostty/Assets/Shaders/shaders.json
@@ -63,6 +63,26 @@
       "source": "https://github.com/sahaj-b/ghostty-cursor-shaders"
     },
     {
+      "id": "cursor_teleport",
+      "file": "cursor_teleport.glsl",
+      "name": "Cursor teleport",
+      "description": "The cursor blinks out, streaks across as a ghost blur, and materializes at its new position.",
+      "category": "cursor",
+      "author": "wintty project",
+      "license": "MIT",
+      "source": ""
+    },
+    {
+      "id": "lightning_strike",
+      "file": "lightning_strike.glsl",
+      "name": "Lightning strike",
+      "description": "A jagged forked bolt strikes from the top edge onto the cursor with an impact flash.",
+      "category": "cursor",
+      "author": "wintty project",
+      "license": "MIT",
+      "source": ""
+    },
+    {
       "id": "scanline",
       "file": "scanline.glsl",
       "name": "Scanline",

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -158,6 +158,16 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     public string? PreviewCustomShader { get; set; }
 
     /// <summary>
+    /// Take keyboard focus as soon as the surface loads. Real terminal
+    /// panes want this so keyboard input starts flowing immediately.
+    /// Preview hosts inside other windows (the shader picker) set false:
+    /// their focus belongs to the picker's own controls, and a loading
+    /// preview would otherwise steal it on every selection change.
+    /// Defaults to true.
+    /// </summary>
+    public bool AutoFocus { get; set; } = true;
+
+    /// <summary>
     /// The raw libghostty surface handle for this control. Used by
     /// <see cref="Ghostty.Hosting.GhosttyHost"/> to resolve a per-surface
     /// userdata pointer back to the handle for clipboard callback completion.
@@ -797,8 +807,13 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         }
 
         // Request focus so keyboard input starts flowing immediately.
-        // Focus lives on the UserControl now, not the panel.
-        this.Focus(FocusState.Programmatic);
+        // Focus lives on the UserControl now, not the panel. Preview
+        // surfaces (AutoFocus = false) opt out: they live inside other
+        // windows whose focus must stay put.
+        if (AutoFocus)
+        {
+            this.Focus(FocusState.Programmatic);
+        }
 
     }
 

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml
@@ -2,8 +2,7 @@
     x:Class="Ghostty.Settings.Pages.AppearancePage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:ctrl="using:Ghostty.Controls.Settings"
-    Unloaded="Page_Unloaded">
+    xmlns:ctrl="using:Ghostty.Controls.Settings">
 
     <ScrollViewer Padding="24">
         <StackPanel MaxWidth="800">
@@ -95,55 +94,45 @@
                 <ctrl:SettingsGroup Header="Shader"
                                     Description="Post-process the terminal with a GLSL shader.">
                     <ctrl:SettingsCard Header="Custom shader"
-                                       Description="Pick a bundled shader, or pick a file of your own below."
+                                       Description="Where the terminal's shader comes from."
                                        ctrl:SettingsCard.ConfigKey="custom-shader">
-                        <ComboBox x:Name="ShaderGalleryCombo"
-                                  MinWidth="300"
-                                  SelectionChanged="ShaderGallery_SelectionChanged">
-                            <ComboBoxItem Tag="">
-                                <StackPanel>
-                                    <TextBlock Text="None" Style="{StaticResource BodyStrongTextBlockStyle}" />
-                                    <TextBlock Text="No custom shader."
-                                               Style="{StaticResource CaptionTextBlockStyle}"
-                                               Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                                </StackPanel>
-                            </ComboBoxItem>
-                            <!-- Gallery entries are inserted before the Custom
-                                 item in code, from Assets/Shaders/shaders.json. -->
-                            <ComboBoxItem x:Name="ShaderCustomFileItem" Tag="custom">
-                                <StackPanel>
-                                    <TextBlock Text="Custom file" Style="{StaticResource BodyStrongTextBlockStyle}" />
-                                    <TextBlock Text="Use the shader file picked below."
-                                               Style="{StaticResource CaptionTextBlockStyle}"
-                                               Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                                </StackPanel>
-                            </ComboBoxItem>
-                        </ComboBox>
-                    </ctrl:SettingsCard>
-                    <!-- No ConfigKey here by design: the gallery card above
-                         owns custom-shader (one key per control, or search
-                         reaches only the first). This card edits the same
-                         value through the shared writer. -->
-                    <ctrl:SettingsCard Header="Shader file"
-                                       Description="Path to a GLSL shader on disk.">
-                        <StackPanel Orientation="Horizontal" Spacing="8">
-                            <TextBox x:Name="ShaderPathBox"
-                                     PlaceholderText="Path to .glsl shader file"
-                                     MinWidth="260"
-                                     LostFocus="ShaderPath_LostFocus" />
-                            <Button Content="Browse..."
-                                    Click="ShaderBrowse_Click" />
+                        <StackPanel Spacing="10">
+                            <RadioButtons x:Name="ShaderModeButtons"
+                                          MaxColumns="1"
+                                          SelectionChanged="ShaderMode_SelectionChanged">
+                                <RadioButton x:Name="ShaderNoneRadio" Content="None" />
+                                <RadioButton x:Name="ShaderGalleryRadio" Content="From gallery" />
+                                <RadioButton x:Name="ShaderFileRadio" Content="From file" />
+                            </RadioButtons>
+                            <!-- Gallery pick row: shown only in gallery mode.
+                                 The picker window owns previewing; this row
+                                 just names the committed pick and reopens it. -->
+                            <StackPanel x:Name="GalleryPickRow"
+                                        Orientation="Horizontal"
+                                        Spacing="8">
+                                <TextBlock x:Name="GalleryPickLabel"
+                                           Text="No shader selected"
+                                           VerticalAlignment="Center"
+                                           TextWrapping="Wrap" />
+                                <Button Content="Choose..."
+                                        Click="ShaderGalleryChoose_Click" />
+                            </StackPanel>
+                            <!-- File row: shown only in file mode. Same
+                                 writer as the old card; no ConfigKey here by
+                                 design (the card above owns custom-shader:
+                                 one key per control, or search reaches only
+                                 the first). -->
+                            <StackPanel x:Name="FilePickRow"
+                                        Orientation="Horizontal"
+                                        Spacing="8">
+                                <TextBox x:Name="ShaderPathBox"
+                                         PlaceholderText="Path to .glsl shader file"
+                                         MinWidth="260"
+                                         LostFocus="ShaderPath_LostFocus" />
+                                <Button Content="Browse..."
+                                        Click="ShaderBrowse_Click" />
+                            </StackPanel>
                         </StackPanel>
-                    </ctrl:SettingsCard>
-                    <ctrl:SettingsCard Header="Preview"
-                                       Description="The selected shader, live. Type in it to see cursor effects move."
-                                       ContentBelow="True">
-                        <Border x:Name="ShaderPreviewHost"
-                                Height="260"
-                                BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
-                                BorderThickness="1"
-                                CornerRadius="4"
-                                Padding="4" />
                     </ctrl:SettingsCard>
                 </ctrl:SettingsGroup>
                 <ctrl:SettingsCard Header="Backdrop preset"

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
@@ -155,9 +155,11 @@ internal sealed partial class AppearancePage : Page
     {
         _configService.ConfigChanged += OnConfigChanged;
         // Page instances are cached, so returning to this page fires Loaded
-        // without the ctor (or any seeding) running again. Re-sync the mode
-        // radios from the seeded value in case the config changed elsewhere.
-        SyncShaderUiForPath(_shaderPathWritten);
+        // without the ctor (or any seeding) running again. ConfigChanged is
+        // unsubscribed in OnUnloaded, so edits made while the page was away
+        // were missed: re-read the file instead of trusting the last value
+        // this page wrote.
+        SeedShaderPath();
     }
 
     private void OnUnloaded(object sender, RoutedEventArgs e)
@@ -290,7 +292,11 @@ internal sealed partial class AppearancePage : Page
 
     // Gallery entries keyed by the absolute installed path of their shader
     // file, so a configured path can be mapped back to its combo item.
-    private readonly Dictionary<string, ShaderGalleryEntry> _shaderGalleryByPath = new();
+    // Case-insensitive: the picker preselects and commits paths with
+    // OrdinalIgnoreCase semantics, and a casing mismatch would otherwise
+    // classify a gallery pick as "From file".
+    private readonly Dictionary<string, ShaderGalleryEntry> _shaderGalleryByPath =
+        new(StringComparer.OrdinalIgnoreCase);
 
     private void PopulateShaderGallery()
     {
@@ -402,6 +408,9 @@ internal sealed partial class AppearancePage : Page
     {
         if (_shaderPicker is { } open)
         {
+            // Activate alone does not reliably restore a minimized window;
+            // Show brings it back first.
+            open.AppWindow?.Show();
             open.Activate();
             return;
         }
@@ -413,14 +422,26 @@ internal sealed partial class AppearancePage : Page
                 : null,
         };
         _shaderPicker = picker;
+
+        // The picker is a top-level window the OS would keep alive after
+        // the app tears down; parent its lifetime to the settings window
+        // it was opened from (same pattern as the about window).
+        var owner = App.SettingsWindow;
+        void OnOwnerClosed(object? s, RoutedEventArgs e) => picker.Close();
+        if (owner is not null) owner.Closed += OnOwnerClosed;
+
         picker.Closed += (sender, args) =>
         {
             _shaderPicker = null;
+            if (owner is not null) owner.Closed -= OnOwnerClosed;
             if (picker.PickedPath is { } path)
             {
                 WriteShaderPathValue(path);
-                SyncShaderUiForPath(path);
             }
+            // Mirror unconditionally, not only on commit: cancelling must
+            // not leave the radios claiming a pick the config never got.
+            // _shaderPathWritten is the post-write truth either way.
+            SyncShaderUiForPath(_shaderPathWritten);
         };
         picker.Activate();
     }

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
@@ -155,9 +155,9 @@ internal sealed partial class AppearancePage : Page
     {
         _configService.ConfigChanged += OnConfigChanged;
         // Page instances are cached, so returning to this page fires Loaded
-        // without the ctor (or any seeding) running again. Recreate whatever
-        // the preview showed; Page_Unloaded disposed it on the way out.
-        UpdateShaderPreview();
+        // without the ctor (or any seeding) running again. Re-sync the mode
+        // radios from the seeded value in case the config changed elsewhere.
+        SyncShaderUiForPath(_shaderPathWritten);
     }
 
     private void OnUnloaded(object sender, RoutedEventArgs e)
@@ -283,8 +283,7 @@ internal sealed partial class AppearancePage : Page
         ShaderPathBox.Text = values.Length > 0 ? values[0] : string.Empty;
         _shaderPathWritten = ShaderPathBox.Text;
         _shaderPathExtraEntries = values.Length > 1;
-        SelectShaderComboForPath(ShaderPathBox.Text);
-        UpdateShaderPreview();
+        SyncShaderUiForPath(ShaderPathBox.Text);
     }
 
     // ── Shader gallery ─────────────────────────────────────────────────────
@@ -299,88 +298,115 @@ internal sealed partial class AppearancePage : Page
         // first consumer to run wires it.
         Ghostty.Core.Settings.ShaderGallery.ManifestParser ??= ShaderGalleryJson.Parse;
 
-        if (ShaderGallery.Entries.Count == 0 && ShaderGallery.LoadDetail is { } detail)
+        if (ShaderGallery.Entries.Count == 0)
         {
             StaticLoggers.SettingsConfigWriter.LogInformation(
                 "shader gallery empty: {Detail} (base: {Base})",
-                detail, AppContext.BaseDirectory);
-            // Visible in the combo itself: a broken gallery install must be
-            // diagnosable from the UI, not only from logs.
-            ShaderGalleryCombo.Items.Insert(0, new ComboBoxItem
-            {
-                IsEnabled = false,
-                Content = $"Gallery unavailable: {detail}",
-            });
+                ShaderGallery.LoadDetail, AppContext.BaseDirectory);
         }
-        var items = ShaderGalleryCombo.Items;
-        // -1 would make Insert below throw and take the whole page down;
-        // appending at the end is the correct degenerate order.
-        var customIndex = items.IndexOf(ShaderCustomFileItem);
-        if (customIndex < 0) customIndex = items.Count;
+        // The picker window renders the entries; this page only needs the
+        // path -> entry map to classify a configured path as gallery vs file.
         foreach (var entry in ShaderGallery.Entries)
         {
             _shaderGalleryByPath[ShaderGallery.AbsolutePathFor(entry)] = entry;
-            var item = new ComboBoxItem { Tag = ShaderGallery.AbsolutePathFor(entry) };
-            var panel = new StackPanel();
-            // Explicit typography rather than style/theme-dictionary lookups:
-            // programmatic theme-resource fetches are unreliable in WinUI 3
-            // desktop, and the two-line shape matches the XAML items.
-            panel.Children.Add(new TextBlock
-            {
-                Text = entry.Name,
-                FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
-            });
-            panel.Children.Add(new TextBlock
-            {
-                Text = entry.Description,
-                FontSize = 12,
-                Opacity = 0.7,
-                TextWrapping = TextWrapping.Wrap,
-            });
-            item.Content = panel;
-            // Before the "Custom file" item, keeping None first.
-            items.Insert(customIndex++, item);
         }
     }
 
-    private void SelectShaderComboForPath(string path)
+    /// <summary>
+    /// Mirrors the configured shader path into the three-state selector:
+    /// empty = None, a gallery path = From gallery (named), anything else =
+    /// From file (path shown in the box). No writes; callers own committing.
+    /// </summary>
+    private void SyncShaderUiForPath(string path)
     {
+        // Radio selection fires ShaderMode_SelectionChanged, which writes
+        // for "None"; a pure UI mirror must not re-commit what it just read.
+        var loading = _loading;
+        _loading = true;
+        try
+        {
+
         if (string.IsNullOrWhiteSpace(path))
         {
-            SelectComboByTag(ShaderGalleryCombo, "");
+            ShaderNoneRadio.IsChecked = true;
+            GalleryPickRow.Visibility = Visibility.Collapsed;
+            FilePickRow.Visibility = Visibility.Collapsed;
+            GalleryPickLabel.Text = "No shader selected";
         }
-        else if (_shaderGalleryByPath.TryGetValue(path, out _))
+        else if (_shaderGalleryByPath.TryGetValue(path, out var entry))
         {
-            SelectComboByTag(ShaderGalleryCombo, path);
+            ShaderGalleryRadio.IsChecked = true;
+            GalleryPickRow.Visibility = Visibility.Visible;
+            FilePickRow.Visibility = Visibility.Collapsed;
+            GalleryPickLabel.Text = $"{entry.Name} — {entry.Description}";
+            ShaderPathBox.Text = path;
         }
         else
         {
-            SelectComboByTag(ShaderGalleryCombo, "custom");
+            ShaderFileRadio.IsChecked = true;
+            GalleryPickRow.Visibility = Visibility.Collapsed;
+            FilePickRow.Visibility = Visibility.Visible;
+            ShaderPathBox.Text = path;
+        }
+        }
+        finally
+        {
+            _loading = loading;
         }
     }
 
-    private void ShaderGallery_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    private void ShaderMode_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
         if (_loading) return;
-        if (sender is not ComboBox combo) return;
-        if (combo.SelectedItem is not ComboBoxItem item) return;
+        if (sender is not RadioButtons buttons) return;
+        if (buttons.SelectedItem is not RadioButton radio) return;
 
-        var tag = item.Tag?.ToString();
-        if (tag == "custom")
+        switch (radio.Name)
         {
-            // No write of its own: the path box below is the source of truth
-            // for a custom file. Preview whatever it holds.
-            UpdateShaderPreview(ShaderPathBox.Text);
-            return;
+            case nameof(ShaderNoneRadio):
+                GalleryPickRow.Visibility = Visibility.Collapsed;
+                FilePickRow.Visibility = Visibility.Collapsed;
+                ShaderPathBox.Text = string.Empty;
+                WriteShaderPathValue(string.Empty);
+                break;
+
+            case nameof(ShaderGalleryRadio):
+                GalleryPickRow.Visibility = Visibility.Visible;
+                FilePickRow.Visibility = Visibility.Collapsed;
+                // Selecting the mode opens the picker: that is where a
+                // gallery shader gets chosen and previewed. Cancelling
+                // leaves the mode checked and the config untouched.
+                OpenShaderPicker();
+                break;
+
+            case nameof(ShaderFileRadio):
+                GalleryPickRow.Visibility = Visibility.Collapsed;
+                FilePickRow.Visibility = Visibility.Visible;
+                // No write of its own: the path box is the source of truth
+                // for a custom file, exactly as before.
+                break;
         }
+    }
 
-        // None ("" or null) clears; a gallery path writes that one shader.
-        var value = string.IsNullOrEmpty(tag) ? null : tag;
-        WriteShaderPathValue(value ?? string.Empty);
+    private void ShaderGalleryChoose_Click(object sender, RoutedEventArgs e) => OpenShaderPicker();
 
-        // Keep the two controls telling the same story.
-        ShaderPathBox.Text = value ?? string.Empty;
-        UpdateShaderPreview(value);
+    private void OpenShaderPicker()
+    {
+        var picker = new ShaderPickerWindow
+        {
+            CurrentPath = _shaderGalleryByPath.ContainsKey(_shaderPathWritten)
+                ? _shaderPathWritten
+                : null,
+        };
+        picker.Closed += (sender, args) =>
+        {
+            if (picker.PickedPath is { } path)
+            {
+                WriteShaderPathValue(path);
+                SyncShaderUiForPath(path);
+            }
+        };
+        picker.Activate();
     }
 
     private async void ShaderBrowse_Click(object sender, RoutedEventArgs e)
@@ -400,8 +426,7 @@ internal sealed partial class AppearancePage : Page
 
             ShaderPathBox.Text = file.Path;
             WriteShaderPathValue(file.Path);
-            SelectShaderComboForPath(file.Path);
-            UpdateShaderPreview(file.Path);
+            SyncShaderUiForPath(file.Path);
         }
         catch (Exception ex)
         {
@@ -438,55 +463,9 @@ internal sealed partial class AppearancePage : Page
     }
 
     // ── Shader preview ─────────────────────────────────────────────────────
-
-    private Controls.TerminalControl? _shaderPreview;
-
-    /// <summary>
-    /// Recreates the preview surface with the given shader applied (null or
-    /// empty = plain terminal). The per-surface override flows through
-    /// TerminalControl.PreviewCustomShader, so browsing the gallery never
-    /// touches the app config or any live terminal.
-    /// </summary>
-    private void UpdateShaderPreview(string? shaderPath = null)
-    {
-        if (ShaderPreviewHost is null) return;
-
-        // Dispose the old preview's surface explicitly. Detaching from the
-        // tree does NOT tear it down (TerminalControl.OnUnloaded is
-        // deliberately a no-op there), and each preview owns a native
-        // surface and a shell process rooted in the shared bootstrap host.
-        _shaderPreview?.DisposeSurface();
-        _shaderPreview = null;
-        ShaderPreviewHost.Child = null;
-
-        var host = App.BootstrapHost;
-        if (host is null) return;
-
-        // The path box is the source of truth for a custom file; the combo's
-        // "custom" Tag is a discriminator, never a shader path (passing it
-        // through would arm the shader-failed notice for a valid file).
-        var path = string.IsNullOrWhiteSpace(shaderPath)
-            ? ShaderPathBox.Text
-            : shaderPath;
-        if (string.IsNullOrEmpty(path)) path = null;
-
-        var control = new Controls.TerminalControl
-        {
-            Host = host,
-            PreviewCustomShader = path,
-        };
-        _shaderPreview = control;
-        ShaderPreviewHost.Child = control;
-    }
-
-    private void Page_Unloaded(object sender, RoutedEventArgs e)
-    {
-        // Dispose the preview surface (and its shell) when leaving the page;
-        // OnLoaded recreates it on return. Detaching alone leaks both.
-        _shaderPreview?.DisposeSurface();
-        _shaderPreview = null;
-        ShaderPreviewHost.Child = null;
-    }
+    // The live preview moved into ShaderPickerWindow (gallery mode). This
+    // page no longer hosts a preview surface, so there is nothing to create
+    // or dispose here; the picker window owns its surface's lifetime.
 
     // The last value this page put in the file, or seeded from it. Blur fires
     // on every pass through the page, including tab-through and the window
@@ -515,8 +494,7 @@ internal sealed partial class AppearancePage : Page
         // write, and the success-checked guards (a failed write must not
         // advance the guard, or retries from this page read as "unchanged").
         WriteShaderPathValue(value);
-        SelectShaderComboForPath(value);
-        UpdateShaderPreview(value);
+        SyncShaderUiForPath(value);
     }
 
     private void BackgroundStyle_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
@@ -426,8 +426,8 @@ internal sealed partial class AppearancePage : Page
         // The picker is a top-level window the OS would keep alive after
         // the app tears down; parent its lifetime to the settings window
         // it was opened from (same pattern as the about window).
-        var owner = App.SettingsWindow;
-        void OnOwnerClosed(object? s, RoutedEventArgs e) => picker.Close();
+        var owner = (Application.Current as App)?.SettingsWindow;
+        void OnOwnerClosed(object? s, WindowEventArgs e) => picker.Close();
         if (owner is not null) owner.Closed += OnOwnerClosed;
 
         picker.Closed += (sender, args) =>

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
@@ -390,16 +390,32 @@ internal sealed partial class AppearancePage : Page
 
     private void ShaderGalleryChoose_Click(object sender, RoutedEventArgs e) => OpenShaderPicker();
 
+    // The one picker instance while it is open. Both entry points
+    // (selecting the gallery radio and Choose...) funnel through
+    // OpenShaderPicker, so a second ask activates the live window instead
+    // of stacking another one on top. Cleared by Closed, not Unloaded:
+    // the page is cached across navigations while the picker is modeless
+    // and outlives them.
+    private ShaderPickerWindow? _shaderPicker;
+
     private void OpenShaderPicker()
     {
+        if (_shaderPicker is { } open)
+        {
+            open.Activate();
+            return;
+        }
+
         var picker = new ShaderPickerWindow
         {
             CurrentPath = _shaderGalleryByPath.ContainsKey(_shaderPathWritten)
                 ? _shaderPathWritten
                 : null,
         };
+        _shaderPicker = picker;
         picker.Closed += (sender, args) =>
         {
+            _shaderPicker = null;
             if (picker.PickedPath is { } path)
             {
                 WriteShaderPathValue(path);

--- a/windows/Ghostty/Settings/ShaderPickerWindow.xaml
+++ b/windows/Ghostty/Settings/ShaderPickerWindow.xaml
@@ -5,10 +5,12 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <!-- Gallery shader picker: a real window (not a dialog) so it can stay
-         open while the caller compares against other windows. The combo and
-         the left/right arrow keys both move through the gallery; the live
-         terminal underneath previews each shader as selected. Focus the
-         terminal to type and see cursor-triggered effects. -->
+         open while the caller compares against other windows. The combo, the
+         chevron buttons, and the left/right arrows all move through the
+         gallery; the live terminal underneath previews each shader as
+         selected. Focus the terminal to type and see cursor-triggered
+         effects; while it holds focus its keystrokes (arrows included) are
+         never intercepted, so the chevrons are how you flip then. -->
 
     <Grid x:Name="RootGrid"
           RowSpacing="12"
@@ -21,15 +23,29 @@
         </Grid.RowDefinitions>
 
         <TextBlock Grid.Row="0"
-                   Text="Pick a shader. Left/Right arrows flip through the gallery; click into the terminal below to type and see cursor effects move."
+                   Text="Pick a shader. The chevrons beside the list flip through the gallery; so do Left/Right arrows while the terminal is not focused. Click into the terminal below to type and see cursor effects move."
                    TextWrapping="Wrap"
                    Opacity="0.7" />
 
-        <ComboBox x:Name="PickerCombo"
-                  Grid.Row="1"
-                  MinWidth="360"
-                  HorizontalAlignment="Left"
-                  SelectionChanged="PickerCombo_SelectionChanged" />
+        <StackPanel Grid.Row="1"
+                    Orientation="Horizontal"
+                    Spacing="8">
+            <Button x:Name="PrevShaderButton"
+                    Click="PrevShader_Click"
+                    ToolTipService.ToolTip="Previous shader"
+                    AutomationProperties.Name="Previous shader">
+                <FontIcon Glyph="&#xE76B;" />
+            </Button>
+            <ComboBox x:Name="PickerCombo"
+                      MinWidth="360"
+                      SelectionChanged="PickerCombo_SelectionChanged" />
+            <Button x:Name="NextShaderButton"
+                    Click="NextShader_Click"
+                    ToolTipService.ToolTip="Next shader"
+                    AutomationProperties.Name="Next shader">
+                <FontIcon Glyph="&#xE76C;" />
+            </Button>
+        </StackPanel>
 
         <Border x:Name="PickerPreviewHost"
                 Grid.Row="2"

--- a/windows/Ghostty/Settings/ShaderPickerWindow.xaml
+++ b/windows/Ghostty/Settings/ShaderPickerWindow.xaml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Window
+    x:Class="Ghostty.Settings.ShaderPickerWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- Gallery shader picker: a real window (not a dialog) so it can stay
+         open while the caller compares against other windows. The combo and
+         the left/right arrow keys both move through the gallery; the live
+         terminal underneath previews each shader as selected. Focus the
+         terminal to type and see cursor-triggered effects. -->
+
+    <Grid x:Name="RootGrid"
+          RowSpacing="12"
+          Padding="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0"
+                   Text="Pick a shader. Left/Right arrows flip through the gallery; click into the terminal below to type and see cursor effects move."
+                   TextWrapping="Wrap"
+                   Opacity="0.7" />
+
+        <ComboBox x:Name="PickerCombo"
+                  Grid.Row="1"
+                  MinWidth="360"
+                  HorizontalAlignment="Left"
+                  SelectionChanged="PickerCombo_SelectionChanged" />
+
+        <Border x:Name="PickerPreviewHost"
+                Grid.Row="2"
+                MinHeight="320"
+                BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
+                BorderThickness="1"
+                CornerRadius="4"
+                Padding="4" />
+
+        <StackPanel Grid.Row="3"
+                    Orientation="Horizontal"
+                    Spacing="8"
+                    HorizontalAlignment="Right">
+            <Button Content="Select"
+                    Style="{StaticResource AccentButtonStyle}"
+                    Click="Select_Click" />
+            <Button Content="Cancel"
+                    Click="Cancel_Click" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/windows/Ghostty/Settings/ShaderPickerWindow.xaml
+++ b/windows/Ghostty/Settings/ShaderPickerWindow.xaml
@@ -13,8 +13,8 @@
          never intercepted, so the chevrons are how you flip then. -->
 
     <Grid x:Name="RootGrid"
-          RowSpacing="12"
-          Padding="16">
+          RowSpacing="4"
+          Padding="0">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
@@ -23,13 +23,15 @@
         </Grid.RowDefinitions>
 
         <TextBlock Grid.Row="0"
+                   Margin="12,8,12,0"
                    Text="Pick a shader. The chevrons beside the list flip through the gallery; so do Left/Right arrows while the terminal is not focused. Click into the terminal below to type and see cursor effects move."
                    TextWrapping="Wrap"
                    Opacity="0.7" />
 
         <StackPanel Grid.Row="1"
                     Orientation="Horizontal"
-                    Spacing="8">
+                    Spacing="8"
+                    Margin="12,0">
             <Button x:Name="PrevShaderButton"
                     Click="PrevShader_Click"
                     ToolTipService.ToolTip="Previous shader"
@@ -52,12 +54,12 @@
                 MinHeight="320"
                 BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
                 BorderThickness="1"
-                CornerRadius="4"
-                Padding="4" />
+                                Padding="0" />
 
         <StackPanel Grid.Row="3"
                     Orientation="Horizontal"
                     Spacing="8"
+                    Margin="12,8"
                     HorizontalAlignment="Right">
             <Button Content="Select"
                     Style="{StaticResource AccentButtonStyle}"

--- a/windows/Ghostty/Settings/ShaderPickerWindow.xaml
+++ b/windows/Ghostty/Settings/ShaderPickerWindow.xaml
@@ -26,7 +26,7 @@
                    Margin="12,8,12,0"
                    Text="Pick a shader. The chevrons beside the list flip through the gallery; so do Left/Right arrows while the terminal is not focused. Click into the terminal below to type and see cursor effects move."
                    TextWrapping="Wrap"
-                   Opacity="0.7" />
+                   Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
 
         <StackPanel Grid.Row="1"
                     Orientation="Horizontal"
@@ -40,6 +40,7 @@
             </Button>
             <ComboBox x:Name="PickerCombo"
                       MinWidth="360"
+                      AutomationProperties.Name="Shader"
                       SelectionChanged="PickerCombo_SelectionChanged" />
             <Button x:Name="NextShaderButton"
                     Click="NextShader_Click"
@@ -54,14 +55,16 @@
                 MinHeight="320"
                 BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
                 BorderThickness="1"
-                                Padding="0" />
+                CornerRadius="4"
+                Padding="0" />
 
         <StackPanel Grid.Row="3"
                     Orientation="Horizontal"
                     Spacing="8"
                     Margin="12,8"
                     HorizontalAlignment="Right">
-            <Button Content="Select"
+            <Button x:Name="SelectButton"
+                    Content="Select"
                     Style="{StaticResource AccentButtonStyle}"
                     Click="Select_Click" />
             <Button Content="Cancel"

--- a/windows/Ghostty/Settings/ShaderPickerWindow.xaml.cs
+++ b/windows/Ghostty/Settings/ShaderPickerWindow.xaml.cs
@@ -2,9 +2,13 @@ using System;
 using System.Collections.Generic;
 using Ghostty.Core.Settings;
 
+using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
+using WinRT.Interop;
+using Windows.Win32;
+using Windows.Win32.Foundation;
 
 namespace Ghostty.Settings;
 
@@ -33,10 +37,32 @@ public sealed partial class ShaderPickerWindow : Window
         InitializeComponent();
 
         Title = "Shader gallery";
+
+        // Mica so the window is not a black flash during first layout,
+        // same as the settings window.
+        SystemBackdrop = new Microsoft.UI.Xaml.Media.MicaBackdrop();
+
         // WinUI 3 Window has no MinWidth/MinHeight; size the OS window.
+        // AppWindow sizing is in PHYSICAL pixels: scale the design size by
+        // the monitor DPI, or above 100% scaling the window is smaller
+        // than the content needs and clips its own button row.
         if (AppWindow is { } appWindow)
         {
-            appWindow.ResizeClient(new Windows.Graphics.SizeInt32(780, 640));
+            var hwnd = new HWND(WindowNative.GetWindowHandle(this));
+            var dpi = PInvoke.GetDpiForWindow(hwnd);
+            var scale = dpi == 0 ? 1.0 : dpi / 96.0;
+            var pxWidth = (int)Math.Round(780 * scale);
+            var pxHeight = (int)Math.Round(640 * scale);
+            appWindow.ResizeClient(new Windows.Graphics.SizeInt32(pxWidth, pxHeight));
+
+            // Center on the window's display (work area, physical pixels),
+            // the same recipe as the settings window.
+            var display = DisplayArea.GetFromWindowId(
+                appWindow.Id, DisplayAreaFallback.Primary);
+            var work = display.WorkArea;
+            appWindow.Move(new Windows.Graphics.PointInt32(
+                work.X + (work.Width - pxWidth) / 2,
+                work.Y + (work.Height - pxHeight) / 2));
         }
 
         // NativeAOT-safe manifest binding (see ShaderGalleryJson). Same
@@ -44,6 +70,14 @@ public sealed partial class ShaderPickerWindow : Window
         ShaderGallery.ManifestParser ??= ShaderGalleryJson.Parse;
 
         PopulateCombo();
+
+        // Keyboard focus starts on the combo, NOT the preview terminal:
+        // the terminal would otherwise own the arrows (PreviewHasFocus)
+        // and the gallery stepper would never fire. The preview sets
+        // AutoFocus = false for the same reason; this is the other half.
+        // Content has not loaded yet in the ctor, so focus once the tree
+        // exists.
+        RootGrid.Loaded += (_, _) => PickerCombo.Focus(FocusState.Programmatic);
 
         // The preview owns a native surface + shell process on the shared
         // bootstrap host; OnUnloaded detachment does NOT free them, so the
@@ -69,6 +103,7 @@ public sealed partial class ShaderPickerWindow : Window
                 IsEnabled = false,
                 Content = $"Gallery unavailable: {ShaderGallery.LoadDetail}",
             });
+            UpdateSelectEnabled();
             return;
         }
 
@@ -95,7 +130,11 @@ public sealed partial class ShaderPickerWindow : Window
                 TextWrapping = TextWrapping.Wrap,
             });
 
-            PickerCombo.Items.Add(new ComboBoxItem { Tag = path, Content = panel });
+            var item = new ComboBoxItem { Tag = path, Content = panel };
+            // The item content is a panel, so UIA would otherwise fall back
+            // to text scraping; give every item a real name.
+            Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(item, entry.Name);
+            PickerCombo.Items.Add(item);
             if (path.Equals(CurrentPath, StringComparison.OrdinalIgnoreCase))
             {
                 selected = PickerCombo.Items.Count - 1;
@@ -108,18 +147,41 @@ public sealed partial class ShaderPickerWindow : Window
         {
             PickerCombo.SelectedIndex = selected;
         }
+        UpdateSelectEnabled();
     }
 
     private void OnRootKeyDown(object sender, KeyRoutedEventArgs e)
     {
         if (_orderedPaths.Count == 0) return;
         if (e.Key is not (Windows.System.VirtualKey.Left or Windows.System.VirtualKey.Right)) return;
+        // Chords (Ctrl+Right, Shift+Left, Alt+...) belong to whatever has
+        // focus; the bare arrows are the gallery stepper.
+        if (IsChordDown()) return;
         // A focused terminal bubbles its (unhandled) arrow KeyDown up to
         // RootGrid; those keys belong to the shell cursor, not the gallery.
         if (PreviewHasFocus) return;
 
         StepSelection(e.Key == Windows.System.VirtualKey.Right ? 1 : -1);
         e.Handled = true;
+    }
+
+    private static bool IsChordDown()
+    {
+        foreach (var key in new[]
+        {
+            Windows.System.VirtualKey.Control,
+            Windows.System.VirtualKey.Shift,
+            Windows.System.VirtualKey.Menu,
+        })
+        {
+            if ((Microsoft.UI.Input.InputKeyboardSource
+                    .GetKeyStateForCurrentThread(key)
+                    & Windows.UI.Core.CoreVirtualKeyStates.Down) != 0)
+            {
+                return true;
+            }
+        }
+        return false;
     }
 
     /// <summary>
@@ -168,7 +230,15 @@ public sealed partial class ShaderPickerWindow : Window
         {
             DisposePreview();
         }
+        UpdateSelectEnabled();
     }
+
+    // Select only means something with a committed gallery entry; the
+    // degenerate one-item diagnostic case would commit null, which is just
+    // Cancel wearing an accent button.
+    private void UpdateSelectEnabled() =>
+        SelectButton.IsEnabled =
+            (PickerCombo.SelectedItem as ComboBoxItem)?.Tag is string;
 
     private void ShowPreview(string shaderPath)
     {
@@ -181,6 +251,11 @@ public sealed partial class ShaderPickerWindow : Window
         {
             Host = host,
             PreviewCustomShader = shaderPath,
+            // The preview must not steal focus when its surface loads:
+            // TerminalControl focuses itself on load by default (real
+            // panes want that), which would hand the arrows to the shell
+            // after every selection change.
+            AutoFocus = false,
         };
         _preview = control;
         PickerPreviewHost.Child = control;

--- a/windows/Ghostty/Settings/ShaderPickerWindow.xaml.cs
+++ b/windows/Ghostty/Settings/ShaderPickerWindow.xaml.cs
@@ -9,11 +9,13 @@ using Microsoft.UI.Xaml.Input;
 namespace Ghostty.Settings;
 
 /// <summary>
-/// Gallery shader picker window. The combo and the left/right arrow keys
-/// both walk the gallery; a live terminal underneath previews the selected
-/// shader immediately (per-surface override, never the app config). Select
-/// commits the picked path to <see cref="PickedPath"/> and closes; Cancel
-/// (or closing the window) leaves it null.
+/// Gallery shader picker window. The combo, the chevron buttons, and the
+/// left/right arrow keys all walk the gallery; a live terminal underneath
+/// previews the selected shader immediately (per-surface override, never
+/// the app config). Arrows leave the gallery alone while the terminal
+/// holds focus, so its keystrokes (cursor movement included) are never
+/// stolen. Select commits the picked path to <see cref="PickedPath"/> and
+/// closes; Cancel (or closing the window) leaves it null.
 /// </summary>
 public sealed partial class ShaderPickerWindow : Window
 {
@@ -48,9 +50,11 @@ public sealed partial class ShaderPickerWindow : Window
         // window closing must dispose explicitly (TerminalControl lesson).
         Closed += (_, _) => DisposePreview();
 
-        // Arrows flip shaders unless the terminal has focus: the terminal
-        // consumes arrow keys itself (typing), so its handled events never
-        // bubble here. Everything else in the window has no arrow use.
+        // Arrows flip shaders unless the terminal preview holds focus: the
+        // terminal forwards keys to the shell without marking them handled,
+        // so its arrow KeyDown still bubbles up here, and keys that move a
+        // shell cursor must not also flip the gallery. The chevron buttons
+        // beside the combo switch regardless of focus.
         RootGrid.KeyDown += OnRootKeyDown;
     }
 
@@ -110,12 +114,48 @@ public sealed partial class ShaderPickerWindow : Window
     {
         if (_orderedPaths.Count == 0) return;
         if (e.Key is not (Windows.System.VirtualKey.Left or Windows.System.VirtualKey.Right)) return;
+        // A focused terminal bubbles its (unhandled) arrow KeyDown up to
+        // RootGrid; those keys belong to the shell cursor, not the gallery.
+        if (PreviewHasFocus) return;
 
-        var delta = e.Key == Windows.System.VirtualKey.Right ? 1 : -1;
-        var next = (PickerCombo.SelectedIndex + delta + _orderedPaths.Count) % _orderedPaths.Count;
-        PickerCombo.SelectedIndex = next;
+        StepSelection(e.Key == Windows.System.VirtualKey.Right ? 1 : -1);
         e.Handled = true;
     }
+
+    /// <summary>
+    /// Whether the live terminal preview (or anything inside it, like its
+    /// search bar) holds keyboard focus. Containment, not identity: focus
+    /// lives on the TerminalControl but can sit on inner elements too, and
+    /// any of them means every keystroke belongs to the terminal.
+    /// </summary>
+    private bool PreviewHasFocus
+    {
+        get
+        {
+            // XamlRoot is null until the window content loads; no focus to own.
+            if (RootGrid.XamlRoot is null) return false;
+            var node = FocusManager.GetFocusedElement(RootGrid.XamlRoot) as DependencyObject;
+            while (node is not null)
+            {
+                if (ReferenceEquals(node, PickerPreviewHost)) return true;
+                node = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(node);
+            }
+            return false;
+        }
+    }
+
+    // Shared by the arrow keys and the chevron buttons: wrap around the
+    // gallery and let SelectionChanged rebuild the preview.
+    private void StepSelection(int delta)
+    {
+        if (_orderedPaths.Count == 0) return;
+        var next = (PickerCombo.SelectedIndex + delta + _orderedPaths.Count) % _orderedPaths.Count;
+        PickerCombo.SelectedIndex = next;
+    }
+
+    private void PrevShader_Click(object sender, RoutedEventArgs e) => StepSelection(-1);
+
+    private void NextShader_Click(object sender, RoutedEventArgs e) => StepSelection(1);
 
     private void PickerCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {

--- a/windows/Ghostty/Settings/ShaderPickerWindow.xaml.cs
+++ b/windows/Ghostty/Settings/ShaderPickerWindow.xaml.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Collections.Generic;
+using Ghostty.Core.Settings;
+
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+
+namespace Ghostty.Settings;
+
+/// <summary>
+/// Gallery shader picker window. The combo and the left/right arrow keys
+/// both walk the gallery; a live terminal underneath previews the selected
+/// shader immediately (per-surface override, never the app config). Select
+/// commits the picked path to <see cref="PickedPath"/> and closes; Cancel
+/// (or closing the window) leaves it null.
+/// </summary>
+public sealed partial class ShaderPickerWindow : Window
+{
+    /// <summary>Path to preselect in the combo, if it is a gallery entry.</summary>
+    public string? CurrentPath { get; set; }
+
+    /// <summary>The committed selection, or null when cancelled.</summary>
+    public string? PickedPath { get; private set; }
+
+    private Controls.TerminalControl? _preview;
+    private readonly List<string> _orderedPaths = new();
+
+    public ShaderPickerWindow()
+    {
+        InitializeComponent();
+
+        Title = "Shader gallery";
+        // WinUI 3 Window has no MinWidth/MinHeight; size the OS window.
+        if (AppWindow is { } appWindow)
+        {
+            appWindow.ResizeClient(new Windows.Graphics.SizeInt32(780, 640));
+        }
+
+        // NativeAOT-safe manifest binding (see ShaderGalleryJson). Same
+        // wiring as the settings page: idempotent, first consumer wins.
+        ShaderGallery.ManifestParser ??= ShaderGalleryJson.Parse;
+
+        PopulateCombo();
+
+        // The preview owns a native surface + shell process on the shared
+        // bootstrap host; OnUnloaded detachment does NOT free them, so the
+        // window closing must dispose explicitly (TerminalControl lesson).
+        Closed += (_, _) => DisposePreview();
+
+        // Arrows flip shaders unless the terminal has focus: the terminal
+        // consumes arrow keys itself (typing), so its handled events never
+        // bubble here. Everything else in the window has no arrow use.
+        RootGrid.KeyDown += OnRootKeyDown;
+    }
+
+    private void PopulateCombo()
+    {
+        if (ShaderGallery.Entries.Count == 0)
+        {
+            // A broken gallery install must be diagnosable from the UI, not
+            // only from logs (same contract as the settings page had).
+            PickerCombo.Items.Add(new ComboBoxItem
+            {
+                IsEnabled = false,
+                Content = $"Gallery unavailable: {ShaderGallery.LoadDetail}",
+            });
+            return;
+        }
+
+        var selected = 0;
+        foreach (var entry in ShaderGallery.Entries)
+        {
+            var path = ShaderGallery.AbsolutePathFor(entry);
+            _orderedPaths.Add(path);
+
+            var panel = new StackPanel();
+            // Explicit typography rather than theme-resource lookups:
+            // programmatic fetches are unreliable in WinUI 3 desktop, and
+            // the two-line shape matches the settings page's old items.
+            panel.Children.Add(new TextBlock
+            {
+                Text = entry.Name,
+                FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+            });
+            panel.Children.Add(new TextBlock
+            {
+                Text = entry.Description,
+                FontSize = 12,
+                Opacity = 0.7,
+                TextWrapping = TextWrapping.Wrap,
+            });
+
+            PickerCombo.Items.Add(new ComboBoxItem { Tag = path, Content = panel });
+            if (path.Equals(CurrentPath, StringComparison.OrdinalIgnoreCase))
+            {
+                selected = PickerCombo.Items.Count - 1;
+            }
+        }
+
+        // Setting the selection fires SelectionChanged, which builds the
+        // first preview. Guard for the degenerate no-selection case.
+        if (PickerCombo.Items.Count > 0)
+        {
+            PickerCombo.SelectedIndex = selected;
+        }
+    }
+
+    private void OnRootKeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        if (_orderedPaths.Count == 0) return;
+        if (e.Key is not (Windows.System.VirtualKey.Left or Windows.System.VirtualKey.Right)) return;
+
+        var delta = e.Key == Windows.System.VirtualKey.Right ? 1 : -1;
+        var next = (PickerCombo.SelectedIndex + delta + _orderedPaths.Count) % _orderedPaths.Count;
+        PickerCombo.SelectedIndex = next;
+        e.Handled = true;
+    }
+
+    private void PickerCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (PickerCombo.SelectedItem is ComboBoxItem item &&
+            item.Tag is string path)
+        {
+            ShowPreview(path);
+        }
+        else
+        {
+            DisposePreview();
+        }
+    }
+
+    private void ShowPreview(string shaderPath)
+    {
+        DisposePreview();
+
+        var host = App.BootstrapHost;
+        if (host is null) return;
+
+        var control = new Controls.TerminalControl
+        {
+            Host = host,
+            PreviewCustomShader = shaderPath,
+        };
+        _preview = control;
+        PickerPreviewHost.Child = control;
+    }
+
+    private void DisposePreview()
+    {
+        _preview?.DisposeSurface();
+        _preview = null;
+        if (PickerPreviewHost is not null) PickerPreviewHost.Child = null;
+    }
+
+    private void Select_Click(object sender, RoutedEventArgs e)
+    {
+        PickedPath = (PickerCombo.SelectedItem as ComboBoxItem)?.Tag as string;
+        Close();
+    }
+
+    private void Cancel_Click(object sender, RoutedEventArgs e) => Close();
+}


### PR DESCRIPTION
## What

- Settings > Appearance: shader selection is now three-state (none, from gallery, from file). Gallery opens a picker window with a combo, chevron buttons, and Left/Right to flip through the gallery over a live terminal preview. The picker is single-instance, and while the preview terminal holds focus its keystrokes (arrows included) pass through untouched; the chevrons or unfocused arrows are how you flip.
- Gallery: new interference shader (rolling band, row jitter, grain, tears, Pip-Boy green phosphor), cursor_teleport, lightning_strike. crt reworked: smooth sine scanlines, vertical aperture grille, subtle barrel and vignette, bezel via step-multiply instead of an early return (the early return lowers to a WGSL path that renders black; zioshade-8h7, fix pending in zioshade).
- windows spawn: resolve bare program names via SearchPathW plus well-known homes before CreateProcessW, and log CreateProcessW/CreatePseudoConsole failures with their codes (a launcher with a stale PATH no longer silently fails with rc=2).
- gpu_test: post-pipeline harness proving the app render path draws scanlines (green at a13913619; the FAILS commit before it is the reproduction).
- stream_terminal: DECSCUSR regression test (block, underline, bar, default) since cursor-mode shaders gate on style-driven width changes.
- build: zioshade v0.8.2 (uniform-derived global initializer fix plus the gallery corpus fixes from zioshade#673).

## Verification

- zig build test-lib-vt -Dtest-filter="DECSCUSR sets cursor style" green.
- gpu_test post-pipeline harness green on ryzen7pro; live SHADERDIAG uniform dump used during bring-up and removed.
- Desktop walkthrough on ryzen7pro: picker window, chevrons, arrows with and without preview focus, three-state radio, crt, interference, cursor_teleport, lightning_strike.