### PR TITLE
windows: clean up after the theme picker even when its tab has moved

### DIFF
--- a/windows/Ghostty.Tests/Commands/PaletteSelectionWiringTests.cs
+++ b/windows/Ghostty.Tests/Commands/PaletteSelectionWiringTests.cs
@@ -89,6 +89,9 @@ public class PaletteSelectionWiringTests
     // FilteredCommands" -- moved into ShellSource.Load, which now parses with
     // the symbol defined and refuses outright to hand back a tree that still
     // has disabled regions. So the demo block in this file is real syntax to
-    // the guards above rather than trivia they look through, and the check is
-    // enforced for every file any wiring test loads instead of this one.
+    // the guards above rather than trivia they look through, and the same now
+    // holds for every file a test reads through Load rather than for this one
+    // alone. It is not corpus-wide: AllUnder hands back raw text, and
+    // ParseForCorpusScan and AllShellSources each skip that refusal on
+    // purpose, for the reason each of them documents.
 }

--- a/windows/Ghostty.Tests/Commands/PaletteSelectionWiringTests.cs
+++ b/windows/Ghostty.Tests/Commands/PaletteSelectionWiringTests.cs
@@ -85,25 +85,10 @@ public class PaletteSelectionWiringTests
         Assert.Equal(2, ShellSource.Load(ViewModel).Root.Calls("PaletteSelection.Step").Count);
     }
 
-    /// <summary>
-    /// The parser runs with no preprocessor symbols, so a disabled `#if`
-    /// region is trivia and every guard above looks straight through it.
-    /// This file has a live `#if DEMO` block, so a demo path that touched
-    /// the list would ship unguarded in DEMO builds.
-    /// </summary>
-    [Fact]
-    public void NoDisabledRegionTouchesTheList()
-    {
-        var hidden = ShellSource.Load(ViewModel).Root
-            .DescendantTrivia()
-            .Where(t => t.IsKind(SyntaxKind.DisabledTextTrivia))
-            .Select(t => t.ToString())
-            .Where(t => t.Contains("FilteredCommands"))
-            .ToList();
-
-        Assert.True(hidden.Count == 0,
-            "A conditionally compiled region assigns FilteredCommands. It is trivia to "
-            + "the parser, so the guards in this file cannot see it: "
-            + string.Join("\n", hidden));
-    }
+    // The guard that used to live here -- "no disabled #if region assigns
+    // FilteredCommands" -- moved into ShellSource.Load, which now parses with
+    // the symbol defined and refuses outright to hand back a tree that still
+    // has disabled regions. So the demo block in this file is real syntax to
+    // the guards above rather than trivia they look through, and the check is
+    // enforced for every file any wiring test loads instead of this one.
 }

--- a/windows/Ghostty.Tests/Wiring/WindowTeardownWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/WindowTeardownWiringTests.cs
@@ -657,6 +657,86 @@ public class WindowTeardownWiringTests
         }
     }
 
