### PR TITLE
app: own the app-targeted config actions on App, not per window

### DIFF
--- a/windows/Ghostty.Tests/Wiring/AppActionOwnershipWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/AppActionOwnershipWiringTests.cs
@@ -1,0 +1,293 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// Who subscribes to the bootstrap host's app-targeted actions.
+///
+/// libghostty sends OpenConfig and ReloadConfig with target=app, so they are
+/// raised on the one host that owns the ghostty_app_t and never on a
+/// per-window host. MainWindow used to subscribe, behind a guard that read as
+/// "only the primary window does" and was in fact "every window that was not
+/// adopting a tab": cold start, quake, each restored session window, each
+/// reopened one. Two consequences, both of which this pins against coming
+/// back. The action ran once per open window -- two Reloads, two settings
+/// windows -- and each closure captured its window, so a host that lives as
+/// long as the process kept every window and its XAML tree alive, unbounded
+/// over an open/close loop.
+///
+/// The fix is ownership rather than a gate. A gate would not have helped: the
+/// handlers are safe to run after a close, because they touch only
+/// process-global state, and detaching per window would leave the last window
+/// to close taking the handler away from the windows still open. So the shape
+/// to hold is exactly one subscriber, on App, for the life of the process.
+/// </summary>
+public class AppActionOwnershipWiringTests
+{
+    /// <summary>The events libghostty raises with target=app.</summary>
+    private static readonly string[] AppActions = { "OpenConfigRequested", "ReloadConfigRequested" };
+
+    /// <summary>
+    /// The two files these names may appear in at all: the host that declares
+    /// and raises them, and the one subscriber. Deliberately not an extensible
+    /// allow-list -- a third file named here would be the bug this test exists
+    /// to catch.
+    /// </summary>
+    private static readonly string[] Owners = { "Ghostty.Hosting.GhosttyHost.cs", "Ghostty.App.xaml.cs" };
+
+    private const string Corpus = "Ghostty.Tests.Interop.Sources.";
+
+    private static ShellSource AppSource() => ShellSource.Load("Ghostty.App.xaml.cs");
+
+    private sealed record Wire(string Event, string Receiver, string Handler);
+
+    /// <summary>
+    /// Every subscription or detach whose left-hand side names one of the app
+    /// actions, read off the parsed tree so a mention in a comment or a string
+    /// is not one. Matched on the event's own name rather than on the
+    /// receiver: a subscription taken out through some other spelling of the
+    /// host is the same subscription.
+    /// </summary>
+    private static List<Wire> Wires(SyntaxNode scope, SyntaxKind kind) =>
+        scope.DescendantNodes()
+            .OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.IsKind(kind))
+            .Select(a => (Assignment: a, Name: EventName(a.Left)))
+            .Where(x => x.Name is not null && AppActions.Contains(x.Name, StringComparer.Ordinal))
+            .Select(x => new Wire(
+                x.Name!,
+                x.Assignment.Left is MemberAccessExpressionSyntax m ? Receiver(m.Expression) : "this",
+                x.Assignment.Right.ToString()))
+            .ToList();
+
+    /// <summary>
+    /// The receiver as written, with a null-forgiving operator dropped: `x!`
+    /// and `x` are the same field, and an assertion that told them apart would
+    /// be pinning punctuation.
+    /// </summary>
+    private static string Receiver(ExpressionSyntax expression) =>
+        expression is PostfixUnaryExpressionSyntax { RawKind: (int)SyntaxKind.SuppressNullableWarningExpression } bang
+            ? bang.Operand.ToString()
+            : expression.ToString();
+
+    /// <summary>The event's own identifier, receiver stripped.</summary>
+    private static string? EventName(ExpressionSyntax left) => left switch
+    {
+        MemberAccessExpressionSyntax member => member.Name.Identifier.ValueText,
+        IdentifierNameSyntax name => name.Identifier.ValueText,
+        _ => null,
+    };
+
+    [Fact]
+    public void AppSubscribesExactlyOnceToEachAppAction()
+    {
+        var app = AppSource();
+        var subscribes = Wires(app.Root, SyntaxKind.AddAssignmentExpression);
+
+        foreach (var action in AppActions)
+        {
+            var wires = subscribes.Where(w => w.Event == action).ToList();
+            Assert.True(
+                wires.Count == 1,
+                $"expected exactly one `+= {action}` in App; found {wires.Count}. One subscriber per "
+                + "process is the whole point: a second one runs the action twice.");
+            Assert.Equal("_bootstrapHost", wires[0].Receiver);
+
+            // A method group, so the detach below has something to name. An
+            // anonymous lambda cannot be unsubscribed at all, and this
+            // subscription lasts as long as the process.
+            Assert.True(
+                SyntaxFactory.ParseExpression(wires[0].Handler) is IdentifierNameSyntax,
+                $"{action} must be handled by a named method, not `{wires[0].Handler}`: a lambda "
+                + "cannot be detached, and the teardown has to take this one back.");
+        }
+    }
+
+    [Fact]
+    public void TheSubscriptionsAreUnconditionalAndRunOnceAtStartup()
+    {
+        var app = AppSource();
+
+        var subscriptions = app.Root.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.IsKind(SyntaxKind.AddAssignmentExpression)
+                        && AppActions.Contains(EventName(a.Left)!, StringComparer.Ordinal))
+            .ToList();
+        Assert.Equal(AppActions.Length, subscriptions.Count);
+
+        var startup = StartupPath(app);
+
+        foreach (var assignment in subscriptions)
+        {
+            // The defect was a subscription under a condition that read as
+            // "the primary window only" and selected almost every window. A
+            // conditional or repeated subscription on App is the same defect
+            // wearing App's name, and it satisfies a count of one whenever the
+            // branch happens to be taken once.
+            var enclosing = assignment.FirstAncestorOrSelf<MemberDeclarationSyntax>();
+            var nested = assignment.Ancestors()
+                .TakeWhile(n => n != enclosing)
+                .FirstOrDefault(n => n is IfStatementSyntax or SwitchStatementSyntax or ElseClauseSyntax
+                    or ForStatementSyntax or ForEachStatementSyntax or WhileStatementSyntax
+                    or DoStatementSyntax or TryStatementSyntax or LambdaExpressionSyntax
+                    or LocalFunctionStatementSyntax);
+
+            Assert.True(
+                nested is null,
+                $"`{assignment}` is inside a {nested?.Kind()}. These have to be taken out once, "
+                + "unconditionally, on the one path that builds the bootstrap host; a guarded "
+                + "subscription is how the per-window version read as one window while nearly "
+                + "every window subscribed.");
+
+            // And on THAT path, not merely on some unconditional statement
+            // somewhere: a subscription sitting in a method that runs per
+            // window, or per settings-window open, is the original defect with
+            // App's name on it, and it satisfies every count above.
+            Assert.Same(startup, enclosing);
+        }
+    }
+
+    /// <summary>
+    /// The member that builds the bootstrap host, identified by the
+    /// assignment that publishes it. That statement runs exactly once per
+    /// process, which is the property the subscriptions need and the one no
+    /// count of syntax can establish on its own.
+    /// </summary>
+    private static MemberDeclarationSyntax StartupPath(ShellSource app)
+    {
+        var published = app.Root.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.IsKind(SyntaxKind.SimpleAssignmentExpression)
+                        && a.Left.ToString() == "BootstrapHost"
+                        && a.Right.ToString() == "_bootstrapHost")
+            .ToList();
+        Assert.True(
+            published.Count == 1,
+            $"expected one `BootstrapHost = _bootstrapHost;` in App, found {published.Count}");
+        return published[0].FirstAncestorOrSelf<MemberDeclarationSyntax>()!;
+    }
+
+    [Fact]
+    public void TheProcessLifetimeSubscriptionsAreTakenBackBeforeTheHostIsFreed()
+    {
+        var app = AppSource();
+        var subscribes = Wires(app.Root, SyntaxKind.AddAssignmentExpression);
+        var detaches = Wires(app.Root, SyntaxKind.SubtractAssignmentExpression);
+
+        // The (event, handler) pair, not the event: two handlers on one event
+        // would otherwise answer for each other, and a detach of null
+        // satisfies a match on the event alone.
+        foreach (var wire in subscribes)
+        {
+            Assert.True(
+                detaches.Contains(wire),
+                $"`{wire.Receiver}.{wire.Event} += {wire.Handler}` is never taken back. It is attached "
+                + "for the life of the process, so nothing else will.");
+        }
+
+        // Nothing else detaches them: the host is freed once, and a detach on
+        // some other path would leave a live session with no handler.
+        Assert.Equal(subscribes.Count, detaches.Count);
+
+        // Order, not presence. The detach has to happen before the host frees
+        // the ghostty app, or an action arriving during teardown reloads config
+        // into freed native state -- the same crash shape as issue #208.
+        var shutdown = app.Root.DescendantNodes().OfType<BlockSyntax>()
+            .Where(b => b.Calls("_bootstrapHost?.Dispose").Count == 1)
+            .OrderBy(b => b.Span.Length)
+            .First()
+            .Statements;
+
+        int IndexOf(Func<StatementSyntax, bool> match) => shutdown.TakeWhile(s => !match(s)).Count();
+
+        var dispose = IndexOf(s => s.Calls("_bootstrapHost?.Dispose").Any());
+        Assert.True(dispose < shutdown.Count, "expected the shutdown block to dispose the bootstrap host");
+
+        foreach (var wire in detaches)
+        {
+            var at = IndexOf(s => s.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+                .Any(a => a.IsKind(SyntaxKind.SubtractAssignmentExpression)
+                          && EventName(a.Left) == wire.Event
+                          && a.Right.ToString() == wire.Handler));
+            Assert.True(
+                at < shutdown.Count,
+                $"{wire.Event} is detached somewhere other than the shutdown that disposes the host");
+            Assert.True(
+                at < dispose,
+                $"{wire.Event} must be detached before _bootstrapHost.Dispose frees the ghostty app");
+        }
+    }
+
+    [Fact]
+    public void EachHandlerIsOneRealMethodOnApp()
+    {
+        var app = AppSource();
+
+        var wires = Wires(app.Root, SyntaxKind.AddAssignmentExpression);
+        Assert.NotEmpty(wires);
+
+        foreach (var wire in wires)
+        {
+            // Method() asserts there is exactly one. Without it a detach could
+            // name a method that no longer exists on the subscribing side, or
+            // two overloads could make "the handler" ambiguous.
+            var method = app.Method(wire.Handler);
+            Assert.True(
+                method.Body is not null || method.ExpressionBody is not null,
+                $"{wire.Handler} has no body");
+        }
+    }
+
+    /// <summary>
+    /// The corpus rule, and the one that actually answers the issue: no file
+    /// other than the host and App may so much as name these events.
+    ///
+    /// Text rather than syntax, deliberately. A parse cannot see inside a
+    /// disabled conditional region, and a subscription reintroduced there is a
+    /// live subscription in the configuration that defines the symbol.
+    /// Matching the token in the raw source has no such blind spot, and the
+    /// cost -- that a comment naming the event also fails -- is worth paying
+    /// for a rule whose whole content is that this name lives in two files.
+    /// </summary>
+    [Fact]
+    public void NoOtherFileSubscribesToTheAppActions()
+    {
+        var corpus = ShellSource.AllUnder(Corpus);
+
+        // Load-bearing: a prefix that stopped matching would pass this test
+        // while reading nothing at all.
+        Assert.True(
+            corpus.Count > 100,
+            $"expected the shell source corpus under '{Corpus}', got {corpus.Count} files");
+        Assert.All(Owners, owner => Assert.Contains(corpus, f => f.Tail == owner));
+
+        var pattern = new Regex(@"\b(" + string.Join("|", AppActions) + @")\b", RegexOptions.Compiled);
+        var offenders = corpus
+            .Where(f => !Owners.Contains(f.Tail, StringComparer.Ordinal) && pattern.IsMatch(f.Text))
+            .Select(f => f.Tail)
+            .ToList();
+
+        Assert.True(
+            offenders.Count == 0,
+            "these files name an app-targeted action event: " + string.Join(", ", offenders)
+            + ". These are raised once per process on the bootstrap host, and App owns the one "
+            + "subscription; a second subscriber runs the action twice and roots whatever its "
+            + "closure captured on a host that lives as long as the process.");
+
+        // And the parsed view agrees. Anything it caught would have failed the
+        // text rule first, which is what makes this a cross-check on the
+        // matcher rather than a second copy of the same rule.
+        foreach (var file in corpus.Where(f => f.Tail != "Ghostty.App.xaml.cs"))
+        {
+            var wires = Wires(ShellSource.ParseForCorpusScan(file.Text).Root, SyntaxKind.AddAssignmentExpression);
+            Assert.True(
+                wires.Count == 0,
+                $"{file.Tail} subscribes to {string.Join(", ", wires.Select(w => w.Event))}");
+        }
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/AppActionOwnershipWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/AppActionOwnershipWiringTests.cs
@@ -27,7 +27,16 @@ namespace Ghostty.Tests.Wiring;
 /// handlers are safe to run after a close, because they touch only
 /// process-global state, and detaching per window would leave the last window
 /// to close taking the handler away from the windows still open. So the shape
-/// to hold is exactly one subscriber, on App, for the life of the process.
+/// to hold is exactly one subscriber, taken out by App.OnLaunched, for the
+/// life of the process.
+///
+/// What this cannot prove: that no window observes the action through some
+/// further indirection. A relay -- App raising an event of its own that
+/// per-window code subscribes to -- reintroduces the whole defect while naming
+/// none of these events, and no source scan can enumerate the ways to write
+/// one. <see cref="TheHandlersActOnTheActionRatherThanRebroadcastingIt"/>
+/// closes the one shape that is cheap to write and impossible to spot in
+/// review; the rest is left to the reader.
 /// </summary>
 public class AppActionOwnershipWiringTests
 {
@@ -35,14 +44,32 @@ public class AppActionOwnershipWiringTests
     private static readonly string[] AppActions = { "OpenConfigRequested", "ReloadConfigRequested" };
 
     /// <summary>
-    /// The two files these names may appear in at all: the host that declares
-    /// and raises them, and the one subscriber. Deliberately not an extensible
-    /// allow-list -- a third file named here would be the bug this test exists
-    /// to catch.
+    /// The file that owns the one subscription.
     /// </summary>
-    private static readonly string[] Owners = { "Ghostty.Hosting.GhosttyHost.cs", "Ghostty.App.xaml.cs" };
+    private const string App = ".Ghostty.App.xaml.cs";
 
-    private const string Corpus = "Ghostty.Tests.Interop.Sources.";
+    /// <summary>
+    /// The file that declares and raises the events.
+    /// </summary>
+    private const string Host = ".Ghostty.Hosting.GhosttyHost.cs";
+
+    /// <summary>
+    /// The only two files that may name these events at all. Deliberately not
+    /// an extensible allow-list -- a third entry here would be the bug this
+    /// test exists to catch. Both are exempt from the text rule below and both
+    /// are therefore checked by parse instead, which is why
+    /// <see cref="OwnerFilesHideNothingInAConditionalRegion"/> exists.
+    /// </summary>
+    private static readonly string[] Owners = { Host, App };
+
+    /// <summary>
+    /// Every embedded C# source, not one of the blocks the test project
+    /// happens to embed. Two shell files (NativeMethods.cs,
+    /// LibGhosttyBuildInfo.cs) are excluded from the Interop.Sources wildcard
+    /// and re-embedded under Interop.Imports, so a corpus keyed on the
+    /// Sources prefix silently never reads them.
+    /// </summary>
+    private const string Corpus = "Ghostty.Tests.";
 
     private static ShellSource AppSource() => ShellSource.Load("Ghostty.App.xaml.cs");
 
@@ -56,15 +83,21 @@ public class AppActionOwnershipWiringTests
     /// host is the same subscription.
     /// </summary>
     private static List<Wire> Wires(SyntaxNode scope, SyntaxKind kind) =>
+        Assignments(scope, kind)
+            .Select(x => new Wire(
+                x.Name,
+                x.Assignment.Left is MemberAccessExpressionSyntax m ? Receiver(m.Expression) : "this",
+                x.Assignment.Right.ToString()))
+            .ToList();
+
+    private static List<(AssignmentExpressionSyntax Assignment, string Name)> Assignments(
+        SyntaxNode scope, SyntaxKind kind) =>
         scope.DescendantNodes()
             .OfType<AssignmentExpressionSyntax>()
             .Where(a => a.IsKind(kind))
             .Select(a => (Assignment: a, Name: EventName(a.Left)))
             .Where(x => x.Name is not null && AppActions.Contains(x.Name, StringComparer.Ordinal))
-            .Select(x => new Wire(
-                x.Name!,
-                x.Assignment.Left is MemberAccessExpressionSyntax m ? Receiver(m.Expression) : "this",
-                x.Assignment.Right.ToString()))
+            .Select(x => (x.Assignment, Name: x.Name!))
             .ToList();
 
     /// <summary>
@@ -115,24 +148,35 @@ public class AppActionOwnershipWiringTests
     {
         var app = AppSource();
 
-        var subscriptions = app.Root.DescendantNodes().OfType<AssignmentExpressionSyntax>()
-            .Where(a => a.IsKind(SyntaxKind.AddAssignmentExpression)
-                        && AppActions.Contains(EventName(a.Left)!, StringComparer.Ordinal))
-            .ToList();
+        var subscriptions = Assignments(app.Root, SyntaxKind.AddAssignmentExpression);
         Assert.Equal(AppActions.Length, subscriptions.Count);
 
-        var startup = StartupPath(app);
+        // OnLaunched by name, not by whatever member happens to build the
+        // host. Anchoring on a landmark ("the member that assigns
+        // BootstrapHost") proves only that the subscription sits beside that
+        // landmark, and both move together for free: hoist the pair and the
+        // assignment into one helper, call the helper from a per-window path,
+        // and every count in this file still reads one while a subscription
+        // accumulates per window. OnLaunched is the framework's entry point,
+        // called once per process by something no refactor in this repo owns.
+        var startup = app.Method("OnLaunched");
+        Assert.Contains(
+            startup.DescendantNodes().OfType<AssignmentExpressionSyntax>(),
+            a => a.IsKind(SyntaxKind.SimpleAssignmentExpression)
+                 && a.Left.ToString() == "BootstrapHost"
+                 && a.Right.ToString() == "_bootstrapHost");
 
-        foreach (var assignment in subscriptions)
+        foreach (var (assignment, _) in subscriptions)
         {
-            // The defect was a subscription under a condition that read as
-            // "the primary window only" and selected almost every window. A
-            // conditional or repeated subscription on App is the same defect
-            // wearing App's name, and it satisfies a count of one whenever the
-            // branch happens to be taken once.
-            var enclosing = assignment.FirstAncestorOrSelf<MemberDeclarationSyntax>();
+            Assert.Same(startup, assignment.FirstAncestorOrSelf<MemberDeclarationSyntax>());
+
+            // Unconditional within it, too. The defect was a subscription
+            // under a condition that read as "the primary window only" and
+            // selected almost every window; a guarded subscription on
+            // OnLaunched is the same defect wearing App's name, and it
+            // satisfies a count of one whenever the branch is taken once.
             var nested = assignment.Ancestors()
-                .TakeWhile(n => n != enclosing)
+                .TakeWhile(n => n != startup)
                 .FirstOrDefault(n => n is IfStatementSyntax or SwitchStatementSyntax or ElseClauseSyntax
                     or ForStatementSyntax or ForEachStatementSyntax or WhileStatementSyntax
                     or DoStatementSyntax or TryStatementSyntax or LambdaExpressionSyntax
@@ -141,35 +185,8 @@ public class AppActionOwnershipWiringTests
             Assert.True(
                 nested is null,
                 $"`{assignment}` is inside a {nested?.Kind()}. These have to be taken out once, "
-                + "unconditionally, on the one path that builds the bootstrap host; a guarded "
-                + "subscription is how the per-window version read as one window while nearly "
-                + "every window subscribed.");
-
-            // And on THAT path, not merely on some unconditional statement
-            // somewhere: a subscription sitting in a method that runs per
-            // window, or per settings-window open, is the original defect with
-            // App's name on it, and it satisfies every count above.
-            Assert.Same(startup, enclosing);
+                + "unconditionally, on the one path that builds the bootstrap host.");
         }
-    }
-
-    /// <summary>
-    /// The member that builds the bootstrap host, identified by the
-    /// assignment that publishes it. That statement runs exactly once per
-    /// process, which is the property the subscriptions need and the one no
-    /// count of syntax can establish on its own.
-    /// </summary>
-    private static MemberDeclarationSyntax StartupPath(ShellSource app)
-    {
-        var published = app.Root.DescendantNodes().OfType<AssignmentExpressionSyntax>()
-            .Where(a => a.IsKind(SyntaxKind.SimpleAssignmentExpression)
-                        && a.Left.ToString() == "BootstrapHost"
-                        && a.Right.ToString() == "_bootstrapHost")
-            .ToList();
-        Assert.True(
-            published.Count == 1,
-            $"expected one `BootstrapHost = _bootstrapHost;` in App, found {published.Count}");
-        return published[0].FirstAncestorOrSelf<MemberDeclarationSyntax>()!;
     }
 
     [Fact]
@@ -203,17 +220,12 @@ public class AppActionOwnershipWiringTests
             .First()
             .Statements;
 
-        int IndexOf(Func<StatementSyntax, bool> match) => shutdown.TakeWhile(s => !match(s)).Count();
-
-        var dispose = IndexOf(s => s.Calls("_bootstrapHost?.Dispose").Any());
+        var dispose = shutdown.TakeWhile(s => !s.Calls("_bootstrapHost?.Dispose").Any()).Count();
         Assert.True(dispose < shutdown.Count, "expected the shutdown block to dispose the bootstrap host");
 
         foreach (var wire in detaches)
         {
-            var at = IndexOf(s => s.DescendantNodes().OfType<AssignmentExpressionSyntax>()
-                .Any(a => a.IsKind(SyntaxKind.SubtractAssignmentExpression)
-                          && EventName(a.Left) == wire.Event
-                          && a.Right.ToString() == wire.Handler));
+            var at = shutdown.TakeWhile(s => !Detaches(s, wire, app)).Count();
             Assert.True(
                 at < shutdown.Count,
                 $"{wire.Event} is detached somewhere other than the shutdown that disposes the host");
@@ -221,6 +233,32 @@ public class AppActionOwnershipWiringTests
                 at < dispose,
                 $"{wire.Event} must be detached before _bootstrapHost.Dispose frees the ghostty app");
         }
+    }
+
+    /// <summary>
+    /// Whether a statement takes <paramref name="wire"/> back, either inline
+    /// or through a method of App it calls.
+    ///
+    /// One level, not zero: hoisting the pair of detaches into a named helper
+    /// changes nothing about when they run, and a rule that reddened on it
+    /// would be rejecting correct code -- which is the failure that gets a
+    /// guard deleted rather than fixed. One level, not arbitrarily many:
+    /// following a chain needs a semantic model, and there is none here.
+    /// </summary>
+    private static bool Detaches(StatementSyntax statement, Wire wire, ShellSource app)
+    {
+        if (Matches(statement)) return true;
+
+        return statement.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Select(call => call.Expression)
+            .OfType<IdentifierNameSyntax>()
+            .SelectMany(name => app.Root.DescendantNodes().OfType<MethodDeclarationSyntax>()
+                .Where(m => m.Identifier.ValueText == name.Identifier.ValueText))
+            .Any(Matches);
+
+        bool Matches(SyntaxNode scope) =>
+            Assignments(scope, SyntaxKind.SubtractAssignmentExpression)
+                .Any(x => x.Name == wire.Event && x.Assignment.Right.ToString() == wire.Handler);
     }
 
     [Fact]
