### PR TITLE
windows: close the theme picker when the surface under it is freed

### DIFF
--- a/windows/Ghostty.Tests/Wiring/WindowTeardownWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/WindowTeardownWiringTests.cs
@@ -173,7 +173,11 @@ public class WindowTeardownWiringTests
         Class: "MainWindow",
         File: "Ghostty.MainWindow.xaml.cs",
         ClosedFlag: "_isClosed",
-        ClosePath: Array.Empty<string>(),
+        // OnClosedAsync's first teardown act, called unconditionally, and the
+        // only place the picker's per-control subscription is taken back --
+        // the control can outlive this window, so nothing on the control's
+        // side can answer for it.
+        ClosePath: new[] { "ClosePicker" },
         AtLeast: 40,
         Owned: MainWindowOwned,
         Exempt: MainWindowExempt);
@@ -735,6 +739,197 @@ public class WindowTeardownWiringTests
             + "ClosePicker bails on the zero handle before it reaches those same clears, so the "
             + "stale surface pointer and the pane subtree behind _pickerTerminal are held until "
             + "the next successful picker or the window's close.");
+    }
+
+    /// <summary>The control that owns the surface the picker installs itself on.</summary>
+    private const string TerminalControlFile = "Controls.TerminalControl.xaml.cs";
+
+    /// <summary>The control event that warns its holders the surface is going.</summary>
+    private const string SurfaceDisposing = "SurfaceDisposing";
+
+    /// <summary>The window's handler for it.</summary>
+    private const string PickerDisposingHandler = "OnPickerSurfaceDisposing";
+
+    /// <summary>
+    /// Matched on the event's own name, whatever the receiver is spelled as: a
+    /// subscription taken out through a local and detached through a field is
+    /// the same subscription, and the census above is what insists the two
+    /// spellings agree.
+    /// </summary>
+    private static bool NamesSurfaceDisposing(string flattened) =>
+        flattened == SurfaceDisposing
+        || flattened.EndsWith("." + SurfaceDisposing, StringComparison.Ordinal);
+
+    /// <summary>
+    /// The warning a control gives before it frees its surface.
+    ///
+    /// The picker's cleanup writes through the surface pointer it saved -- it
+    /// clears three redirects and pushes pty input -- so it is only meaningful
+    /// while the surface is alive. Raised after SurfaceFree it would be
+    /// useless: the liveness check the window makes would already be false and
+    /// the picker, its theme arena, its 50ms poll and the control's whole
+    /// visual subtree would leak for the life of the window, which is exactly
+    /// what a tab close did before this event existed.
+    ///
+    /// Once-only and never-for-a-surface-that-was-not-created are the other
+    /// half. The disposed latch buys the first (DisposeSurface is idempotent
+    /// and callable from both PaneHost and the window's close), the handle
+    /// check the second -- a subscriber told about a surface that never
+    /// existed would be comparing its saved pointer against a zero handle.
+    /// </summary>
+    [Fact]
+    public void TheSurfaceDisposingWarningComesBeforeTheFree()
+    {
+        var source = ShellSource.Load(TerminalControlFile);
+        var statements = source.Method("DisposeSurface").Body!.Statements;
+
+        // Exactly one raise in the whole file: a second one somewhere else
+        // would fire without the latch below and could reach a subscriber
+        // twice, or reach one after the surface is already gone.
+        var raises = source.Root.Calls(SurfaceDisposing + "?.Invoke");
+        Assert.True(
+            raises.Count == 1,
+            $"expected exactly one `{SurfaceDisposing}?.Invoke` in {TerminalControlFile}, found "
+            + $"{raises.Count}; only the raise guarded by the disposed latch is once-only");
+
+        int IndexOfCall(string call) => statements.TakeWhile(s => !s.Calls(call).Any()).Count();
+        var raise = IndexOfCall(SurfaceDisposing + "?.Invoke");
+        var free = IndexOfCall("NativeMethods.SurfaceFree");
+
+        // Both have to be found, or TakeWhile hands back the full count and
+        // the ordering comparison below passes while pinning nothing.
+        Assert.True(raise < statements.Count, "DisposeSurface must raise " + SurfaceDisposing);
+        Assert.True(free < statements.Count, "expected DisposeSurface to free the surface");
+        Assert.True(
+            raise < free,
+            SurfaceDisposing + " must be raised before SurfaceFree: it exists so a holder of "
+            + "surface-keyed native state can hand it back, and after the free there is nothing "
+            + "left to hand back to");
+
+        // The latch, in the two statements that make the raise once-only.
+        Assert.True(
+            IsClosedGuard(statements[0], "_surfaceDisposed"),
+            "DisposeSurface must return early on _surfaceDisposed as its first statement");
+        Assert.True(
+            SetsLatch(statements[1], "_surfaceDisposed"),
+            "DisposeSurface must set _surfaceDisposed before anything else, so the raise below "
+            + "cannot fire twice for one control");
+        Assert.True(raise > 1, "the raise must sit below the latch, or it is not once-only");
+
+        // And the guard that keeps it off a control that never made a surface.
+        var guard = raises[0].Ancestors().OfType<IfStatementSyntax>().FirstOrDefault();
+        Assert.True(
+            guard is not null && TestsSurfaceHandleAgainstZero(guard.Condition),
+            "the raise must be guarded on _surface.Handle != IntPtr.Zero: a control whose surface "
+            + "was never created has nothing installed on it, and a subscriber told about one "
+            + "would be matching its saved pointer against a zero handle");
+
+        // A subscriber that throws must not stop the teardown: everything
+        // below the raise frees native memory, and PaneHost walks the leaves
+        // in a loop, so an escaping exception strands this surface and skips
+        // every leaf after it.
+        var contained = raises[0].Ancestors().OfType<TryStatementSyntax>().FirstOrDefault();
+        Assert.True(
+            contained is not null && contained.Catches.Count > 0,
+            "the raise must be wrapped in try/catch; DisposeSurface is a teardown path and an "
+            + "exception out of a subscriber would leak this surface and every leaf after it");
+        Assert.DoesNotContain(
+            contained!.Catches.SelectMany(c => c.Block.DescendantNodesAndSelf()),
+            n => n.IsKind(SyntaxKind.ThrowStatement));
+    }
+
+    /// <summary>
+    /// <c>_surface.Handle != IntPtr.Zero</c>, either way round.
+    /// </summary>
+    private static bool TestsSurfaceHandleAgainstZero(ExpressionSyntax condition)
+    {
+        if (condition is not BinaryExpressionSyntax comparison) return false;
+        if (!comparison.IsKind(SyntaxKind.NotEqualsExpression)) return false;
+
+        var sides = new[] { Flatten(comparison.Left), Flatten(comparison.Right) };
+        return sides.Contains("_surface.Handle") && sides.Contains("IntPtr.Zero");
+    }
+
+    /// <summary>
+    /// The window following its picker's surface into teardown.
+    ///
+    /// Closing the tab the picker is open in frees the surface through
+    /// TabManager.CloseTab, which calls DisposeAllLeaves BEFORE it raises
+    /// TabRemoved -- so no tab-level notification is early enough, and the
+    /// deinit that clears the picker's redirects and returns its allocation
+    /// was simply skipped, forever, with the poll still ticking every 50ms at
+    /// a picker no key could ever quit.
+    ///
+    /// The subscription is per-control, and the control can outlive this
+    /// window: a detached tab carries it to another window. So it is taken
+    /// back explicitly, and taken out only once the open has succeeded, which
+    /// is what makes that one detach enough -- a subscription exists only
+    /// while _pickerHandle is non-zero, and that is exactly when ClosePicker
+    /// runs past its early return.
+    /// </summary>
+    [Fact]
+    public void ThePickerIsClosedWhenTheSurfaceUnderItGoes()
+    {
+        var source = ShellSource.Load(MainWindow.File);
+
+        var subscribed = Subscriptions(source).Where(s => NamesSurfaceDisposing(s.Event)).ToList();
+        Assert.True(
+            subscribed.Count == 1,
+            $"expected exactly one `{SurfaceDisposing} +=` in {MainWindow.Class}, found "
+            + $"{subscribed.Count}; a second one would outlive the picker it was taken out for");
+        var wire = subscribed[0];
+        Assert.True(
+            wire.Handler == PickerDisposingHandler,
+            $"expected `{SurfaceDisposing} += {PickerDisposingHandler}`; an inline lambda here "
+            + "cannot be detached, and the control outlives this window on a tab detach");
+
+        // Detached, spelled the same way on both sides so the census can pair
+        // them. Nothing on the control's side can answer for this one: nulling
+        // the event during its own disposal is too late for the control that
+        // is carried to another window instead.
+        Assert.Contains(
+            (wire.Event, wire.Handler),
+            Unsubscribes(MainWindow, source).Select(u => (u.Event, u.Handler)));
+
+        // In ClosePicker itself, not merely somewhere the close reaches: every
+        // way the picker ends -- the poll seeing should_quit, a second picker
+        // opening, this very handler -- goes through there, and each of them
+        // has to leave the control clean.
+        var detached = Assignments(source.Method("ClosePicker"), SyntaxKind.SubtractAssignmentExpression)
+            .Where(u => NamesSurfaceDisposing(u.Event))
+            .ToList();
+        Assert.True(
+            detached.Count == 1,
+            $"ClosePicker must take back the one {SurfaceDisposing} subscription, found "
+            + $"{detached.Count}; it is the single exit every picker close funnels through");
+
+        // Taken out after the open, which is the invariant behind that single
+        // detach: ClosePicker returns on a zero handle before it reaches the
+        // detach, so a subscription made before the open would survive a
+        // failed one with nothing left able to remove it.
+        var statements = source.Method("ShowInlineThemePicker").Body!.Statements;
+        var opened = statements
+            .TakeWhile(s => !s.Calls("NativeMethods.SurfaceListThemes").Any())
+            .Count();
+        var wired = statements
+            .TakeWhile(s => !Assignments(s, SyntaxKind.AddAssignmentExpression)
+                .Any(a => NamesSurfaceDisposing(a.Event)))
+            .Count();
+        Assert.True(
+            opened < statements.Count,
+            "expected ShowInlineThemePicker to open the picker through NativeMethods.SurfaceListThemes");
+        Assert.True(
+            wired < statements.Count,
+            $"ShowInlineThemePicker must subscribe to the surface's {SurfaceDisposing}");
+        Assert.True(
+            opened < wired,
+            $"the {SurfaceDisposing} subscription must be taken out after the open succeeds: "
+            + "ClosePicker bails on a zero handle before it reaches the detach, so one taken out "
+            + "earlier would be stranded on the control by a failed open");
+
+        // And the handler hands the picker back rather than doing its own
+        // half of the cleanup, so there is one teardown to keep correct.
+        Assert.Single(source.Method(PickerDisposingHandler).Calls("ClosePicker"));
     }
 
     /// <summary>

