### PR TITLE
build: give src/build/ a test root so its test blocks run

### DIFF
--- a/.agents/scripts/gate_scope.py
+++ b/.agents/scripts/gate_scope.py
@@ -72,16 +72,16 @@ PREFIX_RULES = (
 )
 
 EXACT_RULES = {
-    # Both of these are checked by a gates-leg script rather than by a zig
-    # test, because the Zig legs cannot see a BEHAVIOR change in either.
-    # zig-fmt still sees formatting and the suite still sees a compile
-    # error, but nothing runs the code: src/build_config.zig imports
-    # build/Config.zig only to call fromOptions(), and Zig analyses at
-    # decl level, so Config.init -- which is what decides that `tip` and
-    # `vX.Y.Z` are the only names a version may have -- is never reached
-    # from a test root (issue 748). GitVersion.zig runs in build.zig only.
-    # The selftest hardcodes that same contract, so it has to run when
-    # either side of it moves, or the two drift apart in silence.
+    # Both of these carry a gates-leg check on top of the Zig legs. What
+    # decides that `tip` and `vX.Y.Z` are the only names a version may have
+    # is the describe filter, and only real `git describe` against real tag
+    # layouts can say whether it still holds. The selftest reads the argument
+    # list out of GitVersion.zig, so it has to run when either side of that
+    # contract moves, or the two drift apart in silence.
+    #
+    # No test root reaches Config.init: src/build_config.zig imports
+    # build/Config.zig only to call fromOptions(). GitVersion.zig is reached,
+    # through src/build/test.zig.
     "src/build/GitVersion.zig": ZIG_LEGS + (LEG_GATES,),
     "src/build/Config.zig": ZIG_LEGS + (LEG_GATES,),
     "build.zig": ZIG_LEGS,

--- a/.agents/scripts/gate_scope.py
+++ b/.agents/scripts/gate_scope.py
@@ -72,15 +72,17 @@ PREFIX_RULES = (
 )
 
 EXACT_RULES = {
-    # Both of these carry a gates-leg check on top of the Zig legs. What
-    # decides that `tip` and `vX.Y.Z` are the only names a version may have
-    # is the describe filter, and only real `git describe` against real tag
-    # layouts can say whether it still holds. The selftest reads the argument
-    # list out of GitVersion.zig, so it has to run when either side of that
-    # contract moves, or the two drift apart in silence.
+    # Both of these carry a gates-leg check on top of the Zig legs, because
+    # the contract they share -- that `tip` and `vX.Y.Z` are the only names a
+    # version may have -- is split across them and only real `git describe`
+    # against real tag layouts can say whether it still holds. GitVersion.zig
+    # owns the filter, which the selftest reads out of the source rather than
+    # copying; Config.init owns which names it then accepts, which the
+    # selftest's expectation table hardcodes. Either side moving without the
+    # other is how the two drift apart in silence.
     #
     # No test root reaches Config.init: src/build_config.zig imports
-    # build/Config.zig only to call fromOptions(). GitVersion.zig is reached,
+    # build/Config.zig only to call fromOptions(). GitVersion.zig is reached
     # through src/build/test.zig.
     "src/build/GitVersion.zig": ZIG_LEGS + (LEG_GATES,),
     "src/build/Config.zig": ZIG_LEGS + (LEG_GATES,),

--- a/build.zig
+++ b/build.zig
@@ -374,7 +374,8 @@ pub fn build(b: *std.Build) !void {
     // root, and a test binary collects test blocks only from files its own
     // test and comptime blocks reach. src/build/test.zig says which files
     // those are and why they need a root of their own. Always the host, since
-    // build-time code runs on the host whatever the build is targeting.
+    // build-time code runs on the host whatever the build is targeting -- and
+    // outside the emit_lib_vt guard below for the same reason.
     {
         const build_test = b.addTest(.{
             .name = "ghostty-build-test",

--- a/build.zig
+++ b/build.zig
@@ -368,6 +368,26 @@ pub fn build(b: *std.Build) !void {
         test_lib_vt_build_step.dependOn(&mod_vt_c_test.step);
     }
 
+    // Build-time code tests.
+    //
+    // src/build/ hangs off this file rather than off the src/main.zig test
+    // root, and a test binary collects test blocks only from files its own
+    // test and comptime blocks reach. src/build/test.zig says which files
+    // those are and why they need a root of their own. Always the host, since
+    // build-time code runs on the host whatever the build is targeting.
+    {
+        const build_test = b.addTest(.{
+            .name = "ghostty-build-test",
+            .filters = test_filters,
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("src/build/test.zig"),
+                .target = b.graph.host,
+                .optimize = .Debug,
+            }),
+        });
+        test_step.dependOn(&b.addRunArtifact(build_test).step);
+    }
+
     // Tests (skip when building libghostty-vt)
     if (!config.emit_lib_vt) {
         // Full unit tests

--- a/src/build/GitVersion.zig
+++ b/src/build/GitVersion.zig
@@ -33,19 +33,7 @@ pub fn detect(b: *std.Build) !Version {
             else => return err,
         };
 
-        // Trim before sanitizing, not after: git terminates the ref name with
-        // a newline, and the loop below would rewrite that into a "-" that no
-        // later trim can tell apart from one the branch name really contains.
-        const trimmed = tmp[0..std.mem.trimEnd(u8, tmp, "\r\n ").len];
-
-        // Replace characters that are not valid in semantic version
-        // pre-release identifiers (which only allow [0-9A-Za-z-]).
-        // Slashes would also mess up dist tarball paths.
-        for (trimmed) |*c| {
-            if (!std.ascii.isAlphanumeric(c.*) and c.* != '-') c.* = '-';
-        }
-
-        break :b trimmed;
+        break :b sanitizeBranch(tmp);
     };
 
     const short_hash = short_hash: {
@@ -116,4 +104,33 @@ pub fn detect(b: *std.Build) !Version {
         .tag = if (tag.len > 0) std.mem.trimEnd(u8, tag, "\r\n ") else null,
         .branch = branch,
     };
+}
+
+/// Git's raw `rev-parse --abbrev-ref HEAD` output, rewritten in place into a
+/// name usable as a semantic version pre-release identifier, which only allows
+/// [0-9A-Za-z-]. Slashes would also mess up dist tarball paths.
+///
+/// Trim before sanitizing, not after: git terminates the ref name with a
+/// newline, and the loop would rewrite that into a "-" that no later trim can
+/// tell apart from one the branch name really ends with.
+fn sanitizeBranch(raw: []u8) []u8 {
+    const trimmed = raw[0..std.mem.trimEnd(u8, raw, "\r\n ").len];
+    for (trimmed) |*c| {
+        if (!std.ascii.isAlphanumeric(c.*) and c.* != '-') c.* = '-';
+    }
+    return trimmed;
+}
+
+test "sanitizeBranch trims git's line ending before rewriting it" {
+    var raw = "fix/zero-config\n".*;
+    try std.testing.expectEqualStrings("fix-zero-config", sanitizeBranch(&raw));
+}
+
+test "sanitizeBranch keeps only what a pre-release identifier allows" {
+    // The rewrite is byte-wise, so the two bytes of the non-ASCII codepoint
+    // become two dashes rather than one.
+    var raw = "feature/caf\u{e8}_v1.2\r\n".*;
+    const name = sanitizeBranch(&raw);
+    try std.testing.expectEqualStrings("feature-caf---v1-2", name);
+    for (name) |c| try std.testing.expect(std.ascii.isAlphanumeric(c) or c == '-');
 }

--- a/src/build/GitVersion.zig
+++ b/src/build/GitVersion.zig
@@ -134,3 +134,8 @@ test "sanitizeBranch keeps only what a pre-release identifier allows" {
     try std.testing.expectEqualStrings("feature-caf---v1-2", name);
     for (name) |c| try std.testing.expect(std.ascii.isAlphanumeric(c) or c == '-');
 }
+
+test "sanitizeBranch keeps a dash the branch name really ends with" {
+    var raw = "wip-\n".*;
+    try std.testing.expectEqualStrings("wip-", sanitizeBranch(&raw));
+}

--- a/src/build/test.zig
+++ b/src/build/test.zig
@@ -1,0 +1,21 @@
+//! Test root for the build-time code under src/build/.
+//!
+//! A test binary collects `test` blocks only from files its own `test` and
+//! `comptime` blocks reach. A `pub const` naming the import is not enough: on
+//! 0.16 an unreferenced pub decl pulls nothing in. That is why src/build/ gets
+//! no coverage from the src/main.zig root -- src/build_config.zig imports
+//! build/Config.zig to call fromOptions(), and nothing analysed from there
+//! reaches Config.init, which is where GitVersion is used.
+//!
+//! Rooting these files from that graph instead would mean a comptime block in
+//! a file the ghostty binary already collects, which drags std.Build into
+//! every compilation of it, wasm targets included. So the build-time files get
+//! a root of their own: host target, hung off the same `zig build test` step
+//! the rest of the suite runs under, since build-time code runs on the host
+//! whatever the build is targeting.
+//!
+//! One import per file. A file that is not listed here has no tests running.
+
+test {
+    _ = @import("GitVersion.zig");
+}


### PR DESCRIPTION
A `test` block in src/build/GitVersion.zig never ran. Proven before fixing: a
deliberately failing test there left `zig build test -Dapp-runtime=none` green.
A test binary collects test blocks only from files its own test and comptime
blocks reach, and src/build_config.zig imports build/Config.zig to call
fromOptions(), which never reaches Config.init, where GitVersion is used.

src/build/test.zig is a host-target root for the build-time files, hung off the
existing `test` step so `just test` covers it with no new step to remember. The
alternative, rooting collection from the runtime graph, was rejected: a
`pub const` reference does not collect on 0.16, so it would take a comptime
block in a file the ghostty binary already collects, dragging std.Build into
every compilation of a binary that also builds for wasm. With the root wired,
the same canary went red, then it was removed.

The test that replaced it covers the branch name rewrite, now a pure fn: git's
line ending has to be trimmed before the non-[0-9A-Za-z-] rewrite, or the
newline becomes a trailing "-" no later trim can tell from a real one. That is
the ordering defect b5aff3a fixed, and it had no test. The describe argv is not
retested here; gitversion_selftest.ps1 already runs real `git describe` against
real tag layouts, which a zig test cannot.

The seven test blocks in src/build/wasm_patch_growable_table.zig are still
dead. They pass when run, and adopting them is one import line in the new root,
but that is a different file's coverage.

Refs #748 (item 1 only; item 2, a guard for unreachable test blocks anywhere in
the tree, stays open).
