### PR TITLE
app: own the theme preview server on App, and route it to the active window

### DIFF
--- a/windows/Ghostty.Core/Windows/ActiveWindowTarget.cs
+++ b/windows/Ghostty.Core/Windows/ActiveWindowTarget.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+
+namespace Ghostty.Core.Windows;
+
+/// <summary>
+/// Picks the window a process-wide request should act on. Pure, and public
+/// for the same reason <c>PipeServerRetryPolicy</c> is: the decision belongs
+/// to a service the test project cannot construct (it does not reference the
+/// WinUI shell at all), so leaving it inline in the shell means it is never
+/// exercised by anything but a human with two windows open.
+///
+/// The rule is "the window the user last looked at, if it can still take the
+/// request; otherwise any other that can". Falling back matters more than it
+/// looks: the last-activated window is remembered across its own close on
+/// some paths, and a request routed to it then reaches a window whose
+/// surfaces are already gone.
+/// </summary>
+public static class ActiveWindowTarget
+{
+    /// <summary>
+    /// <paramref name="lastActivated"/> when it passes
+    /// <paramref name="eligible"/>, otherwise the first of
+    /// <paramref name="all"/> that does, otherwise null.
+    /// </summary>
+    /// <param name="lastActivated">
+    /// The window that most recently received activation, or null when the
+    /// process has never had one (or the last one closed).
+    /// </param>
+    /// <param name="all">Every live window, in no particular order.</param>
+    /// <param name="eligible">
+    /// Whether a window can take the request right now. Both halves are
+    /// filtered through it, so an ineligible <paramref name="lastActivated"/>
+    /// does not short-circuit the search.
+    /// </param>
+    public static T? Choose<T>(T? lastActivated, IEnumerable<T> all, Func<T, bool> eligible)
+        where T : class
+    {
+        ArgumentNullException.ThrowIfNull(all);
+        ArgumentNullException.ThrowIfNull(eligible);
+
+        if (lastActivated is not null && eligible(lastActivated)) return lastActivated;
+
+        foreach (var candidate in all)
+        {
+            if (candidate is null) continue;
+            // Skipped rather than returned: it already failed the predicate
+            // above, and the enumeration is the only place it can reappear.
+            if (ReferenceEquals(candidate, lastActivated)) continue;
+            if (eligible(candidate)) return candidate;
+        }
+
+        return null;
+    }
+}