--- a/windows/Ghostty.Tests/Wiring/WindowTeardownWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/WindowTeardownWiringTests.cs
@@ -177,6 +177,18 @@ public class WindowTeardownWiringTests
         // only place the picker's per-control subscription is taken back --
         // the control can outlive this window, so nothing on the control's
         // side can answer for it.
+        //
+        // Naming it here unions its whole body into the detach set for the
+        // WHOLE census, which is a stronger claim than it looks. ClosePicker
+        // is called unconditionally from the close, but the `-=` inside it is
+        // reached CONDITIONALLY: it bails first on a zero handle. And the
+        // close is not its only caller -- the poll tick and a second
+        // ShowInlineThemePicker both run it. So "the close takes this back"
+        // holds only because a subscription exists only while the handle is
+        // non-zero, which is exactly when ClosePicker runs past that bail.
+        // ThePickerIsClosedWhenTheSurfaceUnderItGoes is what pins that
+        // invariant; widening this list further needs the same argument made
+        // again for whatever is added.
         ClosePath: new[] { "ClosePicker" },
         AtLeast: 40,
         Owned: MainWindowOwned,
@@ -761,6 +773,34 @@ public class WindowTeardownWiringTests
         || flattened.EndsWith("." + SurfaceDisposing, StringComparison.Ordinal);
 
     /// <summary>
