### PR TITLE
build: fix two error and ordering defects in GitVersion.detect

### DIFF
--- a/src/build/GitVersion.zig
+++ b/src/build/GitVersion.zig
@@ -33,14 +33,19 @@ pub fn detect(b: *std.Build) !Version {
             else => return err,
         };
 
+        // Trim before sanitizing, not after: git terminates the ref name with
+        // a newline, and the loop below would rewrite that into a "-" that no
+        // later trim can tell apart from one the branch name really contains.
+        const trimmed = tmp[0..std.mem.trimEnd(u8, tmp, "\r\n ").len];
+
         // Replace characters that are not valid in semantic version
         // pre-release identifiers (which only allow [0-9A-Za-z-]).
         // Slashes would also mess up dist tarball paths.
-        for (tmp) |*c| {
+        for (trimmed) |*c| {
             if (!std.ascii.isAlphanumeric(c.*) and c.* != '-') c.* = '-';
         }
 
-        break :b tmp;
+        break :b trimmed;
     };
 
     const short_hash = short_hash: {
@@ -104,6 +109,6 @@ pub fn detect(b: *std.Build) !Version {
         .short_hash = short_hash,
         .changes = changes,
         .tag = if (tag.len > 0) std.mem.trimEnd(u8, tag, "\r\n ") else null,
-        .branch = std.mem.trimEnd(u8, branch, "\r\n "),
+        .branch = branch,
     };
 }

--- a/src/build/GitVersion.zig
+++ b/src/build/GitVersion.zig
@@ -55,6 +55,11 @@ pub fn detect(b: *std.Build) !Version {
             .ignore,
         ) catch |err| switch (err) {
             error.FileNotFound => return error.GitNotFound,
+            // Same degradation as the branch lookup above: a git that runs but
+            // fails here means we cannot describe this checkout, which
+            // Config.init turns into a dev version. Without this prong the
+            // error escapes detect() bare and fails the configure phase.
+            error.ExitCodeFailure => return error.GitNotRepository,
             else => return err,
         };
 


### PR DESCRIPTION
`ci.yml` had two jobs and neither tested this repo.

It ran `just prepare`, which applies `patches/` and `overlay/` from the repo root. Both moved under `builds/<tier>/` when tiering landed. `prepare.ps1` guards them with `Test-Path`, so it applies nothing and leaves a bare OSS checkout at `build/wintty.sha`, a pin far older than any tier's.

- `build-and-test` could never pass: the workflow installs no zig, so `dotnet build` always died on a missing `ghostty.dll`.
- `test-debug` always passed having run nothing. From its log: `No test matches the given testcase filter`, once per assembly. `dotnet test` exits 0 when a filter selects nothing.

`test-tier.yml` already builds and tests every tier at the right toolchain, so the only coverage `ci.yml` was meant to add was the Debug run of the `#if DEBUG` tests the Release matrix compiles out. That moves onto the sponsor leg, which owns those files (pro and pro-legacy inherit them via `parent_tier`). It is cheap there: `Ghostty.Tests` references `Ghostty.Core`, not the WinUI app, so it needs neither zig nor `ghostty.dll`.

`scripts/test-debug-gated.ps1` is called by both the workflow and `smoke-tier.ps1`, so the CI and local paths cannot drift. It fails when the filter matches nothing.

## Local runs

`just ci` runs the test-tier matrix locally, leg for leg, for when Actions is unavailable. It adds the two legs `smoke-all` was missing (pro-legacy, and the enterprise MSI). `smoke-all` stays the faster three-tier sweep, and `just test-debug-gated` runs the Debug pass alone in seconds against a materialised tier.

Making that honest needed a second fix. `smoke-tier.ps1` assumed one libghostty toolchain for every tier and used whatever `zig` was on PATH, but pro is on 0.16.0 while oss, sponsor and pro-legacy are on 0.15.2. CI is fine because setup-zig installs `matrix.zig` per leg; locally three of the five legs built with the wrong compiler and only printed a warning. It now reads `minimum_zig_version` from the materialised `build.zig.zon` and resolves a matching zig: a `WINTTY_ZIG_<major>_<minor>_<patch>` override, else PATH when it matches, else the mise and scoop install trees. `WINTTY_OVERLAY_ZIG_EXE` stays the explicit override for the overlay projects, and a mismatch there is now an error instead of a warning.

## Verified

Actions is down on billing, so this was verified locally, which is rather the point.

- `just smoke-tier sponsor`: GREEN end to end. It picked `zig 0.15.2` out of the mise tree while PATH had 0.16.0, then 1154 + 218 + 19 + 11 tests passed.
- `just smoke-tier pro`: GREEN. Both toolchains resolved with no env vars set (0.15.2 from mise for the overlay, 0.16.0 from PATH for libghostty), then 2254 + 122 + 25 + 21 + 20 tests passed.
- Debug-gated tests: 0 before, 218 now.
- The one `#if DEBUG` test passes when targeted directly, 1/1.
- A filter matching nothing exits 1 instead of going green.

## Not fixed here

`bump.yml` has the same problem. Its validation job runs `just prepare` + `just test`, and its PRs bump `build/wintty.sha`, which nothing consumes any more; the real pins in `builds/*/pin` are advanced by hand. `drift-nudge.yml` reads that same dead file weekly. Moving the bump flow onto tiers is a redesign, not a CI config fix, so this only corrects bump.yml's header comment where it named ci.yml.