--- a/windows/Ghostty.Tests/Windows/ActiveWindowTargetTests.cs
+++ b/windows/Ghostty.Tests/Windows/ActiveWindowTargetTests.cs
@@ -17,8 +17,11 @@ public sealed class ActiveWindowTargetTests
 {
     private sealed record FakeWindow(string Name, bool Quake = false, bool Closing = false);
 
-    // The shell's predicate, verbatim in shape: a hidden quake window cannot
-    // show a picker, and a closing one has no surfaces left.
+    // The shell's predicate, verbatim in shape. The closing half is the one
+    // that fires in the shell; the quake half is a backstop, since the shell
+    // keeps the quake window out of the registry and out of last-activated
+    // both. This helper lives in Core and can see neither, so it has to
+    // answer for a quake window it is handed anyway.
     private static bool Eligible(FakeWindow w) => !w.Quake && !w.Closing;
 
     private static FakeWindow? Choose(FakeWindow? lastActivated, params FakeWindow[] all) =>
@@ -60,8 +63,10 @@ public sealed class ActiveWindowTargetTests
     [Fact]
     public void AQuakeOnlySessionChoosesNothing()
     {
-        // The quake window stays in the registry while hidden, so "some window
-        // exists" is not the same question as "some window can take this".
+        // "Some window exists" is not the same question as "some window can
+        // take this". The shell excludes the quake window upstream, so this
+        // is the backstop being exercised rather than a state the shell
+        // produces.
         var quake = new FakeWindow("quake", Quake: true);
 
         Assert.Null(Choose(quake, quake));

--- a/windows/Ghostty.Tests/Windows/ActiveWindowTargetTests.cs
+++ b/windows/Ghostty.Tests/Windows/ActiveWindowTargetTests.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using Ghostty.Core.Windows;
+using Xunit;
+
+namespace Ghostty.Tests.Windows;
+
+/// <summary>
+/// Routing a process-wide request to one window.
+///
+/// The real callers pass MainWindow, which this project cannot reference, so
+/// the window here is a record with the two flags the shell's predicate reads.
+/// That is the whole reason the decision lives in Ghostty.Core: inline in App
+/// it would only ever be exercised by a person with two windows open.
+/// </summary>
+public sealed class ActiveWindowTargetTests
+{
+    private sealed record FakeWindow(string Name, bool Quake = false, bool Closing = false);
+
+    // The shell's predicate, verbatim in shape: a hidden quake window cannot
+    // show a picker, and a closing one has no surfaces left.
+    private static bool Eligible(FakeWindow w) => !w.Quake && !w.Closing;
+
+    private static FakeWindow? Choose(FakeWindow? lastActivated, params FakeWindow[] all) =>
+        ActiveWindowTarget.Choose(lastActivated, all, Eligible);
+
+    [Fact]
+    public void NoWindowsAtAllChoosesNothing()
+    {
+        Assert.Null(Choose(null));
+    }
+
+    [Fact]
+    public void TheOnlyEligibleWindowIsChosen()
+    {
+        var only = new FakeWindow("only");
+        Assert.Same(only, Choose(null, only));
+    }
+
+    [Fact]
+    public void TheLastActivatedWindowWinsOverListOrder()
+    {
+        var first = new FakeWindow("first");
+        var last = new FakeWindow("last");
+
+        // Enumeration order would hand back `first`; the point of tracking
+        // activation is that it does not.
+        Assert.Same(last, Choose(last, first, last));
+    }
+
+    [Fact]
+    public void AClosingLastActivatedWindowGivesWayToTheNextEligibleOne()
+    {
+        var closing = new FakeWindow("closing", Closing: true);
+        var open = new FakeWindow("open");
+
+        Assert.Same(open, Choose(closing, closing, open));
+    }
+
+    [Fact]
+    public void AQuakeOnlySessionChoosesNothing()
+    {
+        // The quake window stays in the registry while hidden, so "some window
+        // exists" is not the same question as "some window can take this".
+        var quake = new FakeWindow("quake", Quake: true);
+
+        Assert.Null(Choose(quake, quake));
+        Assert.Null(Choose(null, quake));
+    }
+
+    [Fact]
+    public void AClosingLastActivatedWindowWithNoEligibleRestChoosesNothing()
+    {
+        // The failure this guards: falling back to the last-activated window
+        // anyway because it is the only one there is.
+        var closing = new FakeWindow("closing", Closing: true);
+        var quake = new FakeWindow("quake", Quake: true);
+
+        Assert.Null(Choose(closing, closing, quake));
+    }
+
+    [Fact]
+    public void ALastActivatedWindowMissingFromTheListIsStillChosenWhenEligible()
+    {
+        // The two arguments come from different places in App (a field and a
+        // dictionary's values), and there is no moment where they are read
+        // atomically. Preferring the field when it is eligible is the
+        // documented rule, not an accident of it appearing in the list.
+        var detached = new FakeWindow("detached");
+        var other = new FakeWindow("other");
+
+        Assert.Same(detached, Choose(detached, other));
+    }
+
+    [Fact]
+    public void TheEligiblePredicateIsAskedAboutTheLastActivatedWindowOnlyOnce()
+    {
+        // The fallback scan skips the last-activated window rather than
+        // re-testing it. A predicate that is expensive or that changes its
+        // answer would otherwise be able to return a window it just rejected.
+        var last = new FakeWindow("last", Closing: true);
+        var asked = new List<string>();
+
+        var chosen = ActiveWindowTarget.Choose<FakeWindow>(
+            last,
+            new[] { last },
+            w => { asked.Add(w.Name); return Eligible(w); });
+
+        Assert.Null(chosen);
+        Assert.Equal(new[] { "last" }, asked);
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/ThemePreviewOwnershipWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/ThemePreviewOwnershipWiringTests.cs
@@ -36,9 +36,11 @@ namespace Ghostty.Tests.Wiring;
 /// what windows 2..N were.
 ///
 /// What this cannot prove: that no window reaches the request through some
-/// further indirection. <see cref="TheHandlerRoutesTheRequestRatherThanRebroadcastingIt"/>
-/// closes the one shape -- App re-raising an event of its own -- that is cheap
-/// to write and invisible in review; the rest is left to the reader.
+/// further indirection. <see cref="TheHandlerShowsThePickerOnTheOneWindowItChose"/>
+/// closes the shape that is cheap to write and invisible in review -- App
+/// handling the request once and then reaching more than one window with it --
+/// by pinning what the handler must do rather than listing what it must not.
+/// The rest is left to the reader.
 /// </summary>
 public class ThemePreviewOwnershipWiringTests
 {
@@ -47,6 +49,18 @@ public class ThemePreviewOwnershipWiringTests
 
     /// <summary>The service whose constructor claims the pipe name.</summary>
     private const string ServiceType = "ThemePreviewService";
+
+    /// <summary>The field App holds the one service in.</summary>
+    private const string ServiceField = "_themePreview";
+
+    /// <summary>The member that puts a window into the registry.</summary>
+    private const string Registration = "NoteRegularWindowRegistered";
+
+    /// <summary>The registry a window is registered into.</summary>
+    private const string Registry = "WindowsByRoot";
+
+    /// <summary>The one verb a routed request performs on its window.</summary>
+    private const string Picker = "ShowInlineThemePicker";
 
     /// <summary>The file that owns the one construction and the one subscription.</summary>
     private const string App = ".Ghostty.App.xaml.cs";
@@ -120,14 +134,139 @@ public class ThemePreviewOwnershipWiringTests
     };
 
     /// <summary>
-    /// Every `new ThemePreviewService(...)` under <paramref name="scope"/>,
+    /// Every construction of the service under <paramref name="scope"/>,
     /// matched on the simple type name so a fully-qualified spelling counts.
+    ///
+    /// Both spellings of `new`. A target-typed `new(...)` parses as
+    /// ImplicitObjectCreationExpressionSyntax, which is a sibling of
+    /// ObjectCreationExpressionSyntax under BaseObjectCreationExpressionSyntax
+    /// rather than a subtype of it, so a filter on the latter reads a file
+    /// full of `= new()` -- which this codebase writes freely -- as
+    /// constructing nothing at all. It carries no type of its own either, so
+    /// the type has to come from what it initialises: a declaration that
+    /// names it, or a field or property in the same file that does.
     /// </summary>
-    private static List<ObjectCreationExpressionSyntax> Constructions(SyntaxNode scope) =>
-        scope.DescendantNodes()
-            .OfType<ObjectCreationExpressionSyntax>()
-            .Where(n => n.Type.ToString().Split('.').Last() == ServiceType)
+    private static List<BaseObjectCreationExpressionSyntax> Constructions(SyntaxNode scope)
+    {
+        var typed = MembersDeclaredAsTheService(scope);
+
+        return scope.DescendantNodes()
+            .OfType<BaseObjectCreationExpressionSyntax>()
+            .Where(n => n is ObjectCreationExpressionSyntax spelled
+                ? SimpleName(spelled.Type.ToString()) == ServiceType
+                : BuildsTheService(n, typed))
             .ToList();
+    }
+
+    /// <summary>The type name with any qualifier and `?` dropped.</summary>
+    private static string SimpleName(string type) =>
+        type.Trim().TrimEnd('?').Split('.').Last();
+
+    /// <summary>
+    /// The fields and properties in this file declared as the service, which
+    /// is what gives `_themePreview = new(...)` a type to be read against.
+    /// </summary>
+    private static HashSet<string> MembersDeclaredAsTheService(SyntaxNode scope)
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var field in scope.DescendantNodes().OfType<FieldDeclarationSyntax>())
+            if (SimpleName(field.Declaration.Type.ToString()) == ServiceType)
+                foreach (var variable in field.Declaration.Variables)
+                    names.Add(variable.Identifier.ValueText);
+
+        foreach (var property in scope.DescendantNodes().OfType<PropertyDeclarationSyntax>())
+            if (SimpleName(property.Type.ToString()) == ServiceType)
+                names.Add(property.Identifier.ValueText);
+
+        return names;
+    }
+
+    /// <summary>
+    /// Whether a target-typed `new(...)` is building the service: either the
+    /// declaration it initialises names the type, or it is assigned to a
+    /// member of this file that was declared with it.
+    /// </summary>
+    private static bool BuildsTheService(SyntaxNode creation, HashSet<string> typed)
+    {
+        if (creation.Parent is EqualsValueClauseSyntax { Parent: VariableDeclaratorSyntax declarator }
+            && declarator.Parent is VariableDeclarationSyntax declaration)
+            return SimpleName(declaration.Type.ToString()) == ServiceType;
+
+        if (creation.Parent is AssignmentExpressionSyntax assignment)
+            return typed.Contains(LastIdentifier(assignment.Left));
+
+        return false;
+    }
+
+    /// <summary>The last identifier of a dotted expression, or empty.</summary>
+    private static string LastIdentifier(ExpressionSyntax expression) => expression switch
+    {
+        MemberAccessExpressionSyntax member => member.Name.Identifier.ValueText,
+        IdentifierNameSyntax name => name.Identifier.ValueText,
+        _ => string.Empty,
+    };
+
+    /// <summary>The last dotted segment of a callee, `?` dropped.</summary>
+    private static string LastSegment(string callee)
+    {
+        var dot = callee.LastIndexOf('.');
+        return (dot < 0 ? callee : callee[(dot + 1)..]).Trim();
+    }
+
+    /// <summary>
+    /// The identifier a call is made on. `target.Show()` and `target?.Show()`
+    /// are the same receiver; a call on anything that is not a plain
+    /// identifier comes back as written, which is enough to fail a
+    /// comparison against one.
+    /// </summary>
+    private static string ReceiverIdentifier(InvocationExpressionSyntax call)
+    {
+        var callee = call.CalleeText();
+        var dot = callee.LastIndexOf('.');
+        return dot < 0 ? string.Empty : callee[..dot].TrimEnd('?', ' ');
+    }
+
+    /// <summary>
+    /// Every call of <paramref name="verb"/> on something that names the
+    /// service. Matched on the receiver rather than on the one field, so an
+    /// accessor handing the service back out is covered by the same rule.
+    /// </summary>
+    private static List<InvocationExpressionSyntax> ServiceCalls(SyntaxNode scope, string verb) =>
+        scope.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(call => LastSegment(call.CalleeText()) == verb
+                && ReceiverIdentifier(call).Contains("themePreview", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+    /// <summary>
+    /// The same rule by text, which is the half that sees a call parked in a
+    /// disabled conditional region. Returns the files that match.
+    /// </summary>
+    private static List<string> ServiceCallText(
+        string verb, IReadOnlyList<(string Tail, string Text)> corpus)
+    {
+        var pattern = new Regex(
+            @"[Tt]hemePreview\w*\s*\??\.\s*" + verb + @"\s*\(", RegexOptions.Compiled);
+        return corpus.Where(f => pattern.IsMatch(f.Text)).Select(f => f.Tail).ToList();
+    }
+
+    /// <summary>
+    /// How many times <paramref name="scope"/> writes the window registry:
+    /// an insert through the indexer, or a mutating dictionary call on it.
+    /// </summary>
+    private static int RegistryWrites(SyntaxNode scope)
+    {
+        var inserts = scope.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Count(a => a.Left is ElementAccessExpressionSyntax element
+                && LastIdentifier(element.Expression) == Registry);
+
+        var mutations = scope.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Count(call => LastSegment(call.CalleeText())
+                    is "Add" or "TryAdd" or "Remove" or "Clear"
+                && ReceiverIdentifier(call).Split('.').Last().TrimEnd('!') == Registry);
+
+        return inserts + mutations;
+    }
 
     /// <summary>
     /// The rule the subscription-shaped guard next door cannot express: the
@@ -169,7 +308,17 @@ public class ThemePreviewOwnershipWiringTests
         // And by text, which is the half that sees a construction parked in a
         // disabled `#if` region. That region ships in the configuration that
         // defines the symbol, and no parse in this file can read it.
-        var pattern = new Regex(@"\bnew\s+(?:[\w]+\s*\.\s*)*" + ServiceType + @"\b", RegexOptions.Compiled);
+        //
+        // Three spellings, because a target-typed `new(...)` never writes the
+        // type next to the `new`: the explicit form, a declaration that names
+        // the type and defers, and an assignment to the field App holds it
+        // in. The alternatives cannot both match one construction, so a count
+        // stays a count.
+        var pattern = new Regex(
+            @"\bnew\s+(?:[\w]+\s*\.\s*)*" + ServiceType + @"\b"
+            + @"|\b" + ServiceType + @"\b\??\s+\w+\s*=\s*new\s*\("
+            + @"|\b" + ServiceField + @"\s*=\s*new\s*\(",
+            RegexOptions.Compiled);
         var mentions = corpus
             .SelectMany(f => pattern.Matches(f.Text).Select(_ => f.Tail))
             .ToList();
@@ -226,7 +375,7 @@ public class ThemePreviewOwnershipWiringTests
             wires.Count == 1,
             $"expected exactly one `+= {ListThemes}` in App; found {wires.Count}. A second "
             + "subscriber opens a second picker on the same request.");
-        Assert.Equal("_themePreview", wires[0].Receiver);
+        Assert.Equal(ServiceField, wires[0].Receiver);
 
         // A method group, so the teardown has something to name. An anonymous
         // lambda cannot be unsubscribed at all, and this subscription lasts as
@@ -294,35 +443,31 @@ public class ThemePreviewOwnershipWiringTests
     }
 
     /// <summary>
-    /// The handler routes the request. It does not raise an event of its own.
+    /// The handler shows the picker on the one window it chose, and on no
+    /// other.
     ///
-    /// The cheapest way to put the defect back without naming the event is a
-    /// relay: App keeps the one real subscription and re-broadcasts through a
-    /// static event that per-window code subscribes to. Every other rule here
-    /// passes, because the event name never leaves App. Refusing a delegate
-    /// invocation inside the handler is not a proof against indirection in
-    /// general -- nothing here can be -- but it is the difference between
-    /// writing the relay by accident and having to route around a test.
+    /// Stated as a shape the handler must have rather than as a list of
+    /// shapes it must not. The defect wearing another name is a fan-out: App
+    /// keeps the one real subscription and reaches every window anyway, by
+    /// re-broadcasting through an event of its own, by calling a delegate it
+    /// stashed, or by looping the registry next to the one legitimate call.
+    /// A blacklist catches whichever spelling it was written against and none
+    /// of the others -- a delegate invoked through a local reads as
+    /// `relay(e)`, which is not the word "Invoke" anywhere. Pinning the
+    /// positive shape (one picker call, on the identifier Choose's result
+    /// went into) refuses the fan-out without having to have anticipated how
+    /// it was spelled, because a second recipient is a second call site by
+    /// construction.
     /// </summary>
     [Fact]
-    public void TheHandlerRoutesTheRequestRatherThanRebroadcastingIt()
+    public void TheHandlerShowsThePickerOnTheOneWindowItChose()
     {
         var app = AppSource();
         var handler = app.Method(Wires(app.Root, SyntaxKind.AddAssignmentExpression).Single().Handler);
 
-        var raised = handler.DescendantNodes().OfType<InvocationExpressionSyntax>()
-            .Where(call => call.CalleeText().EndsWith("Invoke", StringComparison.Ordinal))
-            .ToList();
-        Assert.True(
-            raised.Count == 0,
-            handler.Identifier.ValueText + " raises "
-            + string.Join(", ", raised.Select(r => r.CalleeText()))
-            + ". A process-wide request handled once and then fanned out to a per-window "
-            + "subscriber is the defect this file exists to prevent, wearing another name.");
-
-        // And it picks the window through the decision that has real unit
-        // tests rather than re-deriving one inline, where it would be
-        // exercised only by a person with two windows open.
+        // It picks the window through the decision that has real unit tests
+        // rather than re-deriving one inline, where it would be exercised
+        // only by a person with two windows open.
         var chosen = handler.DescendantNodes().OfType<InvocationExpressionSyntax>()
             .Where(call => call.CalleeText().EndsWith("ActiveWindowTarget.Choose", StringComparison.Ordinal))
             .ToList();
@@ -330,6 +475,160 @@ public class ThemePreviewOwnershipWiringTests
             chosen.Count == 1,
             handler.Identifier.ValueText + " must route through ActiveWindowTarget.Choose; found "
             + chosen.Count + " call(s).");
+
+        // Into a local, which is what the picker call then has to name. A
+        // Choose whose result is used inline leaves nothing for the call
+        // below to be checked against.
+        var target = chosen[0].FirstAncestorOrSelf<VariableDeclaratorSyntax>();
+        Assert.True(
+            target is not null,
+            "the ActiveWindowTarget.Choose result must be held in a local, so the picker call "
+            + "can be checked against it.");
+
+        var shown = handler.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(call => LastSegment(call.CalleeText()) == Picker)
+            .ToList();
+        Assert.True(
+            shown.Count == 1,
+            handler.Identifier.ValueText + " makes " + shown.Count + " " + Picker
+            + " call(s), expected one: " + string.Join(", ", shown.Select(c => c.CalleeText()))
+            + ". One process-wide request opens one picker; a second call site is the fan-out "
+            + "this file exists to prevent.");
+
+        Assert.Equal(target!.Identifier.ValueText, ReceiverIdentifier(shown[0]));
+    }
+
+    /// <summary>
+    /// App is the only place that disposes the service.
+    ///
+    /// The inverse of the census entry that came out with the per-window
+    /// field. Disposing this from a window's close is one line, it compiles,
+    /// and every other rule in this file stays green -- but it ends the
+    /// accept loop and drops the subscription for every window still open,
+    /// which is the defect the ownership move removed. Written against any
+    /// receiver that names the service rather than against the one field, so
+    /// re-exposing the service through an accessor and disposing that is
+    /// caught too.
+    /// </summary>
+    [Fact]
+    public void OnlyAppDisposesTheService()
+    {
+        var corpus = ShellSource.AllUnder(Corpus);
+        Assert.True(
+            corpus.Count > 100,
+            $"expected the shell source corpus under '{Corpus}', got {corpus.Count} files");
+
+        var disposers = corpus
+            .Where(f => ServiceCalls(ShellSource.ParseForCorpusScan(f.Text).Root, "Dispose").Count > 0)
+            .Select(f => f.Tail)
+            .ToList();
+
+        Assert.True(
+            disposers.Count == 1 && disposers[0].EndsWith(App, StringComparison.Ordinal),
+            "expected only App to dispose " + ServiceType + "; found "
+            + (disposers.Count == 0 ? "nobody" : string.Join(", ", disposers))
+            + ". One service serves the process, so a dispose anywhere else takes the pipe "
+            + "away from every window that is still open.");
+
+        // And by text, for the call parked in a disabled `#if` region that no
+        // parse in this file can read.
+        var mentions = ServiceCallText("Dispose", corpus);
+        Assert.True(
+            mentions.Count == 1 && mentions[0].EndsWith(App, StringComparison.Ordinal),
+            "expected one dispose of " + ServiceType + " in the whole corpus, found "
+            + mentions.Count + ": " + string.Join(", ", mentions));
+    }
+
+    /// <summary>
+    /// The pipe opens when a window registers, and not before.
+    ///
+    /// The pipe's existence is the readiness signal: `wintty +list-themes`
+    /// probes for it with File.Exists and counts a successful write as
+    /// delivery, never waiting for an answer. Opened at construction it
+    /// exists within milliseconds of OnLaunched, which returns before the
+    /// message loop can raise any window's Loaded -- so for the whole of
+    /// startup the CLI connects, writes, exits 0, and the app logs that it
+    /// had no window to draw on. The user gets no picker and no fallback
+    /// either, because finding no pipe is exactly what sends the CLI to
+    /// libghostty's own TUI picker.
+    ///
+    /// Pinned to the registration member by NAME, for the reason the
+    /// construction rule pins OnLaunched: anchoring on a landmark proves only
+    /// that the call sits beside that landmark, and both move together for
+    /// free.
+    /// </summary>
+    [Fact]
+    public void TheServerStartsWhenAWindowRegistersAndNotBefore()
+    {
+        var corpus = ShellSource.AllUnder(Corpus);
+        Assert.True(
+            corpus.Count > 100,
+            $"expected the shell source corpus under '{Corpus}', got {corpus.Count} files");
+
+        var starters = corpus
+            .Where(f => ServiceCalls(ShellSource.ParseForCorpusScan(f.Text).Root, "Start").Count > 0)
+            .Select(f => f.Tail)
+            .ToList();
+        Assert.True(
+            starters.Count == 1 && starters[0].EndsWith(App, StringComparison.Ordinal),
+            "expected exactly one file to start " + ServiceType + ", App; found "
+            + (starters.Count == 0 ? "none" : string.Join(", ", starters)));
+
+        var mentions = ServiceCallText("Start", corpus);
+        Assert.True(
+            mentions.Count == 1 && mentions[0].EndsWith(App, StringComparison.Ordinal),
+            "expected one start of " + ServiceType + " in the whole corpus, found "
+            + mentions.Count + ": " + string.Join(", ", mentions));
+
+        var start = Assert.Single(ServiceCalls(AppSource().Root, "Start"));
+        var member = start.Ancestors().OfType<MethodDeclarationSyntax>().FirstOrDefault();
+        Assert.True(
+            member?.Identifier.ValueText == Registration,
+            "the " + ServiceType + " start is in " + (member?.Identifier.ValueText ?? "no method")
+            + ", not " + Registration + ". The pipe may not exist before some window can host a "
+            + "picker, and registering is the moment one can.");
+    }
+
+    /// <summary>
+    /// App is the only writer of the window registry.
+    ///
+    /// Registering a window is what opens the pipe, so a window that inserts
+    /// itself directly registers without the side effect -- and the rule
+    /// above would still find its one start call, in App, in the right
+    /// member, never reached. Reads are left alone: several files resolve
+    /// their owning window through this dictionary and always have.
+    /// </summary>
+    [Fact]
+    public void OnlyAppWritesTheWindowRegistry()
+    {
+        var corpus = ShellSource.AllUnder(Corpus);
+        Assert.True(
+            corpus.Count > 100,
+            $"expected the shell source corpus under '{Corpus}', got {corpus.Count} files");
+
+        var writers = corpus
+            .Where(f => RegistryWrites(ShellSource.ParseForCorpusScan(f.Text).Root) > 0)
+            .Select(f => f.Tail)
+            .ToList();
+        Assert.True(
+            writers.Count == 1 && writers[0].EndsWith(App, StringComparison.Ordinal),
+            "expected only App to write " + Registry + "; found "
+            + (writers.Count == 0 ? "nobody" : string.Join(", ", writers))
+            + ". Registering a window is also what opens the +list-themes pipe, so an insert "
+            + "that goes around App is a window the pipe never learns about.");
+
+        // And by text, for the insert parked in a disabled `#if` region.
+        var pattern = new Regex(
+            @"\b" + Registry + @"\s*\[[^\]]*\]\s*=(?!=)"
+            + @"|\b" + Registry + @"\s*\??\.\s*(?:Add|TryAdd|Remove|Clear)\s*\(",
+            RegexOptions.Compiled);
+        var mentions = corpus
+            .Where(f => !f.Tail.EndsWith(App, StringComparison.Ordinal) && pattern.IsMatch(f.Text))
+            .Select(f => f.Tail)
+            .ToList();
+        Assert.True(
+            mentions.Count == 0,
+            "these files write " + Registry + ": " + string.Join(", ", mentions));
     }
 
     /// <summary>

--- a/windows/Ghostty.Tests/Wiring/ThemePreviewOwnershipWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/ThemePreviewOwnershipWiringTests.cs
@@ -1,0 +1,417 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// Who owns the +list-themes pipe server.
+///
+/// ThemePreviewService serves a named pipe whose name carries the process id,
+/// created with FirstPipeInstance. There is exactly one of that name in the
+/// process, and the second service to ask for it does not get a degraded
+/// server -- it gets an IOException at construction, which the retry policy
+/// correctly calls permanent, and its accept loop exits before it has ever
+/// accepted anything. Constructing one per window therefore left windows 2..N
+/// with a service that was never going to serve, and left the whole feature
+/// riding on window 1. When window 1's close later learned to dispose its
+/// service, the pipe name was released with nothing reclaiming it and
+/// `wintty +list-themes` went dead for the rest of the session instead.
+///
+/// So the shape to hold is one service for the process, built where the
+/// bootstrap host is built and torn down where it is torn down, with the
+/// request routed to whichever window can currently show a picker.
+///
+/// The load-bearing difference from <see cref="AppActionOwnershipWiringTests"/>
+/// is that CONSTRUCTION is the ownership fact here, not subscription. There,
+/// a service per window was fine and only the subscription had to be unique.
+/// Here the singleton is the pipe, which is claimed by the constructor: a
+/// rule that counted only subscriptions would pass a second
+/// `new ThemePreviewService` that subscribes to nothing, and that is exactly
+/// what windows 2..N were.
+///
+/// What this cannot prove: that no window reaches the request through some
+/// further indirection. <see cref="TheHandlerRoutesTheRequestRatherThanRebroadcastingIt"/>
+/// closes the one shape -- App re-raising an event of its own -- that is cheap
+/// to write and invisible in review; the rest is left to the reader.
+/// </summary>
+public class ThemePreviewOwnershipWiringTests
+{
+    /// <summary>The event the pipe server raises when a LIST_THEMES arrives.</summary>
+    private const string ListThemes = "ListThemesRequested";
+
+    /// <summary>The service whose constructor claims the pipe name.</summary>
+    private const string ServiceType = "ThemePreviewService";
+
+    /// <summary>The file that owns the one construction and the one subscription.</summary>
+    private const string App = ".Ghostty.App.xaml.cs";
+
+    /// <summary>The file that declares the service and raises the event.</summary>
+    private const string Service = ".Ghostty.Services.ThemePreviewService.cs";
+
+    /// <summary>
+    /// The only two files that may name the event at all. Deliberately not an
+    /// extensible allow-list -- a third entry is the bug this file exists to
+    /// catch. Both are exempt from the text rule below and therefore read by
+    /// parse instead, which is why
+    /// <see cref="OwnerFilesHideNothingInAConditionalRegion"/> exists.
+    /// </summary>
+    private static readonly string[] Owners = { App, Service };
+
+    /// <summary>
+    /// Every embedded C# source, not one of the blocks the test project
+    /// happens to embed. Two shell files (NativeMethods.cs,
+    /// LibGhosttyBuildInfo.cs) sit outside the Interop.Sources wildcard and
+    /// are re-embedded under Interop.Imports, so a corpus keyed on the
+    /// Sources prefix silently never reads them.
+    /// </summary>
+    private const string Corpus = "Ghostty.Tests.";
+
+    private static ShellSource AppSource() => ShellSource.Load("Ghostty.App.xaml.cs");
+
+    private static ShellSource ServiceSource() =>
+        ShellSource.Load("Services.ThemePreviewService.cs");
+
+    private sealed record Wire(string Event, string Receiver, string Handler);
+
+    /// <summary>
+    /// Every subscription or detach whose left-hand side names the event, read
+    /// off the parsed tree so a mention in a comment or a string is not one.
+    /// Matched on the event's own name rather than on the receiver: a
+    /// subscription taken out through some other spelling of the service is
+    /// the same subscription.
+    /// </summary>
+    private static List<Wire> Wires(SyntaxNode scope, SyntaxKind kind) =>
+        Assignments(scope, kind)
+            .Select(a => new Wire(
+                ListThemes,
+                a.Left is MemberAccessExpressionSyntax m ? Receiver(m.Expression) : "this",
+                a.Right.ToString()))
+            .ToList();
+
+    private static List<AssignmentExpressionSyntax> Assignments(SyntaxNode scope, SyntaxKind kind) =>
+        scope.DescendantNodes()
+            .OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.IsKind(kind) && EventName(a.Left) == ListThemes)
+            .ToList();
+
+    /// <summary>
+    /// The receiver as written, with a null-forgiving operator dropped: `x!`
+    /// and `x` are the same field, and telling them apart would be pinning
+    /// punctuation.
+    /// </summary>
+    private static string Receiver(ExpressionSyntax expression) =>
+        expression is PostfixUnaryExpressionSyntax
+            { RawKind: (int)SyntaxKind.SuppressNullableWarningExpression } bang
+            ? bang.Operand.ToString()
+            : expression.ToString();
+
+    /// <summary>The event's own identifier, receiver stripped.</summary>
+    private static string? EventName(ExpressionSyntax left) => left switch
+    {
+        MemberAccessExpressionSyntax member => member.Name.Identifier.ValueText,
+        IdentifierNameSyntax name => name.Identifier.ValueText,
+        _ => null,
+    };
+
+    /// <summary>
+    /// Every `new ThemePreviewService(...)` under <paramref name="scope"/>,
+    /// matched on the simple type name so a fully-qualified spelling counts.
+    /// </summary>
+    private static List<ObjectCreationExpressionSyntax> Constructions(SyntaxNode scope) =>
+        scope.DescendantNodes()
+            .OfType<ObjectCreationExpressionSyntax>()
+            .Where(n => n.Type.ToString().Split('.').Last() == ServiceType)
+            .ToList();
+
+    /// <summary>
+    /// The rule the subscription-shaped guard next door cannot express: the
+    /// pipe is claimed by the constructor, so a second construction is a
+    /// second claim on it whether or not anybody subscribes to the result.
+    ///
+    /// Checked over the whole corpus twice, by parse and by text, because the
+    /// two owner files are exempt from nothing here and every other file is
+    /// read through a parse that cannot see a disabled conditional region.
+    /// </summary>
+    [Fact]
+    public void TheProcessConstructsExactlyOneThemePreviewService()
+    {
+        var corpus = ShellSource.AllUnder(Corpus);
+
+        // Load-bearing: a prefix that stopped matching would pass this test
+        // while reading nothing at all.
+        Assert.True(
+            corpus.Count > 100,
+            $"expected the shell source corpus under '{Corpus}', got {corpus.Count} files");
+        Assert.Single(corpus.Where(f => f.Tail.EndsWith(App, StringComparison.Ordinal)));
+        Assert.Single(corpus.Where(f => f.Tail.EndsWith(Service, StringComparison.Ordinal)));
+
+        var built = corpus
+            .Where(f => Constructions(ShellSource.ParseForCorpusScan(f.Text).Root).Count > 0)
+            .Select(f => f.Tail)
+            .ToList();
+
+        Assert.True(
+            built.Count == 1 && built[0].EndsWith(App, StringComparison.Ordinal),
+            "expected exactly one file to construct " + ServiceType + ", App; found "
+            + (built.Count == 0 ? "none" : string.Join(", ", built))
+            + ". The constructor is what claims the per-process pipe name, so a second "
+            + "construction gets an IOException and a server loop that stands down before it "
+            + "has served anything -- which is what a service per window was.");
+
+        Assert.Single(Constructions(AppSource().Root));
+
+        // And by text, which is the half that sees a construction parked in a
+        // disabled `#if` region. That region ships in the configuration that
+        // defines the symbol, and no parse in this file can read it.
+        var pattern = new Regex(@"\bnew\s+(?:[\w]+\s*\.\s*)*" + ServiceType + @"\b", RegexOptions.Compiled);
+        var mentions = corpus
+            .SelectMany(f => pattern.Matches(f.Text).Select(_ => f.Tail))
+            .ToList();
+        Assert.True(
+            mentions.Count == 1 && mentions[0].EndsWith(App, StringComparison.Ordinal),
+            "expected one `new " + ServiceType + "` in the whole corpus, found "
+            + mentions.Count + ": " + string.Join(", ", mentions));
+    }
+
+    /// <summary>
+    /// The one construction runs once per process, on the framework's entry
+    /// point, unconditionally.
+    ///
+    /// OnLaunched by name, not by whatever member happens to build the
+    /// bootstrap host. Anchoring on a landmark proves only that the
+    /// construction sits beside that landmark, and both move together for
+    /// free: hoist the pair into one helper, call it from a per-window path,
+    /// and every count here still reads one while a service accumulates per
+    /// window.
+    /// </summary>
+    [Fact]
+    public void TheServiceIsBuiltOnTheStartupPathAndNotUnderAnyBranch()
+    {
+        var app = AppSource();
+        var startup = app.Method("OnLaunched");
+        var construction = Assert.Single(Constructions(app.Root));
+
+        Assert.Same(startup, construction.FirstAncestorOrSelf<MemberDeclarationSyntax>());
+
+        // Unconditional within it, too. A guarded construction on OnLaunched
+        // satisfies a count of one whenever the branch is taken once, and a
+        // condition that reads as "the first window only" selecting more than
+        // one window is the defect this file is about.
+        var nested = construction.Ancestors()
+            .TakeWhile(n => n != startup)
+            .FirstOrDefault(n => n is IfStatementSyntax or SwitchStatementSyntax or ElseClauseSyntax
+                or ForStatementSyntax or ForEachStatementSyntax or WhileStatementSyntax
+                or DoStatementSyntax or TryStatementSyntax or LambdaExpressionSyntax
+                or LocalFunctionStatementSyntax);
+
+        Assert.True(
+            nested is null,
+            $"the {ServiceType} construction is inside a {nested?.Kind()}. It has to happen once, "
+            + "unconditionally, on the one path that builds the bootstrap host.");
+    }
+
+    [Fact]
+    public void AppSubscribesExactlyOnceWithANamedMethod()
+    {
+        var app = AppSource();
+        var wires = Wires(app.Root, SyntaxKind.AddAssignmentExpression);
+
+        Assert.True(
+            wires.Count == 1,
+            $"expected exactly one `+= {ListThemes}` in App; found {wires.Count}. A second "
+            + "subscriber opens a second picker on the same request.");
+        Assert.Equal("_themePreview", wires[0].Receiver);
+
+        // A method group, so the teardown has something to name. An anonymous
+        // lambda cannot be unsubscribed at all, and this subscription lasts as
+        // long as the process.
+        Assert.True(
+            SyntaxFactory.ParseExpression(wires[0].Handler) is IdentifierNameSyntax,
+            $"{ListThemes} must be handled by a named method, not `{wires[0].Handler}`: a lambda "
+            + "cannot be detached, and the shutdown has to take this one back.");
+
+        // Method() asserts there is exactly one, so a detach cannot name a
+        // method that no longer exists and two overloads cannot make "the
+        // handler" ambiguous.
+        var handler = app.Method(wires[0].Handler);
+        Assert.True(
+            handler.Body is not null || handler.ExpressionBody is not null,
+            $"{wires[0].Handler} has no body");
+    }
+
+    /// <summary>
+    /// Both halves of the teardown, before the bootstrap host is freed.
+    ///
+    /// Detach and dispose are separate claims. The detach is what stops a
+    /// LIST_THEMES that beat the cancel from reaching a window that is already
+    /// tearing down; the dispose is what ends the accept loop and releases the
+    /// pipe name. Ordering them before `_bootstrapHost?.Dispose` is the same
+    /// requirement the app-action handlers have: work started during teardown
+    /// must not reach native state the host is about to free.
+    /// </summary>
+    [Fact]
+    public void TheSubscriptionAndTheServiceAreTornDownBeforeTheHostIsFreed()
+    {
+        var app = AppSource();
+        var subscribes = Wires(app.Root, SyntaxKind.AddAssignmentExpression);
+        var detaches = Wires(app.Root, SyntaxKind.SubtractAssignmentExpression);
+
+        // The (event, receiver, handler) triple, not the event: a detach of
+        // null, or of some other handler, satisfies a match on the event
+        // alone.
+        Assert.Equal(subscribes, detaches);
+
+        var shutdown = app.Root.DescendantNodes().OfType<BlockSyntax>()
+            .Where(b => b.Calls("_bootstrapHost?.Dispose").Count == 1)
+            .OrderBy(b => b.Span.Length)
+            .First()
+            .Statements;
+
+        var free = shutdown.TakeWhile(s => !s.Calls("_bootstrapHost?.Dispose").Any()).Count();
+        Assert.True(free < shutdown.Count, "expected the shutdown block to dispose the bootstrap host");
+
+        var detach = shutdown
+            .TakeWhile(s => Assignments(s, SyntaxKind.SubtractAssignmentExpression).Count == 0)
+            .Count();
+        Assert.True(
+            detach < shutdown.Count,
+            $"{ListThemes} is detached somewhere other than the shutdown that disposes the host. "
+            + "It is attached for the life of the process, so nothing else will.");
+        Assert.True(detach < free, $"{ListThemes} must be detached before the ghostty app is freed");
+
+        var dispose = shutdown.TakeWhile(s => !s.Calls("_themePreview.Dispose").Any()).Count();
+        Assert.True(
+            dispose < shutdown.Count,
+            "the shutdown must dispose _themePreview: detaching alone leaves the accept loop "
+            + "running and the per-process pipe name held with nobody listening on it");
+        Assert.True(dispose < free, "the pipe server must be stopped before the ghostty app is freed");
+    }
+
+    /// <summary>
+    /// The handler routes the request. It does not raise an event of its own.
+    ///
+    /// The cheapest way to put the defect back without naming the event is a
+    /// relay: App keeps the one real subscription and re-broadcasts through a
+    /// static event that per-window code subscribes to. Every other rule here
+    /// passes, because the event name never leaves App. Refusing a delegate
+    /// invocation inside the handler is not a proof against indirection in
+    /// general -- nothing here can be -- but it is the difference between
+    /// writing the relay by accident and having to route around a test.
+    /// </summary>
+    [Fact]
+    public void TheHandlerRoutesTheRequestRatherThanRebroadcastingIt()
+    {
+        var app = AppSource();
+        var handler = app.Method(Wires(app.Root, SyntaxKind.AddAssignmentExpression).Single().Handler);
+
+        var raised = handler.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(call => call.CalleeText().EndsWith("Invoke", StringComparison.Ordinal))
+            .ToList();
+        Assert.True(
+            raised.Count == 0,
+            handler.Identifier.ValueText + " raises "
+            + string.Join(", ", raised.Select(r => r.CalleeText()))
+            + ". A process-wide request handled once and then fanned out to a per-window "
+            + "subscriber is the defect this file exists to prevent, wearing another name.");
+
+        // And it picks the window through the decision that has real unit
+        // tests rather than re-deriving one inline, where it would be
+        // exercised only by a person with two windows open.
+        var chosen = handler.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(call => call.CalleeText().EndsWith("ActiveWindowTarget.Choose", StringComparison.Ordinal))
+            .ToList();
+        Assert.True(
+            chosen.Count == 1,
+            handler.Identifier.ValueText + " must route through ActiveWindowTarget.Choose; found "
+            + chosen.Count + " call(s).");
+    }
+
+    /// <summary>
+    /// The owner files are exempt from the text rule below, so a parse is all
+    /// that reads them -- and a parse cannot see inside a disabled conditional
+    /// region. Wrapping a second construction or a subscription in `#if !DEMO`
+    /// would hide it from both rules at once while shipping in every non-DEMO
+    /// build.
+    ///
+    /// <see cref="ShellSource.Load"/> refuses a file that still has disabled
+    /// text after DEMO is defined, which is the check that closes it. Both
+    /// owners go through Load rather than through the corpus scan's relaxed
+    /// parse.
+    /// </summary>
+    [Fact]
+    public void OwnerFilesHideNothingInAConditionalRegion()
+    {
+        // App is loaded by every other test here. The service is not, and it
+        // is the one file where subscribing to its own event would not look
+        // out of place.
+        var service = ServiceSource();
+
+        var wires = Wires(service.Root, SyntaxKind.AddAssignmentExpression);
+        Assert.True(
+            wires.Count == 0,
+            ServiceType + " subscribes to its own " + ListThemes
+            + ". It declares and raises this; a subscription here is a handler nobody detaches.");
+        Assert.Empty(Constructions(service.Root));
+
+        // Load-bearing: Load is what makes the above meaningful, and it is
+        // silently satisfied by a file that parses to nothing.
+        Assert.NotEmpty(service.Root.DescendantNodes().OfType<MethodDeclarationSyntax>());
+    }
+
+    /// <summary>
+    /// The corpus rule: no file other than the service and App may so much as
+    /// name the event.
+    ///
+    /// Text rather than syntax, deliberately. A parse cannot see inside a
+    /// disabled conditional region, and a subscription reintroduced there is
+    /// live in the configuration that defines the symbol. Matching the token
+    /// in the raw source has no such blind spot. The cost is that a comment
+    /// naming the event also fails -- including a comment explaining why a
+    /// file must not subscribe. Reword it; the rule is worth more than the
+    /// sentence.
+    /// </summary>
+    [Fact]
+    public void NoOtherFileNamesTheThemePickerRequest()
+    {
+        var corpus = ShellSource.AllUnder(Corpus);
+
+        Assert.True(
+            corpus.Count > 100,
+            $"expected the shell source corpus under '{Corpus}', got {corpus.Count} files");
+
+        // The two files that live outside the Interop.Sources wildcard are in
+        // the corpus, because a corpus keyed on that prefix alone silently
+        // skipped them and they are shell sources like any other.
+        Assert.Contains(corpus, f => f.Tail.EndsWith(".NativeMethods.cs", StringComparison.Ordinal));
+
+        var pattern = new Regex(@"\b" + ListThemes + @"\b", RegexOptions.Compiled);
+        var offenders = corpus
+            .Where(f => !Owners.Any(o => f.Tail.EndsWith(o, StringComparison.Ordinal)) && pattern.IsMatch(f.Text))
+            .Select(f => f.Tail)
+            .ToList();
+
+        Assert.True(
+            offenders.Count == 0,
+            "these files name " + ListThemes + ": " + string.Join(", ", offenders)
+            + ". One service serves the whole process and App owns the one subscription; a "
+            + "per-window subscriber is a window rooted on a service that outlives it, and a "
+            + "per-window service is one that never gets the pipe. If the name is only in a "
+            + "comment, reword the comment.");
+
+        // And the parsed view agrees. It reads the owner files too, which the
+        // text rule exempts, so this is not a second copy of the rule above:
+        // it is the half that covers what the exemption opens up.
+        foreach (var file in corpus.Where(f => !f.Tail.EndsWith(App, StringComparison.Ordinal)))
+        {
+            var wires = Wires(
+                ShellSource.ParseForCorpusScan(file.Text).Root, SyntaxKind.AddAssignmentExpression);
+            Assert.True(wires.Count == 0, $"{file.Tail} subscribes to {ListThemes}");
+        }
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/WindowTeardownWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/WindowTeardownWiringTests.cs
@@ -706,14 +706,14 @@ public class WindowTeardownWiringTests
     public void AFailedPickerOpenClearsWhatTheCloseWillNotReach()
     {
         var source = ShellSource.Load(MainWindow.File);
-        var statements = source.Method("OnListThemesRequested").Body!.Statements;
+        var statements = source.Method("ShowInlineThemePicker").Body!.Statements;
 
         var opened = statements
             .TakeWhile(s => !s.Calls("NativeMethods.SurfaceListThemes").Any())
             .Count();
         Assert.True(
             opened < statements.Count,
-            "expected OnListThemesRequested to open the picker through "
+            "expected ShowInlineThemePicker to open the picker through "
             + "NativeMethods.SurfaceListThemes; without that call there is no failure path "
             + "here and this test would pass while reading nothing");
 
@@ -730,35 +730,11 @@ public class WindowTeardownWiringTests
 
         Assert.True(
             cleared.Count == 1,
-            "OnListThemesRequested must clear " + string.Join(", ", PickerFields)
+            "ShowInlineThemePicker must clear " + string.Join(", ", PickerFields)
             + " and return when SurfaceListThemes hands back a zero handle. Nothing else will: "
             + "ClosePicker bails on the zero handle before it reaches those same clears, so the "
             + "stale surface pointer and the pane subtree behind _pickerTerminal are held until "
             + "the next successful picker or the window's close.");
-    }
-
-    /// <summary>
-    /// ThemePreviewService, the one gap #694 named and did not close.
-    ///
-    /// It is not an event source the census can see: it owns a named-pipe
-    /// server running on a background task, and the close only detached the
-    /// window from its ListThemesRequested. The task then ran for the life of
-    /// the process, holding the per-process pipe name with nobody left
-    /// listening to what arrived on it. Disposing cancels the loop, waits for
-    /// it, and drops the subscribers, so the window is neither rooted by it
-    /// nor outlived by it.
-    /// </summary>
-    [Fact]
-    public void TheThemePreviewServiceIsDisposedByTheClose()
-    {
-        var source = ShellSource.Load(MainWindow.File);
-        var statements = source.Method("OnClosedAsync").Body!.Statements;
-
-        var disposed = statements.TakeWhile(s => !s.Calls("_themePreview.Dispose").Any()).Count();
-        Assert.True(
-            disposed < statements.Count,
-            "OnClosedAsync must dispose _themePreview: unsubscribing alone leaves its pipe server "
-            + "task running for the life of the process");
     }
 
     /// <summary>

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -129,6 +129,28 @@ public partial class App : Application
     internal static void NoteRegularWindowActivated(MainWindow window)
         => LastRegularWindow = window;
 
+    /// <summary>
+    /// A regular window has become able to host process-wide work: its
+    /// XamlRoot is live and it is going into the registry. Called from the
+    /// window's one-shot content Loaded handler.
+    /// </summary>
+    internal static void NoteRegularWindowRegistered(MainWindow window)
+    {
+        if (window.RegisteredRoot is not { } root) return;
+        WindowsByRoot[root] = window;
+
+        // Only now may the +list-themes pipe exist. `wintty +list-themes`
+        // probes for it with File.Exists and counts a successful write as
+        // delivery, never waiting for an answer, so a pipe advertised before
+        // any window can draw a picker makes the CLI exit 0 having done
+        // nothing -- and skips the libghostty TUI picker it falls back to
+        // when it finds no pipe. The service is built in OnLaunched, which
+        // returns before the message loop can raise any window's Loaded, so
+        // construction is always too early to start listening. Start is
+        // idempotent, so every window may say this.
+        (Application.Current as App)?._themePreview?.Start();
+    }
+
     // How many recently-closed tabs / windows the reopen stacks retain.
     private const int ClosedItemCapacity = 25;
 
@@ -146,13 +168,17 @@ public partial class App : Application
     internal static GhosttyHost? BootstrapHost { get; private set; }
 
     /// <summary>
-    /// The process-wide theme preview service. Exposed because the inline
-    /// theme picker runs in a window and hands each browsed theme name back
-    /// through the service that parses and applies it; the window has no
-    /// other route to it now that it does not own one. Null before
-    /// OnLaunched runs; null after the last window closes.
+    /// Apply a browsed theme's colors, from the process-wide preview
+    /// service. Null before OnLaunched runs; null again once the shutdown's
+    /// finally block has cleared it.
     /// </summary>
-    internal static Ghostty.Services.ThemePreviewService? ThemePreview { get; private set; }
+    // The one verb the inline theme picker needs, rather than the service
+    // itself. A window that can reach the service can also Dispose it, and a
+    // dispose on one window's close ends the accept loop and drops the
+    // subscription for every window still open -- exactly the defect this
+    // ownership move removed, and it would go back in a single line with
+    // every rule in ThemePreviewOwnershipWiringTests still green.
+    internal static Action<string>? ApplyThemePreview { get; private set; }
 
     internal static ConfigService? ConfigService { get; private set; }
     internal static Ghostty.Core.Profiles.IProfileRegistry? ProfileRegistry { get; private set; }
@@ -750,12 +776,15 @@ public partial class App : Application
         // without anything reclaiming it, leaving the rest of the session with
         // no server for the CLI to find. Constructed unconditionally and
         // subscribed to a named method, so the shutdown can take it back.
+        // Built here but not started here: NoteRegularWindowRegistered opens
+        // the pipe, because the pipe is what the CLI reads as "a window is
+        // ready to show you a picker".
         _themePreview = new Ghostty.Services.ThemePreviewService(
             _configService,
             DispatcherQueue.GetForCurrentThread(),
             factory.CreateLogger<Ghostty.Services.ThemePreviewService>());
         _themePreview.ListThemesRequested += OnAppListThemesRequested;
-        ThemePreview = _themePreview;
+        ApplyThemePreview = _themePreview.ApplyThemePreview;
 
         // App-level: High Contrast is a system-wide state and config is
         // applied app-wide, so a single monitor drives the surface override.
@@ -1475,9 +1504,11 @@ public partial class App : Application
     /// <summary>
     /// A LIST_THEMES arriving on the preview pipe. The picker is drawn by
     /// libghostty into a surface, so it needs a window even though the
-    /// request is process-wide: it goes to the one the user was last in.
-    /// The quake window is skipped because it is usually hidden, and a
-    /// closing one because its surfaces are on their way out.
+    /// request is process-wide: it goes to the one the user was last in,
+    /// skipping any window whose close has started, because its surfaces are
+    /// on their way out. The predicate also refuses the quake window, which
+    /// the shell never registers and never records as last-activated -- that
+    /// half is a backstop for a helper in Core that cannot see either fact.
     /// ThemePreviewService raises this on the UI thread.
     /// </summary>
     private void OnAppListThemesRequested(object? sender, EventArgs e)
@@ -1486,9 +1517,9 @@ public partial class App : Application
             LastRegularWindow, AllWindows, w => !w.IsQuickTerminal && !w.IsClosing);
         if (target is null)
         {
-            // Every window is closing, or the only one left is the quake
-            // window. Nothing to draw the picker on, and the CLI already
-            // wrote its line and moved on, so there is nobody to tell.
+            // Every window is closing. Nothing to draw the picker on, and
+            // the CLI already wrote its line and moved on, so there is
+            // nobody to tell.
             Ghostty.Logging.StaticLoggers.App.LogNoWindowForThemePicker();
             return;
         }
@@ -1937,7 +1968,7 @@ public partial class App : Application
                 _configEditor = null;
                 ConfigFileEditor = null;
                 _themePreview = null;
-                ThemePreview = null;
+                ApplyThemePreview = null;
                 _bootstrapHost = null;
                 BootstrapHost = null;
                 _lifetimeSupervisor = null;
@@ -1997,7 +2028,7 @@ internal static partial class AppLogExtensions
     internal static partial void LogConfigOpenFailed(
         this ILogger<App> logger, System.Exception ex, string configPath);
 
-    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Startup.NoWindowForThemePicker,
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.ThemePreview.NoWindowForThemePicker,
                    Level = LogLevel.Debug,
                    Message = "LIST_THEMES arrived with no window able to host the picker")]
     internal static partial void LogNoWindowForThemePicker(this ILogger<App> logger);

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -79,6 +79,10 @@ public partial class App : Application
     /// </summary>
     internal Window? SettingsWindow => _settingsWindow;
 