+    private static readonly string[] PickerFields =
+        { "_pickerSurface", "_pickerTerminal", "_inlineThemeCb" };
+
+    /// <summary>
+    /// <c>_pickerHandle == IntPtr.Zero</c>, either way round.
+    /// </summary>
+    private static bool TestsPickerHandleAgainstZero(ExpressionSyntax condition)
+    {
+        if (condition is not BinaryExpressionSyntax equality) return false;
+        if (!equality.IsKind(SyntaxKind.EqualsExpression)) return false;
+
+        var sides = new[] { Flatten(equality.Left), Flatten(equality.Right) };
+        return sides.Contains("_pickerHandle") && sides.Contains("IntPtr.Zero");
+    }
+
+    /// <summary>
+    /// The fields <paramref name="scope"/> assigns null or default to. Read
+    /// off the right-hand side, because an assignment that puts something
+    /// back is not a clear.
+    /// </summary>
+    private static HashSet<string> ClearedIn(SyntaxNode scope) =>
+        scope.DescendantNodesAndSelf()
+            .OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.IsKind(SyntaxKind.SimpleAssignmentExpression))
+            .Where(a => a.Right.IsKind(SyntaxKind.NullLiteralExpression)
+                        || a.Right.IsKind(SyntaxKind.DefaultLiteralExpression)
+                        || a.Right is DefaultExpressionSyntax)
+            .Select(a => Flatten(a.Left))
+            .ToHashSet(StringComparer.Ordinal);
+
+    /// <summary>
+    /// The picker open, on the path where libghostty declines to open one.
+    ///
+    /// The three fields the close reads -- the surface copy, the control it
+    /// was opened on, and the callback field that is the only GC root for the
+    /// delegate whose function pointer goes across -- are assigned before the
+    /// native call, and have to be: a local would be collectable while the
+    /// call is still running. So a null return leaves all three set with no
+    /// picker behind them, and ClosePicker returns on the zero handle before
+    /// it reaches the clears. The window is then holding a raw pointer to a
+    /// surface that whoever owns it may free, plus a strong reference to a
+    /// control and its whole pane subtree, until a later picker succeeds.
+    /// ghostty_surface_list_themes returns null on four separate paths, so
+    /// this is not a branch that needs a fault to reach.
+    /// </summary>
+    [Fact]
+    public void AFailedPickerOpenClearsWhatTheCloseWillNotReach()
+    {
+        var source = ShellSource.Load(MainWindow.File);
+        var statements = source.Method("OnListThemesRequested").Body!.Statements;
+
+        var opened = statements
+            .TakeWhile(s => !s.Calls("NativeMethods.SurfaceListThemes").Any())
+            .Count();
+        Assert.True(
+            opened < statements.Count,
+            "expected OnListThemesRequested to open the picker through "
+            + "NativeMethods.SurfaceListThemes; without that call there is no failure path "
+            + "here and this test would pass while reading nothing");
+
+        // After the call only: the same condition written before it would be
+        // testing the previous picker's handle, which is a different claim.
+        var cleared = statements
+            .Skip(opened + 1)
+            .OfType<IfStatementSyntax>()
+            .Where(guard => TestsPickerHandleAgainstZero(guard.Condition))
+            .Where(guard => guard.Statement.DescendantNodesAndSelf()
+                .OfType<ReturnStatementSyntax>().Any())
+            .Where(guard => ClearedIn(guard.Statement).IsSupersetOf(PickerFields))
+            .ToList();
+
+        Assert.True(
+            cleared.Count == 1,
+            "OnListThemesRequested must clear " + string.Join(", ", PickerFields)
+            + " and return when SurfaceListThemes hands back a zero handle. Nothing else will: "
+            + "ClosePicker bails on the zero handle before it reaches those same clears, so the "
+            + "stale surface pointer and the pane subtree behind _pickerTerminal are held until "
+            + "the next successful picker or the window's close.");
+    }
+
     /// <summary>
     /// ThemePreviewService, the one gap #694 named and did not close.
     ///

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -781,6 +781,11 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         // Surface creation runs exactly once per control instance,
         // even across multiple reparents. Subsequent Loaded events
         // skip this entire block.
+        //
+        // MainWindow's picker cleanup leans on that: comparing SurfaceHandle
+        // against the pointer it saved only proves reachability while a
+        // control's handle can be that pointer or zero and never a recycled
+        // third one.
         if (_surfaceCreated) return;
         _surfaceCreated = true;
 

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -770,8 +770,11 @@ internal static partial class NativeMethods
 
     // ---- inline theme picker ---------------------------------------------
 
-    // Callback for the inline theme picker. Fired from the Zig/apprt
-    // thread for each preview/confirm event.
+    // Callback for the inline theme picker, fired for each preview/confirm
+    // event. Synchronous, on the calling thread: the picker only ever runs
+    // from the surface's input and scroll redirects, so this arrives inside
+    // the key or scroll call the embedder made -- the UI thread, not an
+    // apprt one.
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate void InlineThemeCallback(IntPtr namePtr, byte confirmed);
 

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -3866,13 +3866,13 @@ public sealed partial class MainWindow : Window
     private IntPtr _pickerHandle;
 
     /// <summary>
-    /// The control and tab the picker's surface belongs to.
+    /// The control whose surface the picker was opened on.
     /// <see cref="_pickerSurface"/> is a copy of a raw pointer and nothing
-    /// zeroes it when that surface is freed, so these are what make the
-    /// liveness check in <see cref="ClosePicker"/> possible.
+    /// zeroes it when that surface is freed, so this is what makes the
+    /// liveness check in <see cref="ClosePicker"/> possible: the control
+    /// clears its own handle on disposal.
     /// </summary>
     private Ghostty.Controls.TerminalControl? _pickerTerminal;
