### PR TITLE
settings: picker preview plays a canned session, keeps it across flips; Choose button on its own line

### DIFF
--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2103,6 +2103,55 @@ pub const CAPI = struct {
         };
     }
 
+    /// Swap this surface's per-surface custom shader override live. This is
+    /// the same path a config reload takes (core_surface.updateConfig), so
+    /// the renderer rebuilds its post-process pipeline while the grid,
+    /// scrollback, and cursor are preserved: a preview can flip through
+    /// shaders without ever resetting the terminal. A null or empty path
+    /// clears the override (the surface renders with no custom shader).
+    ///
+    /// The override applies immediately only; a later app-level config
+    /// update to this surface re-derives from the app config and drops it
+    /// (the embedder re-applies on its next selection change).
+    ///
+    /// Returns false when the config could not be rebuilt (the surface
+    /// keeps rendering with its current shader).
+    export fn ghostty_surface_set_custom_shader(
+        surface: *Surface,
+        c_shader: ?[*:0]const u8,
+    ) bool {
+        const app = surface.app;
+
+        // Shallow copy of the app config, the same base the surface was
+        // created from, so every other setting keeps its current value.
+        var config = app.config.shallowClone(app.core_app.alloc);
+        defer config.deinit();
+
+        // Replace (never extend) the custom-shader list with the override:
+        // a preview surface shows exactly the selected shader, not the
+        // configured list chained onto it. Arena memory, same pattern as
+        // the creation-time override in Surface.init.
+        var override: configpkg.RepeatablePath = .{};
+        apply: {
+            const c_path = c_shader orelse break :apply;
+            const shader_path = std.mem.sliceTo(c_path, 0);
+            if (shader_path.len == 0) break :apply;
+            const maybe = configpkg.Path.parse(
+                config.arenaAlloc(),
+                shader_path,
+            ) catch break :apply;
+            const item = maybe orelse break :apply;
+            override.value.append(config.arenaAlloc(), item) catch break :apply;
+        }
+        config.@"custom-shader" = override;
+
+        surface.core_surface.updateConfig(&config) catch |err| {
+            log.err("error updating custom shader err={}", .{err});
+            return false;
+        };
+        return true;
+    }
+
     /// Returns true if the surface needs to confirm quitting.
     export fn ghostty_surface_needs_confirm_quit(surface: *Surface) bool {
         return surface.core_surface.needsConfirmQuit();

--- a/windows/Ghostty.Core/Logging/LogEvents.cs
+++ b/windows/Ghostty.Core/Logging/LogEvents.cs
@@ -47,4 +47,10 @@ internal static class LogEvents
         public const int HotKeyRegisterFailed = 1300;
         public const int QuakeFrameSubclassFailed = 1301;
     }
+
+    // 1400-1499: Shader gallery preview (the picker's autoplay feed)
+    internal static class ShaderPreview
+    {
+        public const int FeedStopped = 1400;
+    }
 }

--- a/windows/Ghostty.Core/Settings/ShaderPreviewFeed.cs
+++ b/windows/Ghostty.Core/Settings/ShaderPreviewFeed.cs
@@ -45,6 +45,7 @@ internal sealed partial class ShaderPreviewFeed : IDisposable
     /// spending wall-clock time on it.
     /// </summary>
     internal delegate Task PacingDelay(int milliseconds, CancellationToken ct);
+
     // SGR foregrounds only, never a background: the terminal theme is the
     // only background, so fullscreen shaders light up where text is drawn
     // instead of stopping at a palette-resolved bg cell (website lesson).
@@ -104,39 +105,61 @@ internal sealed partial class ShaderPreviewFeed : IDisposable
     private const string EchoReply =
         "\r\nshaders make terminals fun\r\n\r\n";
 
+    // The loop is endless, so every constant it writes is encoded once at
+    // type load rather than re-encoded on every pass forever.
+    //
+    // "..."u8 literals are not available here: these constants are built by
+    // const string concatenation, and u8 literals are neither const nor
+    // concatenable, so static readonly byte[] is the shape that exists.
+    private static readonly byte[] CrLfVt = Vt("\r\n");
+    private static readonly byte[] PromptVt = Vt(Prompt);
+    private static readonly byte[] BannerVt = Vt(Banner);
+    private static readonly byte[] DirListingVt = Vt(DirListing);
+    private static readonly byte[] AutoexecVt = Vt(Autoexec);
+    private static readonly byte[] VerReplyVt = Vt(VerReply);
+    private static readonly byte[] EchoReplyVt = Vt(EchoReply);
+    private static readonly byte[] CursorBlockVt = Vt(CursorBlock);
+    private static readonly byte[] CursorBarVt = Vt(CursorBar);
+    private static readonly byte[] CursorUnderlineVt = Vt(CursorUnderline);
+
+    private static byte[] Vt(string text) => Encoding.UTF8.GetBytes(text);
+
     /// <summary>
     /// One beat of the loop: the command to type at the prompt (null for a
     /// bare cursor flip) and the VT bytes to emit once Enter lands. The
     /// echo of the typed characters is part of the beat.
     /// </summary>
-    private readonly record struct Beat(string? Command, string Response);
+    private readonly record struct Beat(string? Command, byte[] Response);
 
     // Same shape as the website's demo script: a couple of listings, then
     // repeated cursor-shape flips (each one fires the cursor shaders), a
     // MODE pair that walks underline to block, and a closing echo.
     private static readonly Beat[] Script =
-    {
-        new("dir", DirListing),
-        new("type autoexec.bat", Autoexec),
-        new(null, CursorBar),
-        new(null, CursorBlock),
-        new(null, CursorBar),
-        new("ver", VerReply),
-        new(null, CursorBlock),
-        new("mode cursor=underline", CursorUnderline),
-        new("mode cursor=block", CursorBlock),
-        new("echo shaders make terminals fun", EchoReply),
-        new(null, CursorBar),
-    };
+    [
+        new("dir", DirListingVt),
+        new("type autoexec.bat", AutoexecVt),
+        new(null, CursorBarVt),
+        new(null, CursorBlockVt),
+        new(null, CursorBarVt),
+        new("ver", VerReplyVt),
+        new(null, CursorBlockVt),
+        new("mode cursor=underline", CursorUnderlineVt),
+        new("mode cursor=block", CursorBlockVt),
+        new("echo shaders make terminals fun", EchoReplyVt),
+        new(null, CursorBarVt),
+    ];
 
     private readonly VtSink _sink;
     private readonly PacingDelay _delay;
     private readonly ILogger<ShaderPreviewFeed> _logger;
-    // Fixed seed so the demo plays identically every time (matching the
-    // website's per-character jitter without its nondeterminism).
+    // Fixed seed so the typing jitter is reproducible instead of a fresh
+    // random walk per window. Reproducible within a runtime version, not
+    // across them: Random(int) makes no cross-version stability promise, and
+    // nothing here needs one.
     private readonly Random _random = new(1009);
 
     private CancellationTokenSource? _cts;
+    private bool _disposed;
 
     internal ShaderPreviewFeed(
         VtSink sink,
@@ -148,16 +171,22 @@ internal sealed partial class ShaderPreviewFeed : IDisposable
         _delay = delay ?? ((ms, ct) => Task.Delay(ms, ct));
     }
 