+    // The +list-themes pipe server. One per process, because the pipe name it
+    // claims is per process; see OnLaunched.
+    private Ghostty.Services.ThemePreviewService? _themePreview;
+
     private Ghostty.Session.SessionManager? _sessionManager;
     private Ghostty.Hosting.WindowsGlobalHotKey? _quakeHotKey;
     private Ghostty.Hosting.WindowsSystemMenuHook? _systemMenuHook;
@@ -140,6 +144,16 @@ public partial class App : Application
     internal static readonly Core.Panes.ClosedStack<Core.Session.WindowSession> ClosedWindows = new(ClosedItemCapacity);
 
     internal static GhosttyHost? BootstrapHost { get; private set; }
+
+    /// <summary>
+    /// The process-wide theme preview service. Exposed because the inline
+    /// theme picker runs in a window and hands each browsed theme name back
+    /// through the service that parses and applies it; the window has no
+    /// other route to it now that it does not own one. Null before
+    /// OnLaunched runs; null after the last window closes.
+    /// </summary>
+    internal static Ghostty.Services.ThemePreviewService? ThemePreview { get; private set; }
+
     internal static ConfigService? ConfigService { get; private set; }
     internal static Ghostty.Core.Profiles.IProfileRegistry? ProfileRegistry { get; private set; }
     internal static Ghostty.Session.SessionManager? SessionManager { get; private set; }