+    /// <c>if (!ReferenceEquals(sender, _pickerTerminal)) return;</c>, either
+    /// argument order and however ReferenceEquals is qualified.
+    ///
+    /// The shape, not the text: the operands are what carry the meaning, and a
+    /// guard comparing the sender against anything else -- `this` is the one
+    /// that reads plausibly -- is never true for a control, so the handler
+    /// returns before ClosePicker on every raise and the picker is stranded
+    /// exactly as it was before this event existed. Same style as
+    /// <see cref="IsClosedGuard"/> and
+    /// <see cref="TestsSurfaceHandleAgainstZero"/>, so the file keeps one idea
+    /// of what a guard is.
+    /// </summary>
+    private static bool IsPickerIdentityGuard(StatementSyntax statement)
+    {
+        if (statement is not IfStatementSyntax guard) return false;
+        if (guard.Condition is not PrefixUnaryExpressionSyntax negation) return false;
+        if (!negation.IsKind(SyntaxKind.LogicalNotExpression)) return false;
+        if (negation.Operand is not InvocationExpressionSyntax call) return false;
+        if (!call.CalleeText().EndsWith("ReferenceEquals", StringComparison.Ordinal)) return false;
+
+        var operands = call.ArgumentList.Arguments.Select(a => Flatten(a.Expression)).ToList();
+        return operands.Count == 2
+            && operands.Contains("sender")
+            && operands.Contains("_pickerTerminal")
+            && guard.Statement.DescendantNodesAndSelf().OfType<ReturnStatementSyntax>().Any();
+    }
+
+    /// <summary>
     /// The warning a control gives before it frees its surface.
     ///
     /// The picker's cleanup writes through the surface pointer it saved -- it
