### PR TITLE
build: filter version tags by namespace, and pin that it holds

### DIFF
--- a/.agents/scripts/README.md
+++ b/.agents/scripts/README.md
@@ -29,7 +29,15 @@ human) working in this repo uses the same contract:
   instead of silently absent.
 - `just gates-selftest` - prove the gates still catch what they exist for
   (recorded-PR replays, matcher escapes, exemption anchoring) and that the
-  nightly scripts' helpers roundtrip.
+  nightly scripts' helpers roundtrip. Runs `gitversion-selftest` first.
+- `just gitversion-selftest` - prove a tag outside the release namespace
+  cannot name a version. `sync-publish` tags each published snapshot
+  `series/vN` and Config.init panics on a tag it does not recognise, so
+  the version lookup filters with `--match v* --match tip --exclude */*`.
+  `--match` does not stop at a slash, so `--exclude` is what carries the
+  namespace rule. This runs real `git describe` against a throwaway repo
+  over ten tag layouts, with the argument list read out of
+  GitVersion.zig, and requires three broken argument lists to be caught.
 - `nightly_fuzz.ps1` / `nightly_control.ps1` / `register_nightly_fuzz.ps1` -
   the 23:00 nightly run (tests + fuzz in a dedicated worktree, deduped P1
   issues on breaks, optional hibernate-after) and its control panel.

--- a/.agents/scripts/gate_scope.py
+++ b/.agents/scripts/gate_scope.py
@@ -43,6 +43,7 @@ RECIPE_LEGS = {
     "test-win": (LEG_WIN,),
     "build-win": (LEG_WIN,),
     "gates-selftest": (LEG_GATES,),
+    "gitversion-selftest": (LEG_GATES,),
 }
 
 # Ordered, first match wins, so a more specific prefix must precede its