@@ -726,6 +740,22 @@ public partial class App : Application
         // the teardown below can take them back.
         _bootstrapHost.OpenConfigRequested += OnAppOpenConfigRequested;
         _bootstrapHost.ReloadConfigRequested += OnAppReloadConfigRequested;
+
+        // The +list-themes server, one for the process. The pipe name it
+        // claims carries the process id and it is created with
+        // FirstPipeInstance, so a second service in this process cannot open
+        // the pipe at all: it stood down at construction and never came back.
+        // A service per window therefore meant only the first window served
+        // `wintty +list-themes`, and closing that window released the name
+        // without anything reclaiming it, leaving the rest of the session with
+        // no server for the CLI to find. Constructed unconditionally and
+        // subscribed to a named method, so the shutdown can take it back.
+        _themePreview = new Ghostty.Services.ThemePreviewService(
+            _configService,
+            DispatcherQueue.GetForCurrentThread(),
+            factory.CreateLogger<Ghostty.Services.ThemePreviewService>());
+        _themePreview.ListThemesRequested += OnAppListThemesRequested;
+        ThemePreview = _themePreview;
 
         // App-level: High Contrast is a system-wide state and config is
         // applied app-wide, so a single monitor drives the surface override.
@@ -1443,6 +1473,30 @@ public partial class App : Application
         _configService?.Reload();
 
     /// <summary>