-    private Ghostty.Core.Tabs.TabModel? _pickerTab;
     // Held rather than left local to StartPickerPoll: the dispatcher drives
     // the poll, so the window's teardown has no other way to reach it.
     private Microsoft.UI.Dispatching.DispatcherQueueTimer? _pickerPoll;
@@ -3895,7 +3895,6 @@ public sealed partial class MainWindow : Window
 
         _pickerSurface = new GhosttySurface(surfaceHandle);
         _pickerTerminal = terminal;
-        _pickerTab = _tabManager.ActiveTab;
 
         // Theme callback: apply preview/confirm colors on the UI thread.
         _inlineThemeCb = (namePtr, confirmed) =>
@@ -4000,25 +3999,30 @@ public sealed partial class MainWindow : Window
         // frees the surface without touching anything here.
         //
         // The control zeroes its own handle when it disposes the surface, so
-        // a mismatch means the surface is gone. The tab check answers the
-        // other direction: a detached tab carries its live surface to another
-        // window, and deiniting from here would strip the redirects of a
-        // window that never closed.
+        // a mismatch means the surface is gone and nothing can reach the
+        // picker any more. That is the only case where skipping is right, and
+        // it strands the picker allocation, which is what happened before this
+        // path existed at all. Leaking it beats writing through a dangling
+        // pointer.
         //
-        // When neither holds, the picker allocation is stranded, which is
-        // what happened before this path existed at all. Leaking it is the
-        // right trade against writing through a dangling pointer.
+        // Deliberately NOT conditioned on the tab still being ours. A detached
+        // tab carries its live surface to another window with this picker's
+        // input, scroll and resize redirects still installed on it, and this
+        // deinit is the only thing that clears them or frees the picker. Not
+        // running it leaves that window wedged in the picker's alt screen with
+        // its input redirected, and drops the last GC root for the delegate
+        // whose function pointer the picker still holds, so the next keystroke
+        // there is a callback on a collected delegate, which kills the process
+        // rather than throwing. Cleaning up after our own picker is a repair
+        // for that window, not damage to it.
         var live = _pickerTerminal is { } terminal
-            && terminal.SurfaceHandle == _pickerSurface.Handle
-            && _pickerTab is { } tab
-            && _tabManager.Tabs.Contains(tab);
+            && terminal.SurfaceHandle == _pickerSurface.Handle;
         if (live)
             NativeMethods.SurfaceListThemesDeinit(_pickerSurface, _pickerHandle);
 
         _pickerHandle = IntPtr.Zero;
         _pickerSurface = default;
         _pickerTerminal = null;
-        _pickerTab = null;
         _inlineThemeCb = null;
     }
 }

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -3904,9 +3904,14 @@ public sealed partial class MainWindow : Window
                 var name = Marshal.PtrToStringUTF8(namePtr);
                 if (name is null) return;
 