@@ -781,7 +821,8 @@ public class WindowTeardownWiringTests
     public void TheSurfaceDisposingWarningComesBeforeTheFree()
     {
         var source = ShellSource.Load(TerminalControlFile);
-        var statements = source.Method("DisposeSurface").Body!.Statements;
+        var dispose = source.Method("DisposeSurface");
+        var statements = dispose.Body!.Statements;
 
         // Exactly one raise in the whole file: a second one somewhere else
         // would fire without the latch below and could reach a subscriber
@@ -817,9 +858,25 @@ public class WindowTeardownWiringTests
         Assert.True(raise > 1, "the raise must sit below the latch, or it is not once-only");
 
         // And the guard that keeps it off a control that never made a surface.
-        var guard = raises[0].Ancestors().OfType<IfStatementSyntax>().FirstOrDefault();
+        //
+        // Every `if` between the raise and the method, not the nearest one:
+        // the nearest-ancestor question is answered just as well by an outer
+        // condition that is never true, and wrapping the handle test in one
+        // leaves every count and every index above intact while the event
+        // stops being raised at all. One enclosing `if`, and it is the handle
+        // test, is the only shape that says the raise runs whenever the
+        // surface exists.
+        var enclosing = raises[0].Ancestors()
+            .OfType<IfStatementSyntax>()
+            .Where(node => dispose.Span.Contains(node.Span))
+            .ToList();
         Assert.True(
-            guard is not null && TestsSurfaceHandleAgainstZero(guard.Condition),
+            enclosing.Count == 1,
+            "expected the raise to sit under exactly one `if` inside DisposeSurface, found "
+            + $"{enclosing.Count}; a second condition around it decides whether the warning is "
+            + "given at all, and nothing here can say what that condition is worth");
+        Assert.True(
+            TestsSurfaceHandleAgainstZero(enclosing[0].Condition),
             "the raise must be guarded on _surface.Handle != IntPtr.Zero: a control whose surface "
             + "was never created has nothing installed on it, and a subscriber told about one "
             + "would be matching its saved pointer against a zero handle");
@@ -903,14 +960,31 @@ public class WindowTeardownWiringTests
             $"ClosePicker must take back the one {SurfaceDisposing} subscription, found "
             + $"{detached.Count}; it is the single exit every picker close funnels through");
 