+    /// A LIST_THEMES arriving on the preview pipe. The picker is drawn by
+    /// libghostty into a surface, so it needs a window even though the
+    /// request is process-wide: it goes to the one the user was last in.
+    /// The quake window is skipped because it is usually hidden, and a
+    /// closing one because its surfaces are on their way out.
+    /// ThemePreviewService raises this on the UI thread.
+    /// </summary>
+    private void OnAppListThemesRequested(object? sender, EventArgs e)
+    {
+        var target = Ghostty.Core.Windows.ActiveWindowTarget.Choose(
+            LastRegularWindow, AllWindows, w => !w.IsQuickTerminal && !w.IsClosing);
+        if (target is null)
+        {
+            // Every window is closing, or the only one left is the quake
+            // window. Nothing to draw the picker on, and the CLI already
+            // wrote its line and moved on, so there is nobody to tell.
+            Ghostty.Logging.StaticLoggers.App.LogNoWindowForThemePicker();
+            return;
+        }
+
+        target.ShowInlineThemePicker();
+    }
+
+    /// <summary>
     /// Show the app-wide settings window, or focus the existing one if it is
     /// already open. One settings window serves the whole process, so opening
     /// it from any window reuses the same instance. The caller guards on
@@ -1707,6 +1761,17 @@ public partial class App : Application
                 // a native access violation (issue #208 switch-then-close).
                 _configService.BeginShutdown();
 
