### PR TITLE
build: stop the tag lookup's exit code from leaking into the dirty check

### DIFF
--- a/src/build/GitVersion.zig
+++ b/src/build/GitVersion.zig
@@ -18,11 +18,14 @@ branch: []const u8,
 /// allocates using the build allocator and doesn't free.
 pub fn detect(b: *std.Build) !Version {
     // Execute a bunch of git commands to determine the automatic version.
-    var code: u8 = 0;
+    // runAllowFail needs an out-param but only writes it when the child
+    // fails, and both lookups below return on every failure, so nothing
+    // ever reads this back.
+    var discard_code: u8 = 0;
     const branch: []const u8 = b: {
         const tmp: []u8 = b.runAllowFail(
             &[_][]const u8{ "git", "-C", b.build_root.path orelse ".", "rev-parse", "--abbrev-ref", "HEAD" },
-            &code,
+            &discard_code,
             .ignore,
         ) catch |err| switch (err) {
             error.FileNotFound => return error.GitNotFound,
@@ -43,7 +46,7 @@ pub fn detect(b: *std.Build) !Version {
     const short_hash = short_hash: {
         const output = b.runAllowFail(
             &[_][]const u8{ "git", "-C", b.build_root.path orelse ".", "-c", "log.showSignature=false", "log", "--pretty=format:%h", "-n", "1" },
-            &code,
+            &discard_code,
             .ignore,
         ) catch |err| switch (err) {
             error.FileNotFound => return error.GitNotFound,
@@ -61,9 +64,10 @@ pub fn detect(b: *std.Build) !Version {
     //
     // These two patterns filter by namespace; they do not validate. Whether
     // a v* tag is one Config.init accepts stays Config.init's call.
+    var tag_code: u8 = 0;
     const tag = b.runAllowFail(
         &[_][]const u8{ "git", "-C", b.build_root.path orelse ".", "describe", "--exact-match", "--tags", "--match", "v*", "--match", "tip" },
-        &code,
+        &tag_code,
         .ignore,
     ) catch |err| switch (err) {
         error.FileNotFound => return error.GitNotFound,
@@ -71,6 +75,11 @@ pub fn detect(b: *std.Build) !Version {
         else => return err,
     };
 
+    // Its own out-param: runAllowFail writes a code only when the child fails,
+    // so sharing one would leave the describe failure above still sitting in it
+    // -- 128 whenever HEAD carries no v* or tip tag -- and report a clean
+    // tree as dirty.
+    var diff_code: u8 = 0;
     _ = b.runAllowFail(&[_][]const u8{
         "git",
         "-C",
@@ -78,12 +87,12 @@ pub fn detect(b: *std.Build) !Version {
         "diff",
         "--quiet",
         "--exit-code",
-    }, &code, .ignore) catch |err| switch (err) {
+    }, &diff_code, .ignore) catch |err| switch (err) {
         error.FileNotFound => return error.GitNotFound,
         error.ExitCodeFailure => {}, // expected
         else => return err,
     };
-    const changes = code != 0;
+    const changes = diff_code != 0;
 
     return .{
         .short_hash = short_hash,


### PR DESCRIPTION
`detect()` passed one `code` out-param to all four `runAllowFail` calls, and
`runAllowFail` writes the out-param only when the child fails (zig 0.16.0,
`lib/std/Build.zig`: `out_code.*` is assigned in the `.exited` arm only inside
`if (code != 0)`, and in the `.signal`/`.stopped` and `.unknown` arms). A
failure therefore sits in the variable until some later call fails and
overwrites it.

On a commit carrying no `v*` or `tip` tag -- nearly every commit --
`git describe --exact-match` exits 128 and leaves 128 in `code`.
`git diff --quiet --exit-code` then exits 0 on a clean tree and writes nothing,
so `const changes = code != 0` reads the stale 128 and reports a clean checkout
as dirty.

## What each of the four calls got

The value `changes` reads now has exactly one possible writer.

- `diff --quiet --exit-code` is the call `changes` is about, so it gets
  `diff_code`, declared immediately above it. Giving the *reader* its own
  variable is what closes the bug class: no other call can reach it, so
  inserting a fifth git call later cannot reintroduce this.
- `describe --exact-match` gets `tag_code`. It is the call that was leaking --
  it swallows `ExitCodeFailure` and keeps going.
- `rev-parse --abbrev-ref HEAD` and `log --pretty=format:%h` keep sharing one
  variable. Both return on every failure path, so nothing they write is ever
  read; the variable is renamed `discard_code` to say that out loud rather than
  leaving a plausible-looking `code` in scope for someone to reach for.

## This is latent

`changes` has no reader anywhere in the tree. It is declared at
`GitVersion.zig:9`, computed and assigned into the struct, and that is all --
`Config.init` reads `vsn.tag`, `vsn.branch` and `vsn.short_hash` and never
`vsn.changes`. The bug is real and cheap to fix, but nothing observably
misbehaves today and no user-visible symptom is being claimed.

## Verification

Reproduced at runtime, not only by reading. A throwaway `build.zig` outside the
repo drove the same two git commands through the real `b.runAllowFail` against
this worktree (HEAD untagged, tree clean), first with a shared out-param and
then with separate ones:

    describe failed: ExitCodeFailure, code now 128
    diff exited 0 (clean tree), code untouched: 128
    SHARED   -> changes = true
    SEPARATE -> changes = false (tag_code = 128)

`zig fmt --check` and `zig ast-check` clean, `just build-dll` succeeds, and
`just signoff` is green for this head.

## No regression test

Nothing under `src/build/` is reachable from any test step (#748) -- the
`addTest` artifacts cover the vt module and the main `src/` module, and
`src/build/main.zig` has no test blocks and no `refAllDecls`. A `test` block
here would never run, so it would read as coverage while providing none.
`detect()` also takes a live `*std.Build` and shells out to git four times, so
testing it honestly needs a fixture repo at an untagged clean commit. Not added.

Not sent upstream: upstreaming is deferred until after launch, so this is
fork-local for now even though the file is otherwise upstream code.

Closes #747