-        // Taken out after the open, which is the invariant behind that single
-        // detach: ClosePicker returns on a zero handle before it reaches the
-        // detach, so a subscription made before the open would survive a
-        // failed one with nothing left able to remove it.
+        // Taken out after the open SUCCEEDS, which is the invariant behind
+        // that single detach: ClosePicker returns on a zero handle before it
+        // reaches the detach, so a subscription that can survive a failed open
+        // has nothing left able to remove it.
+        //
+        // Measured against the zero-handle bail, not against the native call.
+        // "Below SurfaceListThemes" is satisfied by a `+=` sitting between the
+        // call and the bail, and that is the failing open: a null return then
+        // leaves a subscription on the control with _pickerTerminal null and
+        // the handle zero, and detaching that tab to another window leaves the
+        // closed window reachable from a live control.
         var statements = source.Method("ShowInlineThemePicker").Body!.Statements;
         var opened = statements
             .TakeWhile(s => !s.Calls("NativeMethods.SurfaceListThemes").Any())
             .Count();
+        var bail = statements
+            .Select((s, i) => (s, i))
+            .Where(x => x.i > opened)
+            .Where(x => x.s is IfStatementSyntax guard
+                        && TestsPickerHandleAgainstZero(guard.Condition)
+                        && guard.Statement.DescendantNodesAndSelf()
+                            .OfType<ReturnStatementSyntax>().Any())
+            .Select(x => x.i)
+            .DefaultIfEmpty(statements.Count)
+            .First();
         var wired = statements
             .TakeWhile(s => !Assignments(s, SyntaxKind.AddAssignmentExpression)
                 .Any(a => NamesSurfaceDisposing(a.Event)))
@@ -919,17 +993,47 @@ public class WindowTeardownWiringTests
             opened < statements.Count,
             "expected ShowInlineThemePicker to open the picker through NativeMethods.SurfaceListThemes");
         Assert.True(
+            bail < statements.Count,
+            "expected ShowInlineThemePicker to return on a zero handle after the open; without "
+            + "that statement there is no failure path to measure the subscription against");
+        Assert.True(
             wired < statements.Count,
             $"ShowInlineThemePicker must subscribe to the surface's {SurfaceDisposing}");
         Assert.True(
-            opened < wired,
-            $"the {SurfaceDisposing} subscription must be taken out after the open succeeds: "
-            + "ClosePicker bails on a zero handle before it reaches the detach, so one taken out "
-            + "earlier would be stranded on the control by a failed open");
+            bail < wired,
+            $"the {SurfaceDisposing} subscription must be taken out below the zero-handle return, "
+            + "not merely below the open: ClosePicker bails on a zero handle before it reaches "
+            + "the detach, so one a failed open can reach is stranded on the control for good");
+
+        // Unconditionally, as a statement of the method rather than something
+        // reached through a branch. Every count and every index above survives
+        // wrapping the `+=` in an `if` that is never taken, and the picker
+        // would then have no subscription at all.
+        var wireStatement = wire.Rhs.FirstAncestorOrSelf<StatementSyntax>();
+        Assert.True(
+            wireStatement is not null && statements.Any(s => s.Span == wireStatement.Span),
+            $"the `{SurfaceDisposing} +=` must be a top-level statement of ShowInlineThemePicker; "
+            + "nested inside a branch it is a subscription that may never be taken out while "
+            + "everything here still reads as wired");
 
         // And the handler hands the picker back rather than doing its own
         // half of the cleanup, so there is one teardown to keep correct.
         Assert.Single(source.Method(PickerDisposingHandler).Calls("ClosePicker"));