+                // Same reason, one line down: the preview pipe server runs on
+                // a background task and can still enqueue a picker onto a
+                // window that is already tearing down. Detach first so a
+                // LIST_THEMES that beat the cancel finds no handler, then
+                // dispose, which cancels the accept loop and waits for it.
+                if (_themePreview is not null)
+                {
+                    _themePreview.ListThemesRequested -= OnAppListThemesRequested;
+                    _themePreview.Dispose();
+                }
+
                 // Stop the process tracker before any tab teardown could
                 // race its Timer callback. Dispose unsubscribes the
                 // Changed handler in addition to cancelling the timer,
@@ -1871,6 +1936,8 @@ public partial class App : Application
                 NotificationService = null;
                 _configEditor = null;
                 ConfigFileEditor = null;
+                _themePreview = null;
+                ThemePreview = null;
                 _bootstrapHost = null;
                 BootstrapHost = null;
                 _lifetimeSupervisor = null;
@@ -1929,6 +1996,11 @@ internal static partial class AppLogExtensions
                    Message = "Failed to open config file {ConfigPath}")]
     internal static partial void LogConfigOpenFailed(
         this ILogger<App> logger, System.Exception ex, string configPath);
+
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Startup.NoWindowForThemePicker,
+                   Level = LogLevel.Debug,
+                   Message = "LIST_THEMES arrived with no window able to host the picker")]
+    internal static partial void LogNoWindowForThemePicker(this ILogger<App> logger);
 
     [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Startup.StaleAumidRemoved,
                    Level = LogLevel.Information,

--- a/windows/Ghostty/Logging/LogEvents.cs
+++ b/windows/Ghostty/Logging/LogEvents.cs
@@ -15,7 +15,6 @@ internal static class LogEvents
         public const int TrayInitFailed      = 2003;
         public const int StaleAumidRemoved   = 2004;
         public const int ConfigOpenFailed    = 2005;
-        public const int NoWindowForThemePicker = 2006;
     }
 
     // 2100-2199: Clipboard
@@ -40,6 +39,7 @@ internal static class LogEvents
         public const int PipeError         = 2204;
         public const int InvalidThemeName  = 2205;
         public const int PipeServerUnavailable = 2206;
+        public const int NoWindowForThemePicker = 2207;
     }
 
     // 2300-2399: WindowState + migration

--- a/windows/Ghostty/Logging/LogEvents.cs
+++ b/windows/Ghostty/Logging/LogEvents.cs
@@ -15,6 +15,7 @@ internal static class LogEvents
         public const int TrayInitFailed      = 2003;
         public const int StaleAumidRemoved   = 2004;
         public const int ConfigOpenFailed    = 2005;
+        public const int NoWindowForThemePicker = 2006;
     }
 
     // 2100-2199: Clipboard

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -137,7 +137,6 @@ public sealed partial class MainWindow : Window
     private readonly TabBellAnnouncer _bellAnnouncer;
     private readonly WindowThemeManager _themeManager;
     private readonly ShellThemeService _shellTheme;
-    private readonly ThemePreviewService _themePreview;
 
     // Set at the top of OnClosedAsync. Theme callbacks route through the
     // dispatcher, so a switch-then-close can leave an ApplyTheme queued to
@@ -280,6 +279,13 @@ public sealed partial class MainWindow : Window
     /// </summary>
     internal bool IsQuickTerminal { get; }
 
