### PR TITLE
gallery: rename reserved identifier active to activeGate

### DIFF
--- a/tools/gallery/verify.sh
+++ b/tools/gallery/verify.sh
@@ -72,15 +72,14 @@ echo "zioshade HLSL: $pass pass, $fail fail"
 # <name>.sc.hlsl and render-diffs them on WARP. A rejection here FAILS the
 # gate: a reference gap is a gate gap (that shader would silently lose its
 # differential).
-# The reference input is the identical prefixed source: no normalization
-# between the two legs. (An earlier normalization renamed the reserved-word
-# identifier `active` on the reference side; the shaders now avoid reserved
-# words, so glslang accepts every gallery source verbatim.)
+# Both legs read the same file, so there is no normalization to drift: a
+# rejection here is a broken gallery entry, not a normalization to add.
+# Gallery sources must be accepted by glslang verbatim, which among other
+# things means no GLSL reserved words as identifiers.
 refpass=0; reffail=0; reffailed=""
 for glsl in "$shaders_dir"/*.glsl; do
   name=$(basename "$glsl" .glsl)
-  cp "$stage/$name.full.glsl" "$stage/$name.ref.glsl"
-  if "$GLSLANG" -V -S frag "$stage/$name.ref.glsl" -o "$stage/$name.spv" >/dev/null 2>"$stage/$name.ref.err" &&
+  if "$GLSLANG" -V -S frag "$stage/$name.full.glsl" -o "$stage/$name.spv" >/dev/null 2>"$stage/$name.ref.err" &&
      "$SPIRV_CROSS" --hlsl --shader-model 60 "$stage/$name.spv" > "$stage/$name.sc.hlsl" 2>>"$stage/$name.ref.err"; then
     refpass=$((refpass+1))
   else

--- a/tools/gallery/verify.sh
+++ b/tools/gallery/verify.sh
@@ -72,16 +72,14 @@ echo "zioshade HLSL: $pass pass, $fail fail"
 # <name>.sc.hlsl and render-diffs them on WARP. A rejection here FAILS the
 # gate: a reference gap is a gate gap (that shader would silently lose its
 # differential).
-# The one normalization: glslang is stricter than zioshade's frontend about
-# reserved words. The gallery uses `active` (reserved in desktop GLSL) as an
-# identifier and zioshade deliberately accepts it (wintty compiles via zioshade
-# alone). Renaming just that identifier on the REFERENCE side is
-# semantics-preserving (a local variable), so the oracle still covers these
-# shaders; anything else glslang or spirv-cross rejects is a loud FAIL.
+# The reference input is the identical prefixed source: no normalization
+# between the two legs. (An earlier normalization renamed the reserved-word
+# identifier `active` on the reference side; the shaders now avoid reserved
+# words, so glslang accepts every gallery source verbatim.)
 refpass=0; reffail=0; reffailed=""
 for glsl in "$shaders_dir"/*.glsl; do
   name=$(basename "$glsl" .glsl)
-  perl -pe 's/\bactive\b/active_/g' "$stage/$name.full.glsl" > "$stage/$name.ref.glsl"
+  cp "$stage/$name.full.glsl" "$stage/$name.ref.glsl"
   if "$GLSLANG" -V -S frag "$stage/$name.ref.glsl" -o "$stage/$name.spv" >/dev/null 2>"$stage/$name.ref.err" &&
      "$SPIRV_CROSS" --hlsl --shader-model 60 "$stage/$name.spv" > "$stage/$name.sc.hlsl" 2>>"$stage/$name.ref.err"; then
     refpass=$((refpass+1))

--- a/windows/Ghostty/Assets/Shaders/README.md
+++ b/windows/Ghostty/Assets/Shaders/README.md
@@ -37,3 +37,10 @@ CC BY-NC-SA, GPL) must not be added.
 3. Add the license text under `LICENSES/` if it is not original work,
    and an entry in the repo's `THIRD_PARTY_NOTICES.md`.
 4. Run `just gallery-verify` and make sure it reports PASS.
+
+The source must compile under `glslang` verbatim: the gate feeds the same
+file to our compiler and to the reference one, so anything glslang refuses
+takes the whole gate down rather than just that shader. The trap worth
+naming is GLSL's reserved-word list (`active`, `filter`, `input`,
+`output`, `union`, `resource` and friends in GLSL 4.60 section 3.6): our
+compiler accepts them, glslang does not.

--- a/windows/Ghostty/Assets/Shaders/cursor_teleport.glsl
+++ b/windows/Ghostty/Assets/Shaders/cursor_teleport.glsl
@@ -61,8 +61,8 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord)
     // resize the rect around a fixed corner, only a real move shifts it.
     float cornerJump = length(iCurrentCursor.xy - iPreviousCursor.xy);
     float age = iTime - iTimeCursorChange;
-    float active = step(cellH * JUMP_THRESHOLD, cornerJump)
-                 * step(age, DURATION) * step(0.0, age);
+    float activeGate = step(cellH * JUMP_THRESHOLD, cornerJump)
+                     * step(age, DURATION) * step(0.0, age);
     float p = clamp(age / DURATION, 0.0, 1.0);
     float e = easeOutQuart(p); // travel: leaves fast, settles in
     float fade = 1.0 - p;
@@ -87,18 +87,18 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord)
     vec3 ghost = acc / wsum;
     // The streak lives in the band only; keep the cursor cell crisp.
     float hole = 1.0 - step(0.0, sdRect(fragCoord.xy, curCenter, curHalf * 1.05));
-    float streakA = band * fade * GHOST_STRENGTH * hole * active;
+    float streakA = band * fade * GHOST_STRENGTH * hole * activeGate;
     vec3 newColor = mix(col, ghost, streakA);
     // A tint over the band so it reads as energy, not smudge.
     newColor += mix(tint, vec3(1.0), 0.25) * band * fade * 0.30
-              * hole * active;
+              * hole * activeGate;
 
     // 1b) Traveling beam: a bright core inside the band, running from
     // the old position to the easing head. It spans the whole path at
     // p=0 and collapses into the arrival point. The radius is sized by
     // the cell, not the jump, so single-cell moves still get a fat
     // visible streak.
-    float beam = exp(-dLine / max(cellH * 0.30, 3.0)) * fade * hole * active;
+    float beam = exp(-dLine / max(cellH * 0.30, 3.0)) * fade * hole * activeGate;
     newColor += mix(tint, vec3(1.0), 0.5) * beam * BEAM_BRIGHT;
 
     // 2) Departure: the old cell flashes and collapses to nothing over
@@ -108,7 +108,7 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord)
     float sdfOld = sdRect(fragCoord.xy, prevCenter, oldHalf);
     float outGlow = exp(-max(sdfOld, 0.0) / max(cellH * 0.50, 3.0));
     newColor += mix(tint, vec3(1.0), 0.4) * outGlow * (1.0 - outP)
-              * (1.0 - outP) * OUT_FLASH * active;
+              * (1.0 - outP) * OUT_FLASH * activeGate;
 
     // 3) Arrival: a pulse of light where the cursor materializes,
     // peaking around 65% and gone by the end.
@@ -118,7 +118,7 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord)
                           curHalf * (1.0 + 0.35 * pulse));
     float inGlow = exp(-max(sdfNew, 0.0) / max(cellH * 0.45, 3.0));
     newColor += mix(tint, vec3(1.0), 0.6) * inGlow * pulse
-              * IN_FLASH * active;
+              * IN_FLASH * activeGate;
 
     fragColor = vec4(newColor, 1.0);
 }

--- a/windows/Ghostty/Assets/Shaders/lightning_strike.glsl
+++ b/windows/Ghostty/Assets/Shaders/lightning_strike.glsl
@@ -83,8 +83,8 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord)
     // around a fixed corner, only a real move shifts it.
     float cornerJump = length(iCurrentCursor.xy - iPreviousCursor.xy);
     float age = iTime - iTimeCursorChange;
-    float active = step(cellH * JUMP_THRESHOLD, cornerJump)
-                 * step(age, DURATION) * step(0.0, age);
+    float activeGate = step(cellH * JUMP_THRESHOLD, cornerJump)
+                     * step(age, DURATION) * step(0.0, age);
     float p = clamp(age / DURATION, 0.0, 1.0);
     vec3 tint = iCurrentCursorColor.rgb;
     vec3 boltCol = mix(tint, vec3(1.0), 0.55);
@@ -101,11 +101,11 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord)
     // Per-frame flicker keeps the channel alive while it glows.
     float flicker = 0.7 + 0.5 * hash1(seed + floor(iTime * 48.0) * 0.618);
     // Full brightness while traveling, then a decaying afterglow.
-    float boltEnv = exp(-max(p - STRIKE_FRAC, 0.0) * 6.0) * flicker * active;
+    float boltEnv = exp(-max(p - STRIKE_FRAC, 0.0) * 6.0) * flicker * activeGate;
 
     // Loop trip counts collapse to zero when idle.
-    int mainSegs = int(active) * MAIN_SEGS;
-    int branchSegs = int(active) * BRANCH_SEGS;
+    int mainSegs = int(activeGate) * MAIN_SEGS;
+    int branchSegs = int(activeGate) * BRANCH_SEGS;
 
     float glowI = 0.0;
     float coreI = 0.0;
@@ -161,7 +161,7 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord)
     // Impact: the flash fires as the front lands and decays from there;
     // a radial bloom plus a bright cell hit the character.
     float flashEnv = smoothstep(STRIKE_FRAC * 0.8, STRIKE_FRAC, p)
-                   * exp(-max(p - STRIKE_FRAC, 0.0) * 9.0) * active;
+                   * exp(-max(p - STRIKE_FRAC, 0.0) * 9.0) * activeGate;
     float dImp = distance(fragCoord.xy, impact);
     float sdfCell = sdRect(fragCoord.xy, impact, cellHalf);
     col += mix(tint, vec3(1.0), 0.6)


### PR DESCRIPTION
## Why

`active` is a reserved word in GLSL. Strict compilers reject shaders that
declare it: glslang fails both gallery shaders with
`'active' : Reserved word` / `compilation terminated` (verified on the
pre-rename sources, exit 2). We only got away with it because the shipped
compile path went through zioshade, which was lenient.

## What

- Rename `active` to `activeGate` in `cursor_teleport.glsl` (6 sites) and
  `lightning_strike.glsl` (5 sites). The name matches the files' own
  vocabulary: camelCase locals and header comments that call this variable
  "the gate".
- `tools/gallery/verify.sh`: drop the reference-side rename shim
  (perl `s/\bactive\b/active_/g`), which existed only to work around our own
  two shaders. It is now a plain copy; the comment states why no
  normalization is needed.

No Zig or C# code references the identifier; `shaders.json` carries
filenames only.

## Evidence

- Shipped compile path (step 1): `zioshade hlsl` over prefix + shader for
  all 16 gallery shaders: 16 pass, 0 fail.
- Reference oracle (step 2, shim removed): `glslang -V -S frag` then
  `spirv-cross --hlsl --shader-model 60`: 16 pass, 0 fail.
- Before/after: pre-rename sources fail glslang with the reserved-word
  error; renamed sources compile clean.
- Full box leg (steps 3-5: DXC DXIL + D3D12 WARP render-diff, pair mode
  vs spirv-cross): GALLERY PASS = 21 / FAIL = 0 / DIFFER = 0.
- `bash -n tools/gallery/verify.sh` clean.

## Follow-up (separate PR)

zioshade's vendored corpus still contains `active`; its tool-side
fallback stays in place until the renamed shaders are re-vendored there.