### PR TITLE
ci: lint the gallery shaders; census every window's teardown

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1971,6 +1971,35 @@ jobs:
             --severity=warning \
             $(find . \( -name "*.sh" -o -name "*.bash" \) -type f ! -path "./zig-out/*" ! -path "./macos/build/*" ! -path "./.git/*" | sort)
 
+  # Parse the bundled gallery shaders with glslang. Nothing else in this
+  # workflow reads GLSL, so a reserved word used as an identifier (`filter`,
+  # `input`, `union`, ... of GLSL 4.60 section 3.6) lands green here and only
+  # fails later, by hand, in `just gallery-verify`, taking that whole gate
+  # down for whoever runs it next. The lint needs neither a renderer build nor
+  # a GPU: it is prefix + shader through glslang, a couple of seconds.
+  #
+  # Unlike every job above, this one is neither gated on the upstream
+  # repository nor run on a namespace profile. The gallery is fork-only
+  # content (windows/Ghostty/Assets/Shaders), so gating it on ghostty-org
+  # would mean it never runs at all, and the fork's own workflows run on
+  # ubuntu-latest.
+  gallery-lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
+        with:
+          name: ghostty
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+          skipPush: true
+          useDaemon: false # sometimes fails on short jobs
+      - name: gallery-lint
+        run: nix develop -c just gallery-lint
+
   translations:
     if: github.repository == 'ghostty-org/ghostty' && needs.skip.outputs.skip != 'true'
     needs: skip

--- a/justfile
+++ b/justfile
@@ -1081,6 +1081,60 @@ sync-verify mode="":
 gallery-verify:
     @bash tools/gallery/verify.sh
 