@@ -71,6 +72,18 @@ PREFIX_RULES = (
 )
 
 EXACT_RULES = {
+    # Both of these are checked by a gates-leg script rather than by a zig
+    # test, because the Zig legs cannot see a BEHAVIOR change in either.
+    # zig-fmt still sees formatting and the suite still sees a compile
+    # error, but nothing runs the code: src/build_config.zig imports
+    # build/Config.zig only to call fromOptions(), and Zig analyses at
+    # decl level, so Config.init -- which is what decides that `tip` and
+    # `vX.Y.Z` are the only names a version may have -- is never reached
+    # from a test root (issue 748). GitVersion.zig runs in build.zig only.
+    # The selftest hardcodes that same contract, so it has to run when
+    # either side of it moves, or the two drift apart in silence.
+    "src/build/GitVersion.zig": ZIG_LEGS + (LEG_GATES,),
+    "src/build/Config.zig": ZIG_LEGS + (LEG_GATES,),
     "build.zig": ZIG_LEGS,
     "build.zig.zon": ZIG_LEGS,
     "build.zig.zon.json": ZIG_LEGS,

--- a/.agents/scripts/gitversion_selftest.ps1
+++ b/.agents/scripts/gitversion_selftest.ps1
@@ -1,0 +1,246 @@
+#!/usr/bin/env pwsh
+#
+# Pin that only a release tag can name a version.
+#
+# GitVersion.detect asks git which tag sits on HEAD. With no filter it answers
+# with whatever tag is there, and Config.init panics on a tag that is neither
+# `tip` nor `vX.Y.Z` -- so `just sync-publish`, which tags every published
+# snapshot `series/vN`, made the commit it had just published unbuildable.
+#
+# The filter is `--match v* --match tip --exclude */*`, and the reason it needs
+# all three is not obvious. `--match` globs the tag name with refs/tags/
+# stripped and does NOT stop at a slash: `v*` rejects `series/v2` only because
+# that name starts with `s`. `vendor/v2`, `v-old/v2` and `verified/1.0` all sail
+# straight through it. `--exclude */*` is what actually carries the namespace
+# rule, and without it renaming the series namespace to anything starting with
+# `v` silently turns a release build into a pre-release version string.
+#
+# So this runs real `git describe` against a throwaway repo, with the argument
+# list read out of GitVersion.zig rather than copied here. A copy would keep
+# passing after the source stopped matching it, which is the failure mode the
+# check exists to prevent.
+#
+# It also runs the same table against three broken argument lists and requires
+# every one to be caught. A check that cannot fail proves nothing, and these
+# are the shapes the regression actually takes: the pre-fix bare `--tags`, the
+# two `--match` patterns collapsed into one permissive pattern, and `--exclude`
+# dropped so a namespaced `v` name gets through.
+#
+# No network, no desktop, no build. Exit 0 pass, 2 finding, 1 the check itself
+# could not run.
+
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Every `describe` in the table below is expected to fail for half the cases.
+# This preference is $false by default today, but if a future pwsh flips it
+# those expected failures become terminating errors and the check reports a
+# harness break for a product that is fine.
+$PSNativeCommandUseErrorActionPreference = $false
+
+# `git -C` loses to these. A run that inherited them -- from a git hook, a
+# `git` alias, `git rebase --exec` -- would aim every command here at the
+# ambient repository instead of the fixture, including the tag deletions.
+foreach ($name in @(
+    'GIT_DIR', 'GIT_WORK_TREE', 'GIT_INDEX_FILE', 'GIT_COMMON_DIR',
+    'GIT_OBJECT_DIRECTORY', 'GIT_CEILING_DIRECTORIES', 'GIT_NAMESPACE'
+)) {
+    Remove-Item "Env:$name" -ErrorAction SilentlyContinue
+}
+
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+$SourceFile = Join-Path $RepoRoot 'src/build/GitVersion.zig'
+$script:FixtureDir = $null
+
+# Nothing global leaks into the fixture: no signing, no hooks, no template.
+$FixtureConfig = @(
+    '-c', 'user.name=gitversion selftest',
+    '-c', 'user.email=selftest@example.invalid',
+    '-c', 'commit.gpgsign=false',
+    '-c', 'tag.gpgsign=false',
+    '-c', 'core.hooksPath='
+)
+
+function Stop-Harness {
+    param([string]$Message)
+    Write-Host "harness: $Message" -ForegroundColor Red
+    exit 1
+}
+
+function Invoke-Git {
+    param([Parameter(Mandatory)][string[]]$Arguments)
+    $output = & git @Arguments 2>&1
+    return [pscustomobject]@{
+        Code = $LASTEXITCODE
+        Text = ($output | Out-String).Trim()
+    }
+}
+
+# The argument list the product actually runs, taken from the Zig source.
+#
+# Anchored on the array literal rather than on the word "describe", because a
+# "describe" in a comment would otherwise hijack the parse and get reported as
+# a product finding rather than as this script failing to read the source.
+function Get-DescribeArguments {
+    if (-not (Test-Path -LiteralPath $SourceFile)) {
+        Stop-Harness "GitVersion.zig not found at $SourceFile"
+    }
+    $text = Get-Content -LiteralPath $SourceFile -Raw
+    $literals = @([regex]::Matches($text, '&\[_\]\[\]const u8\{[^}]*"describe"[^}]*\}'))
+    if ($literals.Count -ne 1) {
+        Stop-Harness "expected one describe argument list in GitVersion.zig, found $($literals.Count)"
+    }
+    $words = @([regex]::Matches($literals[0].Value, '"([^"]*)"') | ForEach-Object { $_.Groups[1].Value })
+
+    # "git", "-C", <the path expression, whose only literal is its orelse
+    # fallback>, "describe", ... A global option slipped in front of
+    # "describe" would mean the product runs a command this script is not
+    # reproducing, and a harness quietly testing a different command is worse
+    # than no harness.
+    $describeAt = [array]::IndexOf($words, 'describe')
+    if ($words.Count -lt 5 -or $words[0] -ne 'git' -or $words[1] -ne '-C' -or $describeAt -ne 3) {
+        Stop-Harness "unexpected describe invocation in GitVersion.zig: $($words -join ' ')"
+    }
+    if ($words -notcontains '--exact-match' -or $words -notcontains '--tags') {
+        Stop-Harness "describe no longer runs --exact-match --tags: $($words -join ' ')"
+    }
+    return , [string[]]$words[$describeAt..($words.Count - 1)]
+}
+
+function New-FixtureRepo {
+    $dir = Join-Path ([System.IO.Path]::GetTempPath()) ("gitversion-selftest-" + [guid]::NewGuid().ToString('N'))
+    New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    # Recorded before the first command that could fail, so the finally block
+    # can still clean up a half-built fixture.
+    $script:FixtureDir = $dir
+
+    $init = Invoke-Git @('-c', 'init.templateDir=', 'init', '--quiet', '--initial-branch=main', $dir)
+    if ($init.Code -ne 0) { Stop-Harness "git init failed: $($init.Text)" }
+    foreach ($subject in @('base', 'head')) {
+        $commit = Invoke-Git (@('-C', $dir) + $FixtureConfig + @('commit', '--quiet', '--allow-empty', '--no-verify', '-m', $subject))
+        if ($commit.Code -ne 0) { Stop-Harness "git commit failed: $($commit.Text)" }
+    }
+    return $dir
+}
+
+function Clear-FixtureTags {
+    param([Parameter(Mandatory)][string]$Repo)
+    # This is the only tag deletion in the script, and it deletes every tag it
+    # finds, so it must never be pointed anywhere but the fixture this process
+    # created.
+    if ($Repo -ne $script:FixtureDir) {
+        Stop-Harness "refusing to delete tags outside the fixture repo"
+    }
+    $list = Invoke-Git @('-C', $Repo, 'tag', '--list')
+    foreach ($tag in ($list.Text -split "`n" | ForEach-Object { $_.Trim() } | Where-Object { $_ })) {
+        $del = Invoke-Git @('-C', $Repo, 'tag', '-d', $tag)
+        if ($del.Code -ne 0) { Stop-Harness "could not clear fixture tag ${tag}: $($del.Text)" }
+    }
+}
+
+# Expect $null where no tag may name a version: describe must fail rather than
+# hand back a string Config.init would then panic on. `On` selects the commit
+# the tag lands on, so the ancestor case checks --exact-match behaviorally
+# instead of just looking for the flag in the argument list.
+$Cases = @(
+    @{ Name = 'published series snapshot'; Tags = @(@{ Name = 'series/v2'; Annotated = $true; On = 'head' }); Expect = $null }
+    @{ Name = 'series namespace renamed to a v name'; Tags = @(@{ Name = 'vendor/v2'; Annotated = $true; On = 'head' }); Expect = $null }
+    @{ Name = 'lightweight namespaced tag'; Tags = @(@{ Name = 'backup/v1.0.0'; Annotated = $false; On = 'head' }); Expect = $null }
+    @{ Name = 'unnamespaced non-release tag'; Tags = @(@{ Name = 'pre-marker-scrub'; Annotated = $false; On = 'head' }); Expect = $null }
+    @{ Name = 'no tag at all'; Tags = @(); Expect = $null }
+    @{ Name = 'release tag on an ancestor only'; Tags = @(@{ Name = 'v1.0.0'; Annotated = $true; On = 'parent' }); Expect = $null }
+    @{ Name = 'annotated release tag'; Tags = @(@{ Name = 'v1.3.1'; Annotated = $true; On = 'head' }); Expect = 'v1.3.1' }
+    @{ Name = 'lightweight release tag'; Tags = @(@{ Name = 'v1.2.3'; Annotated = $false; On = 'head' }); Expect = 'v1.2.3' }
+    @{ Name = 'tip'; Tags = @(@{ Name = 'tip'; Annotated = $false; On = 'head' }); Expect = 'tip' }
+    @{ Name = 'release and series on one commit'; Tags = @(@{ Name = 'series/v2'; Annotated = $true; On = 'head' }, @{ Name = 'v1.3.1'; Annotated = $true; On = 'head' }); Expect = 'v1.3.1' }
+)
+
+# Every argument list is run against each tag layout while that layout is set
+# up, so the fixture is torn down and rebuilt once per case rather than once
+# per case per argument list.
+function Invoke-CaseTable {
+    param(
+        [Parameter(Mandatory)][string]$Repo,
+        [Parameter(Mandatory)][object[]]$CaseTable,
+        [Parameter(Mandatory)][object[]]$ArgumentLists
+    )
+    $failures = @{}
+    foreach ($list in $ArgumentLists) { $failures[$list.Name] = New-Object System.Collections.Generic.List[string] }
+
+    foreach ($case in $CaseTable) {
+        Clear-FixtureTags -Repo $Repo
+        foreach ($tag in $case.Tags) {
+            $target = if ($tag.On -eq 'parent') { 'HEAD~1' } else { 'HEAD' }
+            $create = if ($tag.Annotated) {
+                Invoke-Git (@('-C', $Repo) + $FixtureConfig + @('tag', '-a', $tag.Name, '-m', 'fixture tag', $target))
+            } else {
+                Invoke-Git (@('-C', $Repo) + $FixtureConfig + @('tag', $tag.Name, $target))
+            }
+            if ($create.Code -ne 0) { Stop-Harness "could not create fixture tag $($tag.Name): $($create.Text)" }
+        }
+
+        foreach ($list in $ArgumentLists) {
+            $result = Invoke-Git (@('-C', $Repo) + $list.Arguments)
+            # GitVersion.detect treats a non-zero describe as "no tag";
+            # anything else is the string it hands to Config.init.
+            $got = if ($result.Code -ne 0) { $null } else { $result.Text }
+            if ($got -ne $case.Expect) {
+                $shownGot = if ($null -eq $got) { '<no tag>' } else { $got }
+                $shownWant = if ($null -eq $case.Expect) { '<no tag>' } else { $case.Expect }
+                $failures[$list.Name].Add("$($case.Name): got $shownGot, want $shownWant")
+            }
+        }
+    }
+    return $failures
+}
+
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    Stop-Harness 'git is not on PATH'
+}
+
+$describeArgs = Get-DescribeArguments
+Write-Host "describe args from GitVersion.zig: git $($describeArgs -join ' ')"
+
+$PRODUCT = 'GitVersion.zig'
+$ArgumentLists = @(
+    @{ Name = $PRODUCT; Arguments = $describeArgs }
+    @{ Name = 'no --match filter (the pre-fix form)'; Arguments = [string[]]@('describe', '--exact-match', '--tags') }
+    @{ Name = 'both --match patterns collapsed into one'; Arguments = [string[]]@('describe', '--exact-match', '--tags', '--match', '*') }
+    @{ Name = 'no --exclude (a namespaced v name gets through)'; Arguments = [string[]]@('describe', '--exact-match', '--tags', '--match', 'v*', '--match', 'tip') }
+)
+
+try {
+    $repo = New-FixtureRepo
+    $failures = Invoke-CaseTable -Repo $repo -CaseTable $Cases -ArgumentLists $ArgumentLists
+
+    $real = $failures[$PRODUCT]
+    if ($real.Count -gt 0) {
+        Write-Host "FAIL: a tag that is not a release names a version" -ForegroundColor Red
+        foreach ($f in $real) { Write-Host "  $f" -ForegroundColor Red }
+        exit 2
+    }
+    Write-Host "ok   $($Cases.Count) tag layouts resolve as expected"
+
+    $survivors = New-Object System.Collections.Generic.List[string]
+    foreach ($list in $ArgumentLists) {
+        if ($list.Name -eq $PRODUCT) { continue }
+        if ($failures[$list.Name].Count -eq 0) { $survivors.Add($list.Name) }
+    }
+    if ($survivors.Count -gt 0) {
+        Write-Host "FAIL: the table accepts argument lists it must reject" -ForegroundColor Red
+        foreach ($s in $survivors) { Write-Host "  survived: $s" -ForegroundColor Red }
+        exit 2
+    }
+    Write-Host "ok   $($ArgumentLists.Count - 1) broken argument lists are caught"
+}
+finally {
+    if ($script:FixtureDir -and (Test-Path -LiteralPath $script:FixtureDir)) {
+        Remove-Item -LiteralPath $script:FixtureDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Write-Host "gitversion selftest: pass" -ForegroundColor Green
+exit 0

--- a/.agents/scripts/pr_gate.py
+++ b/.agents/scripts/pr_gate.py
@@ -503,6 +503,8 @@ def self_test():
         ([".gitignore"], False, []),
         ([".agents/scripts/pr_gate.py"], False, ["gates-selftest"]),
         (["src/main.zig"], False, ["zig-fmt", "zig-tests"]),
+        (["src/build/GitVersion.zig"], False, ["gates-selftest", "zig-fmt", "zig-tests"]),
+        (["src/build/Config.zig"], False, ["gates-selftest", "zig-fmt", "zig-tests"]),
         (["windows/App.xaml.cs"], False, ["windows-tests"]),
         (["src/a.zig", "windows/b.cs"], False, ["windows-tests", "zig-fmt", "zig-tests"]),
         (["brand/new/dir/thing.bin"], False, sorted(gate_scope.ALL_LEGS)),

--- a/justfile
+++ b/justfile
@@ -1235,10 +1235,36 @@ pr-gate pr:
 doctor:
     python .agents/scripts/doctor.py
 
-# Prove the gates still catch what they exist for (recorded-PR replays,
-# matcher escapes, exemption anchoring) and that the nightly scripts'
-# helpers roundtrip.
-gates-selftest:
+# Runs real `git describe` against a throwaway repo, over ten tag layouts:
+# `series/vN`, a namespace renamed to a `v` name, plain non-release names, a
+# release tag on an ancestor rather than on HEAD, real releases, and `tip`.
+# The argument list is read out of GitVersion.zig rather than copied here,
+# because a copy keeps passing after the source stops matching it. Three
+# broken argument lists must also be caught, so the check cannot silently
+# stop checking. About eight seconds, no build, no desktop.
+#
+# Why it exists: `sync-publish` tags every published snapshot `series/vN` and
+# Config.init panics on a tag that is neither `tip` nor `vX.Y.Z`, so the
+# version lookup filters with `--match v* --match tip --exclude */*`. The
+# subtlety is that `--match` does not stop at a slash: `v*` rejects
+# `series/v2` only because that name starts with `s`, and lets `vendor/v2`
+# through. `--exclude */*` is what carries the namespace rule, and dropping
+# it turns a release build into a pre-release version string silently.
+#
+# Deliberately not gated to Windows and deliberately not using the
+# `exit ($LASTEXITCODE ?? 1)` idiom the fuzz recipes use: `gates-selftest`
+# depends on this, and that idiom is a syntax error under sh. A gate needs
+# pass or fail, not the fuzz suite's finding-versus-broken-harness split.
+#
+# Prove a tag outside the release namespace cannot name a version.
+gitversion-selftest:
+    pwsh -NoProfile -File .agents/scripts/gitversion_selftest.ps1
+
+# Recorded-PR replays, matcher escapes, exemption anchoring, and the nightly
+# scripts' helpers roundtripping. `gitversion-selftest` runs first.
+#
+# Prove the gates still catch what they exist for.
+gates-selftest: gitversion-selftest
     python .agents/scripts/pr_gate.py --self-test
     python .agents/scripts/workspace_guard.py --self-test
     python .agents/scripts/doctor.py --self-test

--- a/src/build/GitVersion.zig
+++ b/src/build/GitVersion.zig
@@ -56,17 +56,23 @@ pub fn detect(b: *std.Build) !Version {
         break :short_hash std.mem.trimEnd(u8, output, "\r\n ");
     };
 
-    // Only a release tag names a version. With no match pattern this returns
-    // whatever tag happens to sit on HEAD, and Config.init panics on a tag it
-    // does not recognise -- so a tag in an unrelated namespace makes the
-    // commit unbuildable. This fork tags every published sync series/vN,
-    // which lands on exactly such a commit.
+    // Only a release tag names a version. With no filter this returns whatever
+    // tag happens to sit on HEAD, and Config.init panics on a tag it does not
+    // recognise -- so a tag in an unrelated namespace makes the commit
+    // unbuildable. This fork tags every published sync series/vN, which lands
+    // on exactly such a commit.
     //
-    // These two patterns filter by namespace; they do not validate. Whether
-    // a v* tag is one Config.init accepts stays Config.init's call.
+    // --match globs the tag name with refs/tags/ stripped, and it does NOT
+    // stop at a slash: `v*` rejects series/v2 only because that name starts
+    // with `s`, and would accept vendor/v2 or v-old/v2 just fine. So --exclude
+    // carries the namespace rule and --match carries the name rule; drop
+    // either and a tag that is not a release can name a version again.
+    //
+    // They filter; they do not validate. Whether a v* tag is one Config.init
+    // accepts stays Config.init's call.
     var tag_code: u8 = 0;
     const tag = b.runAllowFail(
-        &[_][]const u8{ "git", "-C", b.build_root.path orelse ".", "describe", "--exact-match", "--tags", "--match", "v*", "--match", "tip" },
+        &[_][]const u8{ "git", "-C", b.build_root.path orelse ".", "describe", "--exact-match", "--tags", "--match", "v*", "--match", "tip", "--exclude", "*/*" },
         &tag_code,
         .ignore,
     ) catch |err| switch (err) {


### PR DESCRIPTION
`sync-publish` tags every published snapshot `series/vN`, and `Config.init`
panics on a tag that is neither `tip` nor `vX.Y.Z`. PR 746 filtered the
version lookup with `--match v* --match tip`, on the premise that `--match`
is fnmatch with FNM_PATHNAME so `v*` cannot cross the `/` in `series/v2`.

**That premise is wrong.** `--match` globs the tag name with `refs/tags/`
stripped and does not stop at a slash. Verified on git 2.49.0:

| tag on HEAD | `--match v* --match tip` |
| --- | --- |
| `series/v2` | no match |
| `vendor/v2` | **`vendor/v2`** |
| `v-old/v2` | **`v-old/v2`** |
| `verified/1.0` | **`verified/1.0`** |

`v*` rejects `series/v2` only because that name starts with `s`. The
namespace was never being filtered. Renaming the series namespace to
anything starting with `v` would have turned a release build into a
pre-release version string, silently.

So this adds `--exclude */*`, which carries the namespace rule while
`--match` carries the name rule. Issue #749 needs its FNM_PATHNAME premise
corrected too; that is follow-up.

## The check

`just gitversion-selftest` runs real `git describe` against a throwaway repo
under TEMP, over ten tag layouts: `series/vN`, a namespace renamed to a `v`
name, a lightweight namespaced tag, a plain non-release name, no tag, a
release tag on an ancestor rather than on HEAD, annotated and lightweight
release tags, `tip`, and a release tag sharing a commit with a series tag.

It reads the argument list out of `GitVersion.zig` rather than carrying a
copy, because a copy keeps passing after the source stops matching it. It
also runs the same table against three broken argument lists (the pre-746
bare `--tags`, the two patterns collapsed into `--match *`, and `--exclude`
dropped) and fails if any survives. A check that cannot fail proves nothing.

About eight seconds. No network, no desktop, no build. Hermetic: git's
directory environment variables are cleared first so `git -C` cannot be
redirected at the ambient repo, signing/hooks/templates are neutralised on
the fixture, and the tag deletion refuses to run anywhere but the fixture
this process created.

## Where it lives, and why not in zig

Not under `src/build/`: `src/build_config.zig` imports `build/Config.zig`
only to call `fromOptions()`, and Zig analyses at decl level, so
`Config.init` (which owns the `tip` / `vX.Y.Z` contract) is never reached
from a test root, and `GitVersion.zig` runs in `build.zig` only. A `test`
block there would read as coverage while providing none. It is a gates-leg
script in `.agents/scripts/` instead.

## Wiring

- `gates-selftest` takes it as a prerequisite, so it runs on the leg the
  signoff ladder already selects for `.agents/scripts/` changes.
- `gate_scope.EXACT_RULES` routes `src/build/GitVersion.zig` **and**
  `src/build/Config.zig` through `gates-selftest` as well as the zig legs.
  Without that, editing either selects only the zig legs, which cannot see a
  behavior change in them, and the check would sit unrun by exactly the
  changes it guards. `Config.zig` is included because the table hardcodes
  its contract.
- `RECIPE_LEGS` gains the new recipe, so gutting it invalidates the gates leg.
- `pr_gate.py --self-test` gains cases for both paths, since a PR arguing
  "a check nobody runs proves nothing" should not ship an unexercised rule.

`test` and `test-win` were the alternatives and both are wrong: the zig
aggregate would pull a pwsh dependency into the cross-platform test path,
and the windows leg is the dotnet suite.

The recipe deliberately does not use the `exit ($LASTEXITCODE ?? 1)` idiom
the fuzz recipes use, and is deliberately not `[windows]`-gated: that idiom
is a syntax error under `sh`, and `gates-selftest` depends on this recipe,
so either would have broken the gates leg on Linux and macOS.

## Verification

Passes on the amended `windows`:

    describe args from GitVersion.zig: git describe --exact-match --tags --match v* --match tip --exclude */*
    ok   10 tag layouts resolve as expected
    ok   3 broken argument lists are caught

Mutation tests, each reverting one property in `GitVersion.zig`:

| mutation | result |
| --- | --- |
| `--exclude */*` dropped | exit 2, `vendor/v2` names a version |
| pre-746 bare `--tags` | exit 2, five cases break |
| `--exact-match` dropped | exit 1, harness refuses the source |
| `"describe"` added in a comment | exit 0, parse not hijacked |
| a global `-c` smuggled in front | exit 1, harness refuses the source |

`git tag --list` is unchanged and no fixture directories are left behind.
`just gates-selftest`, `just fuzz-selftest` and `just fuzz-list` are green.

Deliberately not tested: that repeated `--match` flags are OR'd rather than
last-wins. That changed in git 2.13, from 2017, older than any environment
this builds on.

Closes #749