+
+        // Guarded on the control this picker was opened on, as the handler's
+        // first act. Nothing else reads that condition, and the mutation that
+        // matters is small: compare the sender against `this` instead and the
+        // handler returns on every raise, ClosePicker never runs, and the
+        // picker, its arena, the poll and the control's subtree are stranded
+        // for the life of the window -- which is the defect this whole event
+        // exists to fix, back with every rule above still green.
+        var handler = source.Method(PickerDisposingHandler).Body!.Statements;
+        Assert.True(
+            handler.Count > 0 && IsPickerIdentityGuard(handler[0]),
+            $"{PickerDisposingHandler} must open with "
+            + "`if (!ReferenceEquals(sender, _pickerTerminal)) return;`: it is what keeps a stale "
+            + "raise from tearing down a picker it does not belong to, and what makes the raise "
+            + "for the current one get through");
     }
 
     /// <summary>

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -660,6 +660,20 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     /// glow.</summary>
     public event EventHandler? FirstRender;
 
+    /// <summary>Raised from <see cref="DisposeSurface"/> while the surface is
+    /// still valid, for holders of native state keyed on this control's
+    /// surface pointer -- the window's inline theme picker keeps input,
+    /// scroll and resize redirects installed on it, and handing those back
+    /// writes through the pointer.
+    ///
+    /// Nothing at the tab level can serve them: TabManager.CloseTab frees the
+    /// tab's leaves before it announces the tab is gone, so a TabRemoved
+    /// subscriber already holds a dangling pointer by the time it runs.
+    ///
+    /// Fires at most once per control, and never for a control whose surface
+    /// was never created.</summary>
+    internal event EventHandler? SurfaceDisposing;
+
     // Distance the search bar floats from the terminal's top-right, on
     // top of whatever gutter the pane chrome reserves.
     private const double SearchBarInset = 8;
@@ -1011,6 +1025,33 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         if (_surfaceDisposed) return;
         _surfaceDisposed = true;
 
+        // Tell the holders of surface-keyed native state first, while nothing
+        // has been unwound yet: what they have to hand back is written through
+        // this surface pointer, so after SurfaceFree below there is no safe
+        // moment left. The latch above is what makes this fire exactly once,
+        // and the handle check is what keeps it from firing for a control
+        // whose surface was never created -- there is nothing installed on a
+        // surface that does not exist, and a subscriber told about one would
+        // be comparing its saved pointer against a zero handle.
+        if (_surface.Handle != IntPtr.Zero)
+        {
+            try
+            {
+                SurfaceDisposing?.Invoke(this, EventArgs.Empty);
+            }
+            catch (Exception ex)
+            {
+                // Swallowed on purpose. Everything below this point frees
+                // native memory, and PaneHost walks the leaves in a loop, so
+                // an escaping exception would strand this surface and skip
+                // every leaf after it. A subscriber that failed to clean up
+                // after itself is a smaller problem than a teardown that
+                // stops half way, so log it and keep tearing down.
+                Ghostty.Logging.StaticLoggers.App.LogWarning(
+                    "SurfaceDisposing subscriber threw during teardown: {Message}", ex.Message);
+            }
+        }
+
         _bellAudio?.Dispose();
         _bellAudio = null;
 
@@ -1047,6 +1088,9 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         FirstRender = null;
         BellRang = null;
         BellAcknowledged = null;
+        // Already raised above; dropping it here is for a subscriber that did
+        // not detach itself in its handler.
+        SurfaceDisposing = null;
     }
 
     private static IntPtr AllocEmptyUtf8()

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -4074,6 +4074,17 @@ public sealed partial class MainWindow : Window
         // there is a callback on a collected delegate, which kills the process
         // rather than throwing. Cleaning up after our own picker is a repair
         // for that window, not damage to it.