+# Parse every bundled gallery shader with glslang, prefixed exactly the way the
+# renderer assembles it (shadertoy_prefix.glsl + the shader).
+#
+# This is gallery-verify's reference leg with everything unhermetic removed: no
+# zioshade build, no spirv-cross, no Windows box, so CI can run it on every
+# push and a contributor can run it in a second. What it buys is the class of
+# break gallery-verify would otherwise find late and by hand: `active` was a
+# GLSL reserved word sitting in two shipped shaders, and `filter`, `input`,
+# `output`, `union`, `resource` and the rest of GLSL 4.60 section 3.6 are still
+# accepted by the renderer's own lenient frontend. Leniency there is correct
+# for shaders users load from the wild; the shaders WE ship have to be
+# acceptable to a spec-conforming compiler, because gallery-verify's
+# independent reference path compiles them with one.
+#
+# Deliberately the same tool and flags as verify.sh step 2, so a shader that
+# passes here cannot fail there for a parse reason.
+gallery-lint:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    glslang=${GLSLANG:-glslang}
+    command -v "$glslang" >/dev/null || {
+        echo "glslang not found (nix develop, or brew install glslang)" >&2
+        exit 2
+    }
+    prefix=src/renderer/shaders/shadertoy_prefix.glsl
+    prefix_lines=$(wc -l < "$prefix" | tr -d ' ')
+    stage=$(mktemp -d "${TMPDIR:-/tmp}/gallery_lint.XXXXXX")
+    trap 'rm -rf "$stage"' EXIT
+    pass=0
+    failed=""
+    for glsl in windows/Ghostty/Assets/Shaders/*.glsl; do
+        name=$(basename "$glsl" .glsl)
+        cat "$prefix" "$glsl" > "$stage/$name.full.glsl"
+        if "$glslang" -V -S frag "$stage/$name.full.glsl" -o "$stage/$name.spv" \
+                > "$stage/$name.log" 2>&1; then
+            pass=$((pass + 1))
+        else
+            echo "FAIL $glsl"
+            # Point the diagnostics back at a file that exists, and say what
+            # the line numbers are relative to: they are counted in the
+            # concatenation, whose first $prefix_lines lines are the prefix.
+            sed -e "s|$stage/$name.full.glsl|$glsl|g" "$stage/$name.log" | sed '/^$/d'
+            echo "  (line numbers are in ${prefix} + ${glsl}; the prefix is ${prefix_lines} lines)"
+            failed="$failed $name"
+        fi
+    done
+    if [ -n "$failed" ]; then
+        echo "glslang: $pass pass, $(echo $failed | wc -w | tr -d ' ') fail:$failed"
+        echo "A gallery shader must be accepted by glslang verbatim, which among other"
+        echo "things means no GLSL reserved word (section 3.6) used as an identifier."
+        exit 1
+    fi
+    echo "glslang: $pass pass, 0 fail"
+
 # ── quality control ────────────────────────────────────────────────────────
 # These recipes need Python 3 on PATH as `python`. The signoff ladder
 # includes test-win, so signoff is a Windows-host recipe like the rest of

--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -9,6 +9,8 @@
   flatpak-builder,
   gdb,
   cmake,
+  glslang,
+  just,
   #, glxinfo # unused
   ncurses,
   nodejs,
@@ -103,6 +105,9 @@ in
         cmake
         doxygen
         jq
+        # The fork's build and check recipes live in the justfile, and CI
+        # invokes them through `nix develop -c just <recipe>`.
+        just
         llvmPackages_latest.llvm
         minisign
         ncurses
@@ -122,6 +127,10 @@ in
         pinact
         typos
         shellcheck
+        # Parses the bundled gallery shaders (just gallery-lint). The
+        # renderer's own GLSL frontend is lenient on purpose, so glslang is
+        # what holds the shaders we ship to the spec.
+        glslang
 
         # Testing
         parallel

--- a/windows/Ghostty.Tests/Wiring/ShellSource.cs
+++ b/windows/Ghostty.Tests/Wiring/ShellSource.cs
@@ -132,6 +132,50 @@ internal sealed class ShellSource
     private static string Normalize(string resourceName) =>
         resourceName.Replace('\\', '.').Replace('/', '.');
 
+    // The two logical-name prefixes the shell and the core project's sources
+    // are embedded under (see Ghostty.Tests.csproj). Core is nested inside the
+    // shell's prefix, so telling them apart is a second StartsWith rather than
+    // one.
+    private const string ShellPrefix = "Ghostty.Tests.Interop.Sources.Ghostty.";
+    private const string CorePrefix = "Ghostty.Tests.Interop.Sources.Ghostty.Core.";
+
+    /// <summary>
+    /// Every embedded WinUI shell source, parsed, as (dotted resource name,
+    /// syntax root).
+    ///
+    /// For scans that have to see the whole project rather than one named
+    /// file: a census can only claim to enumerate windows if it enumerates
+    /// the files first. Deliberately NOT <see cref="Load"/>, which refuses a
+    /// tree with conditional regions it cannot see -- that refusal is right
+    /// for a file a test is about to make claims about, and wrong here, where
+    /// one such file anywhere in the shell would take the whole sweep down.
+    /// A file this finds and a test then wants to read in earnest still goes
+    /// through Load.
+    /// </summary>
+    public static IReadOnlyList<(string Resource, CompilationUnitSyntax Root)> AllShellSources()
+    {
+        var asm = Assembly.GetExecutingAssembly();
+        var options = new CSharpParseOptions(preprocessorSymbols: new[] { "DEMO" });
+        var found = new List<(string Resource, CompilationUnitSyntax Root)>();
+        foreach (var name in asm.GetManifestResourceNames())
+        {
+            var dotted = Normalize(name);
+            if (!dotted.StartsWith(ShellPrefix, StringComparison.Ordinal)) continue;
+            if (dotted.StartsWith(CorePrefix, StringComparison.Ordinal)) continue;
+            if (!dotted.EndsWith(".cs", StringComparison.Ordinal)) continue;
+
+            using var stream = asm.GetManifestResourceStream(name)!;
+            using var reader = new StreamReader(stream);
+            var tree = CSharpSyntaxTree.ParseText(reader.ReadToEnd(), options);
+            found.Add((dotted, (CompilationUnitSyntax)tree.GetRoot()));
+        }
+
+        // Load-bearing: an empty sweep is a query that stopped matching, and
+        // every caller reads "nothing to check" out of it.
+        Assert.True(found.Count > 0, "no embedded shell sources found under " + ShellPrefix);
+        return found;
+    }
+
     /// <summary>The whole parsed file.</summary>
     public SyntaxNode Root => _root;
 

--- a/windows/Ghostty.Tests/Wiring/WindowTeardownWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/WindowTeardownWiringTests.cs
@@ -9,28 +9,28 @@ using Xunit;
 namespace Ghostty.Tests.Wiring;
 
 /// <summary>
-/// Every event MainWindow subscribes to, checked against what its close
+/// Every event each window subscribes to, checked against what its close
 /// takes back.
 ///
-/// Four separate callbacks accumulated behind this gap -- an OS colour-scheme
-/// handler calling into libghostty through the app pointer the close is about
-/// to free, and three dispatcher-driven timers nothing stopped -- and each was
-/// found by hand, one at a time, because nothing enumerated the subscriptions
-/// against the unsubscribe list. Sixty-odd `+=` against a handful of `-=` is
-/// not a list anyone re-reads.
+/// Four separate callbacks accumulated behind this gap in MainWindow -- an OS
+/// colour-scheme handler calling into libghostty through the app pointer the
+/// close is about to free, and three dispatcher-driven timers nothing stopped
+/// -- and each was found by hand, one at a time, because nothing enumerated
+/// the subscriptions against the unsubscribe list. Sixty-odd `+=` against a
+/// handful of `-=` is not a list anyone re-reads.
 ///
 /// The discrimination that matters is who owns the event source:
 ///
 ///   - A source that outlives the window -- the OS, an app-level service, a
 ///     static event, a timer the window created but the dispatcher drives --
 ///     keeps calling after Window.Closed, and keeps the closed window alive
-///     while it does. It must be unsubscribed in OnClosedAsync, or its handler
-///     must return early on _isClosed.
+///     while it does. It must be unsubscribed on the close path, or its
+///     handler must return early on the window's teardown latch.
 ///   - A source the window itself owns and that dies with it -- its own XAML
 ///     elements, its per-window services, its pane tree -- needs neither.
 ///
 /// There is no semantic model here (see ShellSource), so ownership cannot be
-/// inferred; it has to be declared. <see cref="WindowOwned"/> is that
+/// inferred; it has to be declared. <see cref="Censused.Owned"/> is that
 /// declaration, and it is an allow-list rather than a list of sources known to
 /// need proof, because the failure mode being defended against is a
 /// subscription NOBODY classified. A deny-list is silent on the receiver
@@ -39,22 +39,66 @@ namespace Ghostty.Tests.Wiring;
 /// of the line it falls on, and that sentence is the whole product of this
 /// test.
 ///
+/// The same argument applies one level up, to the files. This census covered
+/// MainWindow alone until ShaderPickerWindow -- a window that owns a native
+/// surface, a child process and an autoplay feed -- turned out to be outside
+/// it entirely. So the windows are not named here: they are found, by looking
+/// for every class in the shell that derives from Window, and each one has to
+/// appear in <see cref="Windows"/> or the census fails. Window number four is
+/// covered the day it is written.
+///
 /// What it cannot see: whether a gated handler's gate covers the turns after
-/// an await, whether an unsubscribe runs on every path through OnClosedAsync,
-/// and every subscription made outside this file. It is a census, not a proof
-/// of safety. The per-case guards below carry the reasoning those need.
+/// an await, whether an unsubscribe runs on every path through the close, and
+/// every subscription made outside the window's own file. It is a census, not
+/// a proof of safety. The per-case guards below carry the reasoning those
+/// need.
 /// </summary>
 public class WindowTeardownWiringTests
 {
-    private static ShellSource Window() => ShellSource.Load("Ghostty.MainWindow.xaml.cs");
+    /// <summary>
+    /// One window under census.
+    /// </summary>
+    /// <param name="Class">Class name, which is what discovery matches on.</param>
+    /// <param name="File">Dotted tail for <see cref="ShellSource.Load"/>.</param>
+    /// <param name="ClosedFlag">
+    /// The field a handler reads to bail out once teardown has started, or
+    /// null when the window has no such latch -- in which case only an
+    /// unsubscribe can prove a subscription safe here.
+    /// </param>
+    /// <param name="ClosePath">
+    /// Methods the Closed handler delegates teardown to, whose unsubscribes
+    /// count as the close's. Declared rather than followed automatically: an
+    /// unsubscribe that moved into a helper the close reaches only on one
+    /// branch is a weaker claim than one written in the close itself, and
+    /// somebody has to say so.
+    /// </param>
+    /// <param name="AtLeast">
+    /// How many subscriptions the query must still find. Load-bearing: every
+    /// assertion is over that list, so a query that stops matching would pass
+    /// the whole census while reading nothing.
+    /// </param>
+    /// <param name="Owned">Receivers whose events die with the window, and why.</param>
+    /// <param name="Exempt">
+    /// Individual events on sources that DO outlive the window and are still
+    /// left attached, each with the reason detaching or gating would be wrong.
+    /// Spelled as whole events, not receivers, so the rest of the receiver
+    /// stays under the rule.
+    /// </param>
+    private sealed record Censused(
+        string Class,
+        string File,
+        string? ClosedFlag,
+        string[] ClosePath,
+        int AtLeast,
+        (string Receiver, string Why)[] Owned,
+        (string Event, string Why)[] Exempt);
 
     /// <summary>
-    /// Receivers whose events die with the window, and why. Adding a line here
-    /// is meant to cost a decision: the claim is that when this window is gone
-    /// nothing can raise the event again, so neither an unsubscribe nor a gate
-    /// buys anything.
+    /// Adding a line to one of these is meant to cost a decision: the claim is
+    /// that when this window is gone nothing can raise the event again, so
+    /// neither an unsubscribe nor a gate buys anything.
     /// </summary>
-    private static readonly (string Receiver, string Why)[] WindowOwned =
+    private static readonly (string Receiver, string Why)[] MainWindowOwned =
     {
         ("this", "the Window's own events; the window raises them and stops when it does"),
         ("fe", "this window's XAML content root"),
@@ -84,17 +128,108 @@ public class WindowTeardownWiringTests
                    + "detaches the two subscriptions taken out alongside it"),
     };
 
-    /// <summary>
-    /// Individual events on sources that DO outlive the window and are still
-    /// left attached, each with the reason detaching or gating would be wrong.
-    /// Spelled as whole events, not receivers, so the rest of the receiver
-    /// stays under the rule.
-    /// </summary>
-    private static readonly (string Event, string Why)[] Exempt =
+    private static readonly (string Event, string Why)[] MainWindowExempt =
     {
         ("AppWindow.Closing", "runs during the close by design: it is what turns a quake close "
                               + "into a hide. _isClosed is still false when it fires"),
     };
+
+    private static readonly (string Receiver, string Why)[] ShaderPickerOwned =
+    {
+        ("this", "the Window's own events; the window raises them and stops when it does"),
+        ("RootGrid", "named element of ShaderPickerWindow.xaml"),
+        // The one that is not obvious. FirstRender is raised through the
+        // shared bootstrap host's dispatcher, which outlives this window, so
+        // the subscription is only safe because of what the close does to the
+        // control: DisposePreview calls DisposeSurface, and DisposeSurface
+        // nulls FirstRender along with the control's other events.
+        ("control", "this window's own preview TerminalControl; the close calls DisposePreview, "
+                    + "whose DisposeSurface nulls FirstRender with the rest of the control's events"),
+    };
+
+    private static readonly (string Receiver, string Why)[] SettingsWindowOwned =
+    {
+        ("this", "the Window's own events; the window raises them and stops when it does"),
+        ("ctrlF", "a KeyboardAccelerator this window creates and hands to its own NavView"),
+        ("root", "a settings page's own element, passed into a static helper; the handler "
+                 + "detaches itself on the first fire"),
+    };
+
+    private static readonly (string Receiver, string Why)[] AboutWindowOwned =
+    {
+        ("this", "the Window's own events; the window raises them and stops when it does"),
+    };
+
+    private static readonly (string Receiver, string Why)[] InspectorWindowOwned =
+    {
+        ("this", "the Window's own events; the window raises them and stops when it does"),
+        ("Panel", "named element of InspectorWindow.xaml"),
+    };
+
+    private static readonly (string Event, string Why)[] NoneExempt =
+        Array.Empty<(string Event, string Why)>();
+
+    private static readonly Censused MainWindow = new(
+        Class: "MainWindow",
+        File: "Ghostty.MainWindow.xaml.cs",
+        ClosedFlag: "_isClosed",
+        ClosePath: Array.Empty<string>(),
+        AtLeast: 40,
+        Owned: MainWindowOwned,
+        Exempt: MainWindowExempt);
+
+    private static readonly Censused ShaderPickerWindow = new(
+        Class: "ShaderPickerWindow",
+        File: "Settings.ShaderPickerWindow.xaml.cs",
+        ClosedFlag: "_closed",
+        // The Closed handler latches and delegates; DisposePreview is the
+        // teardown.
+        ClosePath: new[] { "DisposePreview" },
+        AtLeast: 4,
+        Owned: ShaderPickerOwned,
+        Exempt: NoneExempt);
+
+    private static readonly Censused SettingsWindow = new(
+        Class: "SettingsWindow",
+        File: "Settings.SettingsWindow.xaml.cs",
+        ClosedFlag: null,
+        ClosePath: Array.Empty<string>(),
+        AtLeast: 5,
+        Owned: SettingsWindowOwned,
+        Exempt: NoneExempt);
+
+    private static readonly Censused AboutWindow = new(
+        Class: "AboutWindow",
+        File: "Dialogs.AboutWindow.xaml.cs",
+        ClosedFlag: null,
+        ClosePath: Array.Empty<string>(),
+        AtLeast: 2,
+        Owned: AboutWindowOwned,
+        Exempt: NoneExempt);
+
+    private static readonly Censused InspectorWindow = new(
+        Class: "InspectorWindow",
+        File: "InspectorWindow.xaml.cs",
+        ClosedFlag: "_closed",
+        ClosePath: Array.Empty<string>(),
+        AtLeast: 11,
+        Owned: InspectorWindowOwned,
+        Exempt: NoneExempt);
+
+    private static readonly Censused[] Windows =
+    {
+        MainWindow,
+        ShaderPickerWindow,
+        SettingsWindow,
+        AboutWindow,
+        InspectorWindow,
+    };
+
+    /// <summary>The census cases, named by file so xunit can address one.</summary>
+    public static IEnumerable<object[]> CensusedWindows() =>
+        Windows.Select(w => new object[] { w.File });
+
+    private static Censused Find(string file) => Windows.Single(w => w.File == file);
 
     private sealed record Subscription(string Event, string Receiver, string Handler, ExpressionSyntax Rhs);
 
@@ -129,11 +264,46 @@ public class WindowTeardownWiringTests
             .Select(a => new Subscription(Flatten(a.Left), ReceiverOf(a.Left), Flatten(a.Right), a.Right))
             .ToList();
 
-    private static List<Subscription> Subscriptions() =>
-        Assignments(Window().Root, SyntaxKind.AddAssignmentExpression);
+    private static List<Subscription> Subscriptions(ShellSource source) =>
+        Assignments(source.Root, SyntaxKind.AddAssignmentExpression);
 
-    private static List<Subscription> Unsubscribes() =>
-        Assignments(Window().Method("OnClosedAsync"), SyntaxKind.SubtractAssignmentExpression);
+    /// <summary>
+    /// The window's close path: whatever it attaches to its OWN Closed event
+    /// (`newWindow.Closed += ...` is somebody else's), plus the methods
+    /// declared in <see cref="Censused.ClosePath"/>.
+    ///
+    /// Read off the subscription rather than from a method name, so a window
+    /// that renames or inlines its close handler is still measured against the
+    /// handler it actually installs.
+    /// </summary>
+    private static List<SyntaxNode> CloseScopes(Censused window, ShellSource source)
+    {
+        var handlers = Subscriptions(source).Where(s => s.Event == "Closed").ToList();
+        Assert.True(
+            handlers.Count == 1,
+            $"{window.Class}: expected exactly one `Closed +=` on the window itself, found "
+            + $"{handlers.Count}; the close path is what every claim below is measured against");
+
+        SyntaxNode? entry = handlers[0].Rhs switch
+        {
+            LambdaExpressionSyntax lambda => lambda.Body,
+            IdentifierNameSyntax name => source.Method(name.Identifier.ValueText).Body,
+            _ => null,
+        };
+        Assert.True(
+            entry is not null,
+            $"{window.Class}: its Closed handler is neither a lambda nor a method in this file, "
+            + "so nothing here can read what the close takes back");
+
+        var scopes = new List<SyntaxNode> { entry! };
+        scopes.AddRange(window.ClosePath.Select(m => (SyntaxNode)source.Method(m).Body!));
+        return scopes;
+    }
+
+    private static List<Subscription> Unsubscribes(Censused window, ShellSource source) =>
+        CloseScopes(window, source)
+            .SelectMany(scope => Assignments(scope, SyntaxKind.SubtractAssignmentExpression))
+            .ToList();
 
     /// <summary>
     /// <c>if (_isClosed) ... return;</c> and nothing that merely mentions the
@@ -142,8 +312,10 @@ public class WindowTeardownWiringTests
     /// pins on the layout-switch completion -- the two have to agree on what
     /// counts as a gate, or the file grows two kinds.
     /// </summary>
-    private static bool IsClosedGuard(StatementSyntax statement) =>
-        statement is IfStatementSyntax { Condition: IdentifierNameSyntax { Identifier.Text: "_isClosed" } } guard
+    private static bool IsClosedGuard(StatementSyntax statement, string? flag) =>
+        flag is not null
+        && statement is IfStatementSyntax { Condition: IdentifierNameSyntax condition } guard
+        && condition.Identifier.Text == flag
         && guard.Statement.DescendantNodesAndSelf().OfType<ReturnStatementSyntax>().Any();
 
     /// <summary>
@@ -152,8 +324,10 @@ public class WindowTeardownWiringTests
     /// branch guards that branch, not the handler, and a gate one call deeper
     /// is a fact about the callee that this cannot see.
     /// </summary>
-    private static bool IsGated(Subscription subscription, ShellSource source)
+    private static bool IsGated(Subscription subscription, ShellSource source, string? flag)
     {
+        if (flag is null) return false;
+
         var body = subscription.Rhs switch
         {
             // An expression-bodied lambda has no statement to gate on.
@@ -179,7 +353,7 @@ public class WindowTeardownWiringTests
         // the first statement that does work, where a preceding early-return
         // guard or a Stop call is not work.
         var statements = body.Statements;
-        var gate = statements.Select((st, i) => (st, i)).FirstOrDefault(x => IsClosedGuard(x.st));
+        var gate = statements.Select((st, i) => (st, i)).FirstOrDefault(x => IsClosedGuard(x.st, flag));
         if (gate.st is null) return false;
 
         var firstWorking = statements.TakeWhile(IsPrelude).Count();
@@ -208,21 +382,41 @@ public class WindowTeardownWiringTests
             .ToList();
     }
 
-    [Fact]
-    public void EverySubscriptionIsOwnedByTheWindowOrSurvivesItsClose()
+    /// <summary>
+    /// Every class in the shell that derives from Window, found rather than
+    /// named. The base type is matched as written, so a window declared
+    /// through an alias would be missed; that is the residual hole, and it is
+    /// a smaller one than a hand-kept list of files.
+    /// </summary>
+    private static List<(string Resource, string Class)> WindowClasses() =>
+        ShellSource.AllShellSources()
+            .SelectMany(file => file.Root.DescendantNodes()
+                .OfType<ClassDeclarationSyntax>()
+                .Where(IsWindowClass)
+                .Select(cls => (file.Resource, Class: cls.Identifier.ValueText)))
+            .ToList();
+
+    private static bool IsWindowClass(ClassDeclarationSyntax cls) =>
+        cls.BaseList is { } bases
+        && bases.Types.Any(t => t.Type.ToString() is "Window" or "Microsoft.UI.Xaml.Window");
+
+    [Theory]
+    [MemberData(nameof(CensusedWindows))]
+    public void EverySubscriptionIsOwnedByTheWindowOrSurvivesItsClose(string file)
     {
-        var source = Window();
-        var subscriptions = Subscriptions();
+        var window = Find(file);
+        var source = ShellSource.Load(file);
+        var subscriptions = Subscriptions(source);
 
-        // Load-bearing. Every assertion below is over this list, so a query
-        // that stops matching passes the whole test while reading nothing.
         Assert.True(
-            subscriptions.Count > 40,
-            $"expected MainWindow's event subscriptions to be found, got {subscriptions.Count}");
+            subscriptions.Count >= window.AtLeast,
+            $"expected at least {window.AtLeast} event subscriptions in {window.Class}, got "
+            + $"{subscriptions.Count}; every assertion below is over that list, so a query that "
+            + "stops matching passes the whole test while reading nothing");
 
-        var owned = WindowOwned.Select(x => x.Receiver).ToHashSet(StringComparer.Ordinal);
-        var exempt = Exempt.Select(x => x.Event).ToHashSet(StringComparer.Ordinal);
-        var detached = Unsubscribes()
+        var owned = window.Owned.Select(x => x.Receiver).ToHashSet(StringComparer.Ordinal);
+        var exempt = window.Exempt.Select(x => x.Event).ToHashSet(StringComparer.Ordinal);
+        var detached = Unsubscribes(window, source)
             .Select(u => (u.Event, u.Handler))
             .ToHashSet();
 
@@ -233,51 +427,121 @@ public class WindowTeardownWiringTests
             .Where(s => !owned.Contains(s.Receiver) && !exempt.Contains(s.Event))
             .ToList();
         var unproven = mustProve
-            .Where(s => !detached.Contains((s.Event, s.Handler)) && !IsGated(s, source))
+            .Where(s => !detached.Contains((s.Event, s.Handler)) && !IsGated(s, source, window.ClosedFlag))
             .Select(s => s.Event)
             .Distinct(StringComparer.Ordinal)
             .ToList();
 
         Assert.True(
             unproven.Count == 0,
-            "these subscriptions are to sources that outlive the window and are neither "
-            + "unsubscribed in OnClosedAsync nor gated on _isClosed, so they keep firing at, and "
-            + "keep alive, a window that is tearing down: "
+            $"these {window.Class} subscriptions are to sources that outlive the window and are "
+            + "neither unsubscribed on its close path nor gated on "
+            + (window.ClosedFlag ?? "a teardown latch (it has none)")
+            + ", so they keep firing at, and keep alive, a window that is tearing down: "
             + string.Join(", ", unproven)
-            + ". Unsubscribe it, gate the handler on _isClosed, or -- if the receiver really does "
-            + "die with the window -- add it to WindowOwned with the reason.");
-
-        // Both ways of satisfying the rule have to be live. Without this, a
-        // regression that classified everything as detached (or everything as
-        // gated) would leave the other branch untested and silently rotten.
-        Assert.Contains(mustProve, s => detached.Contains((s.Event, s.Handler)));
-        Assert.Contains(mustProve, s => IsGated(s, source));
+            + ". Unsubscribe it, gate the handler, or -- if the receiver really does die with the "
+            + "window -- add it to that window's Owned list with the reason.");
     }
 
     /// <summary>
-    /// The allow-list has to stay a description of the file. An entry whose
+    /// Both ways of satisfying the census have to stay live. Without this, a
+    /// regression that classified everything as detached (or everything as
+    /// gated) would leave the other branch untested and silently rotten.
+    ///
+    /// Asserted on MainWindow because it is the window that uses both. A
+    /// window whose every receiver dies with it proves neither, and demanding
+    /// it there would be demanding teardown code with nothing to tear down.
+    /// </summary>
+    [Fact]
+    public void BothWaysOfProvingASubscriptionSafeAreExercised()
+    {
+        var source = ShellSource.Load(MainWindow.File);
+        var owned = MainWindow.Owned.Select(x => x.Receiver).ToHashSet(StringComparer.Ordinal);
+        var exempt = MainWindow.Exempt.Select(x => x.Event).ToHashSet(StringComparer.Ordinal);
+        var detached = Unsubscribes(MainWindow, source).Select(u => (u.Event, u.Handler)).ToHashSet();
+
+        var mustProve = Subscriptions(source)
+            .Where(s => !owned.Contains(s.Receiver) && !exempt.Contains(s.Event))
+            .ToList();
+
+        Assert.Contains(mustProve, s => detached.Contains((s.Event, s.Handler)));
+        Assert.Contains(mustProve, s => IsGated(s, source, MainWindow.ClosedFlag));
+    }
+
+    /// <summary>
+    /// Every window in the shell is under census.
+    ///
+    /// This is the assertion that stops the file from silently narrowing to
+    /// whatever it happened to cover on the day it was written, which is
+    /// exactly what happened between #694 and #710: MainWindow was censused,
+    /// ShaderPickerWindow -- native surface, child process, autoplay feed --
+    /// was not, and nothing said so.
+    /// </summary>
+    [Fact]
+    public void EveryWindowInTheShellIsUnderCensus()
+    {
+        var found = WindowClasses();
+        Assert.True(
+            found.Count > 0,
+            "no Window-derived class found in the shell sources; this scan has stopped matching "
+            + "and every window would now pass by not being seen");
+
+        var declared = Windows.Select(w => w.Class).ToHashSet(StringComparer.Ordinal);
+        var uncensused = found
+            .Where(f => !declared.Contains(f.Class))
+            .Select(f => $"{f.Class} ({f.Resource})")
+            .ToList();
+        Assert.True(
+            uncensused.Count == 0,
+            "these windows are outside the teardown census, so nothing checks that what they "
+            + "subscribe to is either theirs to lose or taken back on close: "
+            + string.Join(", ", uncensused)
+            + ". Add a Censused entry naming its close path and who owns its event sources.");
+
+        var vanished = Windows
+            .Where(w => found.All(f => f.Class != w.Class))
+            .Select(w => w.Class)
+            .ToList();
+        Assert.True(
+            vanished.Count == 0,
+            "these censused classes no longer derive from Window, so their entries describe "
+            + "nothing: " + string.Join(", ", vanished));
+    }
+
+    /// <summary>
+    /// The declarations have to stay a description of the file. An entry whose
     /// receiver no longer subscribes to anything is a claim nobody is checking,
     /// and the next receiver to be spelled that way inherits an exemption
     /// nobody granted it.
     /// </summary>
-    [Fact]
-    public void TheOwnershipDeclarationsStillDescribeTheFile()
+    [Theory]
+    [MemberData(nameof(CensusedWindows))]
+    public void TheOwnershipDeclarationsStillDescribeTheFile(string file)
     {
-        var subscriptions = Subscriptions();
+        var window = Find(file);
+        var source = ShellSource.Load(file);
+        var subscriptions = Subscriptions(source);
         var receivers = subscriptions.Select(s => s.Receiver).ToHashSet(StringComparer.Ordinal);
         var events = subscriptions.Select(s => s.Event).ToHashSet(StringComparer.Ordinal);
 
-        var staleOwners = WindowOwned.Where(x => !receivers.Contains(x.Receiver)).Select(x => x.Receiver);
-        var staleExempt = Exempt.Where(x => !events.Contains(x.Event)).Select(x => x.Event);
+        var staleOwners = window.Owned.Where(x => !receivers.Contains(x.Receiver)).Select(x => x.Receiver);
+        var staleExempt = window.Exempt.Where(x => !events.Contains(x.Event)).Select(x => x.Event);
         var stale = staleOwners.Concat(staleExempt).ToList();
 
         Assert.True(
             stale.Count == 0,
-            "these entries no longer match any subscription in MainWindow and should be removed, "
-            + "so the list keeps meaning what it says: " + string.Join(", ", stale));
+            $"these entries no longer match any subscription in {window.Class} and should be "
+            + "removed, so the list keeps meaning what it says: " + string.Join(", ", stale));
 
-        Assert.All(WindowOwned, x => Assert.False(string.IsNullOrWhiteSpace(x.Why)));
-        Assert.All(Exempt, x => Assert.False(string.IsNullOrWhiteSpace(x.Why)));
+        Assert.All(window.Owned, x => Assert.False(string.IsNullOrWhiteSpace(x.Why)));
+        Assert.All(window.Exempt, x => Assert.False(string.IsNullOrWhiteSpace(x.Why)));
+
+        // A latch that no longer exists would silently turn every gated
+        // handler into an ungated one that still reads as gated here.
+        if (window.ClosedFlag is { } flag) source.Field(flag);
+
+        // Same for the declared close-path helpers.
+        foreach (var method in window.ClosePath) source.Method(method);
     }
 
     /// <summary>
@@ -294,28 +558,30 @@ public class WindowTeardownWiringTests
     [Fact]
     public void TheSystemColorSchemeHandlerIsBothDetachedAndGated()
     {
-        var source = Window();
+        var source = ShellSource.Load(MainWindow.File);
         const string Event = "_systemUiSettings.ColorValuesChanged";
         const string Handler = "OnSystemColorValuesChanged";
 
         // Named, not inline: an anonymous lambda cannot be unsubscribed at all.
-        var subscribed = Subscriptions().Where(s => s.Event == Event).ToList();
+        var subscribed = Subscriptions(source).Where(s => s.Event == Event).ToList();
         Assert.True(
             subscribed.Count == 1 && subscribed[0].Handler == Handler,
             $"expected one `{Event} += {Handler}`; a lambda here cannot be detached");
-        Assert.Contains((Event, Handler), Unsubscribes().Select(u => (u.Event, u.Handler)));
+        Assert.Contains(
+            (Event, Handler),
+            Unsubscribes(MainWindow, source).Select(u => (u.Event, u.Handler)));
 
         var method = source.Method(Handler);
         Assert.True(
-            method.Body!.Statements.Any(IsClosedGuard),
-            $"{Handler} must bail on _isClosed before it reads anything");
+            method.Body!.Statements.Any(s => IsClosedGuard(s, MainWindow.ClosedFlag)),
+            $"{Handler} must bail on {MainWindow.ClosedFlag} before it reads anything");
 
         // The enqueued body is the half that runs late, and it is a separate
         // scope: the entry gate above says nothing about the turn it runs on.
         var enqueued = method.Call("DispatcherQueue.TryEnqueue").ArgumentList.Arguments[0].Expression;
         var queued = Assert.IsType<ParenthesizedLambdaExpressionSyntax>(enqueued).Block!.Statements;
 
-        var gateIndex = queued.TakeWhile(s => !IsClosedGuard(s)).Count();
+        var gateIndex = queued.TakeWhile(s => !IsClosedGuard(s, MainWindow.ClosedFlag)).Count();
         var callIndex = queued
             .TakeWhile(s => !s.Calls("Ghostty.Interop.NativeMethods.AppSetColorScheme").Any())
             .Count();
@@ -347,7 +613,8 @@ public class WindowTeardownWiringTests
     [Fact]
     public void TheDispatcherDrivenTimersAreStoppedByTheClose()
     {
-        var statements = Window().Method("OnClosedAsync").Body!.Statements;
+        var source = ShellSource.Load(MainWindow.File);
+        var statements = source.Method("OnClosedAsync").Body!.Statements;
 
         int IndexOfCall(string call) => statements.TakeWhile(s => !s.Calls(call).Any()).Count();
 
@@ -375,8 +642,7 @@ public class WindowTeardownWiringTests
         // Each tick is gated as well, for the one already queued when the stop
         // lands. Read off the subscriptions rather than by searching the file,
         // so a tick handler moved elsewhere is still the one being checked.
-        var source = Window();
-        var subscriptions = Subscriptions();
+        var subscriptions = Subscriptions(source);
         // The picker poll subscribes through the local it captures rather than
         // through the field, so that a tick queued by a previous poll cannot
         // stop the one that replaced it. That is why this names poll.Tick.
@@ -385,9 +651,100 @@ public class WindowTeardownWiringTests
             var ticks = subscriptions.Where(s => s.Event == timer).ToList();
             Assert.True(ticks.Count == 1, $"expected one {timer} subscription, found {ticks.Count}");
             Assert.True(
-                IsGated(ticks[0], source),
+                IsGated(ticks[0], source, MainWindow.ClosedFlag),
                 $"{timer}'s handler must return early on _isClosed: Stop does not recall a tick "
                 + "already queued on the dispatcher");
         }
     }
+
+    /// <summary>
+    /// ThemePreviewService, the one gap #694 named and did not close.
+    ///
+    /// It is not an event source the census can see: it owns a named-pipe
+    /// server running on a background task, and the close only detached the
+    /// window from its ListThemesRequested. The task then ran for the life of
+    /// the process, holding the per-process pipe name with nobody left
+    /// listening to what arrived on it. Disposing cancels the loop, waits for
+    /// it, and drops the subscribers, so the window is neither rooted by it
+    /// nor outlived by it.
+    /// </summary>
+    [Fact]
+    public void TheThemePreviewServiceIsDisposedByTheClose()
+    {
+        var source = ShellSource.Load(MainWindow.File);
+        var statements = source.Method("OnClosedAsync").Body!.Statements;
+
+        var disposed = statements.TakeWhile(s => !s.Calls("_themePreview.Dispose").Any()).Count();
+        Assert.True(
+            disposed < statements.Count,
+            "OnClosedAsync must dispose _themePreview: unsubscribing alone leaves its pipe server "
+            + "task running for the life of the process");
+    }
+
+    /// <summary>
+    /// The shader picker's close, in the two places the census cannot reach.
+    ///
+    /// The picker is the only other window that owns a native surface, and it
+    /// owns a placeholder child process and an autoplay feed with it. None of
+    /// the three is freed by the visual tree going away, and the order matters
+    /// twice over: the feed writes into the surface, so it has to stop before
+    /// the surface is freed; and the latch has to be set before the teardown,
+    /// because a SelectionChanged arriving during the close reaches
+    /// EnsurePreview, and a surface built after DisposePreview has run would be
+    /// owned by nobody at all.
+    /// </summary>
+    [Fact]
+    public void TheShaderPickerCloseFreesTheSurfaceTheChildAndTheFeed()
+    {
+        var source = ShellSource.Load(ShaderPickerWindow.File);
+
+        var closing = Assert.IsType<BlockSyntax>(CloseScopes(ShaderPickerWindow, source)[0]).Statements;
+        var latch = closing.TakeWhile(s => !SetsLatch(s, ShaderPickerWindow.ClosedFlag)).Count();
+        var handoff = closing.TakeWhile(s => !s.Calls("DisposePreview").Any()).Count();
+        Assert.True(latch < closing.Count, "the Closed handler must latch _closed");
+        Assert.True(handoff < closing.Count, "the Closed handler must call DisposePreview");
+        Assert.True(latch < handoff, "the latch is what EnsurePreview reads, so it has to be set first");
+
+        var teardown = source.Method("DisposePreview").Body!.Statements;
+        int IndexOfCall(string call) => teardown.TakeWhile(s => !s.Calls(call).Any()).Count();
+        var feed = IndexOfCall("_feed?.Dispose");
+        var surface = IndexOfCall("_preview?.DisposeSurface");
+        Assert.True(feed < teardown.Count, "DisposePreview must dispose the autoplay feed");
+        Assert.True(
+            surface < teardown.Count,
+            "DisposePreview must free the preview surface; the placeholder child process goes with it");
+        Assert.True(
+            feed < surface,
+            "the feed writes VT into the preview, so it has to stop before the surface is freed");
+
+        var ensure = source.Method("EnsurePreview").Body!.Statements;
+        var gate = ensure.TakeWhile(s => !IsClosedGuard(s, ShaderPickerWindow.ClosedFlag)).Count();
+        var creation = ensure
+            .TakeWhile(s => !s.DescendantNodesAndSelf()
+                .OfType<ObjectCreationExpressionSyntax>()
+                .Any(o => o.Type.ToString().EndsWith("TerminalControl", StringComparison.Ordinal)))
+            .Count();
+        Assert.True(gate < ensure.Count, "EnsurePreview must return early once the window has closed");
+        Assert.True(creation < ensure.Count, "expected EnsurePreview to construct the preview terminal");
+        Assert.True(
+            gate < creation,
+            "the latch must be read before a native surface and its child process are created: "
+            + "DisposePreview has already run, so nothing would own them");
+    }
+
+    /// <summary>
+    /// <c>_closed = true;</c>, as a statement of its own.
+    /// </summary>
+    private static bool SetsLatch(StatementSyntax statement, string? flag) =>
+        flag is not null
+        && statement is ExpressionStatementSyntax
+        {
+            Expression: AssignmentExpressionSyntax
+            {
+                Left: IdentifierNameSyntax left,
+                Right: LiteralExpressionSyntax right
+            }
+        }
+        && left.Identifier.Text == flag
+        && right.IsKind(SyntaxKind.TrueLiteralExpression);
 }

--- a/windows/Ghostty/Assets/Shaders/README.md
+++ b/windows/Ghostty/Assets/Shaders/README.md
@@ -36,7 +36,9 @@ CC BY-NC-SA, GPL) must not be added.
 2. Add an entry to `shaders.json`.
 3. Add the license text under `LICENSES/` if it is not original work,
    and an entry in the repo's `THIRD_PARTY_NOTICES.md`.
-4. Run `just gallery-verify` and make sure it reports PASS.
+4. Run `just gallery-lint` (seconds, no GPU and no zioshade build: it is
+   the parse half of the gate, and it is what CI runs on every push).
+5. Run `just gallery-verify` and make sure it reports PASS.
 
 The source must compile under `glslang` verbatim: the gate feeds the same
 file to our compiler and to the reference one, so anything glslang refuses

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1436,11 +1436,24 @@ public sealed partial class MainWindow : Window
         // pointer _host.Dispose is about to free at the end of this method.
         _systemUiSettings.ColorValuesChanged -= OnSystemColorValuesChanged;
         // The preview service owns a named-pipe server on a background task,
-        // so it raises this from outside the window's own lifetime. The task
-        // itself outlives this window either way -- nothing disposes the
-        // service -- but detaching keeps a LIST_THEMES arriving afterwards
-        // from starting a picker on a window whose surfaces are gone.
+        // so it raises this from outside the window's own lifetime. Detaching
+        // keeps a LIST_THEMES arriving afterwards from starting a picker on a
+        // window whose surfaces are gone; disposing is what ends the task,
+        // which otherwise ran for the life of the process, holding the
+        // per-process pipe name with nobody listening on it. The cancel is
+        // observed by the awaits inside the accept loop, so the synchronous
+        // wait here is bounded.
+        //
+        // The service is per window and the pipe name is per process, so in a
+        // multi-window session only the first one to start ever owns the pipe
+        // (FirstPipeInstance stands the others down at construction). Closing
+        // that window therefore leaves the session with no server rather than
+        // with one whose only subscriber has detached. Both states are broken
+        // for `+list-themes`; this one at least does not leak. The real fix is
+        // to own the service where the bootstrap host lives, the same shape as
+        // the app-targeted config actions, which App owns for that reason.
         _themePreview.ListThemesRequested -= OnListThemesRequested;
+        _themePreview.Dispose();
 
         // CompositionTarget.Rendering is static, so a window closed before
         // its first composed frame would otherwise stay subscribed.

--- a/windows/Ghostty/Settings/SettingsWindow.xaml.cs
+++ b/windows/Ghostty/Settings/SettingsWindow.xaml.cs
@@ -138,7 +138,13 @@ internal sealed partial class SettingsWindow : Window
 
     private void OnClosed(object sender, WindowEventArgs args)
     {
+        // Stop is not enough on its own: the timer runs against the
+        // DispatcherQueue, which outlives this window, and a tick queued in
+        // the same turn as the stop still arrives afterwards and re-enters
+        // ApplyQuery against a torn-down tree. Detaching is what turns that
+        // one away, since the raise reads the invocation list.
         _searchTimer.Stop();
+        _searchTimer.Tick -= OnSearchTimerTick;
 
         // Unsubscribe providers from ConfigChanged to avoid leaking
         // event subscriptions back to the long-lived ConfigService.


### PR DESCRIPTION
Closes #709. Closes #710.

## #709: nothing in CI parses GLSL

`active` was a GLSL reserved word sitting in two shipped shaders until
#701. The trap is still open for `filter`, `input`, `output`, `union`,
`resource` and the rest of section 3.6: zioshade's frontend accepts them,
glslang does not, and the only thing that would catch it needs a built
zioshade CLI, glslang, spirv-cross and an ssh-reachable Windows box, run
by hand.

Adds the hermetic half only: `just gallery-lint` runs prefix + shader
through `glslang -V -S frag` for all 16 shaders. No zioshade, no
spirv-cross, no Windows box, seconds to run. `glslang` and `just` are
added to the devShell (`just` was missing entirely, so `nix develop -c
just <recipe>` would not have resolved), and a `gallery-lint` job runs it
on every push.

On failure it rewrites glslang's temp path back to the real shader path
and prints the prefix line count, because the line numbers are counted in
the concatenation.

**One judgment call worth your eye:** every other job in `test.yml` is
gated to `github.repository == 'ghostty-org/ghostty'` (directly or via
`needs: skip`), so on this fork the whole Test workflow resolves to
skipped: 55 of the last 60 runs. Gating this job the same way would make
it dead on arrival, and the gallery only exists on the fork. It therefore
runs on `ubuntu-latest` with `install-nix-action` + `cachix-action`
(skipPush, so a missing token is fine) rather than the namespace runners,
which the fork's own workflows suggest are not available here. The
reasoning is in a comment above the job. Flip it if the fork does have
those runners.

Evidence: `just gallery-lint` gives `glslang: 16 pass, 0 fail`, exit 0.
Renaming a local in `scanline.glsl` to `filter` gives exit 1 with
`'filter' : Reserved word` and the real file path.

## #710: the census saw one window

`WindowTeardownWiringTests` checked `MainWindow` alone, by name.
`ShaderPickerWindow` owns a native surface, a child process and an
autoplay feed and was outside it.

The census now finds its own subjects: `ShellSource.AllShellSources()`
parses every embedded shell source and the test collects every class
whose base list names `Window`, then fails if any of them is missing from
the table. All five are declared: MainWindow, ShaderPickerWindow,
SettingsWindow, AboutWindow, InspectorWindow. Each entry carries its
teardown latch, extra close-path methods, a minimum subscription count
and its owned/exempt lists, and the close path is read off the window's
own `Closed +=` rather than a hardcoded method name.

Two real gaps fell out of widening it:

- **ThemePreviewService was never disposed.** #705 did not cover this (it
  is the deinit liveness check plus a doc fix and never touches
  `_themePreview`); MainWindow's own comment said nothing disposed the
  service. Now disposed in the close path, pinned by a test. The comment
  is honest about the multi-window consequence: the pipe name is per
  process, so closing the owning window leaves the session with no server
  rather than one nobody listens to. Both are broken for `+list-themes`;
  this one does not leak. The real fix is app-level ownership, the same
  shape as #718.
- **SettingsWindow stopped its search timer without detaching the tick,**
  and `Stop` does not recall a tick already queued on the dispatcher.
  Exempting it would have been inventing a claim, so it is fixed.

## Verification

Box, `dotnet test windows\Ghostty.Tests`:

- baseline on `origin/windows`: 2247 passed
- with this branch: **2291 passed, 0 failed, 1 skipped**

Rebased onto #718 after it landed. One fix was needed for it: a comment
here named `OpenConfigRequested`, which #718's new ownership test forbids
outside `App` (its own message says to reword the comment), so it now
describes the shape without naming the event.