+    /// <summary>
+    /// True once this window's close has started. Process-wide services that
+    /// route work to a window read this so they do not pick one whose panes
+    /// and surfaces are already being torn down.
+    /// </summary>
+    internal bool IsClosing => _isClosed;
+
     internal MainWindow(
         ConfigService configService,
         GhosttyHost bootstrapHost,
@@ -321,8 +327,7 @@ public sealed partial class MainWindow : Window
     /// shared-app ctor. <paramref name="loggerFactory"/> is the
     /// process-wide factory built in App.OnLaunched; MainWindow holds
     /// it to construct loggers for the per-window components it owns
-    /// (GhosttyHost's clipboard trio, TaskbarHost, AcrylicBackdrop,
-    /// ThemePreviewService).
+    /// (GhosttyHost's clipboard trio, TaskbarHost, AcrylicBackdrop).
     /// </summary>
     private MainWindow(
         ConfigService configService,
@@ -509,11 +514,10 @@ public sealed partial class MainWindow : Window
 
         _shellTheme = new ShellThemeService(configService);
         _shellTheme.ThemeChanged += OnShellThemeChanged;
-        _themePreview = new ThemePreviewService(
-            configService,
-            DispatcherQueue,
-            loggerFactory.CreateLogger<ThemePreviewService>());
-        _themePreview.ListThemesRequested += OnListThemesRequested;
+
+        // The +list-themes pipe server is process-wide, not per window: its
+        // pipe name is per process. App owns the one service and routes the
+        // request here; see App.OnLaunched.
 
         _factory = new PaneHostFactory(_host, configService);
         // Restore a saved session into this window when one was passed and
@@ -1435,25 +1439,6 @@ public sealed partial class MainWindow : Window
         // toggle during teardown puts AppSetColorScheme through the app
         // pointer _host.Dispose is about to free at the end of this method.
         _systemUiSettings.ColorValuesChanged -= OnSystemColorValuesChanged;
-        // The preview service owns a named-pipe server on a background task,
-        // so it raises this from outside the window's own lifetime. Detaching
-        // keeps a LIST_THEMES arriving afterwards from starting a picker on a
-        // window whose surfaces are gone; disposing is what ends the task,
-        // which otherwise ran for the life of the process, holding the
-        // per-process pipe name with nobody listening on it. The cancel is
-        // observed by the awaits inside the accept loop, so the synchronous
-        // wait here is bounded.
-        //
-        // The service is per window and the pipe name is per process, so in a
-        // multi-window session only the first one to start ever owns the pipe
-        // (FirstPipeInstance stands the others down at construction). Closing
-        // that window therefore leaves the session with no server rather than
-        // with one whose only subscriber has detached. Both states are broken
-        // for `+list-themes`; this one at least does not leak. The real fix is
-        // to own the service where the bootstrap host lives, the same shape as
-        // the app-targeted config actions, which App owns for that reason.
-        _themePreview.ListThemesRequested -= OnListThemesRequested;
-        _themePreview.Dispose();
 
         // CompositionTarget.Rendering is static, so a window closed before
         // its first composed frame would otherwise stay subscribed.
@@ -3877,8 +3862,19 @@ public sealed partial class MainWindow : Window
     // the poll, so the window's teardown has no other way to reach it.
     private Microsoft.UI.Dispatching.DispatcherQueueTimer? _pickerPoll;
 
-    private void OnListThemesRequested(object? sender, EventArgs e)
+    /// <summary>
+    /// Open the inline theme picker on this window's active surface. Called
+    /// by App when a LIST_THEMES arrives on the preview pipe; App picks the
+    /// window. UI thread only.
+    /// </summary>
+    internal void ShowInlineThemePicker()
     {
+        // App filters closing windows out of the routing, but the request
+        // crosses a thread hop to get here, so one enqueued before this
+        // window's close is delivered after it -- and every surface the
+        // picker would install itself into is already freed by then.
+        if (_isClosed) return;
+
         var leaf = _tabManager.ActiveTab?.PaneHost?.ActiveLeaf;
         if (leaf is null) return;
 
@@ -3914,7 +3910,9 @@ public sealed partial class MainWindow : Window
                 // still handling the key that got us here.
                 DispatcherQueue.TryEnqueue(() =>
                 {
-                    _themePreview.ApplyThemePreview(name);
+                    // Null once the process shutdown has disposed it, which
+                    // an in-flight picker keystroke can still land after.
+                    Ghostty.App.ThemePreview?.ApplyThemePreview(name);
                 });
             }
             catch { }

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -436,7 +436,10 @@ public sealed partial class MainWindow : Window
                 RegisteredRoot = fe.XamlRoot;
                 if (RegisteredRoot != null)
                 {
-                    App.WindowsByRoot[RegisteredRoot] = this;
+                    // App does the insert, because registering is also the
+                    // moment process-wide services may start acting on a
+                    // window and only App knows which those are.
+                    App.NoteRegularWindowRegistered(this);
                 }
             }
         }