-                // The callback fires from the Zig/apprt thread. Dispatch
-                // to the UI thread so ConfigService and ShellThemeService
-                // updates happen on the right thread.
+                // Not a thread hop: the picker calls this synchronously from
+                // the surface's input and scroll redirects, so it arrives
+                // inside the key or scroll call the terminal control made,
+                // on the UI thread. The enqueue earns its place for the
+                // other reason -- it keeps ConfigService and
+                // ShellThemeService off the stack of a native input
+                // callback, rather than re-entering libghostty while it is
+                // still handling the key that got us here.
                 DispatcherQueue.TryEnqueue(() =>
                 {
                     _themePreview.ApplyThemePreview(name);
@@ -3917,18 +3922,33 @@ public sealed partial class MainWindow : Window
         var cbPtr = Marshal.GetFunctionPointerForDelegate(_inlineThemeCb);
 
         _pickerHandle = NativeMethods.SurfaceListThemes(_pickerSurface, cbPtr);
+        if (_pickerHandle == IntPtr.Zero)
+        {
+            // No picker was installed -- no redirects, no allocation -- so
+            // there is nothing to hand back and ClosePicker returns on the
+            // zero handle before it reaches the clears below. Without this
+            // the window keeps a raw copy of a surface pointer that whoever
+            // owns that surface is free to release, and a strong reference
+            // to the control and its whole pane subtree, until some later
+            // picker opens or the window dies.
+            _pickerSurface = default;
+            _pickerTerminal = null;
+            _inlineThemeCb = null;
+            return;
+        }
+
         // Picker is now active. handleKey fires on each key event and
         // sets should_quit when the user confirms/cancels. We poll on
         // a timer to clean up, avoiding a thread that races with the
         // input redirect callback.
-        if (_pickerHandle != IntPtr.Zero)
-            StartPickerPoll();
+        StartPickerPoll();
     }
 
     private void StartPickerPoll()
     {
-        // Use a DispatcherQueue timer so cleanup runs on the UI thread
-        // with no race against the apprt thread's input redirect.
+        // A DispatcherQueue timer rather than a polling thread, so the
+        // cleanup lands on the same thread the input redirect runs the
+        // picker from and cannot tear it down mid-keystroke.
         //
         // One poll at a time: a second picker replaces _pickerHandle, and a
         // leftover timer would then be polling the new picker and could run


### PR DESCRIPTION
Follow-up to # 694, from a post-merge safety pass.

The liveness check I added there asked two questions and should have asked one. Requiring the tab to still belong to this window came from reading the deinit as damage to whoever owns the surface now. It is the opposite: the input, scroll and resize redirects on that surface were installed by *this* picker, and `ghostty_surface_list_themes_deinit` is the only thing that clears them or frees it.

So: open the picker, drag that tab out into another window, close the original. The adopting window is left wedged in the picker's alt screen with its input redirected and nothing able to undo it. Worse, `_inlineThemeCb` was cleared regardless of which branch ran, and it is the only GC root for the delegate whose function pointer the picker still holds -- so the next keystroke in that window is a callback on a collected delegate, which kills the process rather than throwing.

That is a regression against pre-# 694 behaviour, where the poll was never stopped, eventually saw `should_quit`, and deinited a surface that was still valid. It self-healed.

Liveness is now a question about the surface alone: the control clears its own handle when it disposes it, so a mismatch means the picker is unreachable and skipping is correct.

## Review

Two independent passes. One attacked the change five ways -- deinit against a wrong target, the delegate's rooting, the two-window detach, dispatcher affinity, ordering inside teardown -- and cleared all five with evidence. The load-bearing one: the handle comparison cannot ABA, because `TerminalControl` creates exactly one surface for its lifetime, so its handle is that pointer or zero and never a recycled third. A restart-pane feature would break that silently, so the invariant now carries a note where it is established.

Both passes then found the same defect beside it, and it is fixed here. The three fields the close reads are assigned before the native call, and have to be -- a local would be collectable while the call is still running -- so a null return from `ghostty_surface_list_themes` left all three set with no picker behind them, and `ClosePicker` returns on the zero handle before it reaches the clears. The window held a raw pointer to a surface its owner may free, plus a strong reference to a control and its whole pane subtree, until a later picker opened. That return has four paths (non-Windows, discovery failure, zero themes, picker init), so it is not a branch that needs a fault to reach. `AFailedPickerOpenClearsWhatTheCloseWillNotReach` pins it, verified by deleting the branch and watching it go red.

Three claims were wrong and are corrected. The disabled-region guarantee holds for files read through `ShellSource.Load`, not corpus-wide -- `AllUnder` hands back raw text and the two corpus scans skip the refusal deliberately -- so the comment traded for a deleted test said more than it could. And two comments put the theme callback on the apprt thread; it is reachable only from the picker's key and scroll handling, which run from the surface's input and scroll redirects, inside the call the terminal control made, on the UI thread. The enqueue stays, for the reason it actually earns.

## Known residuals, not chased here

If the window that adopted the tab opened its own picker on the same surface first, this frees ours and leaves theirs. That needs two pickers on one surface across two windows, and the per-process pipe makes it very close to unreachable.

Closing the picker's tab -- rather than detaching it -- still leaks the picker and leaves a 50ms poll running for the window's life. `CloseTab` disposes the leaves before raising `TabRemoved`, so nothing on that path can deinit while the surface is still valid. Pre-existing, and the old check skipped it too, but it is now the only remaining hole in this family. The fix wants a `SurfaceDisposing` event on `TerminalControl`, raised before the free, which is its own change.

The picker also ignores the `confirmed` flag, so a browse abandoned with Escape leaves the last previewed theme applied. Pre-existing; this change makes it reachable by a second route, since a window close can now end a picker the user is still driving in another window. The pipe path does not have this bug -- `ThemePreviewService` snapshots the palette and reverts on a disconnect without confirm -- so only the inline path needs it.

Full suite 2266 passing.