@@ -244,15 +282,80 @@ public class AppActionOwnershipWiringTests
     }
 
     /// <summary>
+    /// The handlers do the action. They do not raise an event of their own.
+    ///
+    /// The cheapest way to put the defect back without naming either event is
+    /// a relay: App keeps the one real subscription and re-broadcasts through
+    /// a static event, and per-window code subscribes to that instead. Every
+    /// other rule in this file passes, because the event names never leave
+    /// App. Refusing a delegate invocation inside these two handlers is not a
+    /// proof against indirection in general -- nothing here can be -- but it
+    /// is the difference between writing the relay by accident and having to
+    /// route around a test that says not to.
+    /// </summary>
+    [Fact]
+    public void TheHandlersActOnTheActionRatherThanRebroadcastingIt()
+    {
+        var app = AppSource();
+
+        foreach (var wire in Wires(app.Root, SyntaxKind.AddAssignmentExpression))
+        {
+            var raised = app.Method(wire.Handler)
+                .DescendantNodes().OfType<InvocationExpressionSyntax>()
+                .Where(call => call.CalleeText().EndsWith("Invoke", StringComparison.Ordinal))
+                .ToList();
+
+            Assert.True(
+                raised.Count == 0,
+                $"{wire.Handler} raises {string.Join(", ", raised.Select(r => r.CalleeText()))}. "
+                + "An app-targeted action handled once per process and then fanned out to a "
+                + "per-window subscriber is the defect this file exists to prevent, wearing a "
+                + "different event's name.");
+        }
+    }
+
+    /// <summary>
+    /// The two owner files are exempt from the text rule below, so a parse is
+    /// all that reads them -- and a parse cannot see inside a disabled
+    /// conditional region. Wrapping a subscription in `#if !DEMO` inside
+    /// GhosttyHost therefore hid it from both rules at once, while shipping in
+    /// every non-DEMO build.
+    ///
+    /// <see cref="ShellSource.Load"/> refuses a file that still has disabled
+    /// text after DEMO is defined, which is the check that closes it. So both
+    /// owners go through Load, not through the corpus scan's relaxed parse.
+    /// </summary>
+    [Fact]
+    public void OwnerFilesHideNothingInAConditionalRegion()
+    {
+        // App itself is loaded by every other test here. The host is not, and
+        // it is the one file where a per-window host could reach the
+        // bootstrap host's events without looking out of place.
+        var host = ShellSource.Load("Ghostty.Hosting.GhosttyHost.cs");
+
+        var wires = Wires(host.Root, SyntaxKind.AddAssignmentExpression);
+        Assert.True(
+            wires.Count == 0,
+            "GhosttyHost subscribes to " + string.Join(", ", wires.Select(w => w.Event))
+            + ". It declares and raises these; subscribing to another host's copy is how a "
+            + "per-window host becomes a second subscriber.");
+
+        // Load-bearing: Load is what makes the above meaningful, and it is
+        // silently satisfied by a file that parses to nothing.
+        Assert.NotEmpty(host.Root.DescendantNodes().OfType<MethodDeclarationSyntax>());
+    }
+
+    /// <summary>
     /// The corpus rule, and the one that actually answers the issue: no file
     /// other than the host and App may so much as name these events.
     ///
     /// Text rather than syntax, deliberately. A parse cannot see inside a
     /// disabled conditional region, and a subscription reintroduced there is a
     /// live subscription in the configuration that defines the symbol.