+        //
+        // Ownership of the picker leaves this window here, before the deinit
+        // rather than after it. The native side only checks the pointer is
+        // non-null and then destroys the allocation, so it is not idempotent,
+        // and a second call through a handle the field was still holding is a
+        // double free. Anything that re-entered ClosePicker while the deinit
+        // was running would find a zero handle and turn back at the early
+        // return above instead.
+        var handle = _pickerHandle;
+        _pickerHandle = IntPtr.Zero;
+
         if (_pickerTerminal is { } terminal)
         {
             // Taken back here rather than left to the control to null when it
@@ -4084,10 +4095,9 @@ public sealed partial class MainWindow : Window
             terminal.SurfaceDisposing -= OnPickerSurfaceDisposing;
 
             if (terminal.SurfaceHandle == _pickerSurface.Handle)
-                NativeMethods.SurfaceListThemesDeinit(_pickerSurface, _pickerHandle);
+                NativeMethods.SurfaceListThemesDeinit(_pickerSurface, handle);
         }
 
-        _pickerHandle = IntPtr.Zero;
         _pickerSurface = default;
         _pickerTerminal = null;
         _inlineThemeCb = null;

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -3943,11 +3943,40 @@ public sealed partial class MainWindow : Window
             return;
         }
 
+        // The only warning that this surface is about to go. Closing the
+        // picker's tab frees its leaves before it announces the tab is gone,
+        // so nothing tab-level runs early enough: by then the deinit below
+        // can no longer run, and the picker allocation, its theme arena, the
+        // 50ms poll and the control's whole visual subtree are stranded for
+        // the life of the window.
+        //
+        // Taken out after the open succeeds, not alongside the field
+        // assignments above, so the single detach in ClosePicker is enough: a
+        // subscription then only ever exists while _pickerHandle is non-zero,
+        // which is exactly when ClosePicker runs past its early return.
+        terminal.SurfaceDisposing += OnPickerSurfaceDisposing;
+
         // Picker is now active. handleKey fires on each key event and
         // sets should_quit when the user confirms/cancels. We poll on
         // a timer to clean up, avoiding a thread that races with the
         // input redirect callback.
         StartPickerPoll();
+    }
+
+    /// <summary>
+    /// The surface the picker is installed on is being freed. Close the picker
+    /// now, while the deinit can still reach it: this runs above
+    /// <c>SurfaceFree</c>, so the redirects come off and the allocation comes
+    /// back instead of being stranded.
+    /// </summary>
+    private void OnPickerSurfaceDisposing(object? sender, EventArgs e)
+    {
+        // Act on the control this picker was opened on, never on whatever
+        // raised the event: a stale subscription -- one taken out for a picker
+        // that has since been replaced -- must not tear down the current one.
+        if (!ReferenceEquals(sender, _pickerTerminal)) return;
+
+        ClosePicker();
     }
 
     private void StartPickerPoll()
@@ -4021,8 +4050,12 @@ public sealed partial class MainWindow : Window
         // A non-zero handle does not mean the surface behind it is still
         // there. Deinit writes through that pointer -- it clears three
         // redirects and pushes pty input -- so running it against a freed
-        // surface is a write into freed memory, and closing the picker's tab
-        // frees the surface without touching anything here.
+        // surface is a write into freed memory.
+        //
+        // The control now says so before it frees anything, which is what
+        // gets a tab close here while the deinit still means something. The
+        // mismatch below is the residual case: any path that reaches the free
+        // without this window being told.
         //
         // The control zeroes its own handle when it disposes the surface, so
         // a mismatch means the surface is gone and nothing can reach the
@@ -4041,10 +4074,18 @@ public sealed partial class MainWindow : Window
         // there is a callback on a collected delegate, which kills the process
         // rather than throwing. Cleaning up after our own picker is a repair
         // for that window, not damage to it.
-        var live = _pickerTerminal is { } terminal
-            && terminal.SurfaceHandle == _pickerSurface.Handle;
-        if (live)
-            NativeMethods.SurfaceListThemesDeinit(_pickerSurface, _pickerHandle);
+        if (_pickerTerminal is { } terminal)
+        {
+            // Taken back here rather than left to the control to null when it
+            // disposes, because the control can outlive this window: a
+            // detached tab carries it to another window, and a subscription
+            // left on it would keep this closed window reachable from a
+            // control it no longer owns.
+            terminal.SurfaceDisposing -= OnPickerSurfaceDisposing;
+
+            if (terminal.SurfaceHandle == _pickerSurface.Handle)
+                NativeMethods.SurfaceListThemesDeinit(_pickerSurface, _pickerHandle);
+        }
 
         _pickerHandle = IntPtr.Zero;
         _pickerSurface = default;