@@ -3910,9 +3913,14 @@ public sealed partial class MainWindow : Window
                 // still handling the key that got us here.
                 DispatcherQueue.TryEnqueue(() =>
                 {
-                    // Null once the process shutdown has disposed it, which
-                    // an in-flight picker keystroke can still land after.
-                    Ghostty.App.ThemePreview?.ApplyThemePreview(name);
+                    // Null until OnLaunched builds the service and again
+                    // once the shutdown's finally block clears it; a picker
+                    // keystroke in flight across this dispatch can land in
+                    // either gap. Non-null is not proof the service is still
+                    // live -- the shutdown disposes it well before that
+                    // clearing -- but applying colors after the dispose is
+                    // fenced off by ConfigService's own shutdown flag.
+                    Ghostty.App.ApplyThemePreview?.Invoke(name);
                 });
             }
             catch { }

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -998,6 +998,13 @@ internal sealed partial class ConfigService : IConfigService, Ghostty.Core.Profi
     /// </summary>
     internal void ApplyThemeColors(uint fg, uint bg, uint? cursor, uint? cursorText, uint[] palette)
     {
+        // The same fence Reload takes, for the same reason. The preview
+        // service reaches this from its pipe thread through TryEnqueue, so a
+        // preview or a revert enqueued just before teardown is pumped after
+        // it, and the fan-out below hands every subscriber a config the
+        // shutdown is already unwinding.
+        if (_shuttingDown) return;
+
         ForegroundColor = fg;
         BackgroundColor = bg;
         CursorColor = cursor ?? fg;

--- a/windows/Ghostty/Services/ThemePreviewService.cs
+++ b/windows/Ghostty/Services/ThemePreviewService.cs
@@ -22,7 +22,7 @@ namespace Ghostty.Services;
 ///   "CONFIRM:ThemeName\n"  -- user accepted the theme
 ///   (pipe closed)          -- user cancelled, revert to original
 /// </summary>
-internal sealed partial class ThemePreviewService : IAsyncDisposable, IDisposable
+internal sealed partial class ThemePreviewService : IDisposable
 {
     // Path.GetInvalidFileNameChars() allocates a fresh char[] on each
     // call (defensive copy); SearchValues caches the set once and picks
@@ -61,28 +61,30 @@ internal sealed partial class ThemePreviewService : IAsyncDisposable, IDisposabl
         _serverTask = Task.Run(() => RunServer(_cts.Token));
     }
 
-    public async ValueTask DisposeAsync()
-    {
-        _cts.Cancel();
-        if (_serverTask is not null)
-        {
-            try { await _serverTask; }
-            catch (OperationCanceledException) { }
-            catch (Exception) { /* server loop handles its own errors */ }
-        }
-        _cts.Dispose();
-    }
-
+    /// <summary>
+    /// Ends the accept loop and drops subscribers. Called once, from the
+    /// process shutdown that runs after the last window closes.
+    /// </summary>
+    // Synchronous, and there is no DisposeAsync to prefer: the shutdown that
+    // calls this is a `void` event handler with nothing to await it, so an
+    // async variant would have had no caller able to use it.
+    //
+    // Waiting on the server task from the UI thread is bounded rather than a
+    // deadlock. Every await in the loop -- WaitForConnectionAsync,
+    // ReadLineAsync, the backoff Delay -- takes the token, so the cancel above
+    // completes all three, and the loop never awaits back onto the UI thread:
+    // it hands work over with TryEnqueue and does not wait for it. So nothing
+    // the task still has to do needs the thread that is blocked here.
     public void Dispose()
     {
         _cts.Cancel();
-        // Best-effort synchronous wait -- prefer DisposeAsync.
         try { _serverTask?.GetAwaiter().GetResult(); }
         catch { /* expected OCE or pipe error */ }
         _cts.Dispose();
 
-        // Drop subscribers so MainWindow is not rooted via this event
-        // after the service tears down at window-close.
+        // Drop subscribers. The loop is over by now, but the event is a root
+        // like any other and this service is only ever disposed on the way out
+        // of the process.
         ListThemesRequested = null;
     }
 
@@ -122,11 +124,12 @@ internal sealed partial class ThemePreviewService : IAsyncDisposable, IDisposabl
     /// </summary>
     private async Task<PipeLoopOutcome> RunOneServerSession(CancellationToken ct)
     {
-        // Creating the server is its own failure mode. With FirstPipeInstance
-        // + a per-process PipeName, the ctor throws "All pipe instances are
-        // busy" when another ThemePreviewService in this process already owns
-        // the name -- permanent for this loop, so the policy stands it down
-        // rather than retrying.
+        // Creating the server is its own failure mode. FirstPipeInstance is
+        // what makes the name exclusive, so the ctor throws "All pipe
+        // instances are busy" when anything else already holds it -- another
+        // process squatting the name, or a handle from this process that has
+        // not been released yet. Neither clears by retrying on this loop, so
+        // the policy stands it down rather than spinning.
         NamedPipeServerStream server;
         try
         {

--- a/windows/Ghostty/Services/ThemePreviewService.cs
+++ b/windows/Ghostty/Services/ThemePreviewService.cs
@@ -35,6 +35,7 @@ internal sealed partial class ThemePreviewService : IDisposable
     private readonly ILogger<ThemePreviewService> _logger;
     private readonly CancellationTokenSource _cts = new();
     private Task? _serverTask;
+    private bool _disposed;
 
     /// <summary>
     /// Raised on the UI thread when a CLI process sends LIST_THEMES
@@ -58,6 +59,24 @@ internal sealed partial class ThemePreviewService : IDisposable
         _configService = configService;
         _dispatcher = dispatcher;
         _logger = logger;
+    }
+
+    /// <summary>
+    /// Begin serving the pipe. Idempotent, and a no-op once
+    /// <see cref="Dispose"/> has run. UI thread only, like every other
+    /// call into this service from the shell.
+    /// </summary>
+    // Separate from construction because the pipe's existence is the
+    // readiness signal the CLI reads: `wintty +list-themes` probes for
+    // \\.\pipe\ghostty-theme-preview-{pid} with File.Exists, and treats a
+    // successful write to it as delivery -- it never waits for an answer. So
+    // a pipe opened before any window is able to draw a picker turns the
+    // CLI's fallback (libghostty's own TUI picker, which it runs when it
+    // finds no pipe) into a silent exit 0 that does nothing at all. The
+    // caller starts this when the first window registers.
+    internal void Start()
+    {
+        if (_disposed || _serverTask is not null) return;
         _serverTask = Task.Run(() => RunServer(_cts.Token));
     }
 
@@ -69,14 +88,29 @@ internal sealed partial class ThemePreviewService : IDisposable
     // calls this is a `void` event handler with nothing to await it, so an
     // async variant would have had no caller able to use it.
     //
-    // Waiting on the server task from the UI thread is bounded rather than a
-    // deadlock. Every await in the loop -- WaitForConnectionAsync,
-    // ReadLineAsync, the backoff Delay -- takes the token, so the cancel above
-    // completes all three, and the loop never awaits back onto the UI thread:
-    // it hands work over with TryEnqueue and does not wait for it. So nothing
-    // the task still has to do needs the thread that is blocked here.
+    // Waiting on the server task from the UI thread cannot deadlock. Every
+    // await in the loop -- WaitForConnectionAsync, ReadLineAsync, the backoff
+    // Delay -- takes the token, so the cancel below completes all three, and
+    // each is ConfigureAwait(false), so no continuation wants the thread that
+    // is blocked here. The loop also hands UI work over with TryEnqueue and
+    // does not wait for it.
+    //
+    // Bounded, but not instantly: the token reaches none of the synchronous
+    // work between those awaits, and the long piece of it is reading the
+    // theme file (File.Exists plus ParseThemeFile's File.ReadLines) for a
+    // PREVIEW that arrived just before the cancel. That is one small file
+    // from the config directory, which can be a redirected or UNC path, so
+    // the real bound is a file read that may have to time out. A timeout on
+    // the wait would not improve on that: it would return with the accept
+    // loop still running into the state this shutdown is freeing.
     public void Dispose()
     {
+        // Callers get a Dispose that can be called twice, per the BCL
+        // contract. Without this the second call cancels a disposed
+        // CancellationTokenSource and throws ObjectDisposedException.
+        if (_disposed) return;
+        _disposed = true;
+
         _cts.Cancel();
         try { _serverTask?.GetAwaiter().GetResult(); }
         catch { /* expected OCE or pipe error */ }
@@ -99,14 +133,14 @@ internal sealed partial class ThemePreviewService : IDisposable
     {
         while (!ct.IsCancellationRequested)
         {
-            var outcome = await RunOneServerSession(ct);
+            var outcome = await RunOneServerSession(ct).ConfigureAwait(false);
             switch (_retryPolicy.Decide(outcome))
             {
                 case PipeLoopDecision.Stop:
                 case PipeLoopDecision.StandDown:
                     return;
                 case PipeLoopDecision.RetryAfterBackoff:
-                    try { await Task.Delay(_retryPolicy.Backoff, ct); }
+                    try { await Task.Delay(_retryPolicy.Backoff, ct).ConfigureAwait(false); }
                     catch (OperationCanceledException) { return; }
                     break;
                 case PipeLoopDecision.RetryImmediately:
@@ -118,9 +152,9 @@ internal sealed partial class ThemePreviewService : IDisposable
 
     /// <summary>
     /// Runs one accept-serve cycle of the named-pipe server and classifies
-    /// how it ended. Never throws (cancellation and I/O faults are mapped to
-    /// outcomes); the caller's policy decides whether to retry, back off, or
-    /// stand down.
+    /// how it ended. Never throws -- cancellation and every fault, from
+    /// creating the server through serving it, are mapped to outcomes; the
+    /// caller's policy decides whether to retry, back off, or stand down.
     /// </summary>
     private async Task<PipeLoopOutcome> RunOneServerSession(CancellationToken ct)
     {
@@ -145,13 +179,28 @@ internal sealed partial class ThemePreviewService : IDisposable
             _logger.LogPipeServerUnavailable(ex);
             return PipeLoopOutcome.ServerCreationFailed;
         }
+        catch (Exception ex)
+        {
+            // Everything else the ctor can raise -- an ACL that denies the
+            // create, a disposal race during teardown, an allocation failure
+            // -- is a creation failure too, and this try sits outside the
+            // broad catch below, so without this it escapes into the
+            // fire-and-forget server task instead. A faulted task there is
+            // silent: nothing observes it, .NET Core no longer tears the
+            // process down for it, and +list-themes is dead for the rest of
+            // the session with nothing in the log to say why. Logged through
+            // the general pipe-error message rather than the stand-down one,
+            // which describes the collision case and would misreport this.
+            _logger.LogPipeError(ex);
+            return PipeLoopOutcome.ServerCreationFailed;
+        }
 
         try
         {
             using (server)
             {
                 _logger.LogPipeWaiting(PipeName);
-                await server.WaitForConnectionAsync(ct);
+                await server.WaitForConnectionAsync(ct).ConfigureAwait(false);
                 _logger.LogClientConnected();
 
                 // Snapshot current colors for revert on cancel.
@@ -162,7 +211,7 @@ internal sealed partial class ThemePreviewService : IDisposable
 
                 while (!ct.IsCancellationRequested)
                 {
-                    var line = await reader.ReadLineAsync(ct);
+                    var line = await reader.ReadLineAsync(ct).ConfigureAwait(false);
                     if (line is null) break; // pipe closed
 
                     if (line == "LIST_THEMES")

--- a/windows/docs/logging.md
+++ b/windows/docs/logging.md
@@ -79,7 +79,7 @@ at the message text.
 | 1100-1199 | FrecencyStore (command palette history) |
 | 2000-2099 | Startup (AUMID, jump list) |
 | 2100-2199 | Clipboard (backend + bridge + confirm dialog) |
-| 2200-2299 | ThemePreviewService |
+| 2200-2299 | Theme preview (pipe server, picker routing) |
 | 2300-2399 | WindowState + WindowStateMigration |
 | 2400-2499 | Shell (taskbar host, backdrop) |
 | 2500-2599 | MainWindow |


### PR DESCRIPTION
Closes #706

## The defect, as it actually behaves today

The issue's diagnosis is right and its mechanism is one PR stale, so this is the current shape.

`ThemePreviewService` serves `wintty +list-themes` over a pipe whose name carries the process id, opened with `FirstPipeInstance`. The service was built per window. A second one in the same process therefore could not create the pipe at all -- the retry policy read that as permanent and stood the loop down at construction, for good. So only the first window ever served the CLI, no matter which window the user was actually in.

# 720 then added a `Dispose()` on window close, which was right on its own but moved where the breakage lands. Before it, window 1 held the name forever with nobody listening. Now closing window 1 releases the name and nothing reclaims it, so `Program.FindThemePreviewPipe` scans every live Wintty, finds no `\\.\pipe\ghostty-theme-preview-{pid}`, and `+list-themes` does nothing for the rest of the session. Same dead feature, different path to it.

## The change

One service for the process, built where the bootstrap host is built and disposed on the way out, the same shape the app-targeted config actions already use. Unlike those, the picker is drawn into a surface, so this one still needs a window: the request goes to the last one the user activated, skipping any whose close has started. That is a fix in itself -- the old behaviour sent the picker to whichever window booted first.

The choice of window is extracted to `Ghostty.Core` for the reason `PipeServerRetryPolicy` is: the test project does not reference the shell, so a decision left inline there is only ever exercised by hand. Its fallback carries the case that matters, since `MainWindow`'s close runs before the app hears about it and the last-activated window can still name one whose panes are being freed.

## Review

Two passes. The second drove real `NamedPipeServerStream` instances rather than reading the comment, and settled the thing I was least sure of: cancelling does abort a read waiting on a client that connected and went silent, so closing the last window with a picker session open does not park the UI thread. It also disproved a recreate race I expected to find -- reopening a `FirstPipeInstance` pipe while the old client handle is still open succeeds.

It found a hole this change had opened. Construction in `OnLaunched` is earlier than window registration, which cannot happen until `OnLaunched` returns and the message loop runs. The pipe is the readiness signal the CLI probes, and a successful write counts as delivery, so `+list-themes` during startup connected, exited 0, and got nothing -- while the fallback for finding no pipe, libghostty's own TUI picker, was skipped precisely because the pipe was there. Listening is now separate from construction and starts when the first window registers.

That means a session with only the quake window never advertises the pipe. This is deliberate and is a behaviour change worth naming: the routing does not consider that window, so the pipe would only have promised what it could not deliver, and the CLI's own picker is the better answer.

The other pass found that the accessor handed every file in the shell a service with a public `Dispose`, and that one line in a window's close path put the defect back with the whole suite green -- and additionally threw out of an `async void` close handler. Windows need one verb, so that is all they get now, and the mutation no longer compiles. `Dispose` is idempotent regardless.

Three more share the defect's shape, where something goes quiet and the feature is dead for the session: the pipe constructor guard caught only `IOException` and sat outside the broad catch below it, so any other failure faulted a task nothing observes; `ApplyThemeColors` walked past the fence `BeginShutdown` sets, reaching the same fan-out `Reload` guards; and the awaits now state why the blocking wait is safe rather than resting on `Task.Run` happening to have no synchronization context.

Two guards were themselves defeatable. The one against a second construction read only `ObjectCreationExpressionSyntax`, which target-typed `new(...)` is not -- it parses as a sibling, and this codebase writes `= new()` freely. The anti-relay rule was a blacklist on callees named `Invoke`, which both a local delegate call and a fan-out beside the permitted one walked through; it asserts the shape it wants now.

## Tests

`ThemePreviewOwnershipWiringTests` pins the ownership. The rule that carries the defect is the count of constructions, not of subscriptions: the pipe is what is singular, and windows two and later were services that existed and subscribed to nothing, so a subscription rule would have passed them. Every rule was verified by mutation -- applied, observed red, reverted, observed green.

What no test here proves is the feature itself, which needs a live process, two windows and the CLI. The manual checks:

1. Open a window, open a second, close the first, run `wintty +list-themes`. Expected: the picker opens in the surviving window. Before: nothing.
2. Two windows open, activate the second, run `wintty +list-themes`. Expected: the picker opens in window 2. Before: window 1.
3. Run `wintty +list-themes` during startup, before the first window paints. Expected: libghostty's own TUI picker.

Full suite 2283 passing.

Size-override: 863 of 1201 countable lines are the wiring guards and their per-rule docstrings; the production change is 336 lines across five files. The guard file is what caught this change's own escapes, so it belongs with the fix rather than in a follow-up.