-    /// Matching the token in the raw source has no such blind spot, and the
-    /// cost -- that a comment naming the event also fails -- is worth paying
-    /// for a rule whose whole content is that this name lives in two files.
+    /// Matching the token in the raw source has no such blind spot. The cost
+    /// is that a comment naming either event also fails -- including a comment
+    /// explaining why a file must not subscribe. Reword it; the rule is worth
+    /// more than the sentence.
     /// </summary>
     [Fact]
     public void NoOtherFileSubscribesToTheAppActions()
@@ -264,11 +367,19 @@ public class AppActionOwnershipWiringTests
         Assert.True(
             corpus.Count > 100,
             $"expected the shell source corpus under '{Corpus}', got {corpus.Count} files");
-        Assert.All(Owners, owner => Assert.Contains(corpus, f => f.Tail == owner));
+        foreach (var owner in Owners)
+        {
+            Assert.Single(corpus.Where(f => f.Tail.EndsWith(owner, StringComparison.Ordinal)));
+        }
+
+        // And the two files that live outside the Interop.Sources wildcard are
+        // in it, because a corpus keyed on that prefix alone silently skipped
+        // them and they are shell sources like any other.
+        Assert.Contains(corpus, f => f.Tail.EndsWith(".NativeMethods.cs", StringComparison.Ordinal));
 
         var pattern = new Regex(@"\b(" + string.Join("|", AppActions) + @")\b", RegexOptions.Compiled);
         var offenders = corpus
