### PR TITLE
build: ignore tags that are not release tags when detecting the version

### DIFF
--- a/src/build/GitVersion.zig
+++ b/src/build/GitVersion.zig
@@ -53,8 +53,16 @@ pub fn detect(b: *std.Build) !Version {
         break :short_hash std.mem.trimEnd(u8, output, "\r\n ");
     };
 
+    // Only a release tag names a version. With no match pattern this returns
+    // whatever tag happens to sit on HEAD, and Config.init panics on a tag it
+    // does not recognise -- so a tag in an unrelated namespace makes the
+    // commit unbuildable. This fork tags every published sync series/vN,
+    // which lands on exactly such a commit.
+    //
+    // These two patterns filter by namespace; they do not validate. Whether
+    // a v* tag is one Config.init accepts stays Config.init's call.
     const tag = b.runAllowFail(
-        &[_][]const u8{ "git", "-C", b.build_root.path orelse ".", "describe", "--exact-match", "--tags" },
+        &[_][]const u8{ "git", "-C", b.build_root.path orelse ".", "describe", "--exact-match", "--tags", "--match", "v*", "--match", "tip" },
         &code,
         .ignore,
     ) catch |err| switch (err) {


### PR DESCRIPTION
`GitVersion.detect` ran `git describe --exact-match --tags` with no match
pattern, so it returned whatever tag happened to sit on HEAD. `Config.init`
(src/build/Config.zig:320) panics on a tag that is neither `tip` nor `vX.Y.Z`:

    thread panic: tagged releases must be in vX.Y.Z format matching build.zig

A commit carrying a tag from any other namespace therefore cannot be built at
all. `zig build` dies in the configure phase, which takes `build-dll`,
`build-win` and `just signoff` with it.

`just sync-publish` tags its replay tip `series/vN`, so the checkout a sync
runs from goes unbuildable the moment the publish lands: `sync-verify` runs on
`series-wip` before the tag exists, and every build from that same checkout
afterwards panics. It stays latent because a build rarely lands on exactly a
tagged commit: `origin/windows` carries no tag of its own, `series/v2` is not
an ancestor of it, and `git describe --exact-match` fails there, so a fresh
clone of `windows` builds fine. `series/` is not the only exposed namespace
either -- `main-backup-pre-align-2026-07-14`, `sync-backup-pre-2026-08-22` and
six `*-2026-07-09` proof tags break their commits the same way, and those
predate any series tag.

The fix passes `--match v* --match tip`. Both are named because both are
namespaces `Config.init` knows; `tip` is belt and braces, since a tip build
already resolves to the same version an untagged one does. The filter sorts by
namespace and does not validate, so a `v*` tag `Config.init` rejects (this repo
has `v0.0.1-rc.1`) still panics. That is upstream's guardrail against a
mistagged release and is left alone deliberately: the bug here is tags that
were never releases, and filtering at the git call is a smaller and more
upstreamable change than relaxing the panic.

Release artifacts are unaffected either way -- `release-tag.yml` and the nix
packages pass `-Dversion-string`, which short-circuits git detection entirely.

## Evidence

`git describe` at series/v2 (47df190980):

    $ git describe --exact-match --tags 47df190980
    series/v2
    $ git describe --exact-match --tags --match 'v*' --match tip 47df190980
    fatal: no tag exactly matches '47df190980c8d8d610dbd9065bfcebcf80a311fc'

Build, with a throwaway `series/v*` tag planted on this branch's HEAD:

    # pre-fix GitVersion.zig
    $ zig build -Dapp-runtime=none
    thread 5560 panic: tagged releases must be in vX.Y.Z format matching build.zig
    src/build/Config.zig:320:21 in init
    build.zig:38:44 in build
    -> exit 1

    # with the fix, same tag still on HEAD
    $ zig build -Dapp-runtime=none
    -> exit 0, zig-out/bin/ghostty-vt.dll produced

## Test plan

- [x] the panic above reproduces on the pre-fix file with a non-release tag on HEAD
- [x] `zig build -Dapp-runtime=none` succeeds with the fix and the same tag still on HEAD
- [x] `git describe` returns the series tag without the match patterns and nothing with them
- [x] `just signoff` green (zig-fmt, zig-tests)

No regression test. A Zig unit test would be dead code: `zig build test` roots
its test binary at `src/main.zig` (build.zig:377), so nothing under
`src/build/` is reachable from any test step, and `detect` takes a live
`*std.Build` and shells out to `git` with no seam to fake. A shell-level check
in `.agents/scripts/syncflow-selftest.sh` is possible and would pin the one
load-bearing assumption (git's `--match` uses `FNM_PATHNAME`, so `v*` cannot
cross the `/` in `series/v2`), but that harness drives the sync recipes
end-to-end and this does not belong in it. Tracked in #748, which covers the
wider problem: that whole directory is structurally untestable, which is why
this bug had no regression test to add. The reproduction above is the check
for now. Review also turned up an unrelated latent bug in the same function,
tracked in #747.