-    /// <summary>Begin autoplay. Safe to call once per feed.</summary>
+    /// <summary>
+    /// Begin autoplay. Idempotent, and a no-op after <see cref="Dispose"/>:
+    /// Dispose nulls the token source, so without the disposed flag a late
+    /// Start (a FirstRender arriving during teardown) would hand a torn-down
+    /// feed a fresh session to play into a sink that is going away.
+    /// </summary>
     public void Start()
     {
-        if (_cts is not null) return;
+        if (_disposed || _cts is not null) return;
         _cts = new CancellationTokenSource();
         _ = RunAsync(_cts.Token);
     }
 
     public void Dispose()
     {
+        _disposed = true;
         _cts?.Cancel();
         _cts?.Dispose();
         _cts = null;
@@ -170,25 +199,38 @@ internal sealed partial class ShaderPreviewFeed : IDisposable
             // Boot text lands at once (it is a machine booting, not a
             // person), then the first command comes after a beat so the
             // window has settled and the shader is already visible.
-            Write(Banner);
-            Write(Prompt);
+            Write(BannerVt);
+            Write(PromptVt);
             await _delay(1200, ct);
 
             while (true)
             {
                 foreach (var beat in Script)
                 {
+                    // Observe cancellation here rather than waiting for the
+                    // next _delay to throw it. Without these checks the loop
+                    // can still push a Write past Cancel(), which leans on
+                    // the sink's own disposed guard for correctness; one
+                    // guard carrying that weight is enough.
+                    ct.ThrowIfCancellationRequested();
                     if (beat.Command is { } command)
                     {
                         await TypeAsync(command, ct);
                         await _delay(350, ct);
-                        Write("\r\n" + beat.Response + Prompt);
+                        ct.ThrowIfCancellationRequested();
+                        // Three writes rather than a concatenation: the
+                        // newline, the response and the prompt are already
+                        // encoded, so this beat allocates nothing.
+                        Write(CrLfVt);
+                        Write(beat.Response);
+                        Write(PromptVt);
                     }
                     else
                     {
                         // A flip is a keypress: pause before and after so
                         // the cursor-shape animation has time to read.
                         await _delay(650, ct);
+                        ct.ThrowIfCancellationRequested();
                         Write(beat.Response);
                     }
                 }
@@ -217,14 +259,24 @@ internal sealed partial class ShaderPreviewFeed : IDisposable
     {
         foreach (var ch in text)
         {
-            Write(ch.ToString());
+            ct.ThrowIfCancellationRequested();
+            WriteChar(ch);
             await _delay(55 + _random.Next(70), ct);
         }
     }
 
-    private void Write(string vt)
+    private void Write(ReadOnlySpan<byte> vt) => _sink(vt);
+
+    // One keystroke, encoded onto the stack: the typing path runs a few times
+    // a second forever, and a string plus a byte[] per character is two
+    // allocations for at most four bytes. Four is the ceiling for one char: a
+    // BMP scalar encodes to at most three, and a lone surrogate encodes as
+    // U+FFFD, which is three.
+    private void WriteChar(char ch)
     {
-        _sink(Encoding.UTF8.GetBytes(vt));
+        Span<byte> buffer = stackalloc byte[4];
+        var written = Encoding.UTF8.GetBytes(new ReadOnlySpan<char>(in ch), buffer);
+        _sink(buffer[..written]);
     }
 
     // Its own category, not a borrowed one: raising the config writer's

--- a/windows/Ghostty.Core/Settings/ShaderPreviewFeed.cs
+++ b/windows/Ghostty.Core/Settings/ShaderPreviewFeed.cs
@@ -1,11 +1,11 @@
 using System;
-using System.Diagnostics;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Ghostty.Core.Logging;
 using Microsoft.Extensions.Logging;
 
-namespace Ghostty.Settings;
+namespace Ghostty.Core.Settings;
 
 /// <summary>
 /// Drives the shader picker's preview terminal with a canned session: a
@@ -17,8 +17,34 @@ namespace Ghostty.Settings;
 /// Mirrors the wintty.io/shaders demo: same DOS flavor, same pacing, same
 /// cursor-shape flips that exercise the mode-change cursor shaders.
 /// </summary>
+/// <remarks>
+/// UI-free and dependency-free, like <c>CustomShaderNoticeSource</c>: the
+/// feed writes to a <see cref="VtSink"/> delegate and paces itself through a
+/// <see cref="PacingDelay"/>, so the script, the ordering, and the
+/// cancellation unit-test without a WinUI runtime or a UI thread. The WinUI
+/// side supplies <c>TerminalControl.WriteVt</c> and <c>Task.Delay</c>.
+///
+/// Not thread-safe, and the sink it is given generally is not either:
+/// <c>WriteVt</c> is UI-thread-only. Start the feed on the UI thread so
+/// every continuation resumes there.
+/// </remarks>
 internal sealed partial class ShaderPreviewFeed : IDisposable
 {
+    /// <summary>
+    /// Where the feed's VT bytes go: the preview terminal in the app, a
+    /// recorder in tests. A bespoke delegate rather than
+    /// <c>Action&lt;ReadOnlySpan&lt;byte&gt;&gt;</c> because a ref struct
+    /// cannot be a type argument to the BCL's <c>Action&lt;T&gt;</c>.
+    /// </summary>
+    internal delegate void VtSink(ReadOnlySpan<byte> bytes);
+
+    /// <summary>
+    /// The pacing hook, awaited for every keystroke gap and beat pause.
+    /// Production passes <see cref="Task.Delay(int, CancellationToken)"/>;
+    /// tests pass a completed task so a full pass of the script runs without
+    /// spending wall-clock time on it.
+    /// </summary>
+    internal delegate Task PacingDelay(int milliseconds, CancellationToken ct);
     // SGR foregrounds only, never a background: the terminal theme is the
     // only background, so fullscreen shaders light up where text is drawn
     // instead of stopping at a palette-resolved bg cell (website lesson).
@@ -103,16 +129,23 @@ internal sealed partial class ShaderPreviewFeed : IDisposable
         new(null, CursorBar),
     };
 
-    private readonly Controls.TerminalControl _terminal;
+    private readonly VtSink _sink;
+    private readonly PacingDelay _delay;
+    private readonly ILogger<ShaderPreviewFeed> _logger;
     // Fixed seed so the demo plays identically every time (matching the
     // website's per-character jitter without its nondeterminism).
     private readonly Random _random = new(1009);
 
     private CancellationTokenSource? _cts;
 
-    public ShaderPreviewFeed(Controls.TerminalControl terminal)
+    internal ShaderPreviewFeed(
+        VtSink sink,
+        ILogger<ShaderPreviewFeed> logger,
+        PacingDelay? delay = null)
     {
-        _terminal = terminal;
+        _sink = sink;
+        _logger = logger;
+        _delay = delay ?? ((ms, ct) => Task.Delay(ms, ct));
     }
 
     /// <summary>Begin autoplay. Safe to call once per feed.</summary>
@@ -139,7 +172,7 @@ internal sealed partial class ShaderPreviewFeed : IDisposable
             // window has settled and the shader is already visible.
             Write(Banner);
             Write(Prompt);
-            await Task.Delay(1200, ct);
+            await _delay(1200, ct);
 
             while (true)
             {
@@ -148,14 +181,14 @@ internal sealed partial class ShaderPreviewFeed : IDisposable
                     if (beat.Command is { } command)
                     {
                         await TypeAsync(command, ct);
-                        await Task.Delay(350, ct);
+                        await _delay(350, ct);
                         Write("\r\n" + beat.Response + Prompt);
                     }
                     else
                     {
                         // A flip is a keypress: pause before and after so
                         // the cursor-shape animation has time to read.
-                        await Task.Delay(650, ct);
+                        await _delay(650, ct);
                         Write(beat.Response);
                     }
                 }
@@ -163,7 +196,7 @@ internal sealed partial class ShaderPreviewFeed : IDisposable
                 // Breathe between passes, then keep scrolling: the session
                 // grows exactly like the website demo, and scrollback
                 // bounds it (the configured scrollback limit).
-                await Task.Delay(4000, ct);
+                await _delay(4000, ct);
             }
         }
         catch (OperationCanceledException)
@@ -174,8 +207,7 @@ internal sealed partial class ShaderPreviewFeed : IDisposable
         {
             // A feed glitch must never take the picker down; the preview
             // just stops playing. Log it so it is diagnosable.
-            Logging.StaticLoggers.SettingsConfigWriter.LogInformation(
-                "shader preview feed stopped: {Message}", ex.Message);
+            LogFeedStopped(ex);
         }
     }
 
@@ -186,23 +218,21 @@ internal sealed partial class ShaderPreviewFeed : IDisposable
         foreach (var ch in text)
         {
             Write(ch.ToString());
-            await Task.Delay(55 + _random.Next(70), ct);
+            await _delay(55 + _random.Next(70), ct);
         }
     }
 
     private void Write(string vt)
     {
-        // WriteVt is UI-thread-only: its disposed guard is a non-volatile
-        // field read followed by a native call on a surface DisposeSurface
-        // frees from the UI thread. Today every write lands on the UI thread
-        // because Start is driven from FirstRender (raised through
-        // GhosttyHost's dispatcher) and every continuation below resumes on
-        // that context. Assert it so a future change that moves the feed off
-        // the UI thread fails loudly in Debug instead of silently racing a
-        // free in Release.
-        Debug.Assert(
-            _terminal.DispatcherQueue.HasThreadAccess,
-            "ShaderPreviewFeed must write from the UI thread; WriteVt is not thread-safe.");
-        _terminal.WriteVt(Encoding.UTF8.GetBytes(vt));
+        _sink(Encoding.UTF8.GetBytes(vt));
     }
+
+    // Its own category, not a borrowed one: raising the config writer's
+    // category to Debug to chase a config bug must not also turn on shader
+    // preview noise. Warning with the exception object, so the stack trace
+    // survives; a feed that stopped is a preview that silently froze.
+    [LoggerMessage(EventId = LogEvents.ShaderPreview.FeedStopped,
+                   Level = LogLevel.Warning,
+                   Message = "[ShaderPreviewFeed] shader preview feed stopped")]
+    private partial void LogFeedStopped(Exception ex);
 }