-            .Where(f => !Owners.Contains(f.Tail, StringComparer.Ordinal) && pattern.IsMatch(f.Text))
+            .Where(f => !Owners.Any(o => f.Tail.EndsWith(o, StringComparison.Ordinal)) && pattern.IsMatch(f.Text))
             .Select(f => f.Tail)
             .ToList();
 
@@ -277,12 +388,13 @@ public class AppActionOwnershipWiringTests
             "these files name an app-targeted action event: " + string.Join(", ", offenders)
             + ". These are raised once per process on the bootstrap host, and App owns the one "
             + "subscription; a second subscriber runs the action twice and roots whatever its "
-            + "closure captured on a host that lives as long as the process.");
+            + "closure captured on a host that lives as long as the process. If the name is only "
+            + "in a comment, reword the comment.");
 
-        // And the parsed view agrees. Anything it caught would have failed the
-        // text rule first, which is what makes this a cross-check on the
-        // matcher rather than a second copy of the same rule.
-        foreach (var file in corpus.Where(f => f.Tail != "Ghostty.App.xaml.cs"))
+        // And the parsed view agrees. It reads the owner files too, which the
+        // text rule exempts -- so this is not a second copy of the rule above,
+        // it is the half that covers what the exemption opens up.
+        foreach (var file in corpus.Where(f => !f.Tail.EndsWith(App, StringComparison.Ordinal)))
         {
             var wires = Wires(ShellSource.ParseForCorpusScan(file.Text).Root, SyntaxKind.AddAssignmentExpression);
             Assert.True(

--- a/windows/Ghostty.Tests/Wiring/ShellSource.cs
+++ b/windows/Ghostty.Tests/Wiring/ShellSource.cs
@@ -115,9 +115,11 @@ internal sealed class ShellSource
     ///
     /// Only for a corpus-wide scan, where refusing every file that has a
     /// conditional region would refuse most of the corpus. The blind spot is
-    /// real and does not go away: a caller using this owes a second rule that
-    /// covers the disabled regions -- a text-level one, since no parse sees
-    /// them. Reach for <see cref="Load"/> for anything about one file.
+    /// real and does not go away: a caller using this owes a second rule
+    /// covering the disabled regions for every file it reads this way -- a
+    /// text-level rule, since no parse sees them, or <see cref="Load"/> for
+    /// the handful the text rule exempts. Reach for <see cref="Load"/> for
+    /// anything about one file.
     /// </summary>
     public static ShellSource ParseForCorpusScan(string text)
     {

--- a/windows/Ghostty.Tests/Wiring/ShellSource.cs
+++ b/windows/Ghostty.Tests/Wiring/ShellSource.cs
@@ -83,6 +83,48 @@ internal sealed class ShellSource
         return new ShellSource(root);
     }
 
+    /// <summary>
+    /// Every embedded source whose normalized resource name starts with
+    /// <paramref name="dottedPrefix"/>, as (tail, raw text).
+    ///
+    /// For rules that are about the whole corpus rather than about one file:
+    /// "nothing outside these files subscribes to this event" cannot be
+    /// checked by loading the files that are allowed to.
+    /// </summary>
+    public static IReadOnlyList<(string Tail, string Text)> AllUnder(string dottedPrefix)
+    {
+        var asm = Assembly.GetExecutingAssembly();
+        var found = new List<(string, string)>();
+        foreach (var name in asm.GetManifestResourceNames())
+        {
+            var normalized = Normalize(name);
+            if (!normalized.StartsWith(dottedPrefix, StringComparison.Ordinal)) continue;
+            if (!normalized.EndsWith(".cs", StringComparison.Ordinal)) continue;
+
+            using var stream = asm.GetManifestResourceStream(name)!;
+            using var reader = new StreamReader(stream);
+            found.Add((normalized[dottedPrefix.Length..], reader.ReadToEnd()));
+        }
+
+        return found;
+    }
+
+    /// <summary>
+    /// Parse text that is already in hand, without the disabled-region check
+    /// <see cref="Load"/> makes.
+    ///
+    /// Only for a corpus-wide scan, where refusing every file that has a
+    /// conditional region would refuse most of the corpus. The blind spot is
+    /// real and does not go away: a caller using this owes a second rule that
+    /// covers the disabled regions -- a text-level one, since no parse sees
+    /// them. Reach for <see cref="Load"/> for anything about one file.
+    /// </summary>
+    public static ShellSource ParseForCorpusScan(string text)
+    {
+        var options = new CSharpParseOptions(preprocessorSymbols: new[] { "DEMO" });
+        return new ShellSource((CompilationUnitSyntax)CSharpSyntaxTree.ParseText(text, options).GetRoot());
+    }
+
     // MSBuild substitutes the host's directory separator into the logical
     // name, so neither "\" nor "/" can be assumed. Fold both to dots.
     private static string Normalize(string resourceName) =>

--- a/windows/Ghostty.Tests/Wiring/WindowTeardownWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/WindowTeardownWiringTests.cs
@@ -94,20 +94,6 @@ public class WindowTeardownWiringTests
     {
         ("AppWindow.Closing", "runs during the close by design: it is what turns a quake close "
                               + "into a hide. _isClosed is still false when it fires"),
-        // These two are exempt because a gate is the wrong instrument, not
-        // because they are harmless. The subscription is guarded on seedTab
-        // being null, and only the tab-adoption path passes one, so the
-        // cold-start window, the quake window and every restored or reopened
-        // window all subscribe: the action runs once per window, and each
-        // closure captures this window and keeps it rooted on the bootstrap
-        // host for the life of the process. Detaching on close would leave a
-        // multi-window session with nobody handling the action at all. The fix
-        // is to own these where the bootstrap host lives rather than per
-        // window, which is a behaviour change and is filed separately.
-        ("appHost.OpenConfigRequested", "every non-adopted window subscribes; duplicate execution "
-                                        + "and a per-window leak, fixed by moving ownership to App "
-                                        + "rather than by a gate"),
-        ("appHost.ReloadConfigRequested", "same ownership problem as OpenConfigRequested"),
     };
 
     private sealed record Subscription(string Event, string Receiver, string Handler, ExpressionSyntax Rhs);

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -1404,28 +1404,33 @@ public partial class App : Application
 
         var path = configService.ConfigFilePath;
         if (string.IsNullOrEmpty(path)) return;
+
+        // The config file has no extension so UseShellExecute may fail to find
+        // an associated program. Try shell execute first (respects user file
+        // associations), then fall back to notepad which can always open text
+        // files.
         try
         {
-            // The config file has no extension so UseShellExecute may fail to
-            // find an associated program. Try shell execute first (respects
-            // user file associations), then fall back to notepad which can
-            // always open text files.
-            try
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
             {
-                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
-                {
-                    FileName = path,
-                    UseShellExecute = true,
-                });
-            }
-            catch
+                FileName = path,
+                UseShellExecute = true,
+            });
+        }
+        catch (System.Exception shellEx)
+        {
+            try
             {
                 System.Diagnostics.Process.Start("notepad.exe", path);
             }
-        }
-        catch (System.Exception ex)
-        {
-            Ghostty.Logging.StaticLoggers.App.LogConfigOpenFailed(ex);
+            catch (System.Exception notepadEx)
+            {
+                // Both halves. The shell failure is the one that says why;
+                // notepad failing after it is usually a symptom, and logging
+                // only the symptom is how this becomes unexplainable.
+                Ghostty.Logging.StaticLoggers.App.LogConfigOpenFailed(
+                    new System.AggregateException(shellEx, notepadEx), path);
+            }
         }
     }
 
