### PR TITLE
chore: zig fmt eight files that landed unformatted

### DIFF
--- a/src/build/GhosttyLib.zig
+++ b/src/build/GhosttyLib.zig
@@ -188,7 +188,7 @@ pub fn initShared(
             null,
         .dsym = dsymutil,
         .pkg_config = pcs.shared,
-        .pkg_config_static = pcs.@"static",
+        .pkg_config_static = pcs.static,
     };
 }
 
@@ -257,7 +257,7 @@ pub fn installHeader(self: *const GhosttyLib) void {
 
 const PkgConfigFiles = struct {
     shared: std.Build.LazyPath,
-    @"static": std.Build.LazyPath,
+    static: std.Build.LazyPath,
 };
 
 fn pkgConfigFiles(
@@ -280,7 +280,7 @@ fn pkgConfigFiles(
             \\Cflags: -I${{includedir}}
             \\Libs: -L${{libdir}} -lghostty
         , .{ b.install_prefix, deps.config.version })),
-        .@"static" = wf.add("libghostty-static.pc", b.fmt(
+        .static = wf.add("libghostty-static.pc", b.fmt(
             \\prefix={s}
             \\includedir=${{prefix}}/include
             \\libdir=${{prefix}}/lib

--- a/src/cli/inline_theme_picker.zig
+++ b/src/cli/inline_theme_picker.zig
@@ -488,7 +488,6 @@ pub const InlineThemePicker = struct {
             .search => self.drawSearchBox(),
             .help => self.drawHelpOverlay(),
         }
-
     }
 
     fn drawThemeList(self: *InlineThemePicker) void {
@@ -1115,7 +1114,6 @@ pub const InlineThemePicker = struct {
             remaining -= chunk;
         }
     }
-
 };
 
 fn paletteColor(config: Config, idx: usize) [3]u8 {

--- a/src/font/discovery.zig
+++ b/src/font/discovery.zig
@@ -526,8 +526,12 @@ pub const DirectWrite = struct {
         fn queryInterface(_: *TextAnalysisSource, _: *const dwrite.GUID, _: *?*anyopaque) callconv(.winapi) dwrite.HRESULT {
             return dwrite.E_NOINTERFACE;
         }
-        fn addRef(_: *TextAnalysisSource) callconv(.winapi) u32 { return 1; }
-        fn release(_: *TextAnalysisSource) callconv(.winapi) u32 { return 1; }
+        fn addRef(_: *TextAnalysisSource) callconv(.winapi) u32 {
+            return 1;
+        }
+        fn release(_: *TextAnalysisSource) callconv(.winapi) u32 {
+            return 1;
+        }
 
         fn getTextAtPosition(self: *TextAnalysisSource, pos: u32, text_out: *?[*]const u16, len_out: *u32) callconv(.winapi) dwrite.HRESULT {
             if (pos >= self.text_len) {

--- a/src/input/key_encode.zig
+++ b/src/input/key_encode.zig
@@ -2645,4 +2645,3 @@ test "ctrlseq: ctrl c with no text uses logical key" {
     const seq = ctrlSeq(.key_c, "", 'c', .{ .ctrl = true });
     try testing.expectEqual(@as(u8, 0x03), seq.?);
 }
-

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -593,8 +593,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 // skip the field reads entirely (comptime-gated, the
                 // `.rtv`/`.srv` paths below never get type-checked on
                 // those backends).
-                const front_rtv_slot, const back_rtv_slot,
-                const front_srv_slot, const back_srv_slot =
+                const front_rtv_slot, const back_rtv_slot, const front_srv_slot, const back_srv_slot =
                     if (comptime @hasField(Texture, "rtv")) slots: {
                         const D = @TypeOf(self.front_texture.rtv);
                         const fr = self.front_texture.rtv;

--- a/src/terminal/render.zig
+++ b/src/terminal/render.zig
@@ -2763,4 +2763,3 @@ test "resolveCell out of range resolves to blank" {
     try testing.expectEqual(state.colors.foreground, wide_y.fg);
     try testing.expectEqual(state.colors.background, wide_y.bg);
 }
-

--- a/src/terminal/sixel/palette.zig
+++ b/src/terminal/sixel/palette.zig
@@ -17,21 +17,21 @@ pub const Rgba = packed struct(u32) {
 /// slightly (e.g. red is documented as 80,13,13 but ships as
 /// 204,36,36 in libsixel). Match the reference, not the manual.
 pub const dec_default_palette: [16]Rgba = .{
-    .{ .r = 0,   .g = 0,   .b = 0,   .a = 255 }, // 0: black
-    .{ .r = 51,  .g = 51,  .b = 204, .a = 255 }, // 1: blue
-    .{ .r = 204, .g = 36,  .b = 36,  .a = 255 }, // 2: red
-    .{ .r = 51,  .g = 204, .b = 51,  .a = 255 }, // 3: green
-    .{ .r = 204, .g = 51,  .b = 204, .a = 255 }, // 4: magenta
-    .{ .r = 51,  .g = 204, .b = 204, .a = 255 }, // 5: cyan
-    .{ .r = 204, .g = 204, .b = 51,  .a = 255 }, // 6: yellow
+    .{ .r = 0, .g = 0, .b = 0, .a = 255 }, // 0: black
+    .{ .r = 51, .g = 51, .b = 204, .a = 255 }, // 1: blue
+    .{ .r = 204, .g = 36, .b = 36, .a = 255 }, // 2: red
+    .{ .r = 51, .g = 204, .b = 51, .a = 255 }, // 3: green
+    .{ .r = 204, .g = 51, .b = 204, .a = 255 }, // 4: magenta
+    .{ .r = 51, .g = 204, .b = 204, .a = 255 }, // 5: cyan
+    .{ .r = 204, .g = 204, .b = 51, .a = 255 }, // 6: yellow
     .{ .r = 120, .g = 120, .b = 120, .a = 255 }, // 7: grey 50%
-    .{ .r = 69,  .g = 69,  .b = 69,  .a = 255 }, // 8: grey 25%
-    .{ .r = 92,  .g = 92,  .b = 158, .a = 255 }, // 9: blue*
-    .{ .r = 158, .g = 92,  .b = 92,  .a = 255 }, // 10: red*
-    .{ .r = 92,  .g = 158, .b = 92,  .a = 255 }, // 11: green*
-    .{ .r = 158, .g = 92,  .b = 158, .a = 255 }, // 12: magenta*
-    .{ .r = 92,  .g = 158, .b = 158, .a = 255 }, // 13: cyan*
-    .{ .r = 158, .g = 158, .b = 92,  .a = 255 }, // 14: yellow*
+    .{ .r = 69, .g = 69, .b = 69, .a = 255 }, // 8: grey 25%
+    .{ .r = 92, .g = 92, .b = 158, .a = 255 }, // 9: blue*
+    .{ .r = 158, .g = 92, .b = 92, .a = 255 }, // 10: red*
+    .{ .r = 92, .g = 158, .b = 92, .a = 255 }, // 11: green*
+    .{ .r = 158, .g = 92, .b = 158, .a = 255 }, // 12: magenta*
+    .{ .r = 92, .g = 158, .b = 158, .a = 255 }, // 13: cyan*
+    .{ .r = 158, .g = 158, .b = 92, .a = 255 }, // 14: yellow*
     .{ .r = 204, .g = 204, .b = 204, .a = 255 }, // 15: grey 75%
 };
 
@@ -121,12 +121,31 @@ fn hlsToRgba(h_in: u16, l: u8, s: u8) Rgba {
     var r1: f64 = 0;
     var g1: f64 = 0;
     var b1: f64 = 0;
-    if (h_sector < 1) { r1 = c; g1 = x; b1 = 0; }
-    else if (h_sector < 2) { r1 = x; g1 = c; b1 = 0; }
-    else if (h_sector < 3) { r1 = 0; g1 = c; b1 = x; }
-    else if (h_sector < 4) { r1 = 0; g1 = x; b1 = c; }
-    else if (h_sector < 5) { r1 = x; g1 = 0; b1 = c; }
-    else { r1 = c; g1 = 0; b1 = x; }
+    if (h_sector < 1) {
+        r1 = c;
+        g1 = x;
+        b1 = 0;
+    } else if (h_sector < 2) {
+        r1 = x;
+        g1 = c;
+        b1 = 0;
+    } else if (h_sector < 3) {
+        r1 = 0;
+        g1 = c;
+        b1 = x;
+    } else if (h_sector < 4) {
+        r1 = 0;
+        g1 = x;
+        b1 = c;
+    } else if (h_sector < 5) {
+        r1 = x;
+        g1 = 0;
+        b1 = c;
+    } else {
+        r1 = c;
+        g1 = 0;
+        b1 = x;
+    }
 
     // The L/S clamps above mean (r1+m)*255 etc. can't escape [0, 255]
     // mathematically; the saturating min/max here is defensive against

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -137,26 +137,26 @@ pub fn threadEnter(
     // independently of the Command's handle.
     const win_proc_handle: if (builtin.os.tag == .windows) windows.HANDLE else void =
         if (comptime builtin.os.tag == .windows) blk: {
-        const cmd = switch (self.subprocess.process orelse return error.ProcessNotStarted) {
-            .fork_exec => |c| c,
-            .flatpak => unreachable, // Flatpak is Linux-only
-        };
-        const src = cmd.pid orelse return error.ProcessNoPid;
-        var dup: windows.HANDLE = undefined;
-        const self_proc = windows.GetCurrentProcess();
-        if (windows.exp.kernel32.DuplicateHandle(
-            self_proc,
-            src,
-            self_proc,
-            &dup,
-            0,
-            windows.FALSE,
-            windows.DUPLICATE_SAME_ACCESS,
-        ) == .FALSE) {
-            return windows.unexpectedError(windows.GetLastError());
-        }
-        break :blk dup;
-    } else {};
+            const cmd = switch (self.subprocess.process orelse return error.ProcessNotStarted) {
+                .fork_exec => |c| c,
+                .flatpak => unreachable, // Flatpak is Linux-only
+            };
+            const src = cmd.pid orelse return error.ProcessNoPid;
+            var dup: windows.HANDLE = undefined;
+            const self_proc = windows.GetCurrentProcess();
+            if (windows.exp.kernel32.DuplicateHandle(
+                self_proc,
+                src,
+                self_proc,
+                &dup,
+                0,
+                windows.FALSE,
+                windows.DUPLICATE_SAME_ACCESS,
+            ) == .FALSE) {
+                return windows.unexpectedError(windows.GetLastError());
+            }
+            break :blk dup;
+        } else {};
 
     // Track our process start time for abnormal exits
     const process_start: std.Io.Timestamp = .now(global.io(), .awake);


### PR DESCRIPTION
Formatting only: zig fmt over eight fork-modified src files that landed unformatted while the fmt check was not enforced. Caught by the new signoff gate on its first run. No code changes; zig fmt --check src is clean after this. The quality-gates PR merging right behind this runs the full test ladder on a tree that includes these changes.