--- a/windows/Ghostty.Tests/Logging/ShaderPreviewFeedLoggingTests.cs
+++ b/windows/Ghostty.Tests/Logging/ShaderPreviewFeedLoggingTests.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Ghostty.Core.Logging;
+using Ghostty.Core.Logging.Testing;
+using Ghostty.Core.Settings;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Ghostty.Tests.Logging;
+
+public class ShaderPreviewFeedLoggingTests
+{
+    private static Task NoDelay(int milliseconds, CancellationToken ct) => Task.CompletedTask;
+
+    [Fact]
+    public void SinkThatThrows_EmitsWarningWithFeedStoppedEventIdAndTheException()
+    {
+        var capture = new CapturingLoggerProvider();
+        using var factory = LoggerFactory.Create(b => b.AddProvider(capture));
+
+        using var feed = new ShaderPreviewFeed(
+            (ReadOnlySpan<byte> _) => throw new InvalidOperationException("injected"),
+            factory.CreateLogger<ShaderPreviewFeed>(),
+            NoDelay);
+        feed.Start();
+
+        var entry = Assert.Single(capture.Entries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Equal(LogEvents.ShaderPreview.FeedStopped, entry.EventId.Id);
+        // The exception object, not just its Message: a feed that died takes
+        // the whole preview with it, and the stack is the only clue why.
+        Assert.IsType<InvalidOperationException>(entry.Exception);
+    }
+
+    [Fact]
+    public void FeedLogsUnderItsOwnCategory_NotABorrowedOne()
+    {
+        var capture = new CapturingLoggerProvider();
+        using var factory = LoggerFactory.Create(b => b.AddProvider(capture));
+
+        using var feed = new ShaderPreviewFeed(
+            (ReadOnlySpan<byte> _) => throw new InvalidOperationException("injected"),
+            factory.CreateLogger<ShaderPreviewFeed>(),
+            NoDelay);
+        feed.Start();
+
+        // The point of the category: raising SettingsConfigWriter to Debug to
+        // chase a config bug must not also turn on shader preview noise.
+        var entry = Assert.Single(capture.Entries);
+        Assert.Equal("Ghostty.Core.Settings.ShaderPreviewFeed", entry.Category);
+    }
+}

--- a/windows/Ghostty.Tests/Settings/ShaderPreviewFeedTests.cs
+++ b/windows/Ghostty.Tests/Settings/ShaderPreviewFeedTests.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Ghostty.Core.Settings;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Ghostty.Tests.Settings;
+
+/// <summary>
+/// The shader picker's autoplay feed, exercised without a WinUI runtime.
+/// The feed writes to a delegate and paces itself through another one, so a
+/// test can hand it a recorder and a pacing hook that never waits: a full
+/// pass of the demo script then runs synchronously, in no wall-clock time,
+/// on the test thread.
+///
+/// What the pacing hook deliberately does NOT do is observe the token. If it
+/// threw on cancellation, every one of these tests would pass on the hook's
+/// behaviour rather than the feed's, and the loop's own cancellation checks
+/// (the thing that stops a Write landing after Dispose) would go untested.
+/// </summary>
+public class ShaderPreviewFeedTests
+{
+    private static Task NoDelay(int milliseconds, CancellationToken ct) => Task.CompletedTask;
+
+    [Fact]
+    public void BootTextAndPromptLandBeforeAnythingIsTyped()
+    {
+        var recorder = new Recorder { StopAfter = 3 };
+        var feed = NewFeed(recorder);
+        feed.Start();
+
+        Assert.Contains("Starting MS-DOS...", recorder.TextOf(0));
+        Assert.Contains("Version 6.22", recorder.TextOf(0));
+        Assert.Contains("C:\\>", recorder.TextOf(1));
+        // The third write is the first typed character, not more boot text.
+        Assert.Equal("d", recorder.TextOf(2));
+    }
+
+    [Fact]
+    public void CommandsAreTypedOneCharacterPerWrite()
+    {
+        var recorder = new Recorder { StopAfter = 5 };
+        var feed = NewFeed(recorder);
+        feed.Start();
+
+        // Banner, prompt, then "dir" one keystroke at a time. One byte per
+        // write is what makes the preview look hand-keyed rather than pasted.
+        Assert.Equal(new[] { "d", "i", "r" }, recorder.Writes.Skip(2).Select(Decode));
+        Assert.All(recorder.Writes.Skip(2), w => Assert.Single(w));
+    }
+
+    [Fact]
+    public void ScriptPlaysEveryBeatInOrder()
+    {
+        var recorder = new Recorder { StopAfter = 400 };
+        var feed = NewFeed(recorder);
+        feed.Start();
+
+        var text = recorder.Text;
+        var banner = IndexOf(text, "Starting MS-DOS...");
+        var listing = IndexOf(text, "Volume in drive C is WINTTY");
+        var autoexec = IndexOf(text, "LH C:\\WINTTY\\SHADERLAB.EXE /GALLERY");
+        var version = IndexOf(text, "wintty shader gallery, live preview");
+        var echo = IndexOf(text, "shaders make terminals fun");
+
+        Assert.True(banner < listing, "boot banner must precede the dir listing");
+        Assert.True(listing < autoexec, "dir must precede type autoexec.bat");
+        Assert.True(autoexec < version, "type autoexec.bat must precede ver");
+        Assert.True(version < echo, "ver must precede the closing echo");
+
+        // The cursor-shape flips are the whole reason the script exists: they
+        // are the event the mode-change cursor shaders animate on.
+        Assert.Contains("\x1b[5 q", text, StringComparison.Ordinal);
+        Assert.Contains("\x1b[2 q", text, StringComparison.Ordinal);
+        Assert.Contains("\x1b[4 q", text, StringComparison.Ordinal);
+
+        // Foregrounds only, never a background: a background SGR (40-49)
+        // would stop fullscreen shaders at a palette-resolved cell. The only
+        // other sequence the script emits starting "ESC [ 4" is the DECSCUSR
+        // underline flip, so drop that and nothing beginning in 4 is left.
+        Assert.DoesNotContain(
+            "\x1b[4",
+            text.Replace("\x1b[4 q", "", StringComparison.Ordinal),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DisposeStopsTheFeed()
+    {
+        var recorder = new Recorder { StopAfter = 10 };
+        var feed = NewFeed(recorder);
+        feed.Start();
+
+        // Start returns only once the loop has stopped, which it can only do
+        // by observing the cancellation the recorder triggered on write 10.
+        // The upper bound is slack for the three writes a command beat emits
+        // back to back after its single check.
+        Assert.InRange(recorder.Writes.Count, 10, 12);
+    }
+
+    [Fact]
+    public void StartAfterDisposeIsANoOp()
+    {
+        var recorder = new Recorder();
+        var feed = NewFeed(recorder);
+
+        feed.Dispose();
+        feed.Start();
+
+        // Without the disposed latch this hangs rather than fails: Dispose
+        // nulls the token source, so Start would hand the loop a brand new,
+        // never-cancelled session.
+        Assert.Empty(recorder.Writes);
+    }
+
+    private static ShaderPreviewFeed NewFeed(Recorder recorder)
+    {
+        var feed = new ShaderPreviewFeed(
+            recorder.Write, NullLogger<ShaderPreviewFeed>.Instance, NoDelay);
+        recorder.Feed = feed;
+        return feed;
+    }
+
+    private static string Decode(byte[] bytes) => Encoding.UTF8.GetString(bytes);
+
+    private static int IndexOf(string haystack, string needle)
+    {
+        var index = haystack.IndexOf(needle, StringComparison.Ordinal);
+        Assert.True(index >= 0, $"feed never wrote {needle}");
+        return index;
+    }
+
+    /// <summary>
+    /// Collects every write and stops the feed once it has seen enough. The
+    /// feed loops forever by design, so a bound is not optional here: the
+    /// recorder disposing the feed from inside a write is exactly the
+    /// "picker closed mid-session" path.
+    /// </summary>
+    private sealed class Recorder
+    {
+        private readonly List<byte[]> _writes = new();
+
+        public int StopAfter { get; init; } = int.MaxValue;
+        public ShaderPreviewFeed? Feed { get; set; }
+
+        public IReadOnlyList<byte[]> Writes => _writes;
+
+        public string Text => string.Concat(_writes.Select(Encoding.UTF8.GetString));
+
+        public string TextOf(int index) => Encoding.UTF8.GetString(_writes[index]);
+
+        public void Write(ReadOnlySpan<byte> bytes)
+        {
+            _writes.Add(bytes.ToArray());
+            if (_writes.Count >= StopAfter) Feed?.Dispose();
+        }
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/CustomShaderNoticeWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/CustomShaderNoticeWiringTests.cs
@@ -1,0 +1,61 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// The notice itself (its copy, and the latch that stops it repeating) is
+/// unit-tested in CustomShaderNoticeSourceTests. What that cannot reach is
+/// which surfaces are allowed to reach the notice at all, which lives in the
+/// WinUI host's action switch.
+///
+/// A gallery preview's shader does not come from the user's custom-shader
+/// setting, so a preview failure must neither show the notice (its copy
+/// blames settings the user never touched) nor consume the source's latch
+/// (which never re-arms for the same reason, and would swallow a later
+/// genuine config-shader failure for the rest of the session).
+/// </summary>
+public class CustomShaderNoticeWiringTests
+{
+    private static ShellSource Host() => ShellSource.Load("Hosting.GhosttyHost.cs");
+
+    private static IfStatementSyntax PreviewGuard(SyntaxNode section) =>
+        Assert.Single(
+            section.DescendantNodes().OfType<IfStatementSyntax>(),
+            s => s.Condition.ToString() == "control.IsPreviewSurface");
+
+    [Fact]
+    public void PreviewSurfaces_LeaveTheCustomShaderCaseImmediately()
+    {
+        var section = Host().Case("OnAction", "CustomShaderFailed");
+
+        // Handled, not unhandled: returning 0 would let libghostty treat the
+        // action as unconsumed.
+        Assert.Equal("return 1;", PreviewGuard(section).Statement.ToString());
+    }
+
+    [Fact]
+    public void PreviewGuard_RunsBeforeTheNoticeSourceIsConsulted()
+    {
+        var section = Host().Case("OnAction", "CustomShaderFailed");
+
+        // Order is the whole fix. Resolve latches on the reason and never
+        // re-arms, so a preview reaching it suppresses the next real one even
+        // if the banner itself is skipped afterwards.
+        Assert.True(
+            PreviewGuard(section).SpanStart < section.Call("_customShaderNotices.Resolve").SpanStart,
+            "the preview guard must precede _customShaderNotices.Resolve");
+    }
+
+    [Fact]
+    public void ConfigShaderFailures_StillShowTheNotice()
+    {
+        var section = Host().Case("OnAction", "CustomShaderFailed");
+
+        // The other half: gating must not have quietly removed the real path.
+        Assert.Single(section.Calls("notifications.Show"));
+        Assert.Equal("notice", section.Call("notifications.Show").Arg(0));
+    }
+}

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -69,6 +69,18 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     private IntPtr _initialInputUtf8;
     private IntPtr _customShaderUtf8;
 
+    /// <summary>
+    /// True when this surface was created with a per-surface shader override
+    /// (<see cref="PreviewCustomShader"/>), i.e. it is a gallery preview and
+    /// not a real terminal pane. Latched at surface creation, because that is
+    /// the one point the override property is read. Used by
+    /// <see cref="Ghostty.Hosting.GhosttyHost"/> to keep a preview shader's
+    /// failure out of the app-level custom-shader notice, which talks about
+    /// the user's config.
+    /// </summary>
+    internal bool IsPreviewSurface => _isPreviewSurface;
+    private bool _isPreviewSurface;
+
     // The libghostty surface lifecycle is decoupled from
     // OnLoaded/OnUnloaded so that visual-tree reparenting (which fires
     // Unloaded then Loaded asynchronously) does NOT tear down the
@@ -796,6 +808,12 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         _customShaderUtf8 = string.IsNullOrEmpty(PreviewCustomShader)
             ? IntPtr.Zero
             : AllocUtf8(PreviewCustomShader);
+        // Latched here rather than recomputed from PreviewCustomShader later:
+        // this is the one moment the property is defined to be read, and
+        // SetPreviewCustomShader swaps the surface's shader without touching
+        // it. What the flag means is "this surface was born a preview", which
+        // is exactly the question the shader-failure notice needs answered.
+        _isPreviewSurface = _customShaderUtf8 != IntPtr.Zero;
 
         var panelPtr = SwapChainPanelInterop.QueryInterface(Panel);
         var surfaceConfig = NativeMethods.SurfaceConfigNew();

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -152,10 +152,22 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     /// Per-surface custom shader override for preview surfaces. When set
     /// (non-empty path), the surface's renderer uses ONLY this shader,
     /// replacing the configured custom-shader list. Must be set before the
-    /// control loads: it is read once at surface creation. Regular terminal
+    /// control loads: it is read once at surface creation (swap it later
+    /// through <see cref="SetPreviewCustomShader"/>). Regular terminal
     /// surfaces leave it null and follow the app config.
     /// </summary>
     public string? PreviewCustomShader { get; set; }
+
+    /// <summary>
+    /// Command the surface runs instead of the profile's shell. Must be set
+    /// before the control loads. Preview surfaces point this at a silent,
+    /// never-exiting placeholder so the pty never delivers a single byte of
+    /// its own: everything on screen comes from <see cref="WriteVt"/>, which
+    /// makes the preview deterministic and race-free against shell banners.
+    /// Regular terminal surfaces leave it null and use the snapshot's
+    /// resolved command.
+    /// </summary>
+    public string? PreviewCommand { get; set; }
 
     /// <summary>
     /// Take keyboard focus as soon as the surface loads. Real terminal
@@ -190,6 +202,36 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     {
         if (_surfaceDisposed || _surface.Handle == IntPtr.Zero) return;
         NativeMethods.SurfaceDraw(_surface);
+    }
+
+    /// <summary>
+    /// Swap this surface's custom shader override live. The renderer rebuilds
+    /// its post-process pipeline (the config-change path) while the terminal
+    /// content, scrollback, and cursor are preserved, so a preview flipping
+    /// through shaders never resets. A null or empty path clears the shader.
+    /// No-op once the surface is gone. Only meaningful for surfaces created
+    /// with <see cref="PreviewCustomShader"/>; regular surfaces follow the
+    /// app config.
+    /// </summary>
+    internal void SetPreviewCustomShader(string? shaderPath)
+    {
+        if (_surfaceDisposed || _surface.Handle == IntPtr.Zero) return;
+        NativeMethods.SurfaceSetCustomShader(_surface, shaderPath);
+    }
+
+    /// <summary>
+    /// Feed raw VT bytes into the terminal as if the child program wrote
+    /// them: sequences update the grid, cursor, and colors exactly like pty
+    /// output. Thread-safe. Used by preview surfaces, whose placeholder
+    /// child never writes, to drive their canned session.
+    /// </summary>
+    internal unsafe void WriteVt(ReadOnlySpan<byte> bytes)
+    {
+        if (_surfaceDisposed || bytes.IsEmpty || _surface.Handle == IntPtr.Zero) return;
+        fixed (byte* p = bytes)
+        {
+            NativeMethods.SurfaceVtWrite(_surface, p, (nuint)bytes.Length);
+        }
     }
 
     /// <summary>
@@ -730,9 +772,13 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         _workingDirectoryUtf8 = Snapshot is { WorkingDirectory: { Length: > 0 } wd }
             ? AllocUtf8(wd)
             : AllocEmptyUtf8();
-        _commandUtf8 = Snapshot is { ResolvedCommand: { Length: > 0 } cmd }
-            ? AllocUtf8(cmd)
-            : AllocEmptyUtf8();
+        // PreviewCommand wins over the snapshot: a preview surface never
+        // wants the real shell's banner interleaving with its canned feed.
+        _commandUtf8 = PreviewCommand is { Length: > 0 } previewCmd
+            ? AllocUtf8(previewCmd)
+            : Snapshot is { ResolvedCommand: { Length: > 0 } cmd }
+                ? AllocUtf8(cmd)
+                : AllocEmptyUtf8();
         _initialInputUtf8 = AllocEmptyUtf8();
         // Preview shader override: set BEFORE the control loads (it is read
         // once at surface creation in OnLoaded).

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -222,8 +222,19 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     /// <summary>
     /// Feed raw VT bytes into the terminal as if the child program wrote
     /// them: sequences update the grid, cursor, and colors exactly like pty
-    /// output. Thread-safe. Used by preview surfaces, whose placeholder
-    /// child never writes, to drive their canned session.
+    /// output. Used by preview surfaces, whose placeholder child never
+    /// writes, to drive their canned session.
+    ///
+    /// Must be called on the UI thread, like the sibling
+    /// <see cref="RequestRepaint"/> and <see cref="SetPreviewCustomShader"/>.
+    /// The guard below is a plain read of a non-volatile field plus a read of
+    /// <c>_surface.Handle</c>, and <see cref="DisposeSurface"/> flips that
+    /// field and calls <c>SurfaceFree</c> from the UI thread with no
+    /// synchronization at all. An off-thread caller can therefore see the
+    /// guard pass, be preempted, and hand a freed surface pointer to
+    /// libghostty (an access violation, not an exception). Making this
+    /// genuinely callable from a pty reader thread needs a lock or an
+    /// interlocked handle swap on BOTH sides, not a comment.
     /// </summary>
     internal unsafe void WriteVt(ReadOnlySpan<byte> bytes)
     {

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -943,6 +943,20 @@ internal sealed partial class GhosttyHost : IDisposable
                     // nothing. Raised app-level rather than per-surface because
                     // it explains a config problem, not something about this
                     // one pane.
+                    //
+                    // Which is exactly why a gallery preview must not raise it.
+                    // Its shader comes from the picker, not from custom-shader,
+                    // so the notice's copy ("Your custom-shader did not
+                    // compile") would blame settings the user never touched.
+                    // Worse, CustomShaderNoticeSource latches on the reason and
+                    // never re-arms, so one broken gallery entry would also
+                    // swallow a genuine config-shader failure for the rest of
+                    // the session. Returning before Resolve leaves that latch
+                    // untouched, which is the half that matters. A preview
+                    // failure is not silent either way: the preview visibly
+                    // renders unshaded, and libghostty still logs it.
+                    if (control.IsPreviewSurface) return 1;
+
                     var failure = (Ghostty.Core.Renderer.CustomShaderFailure)
                         Marshal.ReadInt32(actionPtr, 8);
                     _dispatcher.TryEnqueue(() =>

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -710,15 +710,21 @@ internal static partial class NativeMethods
     // StringMarshalling.Utf8 is a [LibraryImport] option, not a
     // [MarshalAs], so it coexists with DisableRuntimeMarshalling (same
     // rationale as the clipboard request binding above).
+    //
+    // Imported as void even though the Zig side returns a bool. That bool is
+    // false only when updateConfig fails, NOT when the shader fails to load
+    // or compile (those arrive as the custom_shader_failed action), and there
+    // is nothing a caller can do with it: the preview has no second shader to
+    // fall back to and the surface keeps rendering with whatever it had. A
+    // bool return would promise information nobody consumes, and discarding
+    // one at the call site is how a silent failure hides. Dropping a cdecl
+    // return value is well defined; the callee still pops nothing.
     [LibraryImport(Dll, EntryPoint = "ghostty_surface_set_custom_shader",
         StringMarshalling = StringMarshalling.Utf8)]
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
-    private static partial byte SurfaceSetCustomShaderNative(
+    internal static partial void SurfaceSetCustomShader(
         GhosttySurface surface,
         string? shaderPath);
-
-    internal static bool SurfaceSetCustomShader(GhosttySurface surface, string? shaderPath)
-        => SurfaceSetCustomShaderNative(surface, shaderPath) != 0;
 
     // ghostty_surface_vt_write feeds raw VT bytes into the surface's
     // terminal parser as if they came from the PTY. Raw-pointer overload:
@@ -729,7 +735,7 @@ internal static partial class NativeMethods
     internal static unsafe partial void SurfaceVtWrite(
         GhosttySurface surface,
         byte* utf8,
-        UIntPtr len);
+        nuint len);
 
     [LibraryImport(Dll, EntryPoint = "ghostty_surface_process_exited")]
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -702,6 +702,35 @@ internal static partial class NativeMethods
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
     internal static partial void SurfaceRequestClose(GhosttySurface surface);
 
+    // ghostty_surface_set_custom_shader swaps the per-surface custom shader
+    // override live: the renderer rebuilds its post-process pipeline through
+    // the config-change path while the grid, scrollback, and cursor are
+    // preserved. Null or empty clears the override (no shader). Used by the
+    // shader gallery picker so flipping entries never resets the preview.
+    // StringMarshalling.Utf8 is a [LibraryImport] option, not a
+    // [MarshalAs], so it coexists with DisableRuntimeMarshalling (same
+    // rationale as the clipboard request binding above).
+    [LibraryImport(Dll, EntryPoint = "ghostty_surface_set_custom_shader",
+        StringMarshalling = StringMarshalling.Utf8)]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    private static partial byte SurfaceSetCustomShaderNative(
+        GhosttySurface surface,
+        string? shaderPath);
+
+    internal static bool SurfaceSetCustomShader(GhosttySurface surface, string? shaderPath)
+        => SurfaceSetCustomShaderNative(surface, shaderPath) != 0;
+
+    // ghostty_surface_vt_write feeds raw VT bytes into the surface's
+    // terminal parser as if they came from the PTY. Raw-pointer overload:
+    // the caller owns the buffer for the duration of the call and passes
+    // its length in bytes (no NUL terminator involved).
+    [LibraryImport(Dll, EntryPoint = "ghostty_surface_vt_write")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    internal static unsafe partial void SurfaceVtWrite(
+        GhosttySurface surface,
+        byte* utf8,
+        UIntPtr len);
+
     [LibraryImport(Dll, EntryPoint = "ghostty_surface_process_exited")]
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
     private static partial byte SurfaceProcessExitedNative(GhosttySurface surface);

--- a/windows/Ghostty/Logging/StaticLoggers.cs
+++ b/windows/Ghostty/Logging/StaticLoggers.cs
@@ -46,6 +46,11 @@ namespace Ghostty.Logging;
 ///     constructed by the XAML Settings pages (same no-DI-Frame
 ///     constraint as <see cref="GeneralPage"/>); logs config-file
 ///     write failures from immediate-write handlers.
+///   - <see cref="ShaderPreviewFeed"/>: Core helper owned by
+///     <see cref="Ghostty.Settings.ShaderPickerWindow"/>, a
+///     <c>Window</c> the settings pages construct directly (same
+///     no-DI-Frame constraint as <see cref="GeneralPage"/>); logs
+///     the autoplay feed dying.
 ///
 /// Tests should use <see cref="Install"/> which returns an
 /// <see cref="IDisposable"/> scope that restores the pre-install
@@ -71,6 +76,7 @@ internal static partial class StaticLoggers
     private static ILogger<Ghostty.Settings.Pages.KeybindingsPage>? _keybindingsPage;
     private static ILogger<Ghostty.Settings.CheatSheetDialog>? _cheatSheet;
     private static ILogger<Ghostty.Core.Config.SettingsConfigWriter>? _settingsConfigWriter;
+    private static ILogger<Ghostty.Core.Settings.ShaderPreviewFeed>? _shaderPreviewFeed;
     private static ILogger<App>? _app;
     private static ILogger<Ghostty.Hosting.BellAudioPlayer>? _bellAudio;
 
@@ -88,6 +94,8 @@ internal static partial class StaticLoggers
         => _cheatSheet ?? NullLogger<Ghostty.Settings.CheatSheetDialog>.Instance;
     internal static ILogger<Ghostty.Core.Config.SettingsConfigWriter> SettingsConfigWriter
         => _settingsConfigWriter ?? NullLogger<Ghostty.Core.Config.SettingsConfigWriter>.Instance;
+    internal static ILogger<Ghostty.Core.Settings.ShaderPreviewFeed> ShaderPreviewFeed
+        => _shaderPreviewFeed ?? NullLogger<Ghostty.Core.Settings.ShaderPreviewFeed>.Instance;
     internal static ILogger<App> App
         => _app ?? NullLogger<App>.Instance;
     internal static ILogger<Ghostty.Hosting.BellAudioPlayer> BellAudio
@@ -102,6 +110,7 @@ internal static partial class StaticLoggers
         _keybindingsPage = factory.CreateLogger<Ghostty.Settings.Pages.KeybindingsPage>();
         _cheatSheet = factory.CreateLogger<Ghostty.Settings.CheatSheetDialog>();
         _settingsConfigWriter = factory.CreateLogger<Ghostty.Core.Config.SettingsConfigWriter>();
+        _shaderPreviewFeed = factory.CreateLogger<Ghostty.Core.Settings.ShaderPreviewFeed>();
         _app = factory.CreateLogger<App>();
         _bellAudio = factory.CreateLogger<Ghostty.Hosting.BellAudioPlayer>();
     }
@@ -115,7 +124,7 @@ internal static partial class StaticLoggers
 
     private static Snapshot CaptureSnapshot() => new(
         _configService, _windowStateMigration, _windowState, _generalPage, _keybindingsPage,
-        _cheatSheet, _settingsConfigWriter, _app, _bellAudio);
+        _cheatSheet, _settingsConfigWriter, _shaderPreviewFeed, _app, _bellAudio);
 
     private readonly record struct Snapshot(
         ILogger<Ghostty.Services.ConfigService>? ConfigService,
@@ -125,6 +134,7 @@ internal static partial class StaticLoggers
         ILogger<Ghostty.Settings.Pages.KeybindingsPage>? KeybindingsPage,
         ILogger<Ghostty.Settings.CheatSheetDialog>? CheatSheet,
         ILogger<Ghostty.Core.Config.SettingsConfigWriter>? SettingsConfigWriter,
+        ILogger<Ghostty.Core.Settings.ShaderPreviewFeed>? ShaderPreviewFeed,
         ILogger<App>? App,
         ILogger<Ghostty.Hosting.BellAudioPlayer>? BellAudio);
 
@@ -142,6 +152,7 @@ internal static partial class StaticLoggers
             _keybindingsPage = _prior.KeybindingsPage;
             _cheatSheet = _prior.CheatSheet;
             _settingsConfigWriter = _prior.SettingsConfigWriter;
+            _shaderPreviewFeed = _prior.ShaderPreviewFeed;
             _app = _prior.App;
             _bellAudio = _prior.BellAudio;
         }

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml
@@ -113,6 +113,7 @@
                                  how Choose... got pushed off the card. The
                                  button always sits on its own line below. -->
                             <StackPanel x:Name="GalleryPickRow"
+                                        Orientation="Vertical"
                                         Spacing="8">
                                 <TextBlock x:Name="GalleryPickLabel"
                                            Text="No shader selected"

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml
@@ -106,16 +106,20 @@
                             </RadioButtons>
                             <!-- Gallery pick row: shown only in gallery mode.
                                  The picker window owns previewing; this row
-                                 just names the committed pick and reopens it. -->
+                                 just names the committed pick and reopens it.
+                                 Vertical on purpose: gallery descriptions
+                                 run long, and a wrapping label sharing a
+                                 horizontal row with the button is exactly
+                                 how Choose... got pushed off the card. The
+                                 button always sits on its own line below. -->
                             <StackPanel x:Name="GalleryPickRow"
-                                        Orientation="Horizontal"
                                         Spacing="8">
                                 <TextBlock x:Name="GalleryPickLabel"
                                            Text="No shader selected"
-                                           VerticalAlignment="Center"
                                            TextWrapping="Wrap" />
                                 <Button Content="Choose..."
-                                        Click="ShaderGalleryChoose_Click" />
+                                        Click="ShaderGalleryChoose_Click"
+                                        HorizontalAlignment="Left" />
                             </StackPanel>
                             <!-- File row: shown only in file mode. Same
                                  writer as the old card; no ConfigKey here by

--- a/windows/Ghostty/Settings/ShaderPickerWindow.xaml
+++ b/windows/Ghostty/Settings/ShaderPickerWindow.xaml
@@ -7,10 +7,11 @@
     <!-- Gallery shader picker: a real window (not a dialog) so it can stay
          open while the caller compares against other windows. The combo, the
          chevron buttons, and the left/right arrows all move through the
-         gallery; the live terminal underneath previews each shader as
-         selected. Focus the terminal to type and see cursor-triggered
-         effects; while it holds focus its keystrokes (arrows included) are
-         never intercepted, so the chevrons are how you flip then. -->
+         gallery; the preview terminal underneath plays a canned session that
+         types itself, so every shader has moving content (and cursor-shape
+         flips for the cursor shaders) from the moment the window opens.
+         Flipping entries swaps only the shader: the terminal and its content
+         are never reset. -->
 
     <Grid x:Name="RootGrid"
           RowSpacing="4"
@@ -24,7 +25,7 @@
 
         <TextBlock Grid.Row="0"
                    Margin="12,8,12,0"
-                   Text="Pick a shader. The chevrons beside the list flip through the gallery; so do Left/Right arrows while the terminal is not focused. Click into the terminal below to type and see cursor effects move."
+                   Text="Pick a shader. The chevrons beside the list flip through the gallery; so do Left/Right arrows while the terminal is not focused. The preview below plays by itself and keeps its content while you flip; only the shader changes."
                    TextWrapping="Wrap"
                    Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
 

--- a/windows/Ghostty/Settings/ShaderPickerWindow.xaml.cs
+++ b/windows/Ghostty/Settings/ShaderPickerWindow.xaml.cs
@@ -297,9 +297,21 @@ public sealed partial class ShaderPickerWindow : Window
         PickerPreviewHost.Child = control;
 
         // Autoplay starts the moment the preview exists: the demo types
-        // itself, no clicks needed.
+        // itself, no clicks needed. The feed's opening writes (banner and
+        // first prompt) must wait for FirstRender: this method runs from
+        // the ctor's SelectionChanged, before the window is activated,
+        // when the surface handle is still zero and WriteVt would silently
+        // drop them. Starting on FirstRender also buys the loop a surface
+        // that has actually drawn a frame.
         _feed = new ShaderPreviewFeed(control);
-        _feed.Start();
+        control.FirstRender += OnPreviewFirstRender;
+    }
+
+    private void OnPreviewFirstRender(object? sender, EventArgs e)
+    {
+        // Fires once, from the terminal's first-render callback; Start is
+        // idempotent anyway.
+        _feed?.Start();
     }
 
     private void DisposePreview()

--- a/windows/Ghostty/Settings/ShaderPickerWindow.xaml.cs
+++ b/windows/Ghostty/Settings/ShaderPickerWindow.xaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Ghostty.Core.Settings;
 
 using Microsoft.UI.Windowing;
@@ -303,7 +304,22 @@ public sealed partial class ShaderPickerWindow : Window
         // when the surface handle is still zero and WriteVt would silently
         // drop them. Starting on FirstRender also buys the loop a surface
         // that has actually drawn a frame.
-        _feed = new ShaderPreviewFeed(control);
+        // The feed is UI-free by design (it unit-tests without a WinUI
+        // runtime), so the WinUI half of it lives here: the sink is the
+        // control's WriteVt, which is UI-thread-only. FirstRender is raised
+        // through GhosttyHost's dispatcher and every continuation in the feed
+        // resumes on that context, so every write lands on the UI thread; the
+        // assert is what makes a future regression loud rather than a race
+        // against SurfaceFree.
+        _feed = new ShaderPreviewFeed(
+            bytes =>
+            {
+                Debug.Assert(
+                    control.DispatcherQueue.HasThreadAccess,
+                    "ShaderPreviewFeed must write from the UI thread; WriteVt is not thread-safe.");
+                control.WriteVt(bytes);
+            },
+            Logging.StaticLoggers.ShaderPreviewFeed);
         control.FirstRender += OnPreviewFirstRender;
     }
 

--- a/windows/Ghostty/Settings/ShaderPickerWindow.xaml.cs
+++ b/windows/Ghostty/Settings/ShaderPickerWindow.xaml.cs
@@ -52,6 +52,10 @@ public sealed partial class ShaderPickerWindow : Window
     private Controls.TerminalControl? _preview;
     private ShaderPreviewFeed? _feed;
     private readonly List<string> _orderedPaths = new();
+    // Latched by Closed. The window's teardown is the point after which no
+    // native surface may be created, and Closed is not a state the WinUI
+    // Window type otherwise exposes.
+    private bool _closed;
 
     public ShaderPickerWindow()
     {
@@ -104,7 +108,11 @@ public sealed partial class ShaderPickerWindow : Window
         // the shared bootstrap host, plus its autoplay feed; OnUnloaded
         // detachment does NOT free them, so the window closing must
         // dispose explicitly (TerminalControl lesson).
-        Closed += (_, _) => DisposePreview();
+        Closed += (_, _) =>
+        {
+            _closed = true;
+            DisposePreview();
+        };
 
         // Arrows flip shaders unless the terminal preview holds focus: the
         // terminal forwards keys to the shell without marking them handled,
@@ -243,14 +251,17 @@ public sealed partial class ShaderPickerWindow : Window
 
     private void PickerCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
+        // No else branch. The only tagless item is the "Gallery unavailable"
+        // diagnostic, which exists exactly when there are no entries at all,
+        // so nothing can select away from a preview and back. Tearing the
+        // preview down here would also contradict the contract above: the
+        // terminal is built once and lives for the whole window, and
+        // rebuilding it would spawn a second placeholder powershell and
+        // restart the session mid-browse.
         if (PickerCombo.SelectedItem is ComboBoxItem item &&
             item.Tag is string path)
         {
             ShowPreview(path);
-        }
-        else
-        {
-            DisposePreview();
         }
         UpdateSelectEnabled();
     }
@@ -276,6 +287,12 @@ public sealed partial class ShaderPickerWindow : Window
     private void EnsurePreview(string initialShaderPath)
     {
         if (_preview is not null) return;
+        // Nothing may build a native surface (and a placeholder child
+        // process) after the window has closed: DisposePreview has already
+        // run, so whatever this created would be owned by nobody and leak the
+        // surface and the powershell with it. A SelectionChanged arriving
+        // during teardown is the path that gets here.
+        if (_closed) return;
 
         var host = App.BootstrapHost;
         if (host is null) return;

--- a/windows/Ghostty/Settings/ShaderPickerWindow.xaml.cs
+++ b/windows/Ghostty/Settings/ShaderPickerWindow.xaml.cs
@@ -14,15 +14,34 @@ namespace Ghostty.Settings;
 
 /// <summary>
 /// Gallery shader picker window. The combo, the chevron buttons, and the
-/// left/right arrow keys all walk the gallery; a live terminal underneath
-/// previews the selected shader immediately (per-surface override, never
-/// the app config). Arrows leave the gallery alone while the terminal
-/// holds focus, so its keystrokes (cursor movement included) are never
+/// left/right arrow keys all walk the gallery; a preview terminal
+/// underneath plays a canned, self-typing session (see <see
+/// cref="ShaderPreviewFeed"/>) so every shader, cursor-effect ones
+/// included, has moving content to work on. The preview terminal is
+/// created once and lives for the whole window: flipping entries swaps
+/// only the per-surface shader (never the app config), so its content,
+/// scrollback, and cursor survive every switch. Arrows leave the gallery
+/// alone while the terminal holds focus, so its keystrokes are never
 /// stolen. Select commits the picked path to <see cref="PickedPath"/> and
 /// closes; Cancel (or closing the window) leaves it null.
 /// </summary>
 public sealed partial class ShaderPickerWindow : Window
 {
+    /// <summary>
+    /// The preview's placeholder child: PowerShell put to sleep writes
+    /// nothing, never exits, and never reads stdin, so the pty stays
+    /// silent and the canned feed is the terminal's only writer
+    /// (deterministic content, no banner race, stray clicks into the
+    /// preview cannot produce output). A real shell here would interleave
+    /// its own prompt with the feed. No shell metacharacters on purpose:
+    /// the spawn path wraps commands containing them in cmd.exe, which
+    /// would make the placeholder noisier and quoting-dependent. The sleep
+    /// length is Start-Sleep's documented maximum (~24.8 days); the picker
+    /// closing kills the surface and the child with it.
+    /// </summary>
+    private const string PreviewPlaceholderCommand =
+        "powershell.exe -NoLogo -NoProfile -Command Start-Sleep -Seconds 2147483";
+
     /// <summary>Path to preselect in the combo, if it is a gallery entry.</summary>
     public string? CurrentPath { get; set; }
 
@@ -30,6 +49,7 @@ public sealed partial class ShaderPickerWindow : Window
     public string? PickedPath { get; private set; }
 
     private Controls.TerminalControl? _preview;
+    private ShaderPreviewFeed? _feed;
     private readonly List<string> _orderedPaths = new();
 
     public ShaderPickerWindow()
@@ -79,9 +99,10 @@ public sealed partial class ShaderPickerWindow : Window
         // exists.
         RootGrid.Loaded += (_, _) => PickerCombo.Focus(FocusState.Programmatic);
 
-        // The preview owns a native surface + shell process on the shared
-        // bootstrap host; OnUnloaded detachment does NOT free them, so the
-        // window closing must dispose explicitly (TerminalControl lesson).
+        // The preview owns a native surface + placeholder child process on
+        // the shared bootstrap host, plus its autoplay feed; OnUnloaded
+        // detachment does NOT free them, so the window closing must
+        // dispose explicitly (TerminalControl lesson).
         Closed += (_, _) => DisposePreview();
 
         // Arrows flip shaders unless the terminal preview holds focus: the
@@ -141,7 +162,7 @@ public sealed partial class ShaderPickerWindow : Window
             }
         }
 
-        // Setting the selection fires SelectionChanged, which builds the
+        // Setting the selection fires SelectionChanged, which shows the
         // first preview. Guard for the degenerate no-selection case.
         if (PickerCombo.Items.Count > 0)
         {
@@ -207,7 +228,7 @@ public sealed partial class ShaderPickerWindow : Window
     }
 
     // Shared by the arrow keys and the chevron buttons: wrap around the
-    // gallery and let SelectionChanged rebuild the preview.
+    // gallery; SelectionChanged swaps the preview's shader in place.
     private void StepSelection(int delta)
     {
         if (_orderedPaths.Count == 0) return;
@@ -240,9 +261,20 @@ public sealed partial class ShaderPickerWindow : Window
         SelectButton.IsEnabled =
             (PickerCombo.SelectedItem as ComboBoxItem)?.Tag is string;
 
+    // The preview terminal is built once and reused for every selection:
+    // switching a shader only swaps the surface's custom shader in place
+    // (TerminalControl.SetPreviewCustomShader), so the terminal, its
+    // content, and its autoplay feed are never reset, no new surface is
+    // spawned per change, and nothing steals focus from the combo.
     private void ShowPreview(string shaderPath)
     {
-        DisposePreview();
+        EnsurePreview(shaderPath);
+        _preview?.SetPreviewCustomShader(shaderPath);
+    }
+
+    private void EnsurePreview(string initialShaderPath)
+    {
+        if (_preview is not null) return;
 
         var host = App.BootstrapHost;
         if (host is null) return;
@@ -250,7 +282,11 @@ public sealed partial class ShaderPickerWindow : Window
         var control = new Controls.TerminalControl
         {
             Host = host,
-            PreviewCustomShader = shaderPath,
+            // Seed the override at creation so the very first rendered
+            // frame already wears the selected shader.
+            PreviewCustomShader = initialShaderPath,
+            // Silence the child: everything on screen comes from the feed.
+            PreviewCommand = PreviewPlaceholderCommand,
             // The preview must not steal focus when its surface loads:
             // TerminalControl focuses itself on load by default (real
             // panes want that), which would hand the arrows to the shell
@@ -259,10 +295,17 @@ public sealed partial class ShaderPickerWindow : Window
         };
         _preview = control;
         PickerPreviewHost.Child = control;
+
+        // Autoplay starts the moment the preview exists: the demo types
+        // itself, no clicks needed.
+        _feed = new ShaderPreviewFeed(control);
+        _feed.Start();
     }
 
     private void DisposePreview()
     {
+        _feed?.Dispose();
+        _feed = null;
         _preview?.DisposeSurface();
         _preview = null;
         if (PickerPreviewHost is not null) PickerPreviewHost.Child = null;

--- a/windows/Ghostty/Settings/ShaderPreviewFeed.cs
+++ b/windows/Ghostty/Settings/ShaderPreviewFeed.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -191,6 +192,17 @@ internal sealed partial class ShaderPreviewFeed : IDisposable
 
     private void Write(string vt)
     {
+        // WriteVt is UI-thread-only: its disposed guard is a non-volatile
+        // field read followed by a native call on a surface DisposeSurface
+        // frees from the UI thread. Today every write lands on the UI thread
+        // because Start is driven from FirstRender (raised through
+        // GhosttyHost's dispatcher) and every continuation below resumes on
+        // that context. Assert it so a future change that moves the feed off
+        // the UI thread fails loudly in Debug instead of silently racing a
+        // free in Release.
+        Debug.Assert(
+            _terminal.DispatcherQueue.HasThreadAccess,
+            "ShaderPreviewFeed must write from the UI thread; WriteVt is not thread-safe.");
         _terminal.WriteVt(Encoding.UTF8.GetBytes(vt));
     }
 }

--- a/windows/Ghostty/Settings/ShaderPreviewFeed.cs
+++ b/windows/Ghostty/Settings/ShaderPreviewFeed.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Ghostty.Settings;
+
+/// <summary>
+/// Drives the shader picker's preview terminal with a canned session: a
+/// scripted MS-DOS box that types itself, forever, with human-ish pacing.
+/// The preview surface runs a silent placeholder child, so these VT bytes
+/// are the only thing that ever reaches the grid: the content is
+/// deterministic, it starts playing the moment the picker opens, and it
+/// survives every shader flip (the feed never rebuilds the surface).
+/// Mirrors the wintty.io/shaders demo: same DOS flavor, same pacing, same
+/// cursor-shape flips that exercise the mode-change cursor shaders.
+/// </summary>
+internal sealed partial class ShaderPreviewFeed : IDisposable
+{
+    // SGR foregrounds only, never a background: the terminal theme is the
+    // only background, so fullscreen shaders light up where text is drawn
+    // instead of stopping at a palette-resolved bg cell (website lesson).
+    private const string FgGray = "\x1b[37m";
+    private const string FgBright = "\x1b[1;37m";
+    private const string FgBlue = "\x1b[34;1m";
+
+    // DECSCUSR: cursor shape flips are the exact event the mode-change
+    // cursor shaders (ripple, boom) animate on.
+    private const string CursorBlock = "\x1b[2 q";
+    private const string CursorBar = "\x1b[5 q";
+    private const string CursorUnderline = "\x1b[4 q";
+
+    private const string Prompt = FgBlue + "C:\\>" + FgGray + " ";
+
+    private const string Banner =
+        "\r\n" +
+        "Starting MS-DOS...\r\n" +
+        "\r\n" +
+        FgBright + "Microsoft(R) MS-DOS(R) Version 6.22\r\n" + FgGray +
+        "(C)Copyright Microsoft Corp 1981-1994.\r\n" +
+        "\r\n" +
+        "WINTTY Shader Lab Extension v1.0 installed.\r\n" +
+        "\r\n" +
+        "Type HELP for the command list.\r\n" +
+        "\r\n";
+
+    private const string DirListing =
+        "\r\n Volume in drive C is WINTTY\r\n" +
+        "\r\n" +
+        " IO       SYS      40,766  06-22-94\r\n" +
+        " MSDOS    SYS      38,138  06-22-94\r\n" +
+        " COMMAND  COM      54,619  06-22-94\r\n" +
+        " AUTOEXEC BAT        214  06-22-94\r\n" +
+        " CONFIG   SYS        168  06-22-94\r\n" +
+        " WINTTY      <DIR>          06-22-94\r\n" +
+        " CRT      GLS      1,842  06-22-94\r\n" +
+        " SCANLINE GLS        916  06-22-94\r\n" +
+        " SNOWFALL GLS      1,024  06-22-94\r\n" +
+        " AURORA   GLS      2,048  06-22-94\r\n" +
+        " PIPBOY   GLS      1,536  06-22-94\r\n" +
+        "        10 file(s)     141,271 bytes\r\n" +
+        "         2 dir(s)   33,554,432 bytes free\r\n" +
+        "\r\n";
+
+    private const string Autoexec =
+        "\r\n" +
+        "@ECHO OFF\r\n" +
+        "PROMPT $p$g\r\n" +
+        "SET SHADER=CRT.GLS\r\n" +
+        "LH C:\\WINTTY\\SHADERLAB.EXE /GALLERY\r\n" +
+        "\r\n";
+
+    private const string VerReply =
+        "\r\nMS-DOS Version 6.22\r\nwintty shader gallery, live preview\r\n\r\n";
+
+    private const string EchoReply =
+        "\r\nshaders make terminals fun\r\n\r\n";
+
+    /// <summary>
+    /// One beat of the loop: the command to type at the prompt (null for a
+    /// bare cursor flip) and the VT bytes to emit once Enter lands. The
+    /// echo of the typed characters is part of the beat.
+    /// </summary>
+    private readonly record struct Beat(string? Command, string Response);
+
+    // Same shape as the website's demo script: a couple of listings, then
+    // repeated cursor-shape flips (each one fires the cursor shaders), a
+    // MODE pair that walks underline to block, and a closing echo.
+    private static readonly Beat[] Script =
+    {
+        new("dir", DirListing),
+        new("type autoexec.bat", Autoexec),
+        new(null, CursorBar),
+        new(null, CursorBlock),
+        new(null, CursorBar),
+        new("ver", VerReply),
+        new(null, CursorBlock),
+        new("mode cursor=underline", CursorUnderline),
+        new("mode cursor=block", CursorBlock),
+        new("echo shaders make terminals fun", EchoReply),
+        new(null, CursorBar),
+    };
+
+    private readonly Controls.TerminalControl _terminal;
+    // Fixed seed so the demo plays identically every time (matching the
+    // website's per-character jitter without its nondeterminism).
+    private readonly Random _random = new(1009);
+
+    private CancellationTokenSource? _cts;
+
+    public ShaderPreviewFeed(Controls.TerminalControl terminal)
+    {
+        _terminal = terminal;
+    }
+
+    /// <summary>Begin autoplay. Safe to call once per feed.</summary>
+    public void Start()
+    {
+        if (_cts is not null) return;
+        _cts = new CancellationTokenSource();
+        _ = RunAsync(_cts.Token);
+    }
+
+    public void Dispose()
+    {
+        _cts?.Cancel();
+        _cts?.Dispose();
+        _cts = null;
+    }
+
+    private async Task RunAsync(CancellationToken ct)
+    {
+        try
+        {
+            // Boot text lands at once (it is a machine booting, not a
+            // person), then the first command comes after a beat so the
+            // window has settled and the shader is already visible.
+            Write(Banner);
+            Write(Prompt);
+            await Task.Delay(1200, ct);
+
+            while (true)
+            {
+                foreach (var beat in Script)
+                {
+                    if (beat.Command is { } command)
+                    {
+                        await TypeAsync(command, ct);
+                        await Task.Delay(350, ct);
+                        Write("\r\n" + beat.Response + Prompt);
+                    }
+                    else
+                    {
+                        // A flip is a keypress: pause before and after so
+                        // the cursor-shape animation has time to read.
+                        await Task.Delay(650, ct);
+                        Write(beat.Response);
+                    }
+                }
+
+                // Breathe between passes, then keep scrolling: the session
+                // grows exactly like the website demo, and scrollback
+                // bounds it (the configured scrollback limit).
+                await Task.Delay(4000, ct);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // The picker closed; nothing to clean up beyond stopping.
+        }
+        catch (Exception ex)
+        {
+            // A feed glitch must never take the picker down; the preview
+            // just stops playing. Log it so it is diagnosable.
+            Logging.StaticLoggers.SettingsConfigWriter.LogInformation(
+                "shader preview feed stopped: {Message}", ex.Message);
+        }
+    }
+
+    // Type one character at a time so it looks hand-keyed, with the same
+    // jitter band the website uses.
+    private async Task TypeAsync(string text, CancellationToken ct)
+    {
+        foreach (var ch in text)
+        {
+            Write(ch.ToString());
+            await Task.Delay(55 + _random.Next(70), ct);
+        }
+    }
+
+    private void Write(string vt)
+    {
+        _terminal.WriteVt(Encoding.UTF8.GetBytes(vt));
+    }
+}


### PR DESCRIPTION
Two founder asks on the shader picker (Settings > Appearance > Custom
shader > From gallery).

## 1. Preview continuity + autoplay

Changing the shader with the arrows or the dropdown used to dispose and
recreate the preview TerminalControl, resetting the terminal. Now one
TerminalControl lives for the window's lifetime and only the shader
swaps.

Route: fake terminal, like wintty.io/shaders. A live shell is a poor
shader showcase (idle prompt is static and cursor-triggered shaders never
fire); the canned session gives every shader motion to show and makes
continuity trivial. A new native seam makes the swap cheap for either
route:

- `ghostty_surface_set_custom_shader` (src/apprt/embedded.zig): shallow
  config clone, replaces the custom-shader repeatable path, runs the same
  updateConfig path a config reload takes. Grid, scrollback, and cursor
  survive; only the renderer's post-process pipeline rebuilds.
- C# bindings for it and for the existing `ghostty_surface_vt_write`;
  TerminalControl gains PreviewCommand / SetPreviewCustomShader / WriteVt.
- The preview surface's child is a sleeping powershell (no shell
  metacharacters, so no cmd wrapping; it never writes and never reads),
  so the pty delivers zero bytes and the canned feed is the only writer:
  no banner race, no stray output from clicks.
- ShaderPreviewFeed.cs types a DOS 6.22 session (banner, dir, type
  autoexec.bat, ver, echo), ~1.2s after the preview appears, then loops
  forever with a 4s pause, no clear between passes. DECSCUSR cursor-shape
  flips are in the feed so mode-change shaders (ripple, boom) fire.
  Fixed seed for reproducibility. Feed stops on window close.

## 2. Choose button on its own line

On the Appearance page, the committed gallery pick row (name + long
description next to Choose...) is now vertical: the description wraps on
its own lines and Choose... sits below, left-aligned, so long
descriptions can never push it off screen.

## Build evidence (box, fresh clone)

- zig build exit 0; both new export names verified present in the fresh
  ghostty.dll.
- dotnet build: Build succeeded, 0 errors (only the pre-existing
  CS0105/CS8602/WMC1510 warnings, untouched).

## Founder eyeball checklist (behaviors that need a human)

1. Picker preview starts typing the DOS session by itself within ~1-2s
   and keeps looping.
2. Flip shaders with arrows/dropdown: content persists mid-word and
   mid-listing; only the shader changes; focus stays on the combo.
3. Cursor-shape shaders visibly fire on the autoplay flips.
4. Close the picker: no stray powershell process lingers.
5. Resize the picker while the feed plays: ConPTY may repaint the
   preview blank on resize (pre-existing behavior in spirit); confirm it
   is acceptable or worth a follow-up.
6. Commit a pick with a long description and narrow the settings window:
   Choose... stays visible below the description.