@@ -1921,9 +1926,9 @@ internal static partial class AppLogExtensions
 
     [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Startup.ConfigOpenFailed,
                    Level = LogLevel.Warning,
-                   Message = "Failed to open config file")]
+                   Message = "Failed to open config file {ConfigPath}")]
     internal static partial void LogConfigOpenFailed(
-        this ILogger<App> logger, System.Exception ex);
+        this ILogger<App> logger, System.Exception ex, string configPath);
 
     [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Startup.StaleAumidRemoved,
                    Level = LogLevel.Information,

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -717,6 +717,16 @@ public partial class App : Application
         BootstrapHost = _bootstrapHost;
         _configService.SetApp(_bootstrapHost.App);
 
+        // App-targeted actions (OpenConfig, ReloadConfig) are sent by
+        // libghostty with target=app, so they arrive here and never on a
+        // per-window host. Exactly one subscriber for the process: they act on
+        // process-global state, so a subscriber per window ran them once per
+        // window, and the closures kept every window alive on a host that
+        // lives as long as the process. Named methods rather than lambdas so
+        // the teardown below can take them back.
+        _bootstrapHost.OpenConfigRequested += OnAppOpenConfigRequested;
+        _bootstrapHost.ReloadConfigRequested += OnAppReloadConfigRequested;
+
         // App-level: High Contrast is a system-wide state and config is
         // applied app-wide, so a single monitor drives the surface override.
         // Constructed AFTER SetApp so its initial Apply() reloads into a live
@@ -1377,6 +1387,57 @@ public partial class App : Application
     }
 
     /// <summary>