### PR DESCRIPTION
Closes #731

## The defect

Closing the tab a theme picker is open in stranded it. `TabManager.CloseTab` frees the tab's leaves before it announces the tab is gone, so nothing at the tab level runs early enough: by the time `TabRemoved` fires, the control has already zeroed its handle and the liveness check in `ClosePicker` correctly refuses to deinit through a freed pointer.

So the picker allocation and its theme arena leaked, the 50ms poll went on calling `should_quit` forever against a surface no key could reach, and the disposed control kept its whole visual subtree rooted -- all for the life of the window. Pre-existing, and the last remaining hole in this family.

## The change

`TerminalControl` now announces its own surface's death from the top of `DisposeSurface`, while the surface is still valid, and the window closes the picker on that. Same deinit as before, against a pointer that still means something, so the redirects come off and the allocation comes back.

The subscription is taken out after the open succeeds rather than beside the field assignments, so its existence implies a non-zero picker handle -- which is exactly when `ClosePicker` runs past its early return, making the one detach there cover every exit. It is taken back in `ClosePicker` rather than left to the control's own event clearing, because the control outlives this window when a detached tab carries it elsewhere, and a subscription left on it would keep a closed window reachable from a control it no longer owns.

The raise is latched to fire once, skipped for a control whose surface was never created, and wrapped: `PaneHost` walks leaves in a loop and everything below the raise frees native memory, so a throwing subscriber would strand this surface and skip every leaf after it.

## Review

The pass cleared the product code on every angle it attacked, including the one I was least sure of. The handler runs inside `DisposeSurface` and the deinit writes VT and pushes pty input, so re-entrancy was the question: it is closed at both ends, by the disposed latch above the raise, and on the native side by the three redirects being nulled before `picker.exit()` so no input can reach a half-torn-down picker. The only synchronous route back into C# is the wakeup, which defers.

What it broke was the guards. Three one-token mutations put the defect back while every new rule stayed green:

- The handler's identity check was unpinned. Swapping `_pickerTerminal` for `this` makes it return early forever, and the only assertion about that method was that it calls `ClosePicker` once. Its shape is matched now, the way the closed-flag and handle-zero guards in that file already are.
- The subscription rule measured the wrong thing: that the subscribe sits below the open, when what the single detach rests on is that a subscription exists only while the handle is non-zero. Moving the subscribe above the zero-handle bail satisfied the old rule and left a failed open subscribed forever. It is measured against the bail now.
- Both rules walked through an always-false wrapper, because a Roslyn scan over descendants sees a statement whether or not it can run. That is a fourth way past this census, alongside the missing, the hidden and the hoisted: present but unreachable. The raise must now sit under exactly one condition inside the dispose, and the subscribe must be a top-level statement.

One latent hardening came with it. `ClosePicker` held a live copy of the handle across the deinit, and the native side checks only that the pointer is non-null before destroying the allocation, so a second call through a field still holding it is a double free. Nothing reaches that today, but ownership now leaves the field before the call.

## Not fixed here

Two windows can still hold pickers on one surface: opening a picker on a surface that already has one overwrites all three redirects, orphaning the first from any key that could set its `should_quit`. Pre-existing, and mildly amplified by this change since both windows' handlers now fire off one dispose (harmless -- the handles differ and redirect nulling is idempotent). # 739 removes it by construction, since a process-wide singleton never installs a second picker.

## Tests

Every rule verified by mutation, applied and observed red, reverted and observed green -- including that moving the raise below the free and deleting the detach both still go red, so the rules the first commit established were not weakened by the rewrite.

Full suite 2285 passing, shell builds clean.
