### PR TITLE
build: pin zioshade v0.8.3

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -95,8 +95,8 @@
         // between zioshade versions on unchanged input (lowering and
         // identifier fixes); regenerate any golden outputs.
         .zioshade = .{
-            .url = "https://github.com/zioShade/zioshade/archive/refs/tags/v0.8.2.tar.gz",
-            .hash = "zioshade-0.8.2-8s3a2s7QUQAEWvH3AJKcrOm1imGnTcuKO-lLTj8tLIKZ",
+            .url = "https://github.com/zioShade/zioshade/archive/refs/tags/v0.8.3.tar.gz",
+            .hash = "zioshade-0.8.3-8s3a2iYpUgAhs9iKuHeZxih1_anDBa1eFX1zjlHjCU6T",
             .lazy = true,
         },
 


### PR DESCRIPTION
Pins the shader translator to the v0.8.3 release.

v0.8.3 over v0.8.2:

- WGSL: region-mode branch to the enclosing loop continue is emitted as the case's continue (a dropped wire that leaked one case arm's body into another; found as the render proxy's one non-chaos standing DIFFER).
- WGSL: loop-counter-phi load substitution uses a real dominator computation.
- Frontend: SSA spill stores placed to dominate every reader (the cursor_teleport loop-in-if store sink).
- WGSL: SelectionMerge phi initializer taken from the selection-header incoming (the cursor_sweep whole-frame-black trailing-conditional bug).

Plus the gallery consumer-corpus gates that found these: vendored corpus + SPIR-V dropped-initializer lint + baseline-gated WGSL render proxy in ci-full + WARP gallery pair-diff (zioshade frame must match spirv-cross) + a Chrome/tint/SwiftShader browser oracle.

Verification: two-step box rebuild (zig build then dotnet build) plus gallery-verify through the pair-diff gate follows the merge.