+    /// The app-targeted OpenConfig action. Opens the settings window when the
+    /// settings UI is enabled, and otherwise hands the config file to the
+    /// shell. GhosttyHost raises this on the UI thread.
+    /// </summary>
+    private void OnAppOpenConfigRequested(object? sender, EventArgs e)
+    {
+        var configService = _configService;
+        if (configService is null) return;
+
+        if (configService.SettingsUiEnabled)
+        {
+            ShowOrActivateSettings();
+            return;
+        }
+
+        var path = configService.ConfigFilePath;
+        if (string.IsNullOrEmpty(path)) return;
+        try
+        {
+            // The config file has no extension so UseShellExecute may fail to
+            // find an associated program. Try shell execute first (respects
+            // user file associations), then fall back to notepad which can
+            // always open text files.
+            try
+            {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = path,
+                    UseShellExecute = true,
+                });
+            }
+            catch
+            {
+                System.Diagnostics.Process.Start("notepad.exe", path);
+            }
+        }
+        catch (System.Exception ex)
+        {
+            Ghostty.Logging.StaticLoggers.App.LogConfigOpenFailed(ex);
+        }
+    }
+
+    /// <summary>
+    /// The app-targeted ReloadConfig action. ConfigService is process-wide and
+    /// fans its ConfigChanged out to every window, so one reload is the whole
+    /// action. GhosttyHost raises this on the UI thread.
+    /// </summary>
+    private void OnAppReloadConfigRequested(object? sender, EventArgs e) =>
+        _configService?.Reload();
+
+    /// <summary>
     /// Show the app-wide settings window, or focus the existing one if it is
     /// already open. One settings window serves the whole process, so opening
     /// it from any window reuses the same instance. The caller guards on
@@ -1728,6 +1789,15 @@ public partial class App : Application
                 // onto the UI thread).
                 _singleInstanceServer?.Dispose();
 
+                // Take the app-action subscriptions back before the host
+                // frees the ghostty app. They are attached for the life of
+                // the process, so nothing else would.
+                if (_bootstrapHost is not null)
+                {
+                    _bootstrapHost.OpenConfigRequested -= OnAppOpenConfigRequested;
+                    _bootstrapHost.ReloadConfigRequested -= OnAppReloadConfigRequested;
+                }
+
                 // Bootstrap host is the LAST host. Its Dispose drains
                 // _hostBySurface (asserts empty), notifies the
                 // supervisor (which throws if anything is still live),
@@ -1847,6 +1917,12 @@ internal static partial class AppLogExtensions
                    Level = LogLevel.Warning,
                    Message = "Failed to register for toast notifications")]
     internal static partial void LogToastRegisterFailed(
+        this ILogger<App> logger, System.Exception ex);
+
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Startup.ConfigOpenFailed,
+                   Level = LogLevel.Warning,
+                   Message = "Failed to open config file")]
+    internal static partial void LogConfigOpenFailed(
         this ILogger<App> logger, System.Exception ex);
 
     [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Startup.StaleAumidRemoved,

--- a/windows/Ghostty/Logging/LogEvents.cs
+++ b/windows/Ghostty/Logging/LogEvents.cs
@@ -14,6 +14,7 @@ internal static class LogEvents
         public const int ToastRegisterFailed = 2002;
         public const int TrayInitFailed      = 2003;
         public const int StaleAumidRemoved   = 2004;
+        public const int ConfigOpenFailed    = 2005;
     }
 
     // 2100-2199: Clipboard
@@ -60,7 +61,8 @@ internal static class LogEvents
     // 2500-2599: MainWindow
     internal static class MainWindow
     {
-        public const int ConfigOpenFailed  = 2500;
+        // 2500 retired (was ConfigOpenFailed; the action moved to App and
+        // logs under Startup.ConfigOpenFailed). Not reused: old logs carry it.
         public const int DialogDrainFailed = 2501;
     }
 

--- a/windows/Ghostty/Logging/StaticLoggers.cs
+++ b/windows/Ghostty/Logging/StaticLoggers.cs
@@ -20,9 +20,11 @@ namespace Ghostty.Logging;
 /// are safe no-ops.
 ///
 /// Why each remaining site stays here:
-///   - <see cref="App"/>: logs AUMID/jump-list failures in
-///     <c>App.OnLaunched</c> BEFORE the factory is built. No ctor
-///     available in the early-startup scope.
+///   - <see cref="App"/>: XAML constructs it, so there is no ctor the
+///     factory can be handed to, and its earliest records (AUMID,
+///     jump list) are written before the factory exists at all.
+///     Every App-scoped record goes through here, including the ones
+///     written long after startup.
 ///   - <see cref="ConfigService"/>: constructed before the factory
 ///     exists because the factory reads <c>log-level</c> /
 ///     <c>log-filter</c> off <c>ConfigService</c>. Chicken-and-egg,

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -823,13 +823,9 @@ public sealed partial class MainWindow : Window
         // forward straight into the router that owns the pane/tab state.
         _host.PaneActionRequested += action => _router.Invoke(action);
 
-        // App-targeted actions (OpenConfig, ReloadConfig) arrive on the
-        // bootstrap host, because libghostty sends them with target=app rather
-        // than target=surface, so the per-window _host never receives them.
-        // App owns that subscription for the whole process: one subscriber
-        // means the action runs once no matter how many windows are open, and
-        // no window is left rooted on a process-lifetime host by a closure
-        // that captured it.
+        // Actions libghostty sends with target=app never reach the per-window
+        // _host. App subscribes to those on the bootstrap host, once for the
+        // process; see App.OnLaunched.
 
         // Ctrl+Shift+Scroll wheel opacity adjustment from any terminal surface.
         _host.OpacityAdjustRequested += (_, direction) => AdjustOpacity(direction);

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -823,58 +823,13 @@ public sealed partial class MainWindow : Window
         // forward straight into the router that owns the pane/tab state.
         _host.PaneActionRequested += action => _router.Invoke(action);
 
-        // App-targeted actions (OpenConfig, ReloadConfig) fire on the
-        // bootstrap host because libghostty sends them with target=app,
-        // not target=surface. The per-window _host never receives them.
-        // Every window except an adopted one subscribes, because that is the
-        // only path that passes a seed tab. So the cold-start window, the
-        // quake window and each restored window all handle these, the action
-        // runs once per window, and each closure keeps its window rooted on
-        // the bootstrap host. Owning them on App instead is the fix; it is a
-        // behaviour change and is tracked separately.
-        if (seedTab is null)
-        {
-            var appHost = Ghostty.App.BootstrapHost!;
-            appHost.OpenConfigRequested += (_, _) =>
-            {
-                if (configService.SettingsUiEnabled)
-                {
-                    // One settings window serves the whole process; App owns
-                    // the singleton (mirrors the quake window), so opening it
-                    // from any window reuses the same instance.
-                    ((App)Application.Current).ShowOrActivateSettings();
-                    return;
-                }
-
-                var path = configService.ConfigFilePath;
-                if (string.IsNullOrEmpty(path)) return;
-                try
-                {
-                    // The config file has no extension so UseShellExecute
-                    // may fail to find an associated program. Try shell
-                    // execute first (respects user file associations), then
-                    // fall back to notepad which can always open text files.
-                    try
-                    {
-                        System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
-                        {
-                            FileName = path,
-                            UseShellExecute = true,
-                        });
-                    }
-                    catch
-                    {
-                        System.Diagnostics.Process.Start("notepad.exe", path);
-                    }
-                }
-                catch (System.Exception ex)
-                {
-                    _logger.LogConfigOpenFailed(ex);
-                }
-            };
-
-            appHost.ReloadConfigRequested += (_, _) => configService.Reload();
-        }
+        // App-targeted actions (OpenConfig, ReloadConfig) arrive on the
+        // bootstrap host, because libghostty sends them with target=app rather
+        // than target=surface, so the per-window _host never receives them.
+        // App owns that subscription for the whole process: one subscriber
+        // means the action runs once no matter how many windows are open, and
+        // no window is left rooted on a process-lifetime host by a closure
+        // that captured it.
 
         // Ctrl+Shift+Scroll wheel opacity adjustment from any terminal surface.
         _host.OpacityAdjustRequested += (_, direction) => AdjustOpacity(direction);
@@ -4061,12 +4016,6 @@ public sealed partial class MainWindow : Window
 
 internal static partial class MainWindowLogExtensions
 {
-    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.MainWindow.ConfigOpenFailed,
-                   Level = LogLevel.Warning,
-                   Message = "[MainWindow] Failed to open config file")]
-    internal static partial void LogConfigOpenFailed(
-        this ILogger<MainWindow> logger, System.Exception ex);
-
     [LoggerMessage(EventId = Ghostty.Logging.LogEvents.MainWindow.DialogDrainFailed,
                    Level = LogLevel.Warning,
                    Message = "DialogTracker drain failed")]


### PR DESCRIPTION
Closes #704

`OpenConfig` and `ReloadConfig` arrive with `target=app`, so libghostty raises them on the bootstrap host. `MainWindow` subscribed behind `seedTab is null`, which only tab adoption fails, so the cold-start window, the quake window and every restored or reopened window all subscribed. The action ran once per open window, and each closure kept its window rooted on a host that lives as long as the process.

Both handlers now live on `App`, subscribed once in `OnLaunched` and detached before the bootstrap host is disposed. A gate would not have worked: the handlers are safe to run after a close, and a per-window detach would take the handler away from the windows still open.

The log identity moves with the handler: category `Ghostty.MainWindow` to `Ghostty.App`, event id 2500 (retired, not reused) to 2005, and the `[MainWindow]` message prefix is gone. A `log-filter` rule keyed on the old category stops matching.

`AppActionOwnershipWiringTests` pins one subscriber, in `OnLaunched`, unconditional, named handlers, detached before `AppFree`, no re-broadcast from either handler, and no other embedded C# source naming these events. It was attacked adversarially and defeated four ways before it held; the second commit closes those, and the PR comment lists them.

`dotnet test`: 2244 passed, 0 failed. Shell project builds.

Follow-up filed as #719: `ShellThemeService` has the same shape (per-window subscriber to `ConfigService.ConfigChanged`, anonymous lambda, not `IDisposable`).
