### PR TITLE
Capture crashes on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ crash report was generated.
 > reports. A future version of Ghostty will make the contents of the crash
 > reports more easily viewable through the CLI and GUI.
 
-Crash reports end in the `.ghosttycrash` extension. The crash reports are in
+Crash reports end in the `.winttycrash` extension. The crash reports are in
 [Sentry envelope format](https://develop.sentry.dev/sdk/envelopes/). You can
 upload these to your own Sentry account to view their contents, but the format
 is also publicly documented so any other available tools can also be used.

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1204,6 +1204,15 @@ GHOSTTY_API int ghostty_init(uintptr_t, char**);
 // outlive the process's use of the args.
 GHOSTTY_API int ghostty_init_wide(const uint16_t*, uintptr_t);
 #endif
+// Block until the crash reporter's handler is installed, or until the
+// timeout elapses. Returns whether it is armed.
+//
+// sentry_init runs on a background thread, so returning from ghostty_init
+// does not mean a crash raised now would be captured. Anything that means to
+// provoke a crash and watch it be reported has to wait for this, and cannot
+// infer it from the database directory appearing: that is created during
+// init, before the handler exists, and it outlives the process.
+GHOSTTY_API bool ghostty_crash_wait_ready(uint32_t);
 GHOSTTY_API void ghostty_cli_try_action(void);
 GHOSTTY_API void ghostty_build_info(ghostty_build_info_s *out);
 GHOSTTY_API ghostty_info_s ghostty_info(void);

--- a/pkg/sentry/build.zig
+++ b/pkg/sentry/build.zig
@@ -32,6 +32,24 @@ pub fn build(b: *std.Build) !void {
     // decorate its API with __declspec(dllimport); without this every
     // sentry_* symbol comes out as an unresolved dllimport on Windows.
     try flags.append(b.allocator, "-DSENTRY_BUILD_STATIC=1");
+    // Zig's ubsan runtime cannot be bundled on Windows (LNK4229), so every
+    // C object built with the default sanitizer settings leaves
+    // __ubsan_handle_* undefined. That is invisible while Zig links the
+    // artifact and fatal the moment an external linker consumes the archive,
+    // which on Windows is exactly what happens: ghostty-static.lib is linked
+    // into the NativeAOT image by MSVC link.exe. src/build/SharedDeps.zig
+    // already does this for ghostty's own C sources; sentry's were the set
+    // that did not go through it.
+    //
+    // Nothing in a `zig build` or a `dotnet build` catches this. Both link
+    // with Zig or run on CoreCLR; only `dotnet publish` reaches link.exe, so
+    // the whole four-tier gate stayed green while no release could link.
+    if (target.result.abi == .msvc) {
+        try flags.appendSlice(b.allocator, &.{
+            "-fno-sanitize=undefined",
+            "-fno-sanitize-trap=undefined",
+        });
+    }
     if (target.result.os.tag == .windows) {
         try flags.appendSlice(b.allocator, &.{
             "-DSENTRY_WITH_UNWINDER_DBGHELP",

--- a/pkg/sentry/build.zig
+++ b/pkg/sentry/build.zig
@@ -71,12 +71,19 @@ pub fn build(b: *std.Build) !void {
 
         // Symbolizer + Unwinder
         if (target.result.os.tag == .windows) {
-            // dbghelp: symbolizer, dbghelp unwinder, modulefinder.
+            // dbghelp:  symbolizer, dbghelp unwinder, modulefinder.
             // version:  sentry_os.c version lookup.
+            // advapi32: sentry_os.c reads the OS build from the registry with
+            //           RegGetValueA. The app pulls advapi32 in by other
+            //           routes, so this only shows up as an undefined symbol
+            //           in targets that link sentry and little else, which is
+            //           what the test target is.
             lib.root_module.linkSystemLibrary("dbghelp", .{});
             lib.root_module.linkSystemLibrary("version", .{});
+            lib.root_module.linkSystemLibrary("advapi32", .{});
             module.linkSystemLibrary("dbghelp", .{});
             module.linkSystemLibrary("version", .{});
+            module.linkSystemLibrary("advapi32", .{});
             lib.root_module.addCSourceFiles(.{
                 .root = upstream.path(""),
                 .files = &.{

--- a/pkg/sentry/build.zig
+++ b/pkg/sentry/build.zig
@@ -44,7 +44,11 @@ pub fn build(b: *std.Build) !void {
     // Nothing in a `zig build` or a `dotnet build` catches this. Both link
     // with Zig or run on CoreCLR; only `dotnet publish` reaches link.exe, so
     // the whole four-tier gate stayed green while no release could link.
-    if (target.result.abi == .msvc) {
+    // Gated on the OS, not the ABI. src/build/SharedDeps.zig states the rule
+    // for this repo and says why: it affects both the MSVC and GNU ABIs.
+    // Gating on .msvc alone re-opens the same link failure for windows-gnu,
+    // which is the last thing to do in the commit that fixes it.
+    if (target.result.os.tag == .windows) {
         try flags.appendSlice(b.allocator, &.{
             "-fno-sanitize=undefined",
             "-fno-sanitize-trap=undefined",

--- a/pkg/sentry/build.zig
+++ b/pkg/sentry/build.zig
@@ -28,6 +28,10 @@ pub fn build(b: *std.Build) !void {
 
     var flags: std.ArrayList([]const u8) = .empty;
     defer flags.deinit(b.allocator);
+    // The library is built with .linkage = .static, so sentry.h must not
+    // decorate its API with __declspec(dllimport); without this every
+    // sentry_* symbol comes out as an unresolved dllimport on Windows.
+    try flags.append(b.allocator, "-DSENTRY_BUILD_STATIC=1");
     if (target.result.os.tag == .windows) {
         try flags.appendSlice(b.allocator, &.{
             "-DSENTRY_WITH_UNWINDER_DBGHELP",
@@ -67,6 +71,12 @@ pub fn build(b: *std.Build) !void {
 
         // Symbolizer + Unwinder
         if (target.result.os.tag == .windows) {
+            // dbghelp: symbolizer, dbghelp unwinder, modulefinder.
+            // version:  sentry_os.c version lookup.
+            lib.root_module.linkSystemLibrary("dbghelp", .{});
+            lib.root_module.linkSystemLibrary("version", .{});
+            module.linkSystemLibrary("dbghelp", .{});
+            module.linkSystemLibrary("version", .{});
             lib.root_module.addCSourceFiles(.{
                 .root = upstream.path(""),
                 .files = &.{

--- a/pkg/sentry/c.zig
+++ b/pkg/sentry/c.zig
@@ -1,3 +1,18 @@
+const builtin = @import("builtin");
+
 pub const c = @cImport({
+    // aro, which backs translate-c in zig 0.16, cannot parse the __ptr64
+    // attribute the Windows SDK uses in basetsd.h ("typedef void* POINTER_64
+    // HANDLE64;"), so any @cImport that reaches windows.h fails. sentry.h
+    // includes windows.h for exactly one declaration, the EXCEPTION_POINTERS
+    // field of sentry_ucontext_s, which nothing on the Zig side references.
+    // Suppress the include and supply a stand-in for that field.
+    if (builtin.target.os.tag == .windows) {
+        @cDefine("_WINDOWS_", "1");
+        @cDefine("EXCEPTION_POINTERS", "struct { int _unused; }");
+    }
+    // Matches -DSENTRY_BUILD_STATIC in build.zig: without it sentry.h
+    // decorates every function with __declspec(dllimport).
+    @cDefine("SENTRY_BUILD_STATIC", "1");
     @cInclude("sentry.h");
 });

--- a/pkg/sentry/c.zig
+++ b/pkg/sentry/c.zig
@@ -9,7 +9,13 @@ pub const c = @cImport({
     // Suppress the include and supply a stand-in for that field.
     if (builtin.target.os.tag == .windows) {
         @cDefine("_WINDOWS_", "1");
-        @cDefine("EXCEPTION_POINTERS", "struct { int _unused; }");
+        // Two pointers, matching the real EXCEPTION_POINTERS
+        // (PEXCEPTION_RECORD, PCONTEXT). The stand-in used to be a single
+        // int, which made Zig's view of sentry_ucontext_s four bytes where
+        // the C side's is sixteen. Nothing on the Zig side references that
+        // field today, which is the only reason it worked; getting the size
+        // right costs nothing and removes a landmine for whoever does.
+        @cDefine("EXCEPTION_POINTERS", "struct { void *_record; void *_context; }");
     }
     // Matches -DSENTRY_BUILD_STATIC in build.zig: without it sentry.h
     // decorates every function with __declspec(dllimport).

--- a/pkg/sentry/value.zig
+++ b/pkg/sentry/value.zig
@@ -50,6 +50,23 @@ pub const Value = struct {
         return .{ .value = c.sentry_value_new_int32(value) };
     }
 
+    /// Number of entries in a list or object.
+    pub fn len(self: Value) usize {
+        return c.sentry_value_get_length(self.value);
+    }
+
+    /// Borrowed element of a list. Not owned: do not decref the result.
+    pub fn getIndex(self: Value, index: usize) Value {
+        return .{ .value = c.sentry_value_get_by_index(self.value, index) };
+    }
+
+    /// The string contents of a value, or null if it is not a string.
+    /// Borrowed from the value and only valid while it lives.
+    pub fn asString(self: Value) ?[]const u8 {
+        const ptr = c.sentry_value_as_string(self.value) orelse return null;
+        return std.mem.span(ptr);
+    }
+
     pub fn decref(self: Value) void {
         c.sentry_value_decref(self.value);
     }

--- a/pkg/sentry/value.zig
+++ b/pkg/sentry/value.zig
@@ -50,23 +50,6 @@ pub const Value = struct {
         return .{ .value = c.sentry_value_new_int32(value) };
     }
 
-    /// Number of entries in a list or object.
-    pub fn len(self: Value) usize {
-        return c.sentry_value_get_length(self.value);
-    }
-
-    /// Borrowed element of a list. Not owned: do not decref the result.
-    pub fn getIndex(self: Value, index: usize) Value {
-        return .{ .value = c.sentry_value_get_by_index(self.value, index) };
-    }
-
-    /// The string contents of a value, or null if it is not a string.
-    /// Borrowed from the value and only valid while it lives.
-    pub fn asString(self: Value) ?[]const u8 {
-        const ptr = c.sentry_value_as_string(self.value) orelse return null;
-        return std.mem.span(ptr);
-    }
-
     pub fn decref(self: Value) void {
         c.sentry_value_decref(self.value);
     }

--- a/pkg/sentry/value.zig
+++ b/pkg/sentry/value.zig
@@ -24,6 +24,16 @@ pub const Value = struct {
         ) };
     }
 
+    /// Attach the current call stack to an event.
+    ///
+    /// Without this a panic event carries the message but no frames, so a
+    /// report says what happened and not where. Passing null captures the
+    /// stack at the point of call, which is inside the panic handler, so the
+    /// crash site sits a few frames up.
+    pub fn addStacktrace(self: Value) void {
+        c.sentry_event_value_add_stacktrace(self.value, null, 0);
+    }
+
     pub fn initObject() Value {
         return .{ .value = c.sentry_value_new_object() };
     }

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -4888,6 +4888,15 @@ fn showMouse(self: *Surface) void {
 /// will ever return false. We can expand this in the future if it becomes
 /// useful. We did previous/next tab so we could implement #498.
 pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool {
+    // Tag the thread the way every surface callback does. Callbacks set this
+    // on the way in, but a binding action can also arrive straight from the
+    // C API (ghostty_surface_binding_action in src/apprt/embedded.zig), which
+    // goes through no callback at all. Without this a crash on that path
+    // reaches beforeSend with no thread state and loses its thread type and
+    // surface dimensions, which is most crashes for an embedder.
+    crash.sentry.thread_state = self.crashThreadState();
+    defer crash.sentry.thread_state = null;
+
     // Forward app-scoped actions to the app. Some app-scoped actions are
     // special-cased here because they do some special things when performed
     // from the surface.

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -4894,8 +4894,16 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
     // goes through no callback at all. Without this a crash on that path
     // reaches beforeSend with no thread state and loses its thread type and
     // surface dimensions, which is most crashes for an embedder.
+    //
+    // Restore rather than clear, because unlike every other site that sets
+    // this, we are not always the outermost frame: keyCallback and
+    // mouseButtonCallback set it and then reach here through
+    // maybeHandleBinding. Clearing to null on the way out would leave the
+    // rest of those callbacks, the inspector append and the encode and the
+    // render queue, running untagged.
+    const prev_thread_state = crash.sentry.thread_state;
     crash.sentry.thread_state = self.crashThreadState();
-    defer crash.sentry.thread_state = null;
+    defer crash.sentry.thread_state = prev_thread_state;
 
     // Forward app-scoped actions to the app. Some app-scoped actions are
     // special-cased here because they do some special things when performed

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -10,6 +10,7 @@ const assert = @import("../quirks.zig").inlineAssert;
 const Allocator = std.mem.Allocator;
 const objc = @import("objc");
 const apprt = @import("../apprt.zig");
+const crash = @import("../crash/main.zig");
 const font = @import("../font/main.zig");
 const global = @import("../global.zig");
 const input = @import("../input.zig");
@@ -2160,6 +2161,20 @@ pub const CAPI = struct {
         if (builtin.os.tag == .windows) {
             _ = Windows;
         }
+    }
+
+    /// Block until the crash reporter is armed, or until `timeout_ms`
+    /// elapses. Returns true when it is armed.
+    ///
+    /// For deliberate crash triggers. The reporter initialises on its own
+    /// thread, so a trigger fired straight after ghostty_init can beat the
+    /// handler into place and produce no report, which reads as "this class
+    /// cannot be captured" when the truth is "nobody was listening yet".
+    /// Callers must not infer readiness from the database directory: sentry
+    /// creates it during init, before the handler exists, and it outlives the
+    /// process.
+    export fn ghostty_crash_wait_ready(timeout_ms: u32) bool {
+        return crash.sentry.waitReady(timeout_ms);
     }
 
     /// Create a new app.

--- a/src/build/Config.zig
+++ b/src/build/Config.zig
@@ -224,10 +224,14 @@ pub fn init(b: *std.Build, appVersion: []const u8, libVersion: []const u8) !Conf
     config.sentry = b.option(
         bool,
         "sentry",
-        "Build with Sentry crash reporting. Default for macOS is true, false for any other system.",
+        "Build with Sentry crash reporting. Default is true for macOS and Windows, false for any other system.",
     ) orelse sentry: {
         switch (target.result.os.tag) {
             .macos, .ios => break :sentry true,
+
+            // Windows uses the in-process backend; see SharedDeps.zig. The
+            // capture is local-only, exactly as on macOS.
+            .windows => break :sentry true,
 
             // Note its false for linux because the crash reports on Linux
             // don't have much useful information.

--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -12,6 +12,13 @@ const GhosttyFrameData = @import("GhosttyFrameData.zig");
 const DistResource = @import("GhosttyDist.zig").Resource;
 const gtk_helpers = @import("gtk.zig");
 
+// Mirrors pkg/sentry/build.zig's `Backend` enum. We can't `@import` that
+// file directly: it's the root of the "sentry" dependency module, and Zig
+// won't let the same file belong to two modules. Dependency options are
+// passed by tag name, not by nominal type identity, so a structurally
+// matching local enum works the same as importing the real one.
+const SentryBackend = enum { crashpad, breakpad, inproc, none };
+
 config: *const Config,
 
 options: *std.Build.Step.Options,
@@ -450,10 +457,21 @@ pub fn add(
 
     // Sentry
     if (self.config.sentry) {
+        // Windows has no vendored breakpad client layer (pkg/breakpad/build.zig
+        // has no Windows branch), so the in-process backend is the only one
+        // that links there. pkg/sentry's own Windows source set is complete:
+        // dbghelp unwinder, Windows symbolizer, Windows modulefinder.
+        //
+        // Typed rather than a bare enum literal: the backend depends on the
+        // target, which is runtime control flow here, and an untyped enum
+        // literal is comptime-only.
+        const sentry_windows = target.result.os.tag == .windows;
+        const sentry_backend: SentryBackend =
+            if (sentry_windows) .inproc else .breakpad;
         if (b.lazyDependency("sentry", .{
             .target = target,
             .optimize = optimize,
-            .backend = .breakpad,
+            .backend = sentry_backend,
         })) |sentry_dep| {
             step.root_module.addImport(
                 "sentry",
@@ -465,15 +483,18 @@ pub fn add(
                 sentry_dep.artifact("sentry").getEmittedBin(),
             );
 
-            // We also need to include breakpad in the static libs.
-            if (sentry_dep.builder.lazyDependency("breakpad", .{
-                .target = target,
-                .optimize = optimize,
-            })) |breakpad_dep| {
-                try static_libs.append(
-                    b.allocator,
-                    breakpad_dep.artifact("breakpad").getEmittedBin(),
-                );
+            // Breakpad is only linked for the breakpad backend. The inproc
+            // backend has no external dependency.
+            if (!sentry_windows) {
+                if (sentry_dep.builder.lazyDependency("breakpad", .{
+                    .target = target,
+                    .optimize = optimize,
+                })) |breakpad_dep| {
+                    try static_libs.append(
+                        b.allocator,
+                        breakpad_dep.artifact("breakpad").getEmittedBin(),
+                    );
+                }
             }
         }
     }

--- a/src/crash/sentry.zig
+++ b/src/crash/sentry.zig
@@ -15,6 +15,11 @@ const log = std.log.scoped(.sentry);
 /// handling is a global process-wide thing.
 var init_thread: ?std.Thread = null;
 
+/// Set once `sentry_init` has returned, so the backend's handler is
+/// installed. `waitReady` is what the crash triggers use to know the reporter
+/// is actually armed rather than merely started.
+var init_done: std.atomic.Value(bool) = .init(false);
+
 /// Directory memory, holds the cache and state dirs persistently. This
 /// prevents any sort of crashes due to initialization races.
 var dir_mem: [std.fs.max_path_bytes * 2]u8 = undefined;
@@ -168,6 +173,14 @@ fn initThread(gpa: Allocator, environ_map_: std.process.Environ.Map) !void {
     // Initialize
     if (sentry.c.sentry_init(opts) != 0) return error.SentryInitFailed;
 
+    // Only once sentry_init has returned is the backend's exception handler
+    // installed. Anything that means to provoke a crash and watch it be
+    // captured has to wait for this, and cannot infer it from the database
+    // directory appearing: sentry creates that during init, before the
+    // handler exists, and it outlives the process, so on every run after the
+    // first it is already there before we start.
+    init_done.store(true, .release);
+
     // Setup some basic tags that we always want present
     sentry.setTag("build-mode", build_config.mode_string);
     sentry.setTag("app-runtime", @tagName(build_config.app_runtime));
@@ -206,6 +219,10 @@ fn cacheDir(io: std.Io, alloc: Allocator, environ_map: *const std.process.Enviro
 /// panic cannot recurse into the reporter.
 var panic_reported: bool = false;
 
+/// Set once the thread that won `panic_reported` has finished writing. Threads
+/// that lost wait on this rather than racing ahead into abort.
+var panic_capture_done: std.atomic.Value(bool) = .init(false);
+
 /// Report a panic to sentry, best effort, before the process goes down.
 ///
 /// This exists because a Zig panic on Windows raises no exception that the
@@ -224,7 +241,21 @@ pub fn capturePanic(msg: []const u8) void {
 
     // Reporting runs in an already broken process, so keep it to the one
     // call and let anything it touches fail silently.
-    if (@atomicRmw(bool, &panic_reported, .Xchg, true, .seq_cst)) return;
+    //
+    // The latch also stops a panic inside captureEvent from recursing: the
+    // exchange happens before any sentry call, so the re-entry loses it and
+    // falls through to defaultPanic.
+    if (@atomicRmw(bool, &panic_reported, .Xchg, true, .seq_cst)) {
+        // A second thread panicking concurrently must not race us to
+        // abort(). std.debug.defaultPanic serialises panics against each
+        // other, but only once a thread is inside it, and the winner is
+        // still here writing a report. Losing that race truncates the file
+        // the winner is in the middle of writing. Wait for the winner to
+        // finish, then let this thread continue into defaultPanic, which
+        // takes over the serialising from there.
+        while (!panic_capture_done.load(.acquire)) std.Thread.yield() catch {};
+        return;
+    }
 
     const event = sentry.Value.initMessageEvent(.fatal, "panic", msg);
 
@@ -234,6 +265,8 @@ pub fn capturePanic(msg: []const u8) void {
     event.addStacktrace();
 
     _ = sentry.captureEvent(event);
+
+    panic_capture_done.store(true, .release);
 }
 
 pub fn deinit() void {
@@ -243,8 +276,36 @@ pub fn deinit() void {
     // is highly unlikely since init is a very fast operation but we want
     // to avoid the possibility.
     const thr = init_thread orelse return;
+    init_thread = null;
     thr.join();
     _ = sentry.c.sentry_close();
+}
+
+/// Block until the crash reporter is armed, or until `timeout_ms` elapses.
+/// Returns whether it is armed.
+///
+/// Exists for the crash triggers, which are worthless if they fire before the
+/// handler is installed: the report then does not appear, and the honest
+/// reading of that ("the backend cannot capture this class") is the opposite
+/// of the truth. A probe that reports success on an error condition is worse
+/// than one that fails.
+pub fn waitReady(timeout_ms: u64) bool {
+    // Nothing to arm, so nothing to wait for. Callers still get a truthful
+    // answer: no reporter is going to appear later.
+    if (comptime !build_options.sentry) return false;
+
+    var io_threaded: std.Io.Threaded = .init_single_threaded;
+    defer io_threaded.deinit();
+    const io = io_threaded.io();
+
+    var waited: u64 = 0;
+    while (!init_done.load(.acquire)) {
+        if (waited >= timeout_ms) return false;
+        std.Io.sleep(io, .fromMilliseconds(5), .awake) catch return false;
+        waited += 5;
+    }
+
+    return true;
 }
 
 fn beforeSend(
@@ -354,9 +415,19 @@ fn scrubImagePaths(alloc: Allocator, json: []const u8) ![]const u8 {
 
         // The value ends at the first quote that is not escaped. Paths carry
         // no escaped quotes in practice, but a filename legally could.
+        // A quote is the terminator only when the run of backslashes before
+        // it is even: `\\` is an escaped backslash and the quote after it is
+        // real, while `\"` is an escaped quote and it is not. Testing only
+        // the single preceding byte gets `"C:\\dir\\"` wrong and swallows the
+        // rest of the object.
         var i: usize = value_start;
         const value_end = while (i < rest.len) : (i += 1) {
-            if (rest[i] == '"' and (i == 0 or rest[i - 1] != '\\')) break i;
+            if (rest[i] != '"') continue;
+            var slashes: usize = 0;
+            while (i - slashes > value_start and rest[i - slashes - 1] == '\\') {
+                slashes += 1;
+            }
+            if (slashes % 2 == 0) break i;
         } else rest.len;
 
         const value = rest[value_start..value_end];
@@ -381,6 +452,157 @@ fn scrubImagePaths(alloc: Allocator, json: []const u8) ![]const u8 {
     try out.appendSlice(alloc, rest);
 
     return try out.toOwnedSlice(alloc);
+}
+
+/// Scrub image paths across a whole serialized envelope, keeping the framing
+/// intact.
+///
+/// An envelope is a header line followed by items, and each item is its own
+/// header line carrying `"length":N` followed by exactly N payload bytes.
+/// Scrubbing shortens `code_file`, so rewriting payload bytes without
+/// correcting N produces a file that declares more bytes than it holds. Our
+/// own reader (`sentry_envelope.zig`, `streamExact`) then fails with
+/// `EnvelopeItemPayloadTooShort`, and so does anything else that reads the
+/// format. This walks the framing so the lengths stay true.
+///
+/// Returns a slice owned by `alloc`, or the input unchanged when there is
+/// nothing to rewrite.
+fn scrubEnvelope(alloc: Allocator, bytes: []const u8) ![]const u8 {
+    if (std.mem.indexOf(u8, bytes, "\"code_file\":\"") == null) return bytes;
+
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(alloc);
+
+    // The envelope header line, which carries no module paths.
+    var rest = bytes;
+    const first_break = std.mem.indexOfScalar(u8, rest, '\n') orelse
+        return bytes;
+    try out.appendSlice(alloc, rest[0 .. first_break + 1]);
+    rest = rest[first_break + 1 ..];
+
+    while (rest.len > 0) {
+        const head_end = std.mem.indexOfScalar(u8, rest, '\n') orelse {
+            // Trailing bytes with no item header. Nothing claims a length
+            // over them, so pass them through untouched.
+            try out.appendSlice(alloc, rest);
+            break;
+        };
+        const header = rest[0..head_end];
+        rest = rest[head_end + 1 ..];
+
+        // A length-less item runs to the next newline. Nothing to correct.
+        const declared = parseItemLength(header) orelse {
+            const body_end = std.mem.indexOfScalar(u8, rest, '\n') orelse rest.len;
+            const scrubbed = try scrubImagePaths(alloc, rest[0..body_end]);
+            defer if (scrubbed.ptr != rest.ptr) alloc.free(scrubbed);
+            try out.appendSlice(alloc, header);
+            try out.append(alloc, '\n');
+            try out.appendSlice(alloc, scrubbed);
+            if (body_end < rest.len) try out.append(alloc, '\n');
+            rest = rest[@min(body_end + 1, rest.len)..];
+            continue;
+        };
+
+        // A declared length longer than what is left means the envelope was
+        // already truncated. Copy the remainder rather than inventing one.
+        if (declared > rest.len) {
+            try out.appendSlice(alloc, header);
+            try out.append(alloc, '\n');
+            try out.appendSlice(alloc, rest);
+            break;
+        }
+
+        const payload = rest[0..declared];
+        const scrubbed = try scrubImagePaths(alloc, payload);
+        defer if (scrubbed.ptr != payload.ptr) alloc.free(scrubbed);
+
+        try writeItemHeader(alloc, &out, header, scrubbed.len);
+        try out.append(alloc, '\n');
+        try out.appendSlice(alloc, scrubbed);
+
+        rest = rest[declared..];
+        if (rest.len > 0 and rest[0] == '\n') {
+            try out.append(alloc, '\n');
+            rest = rest[1..];
+        }
+    }
+
+    return try out.toOwnedSlice(alloc);
+}
+
+/// The `length` field of an item header, or null when it has none.
+fn parseItemLength(header: []const u8) ?usize {
+    const needle = "\"length\":";
+    const at = std.mem.indexOf(u8, header, needle) orelse return null;
+    var i = at + needle.len;
+    while (i < header.len and header[i] == ' ') i += 1;
+    const start = i;
+    while (i < header.len and header[i] >= '0' and header[i] <= '9') i += 1;
+    if (i == start) return null;
+    return std.fmt.parseInt(usize, header[start..i], 10) catch null;
+}
+
+/// Re-emit an item header with `length` replaced by the post-scrub value.
+fn writeItemHeader(
+    alloc: Allocator,
+    out: *std.ArrayList(u8),
+    header: []const u8,
+    length: usize,
+) !void {
+    const needle = "\"length\":";
+    const at = std.mem.indexOf(u8, header, needle) orelse {
+        try out.appendSlice(alloc, header);
+        return;
+    };
+    var i = at + needle.len;
+    while (i < header.len and header[i] == ' ') i += 1;
+    const digits_start = i;
+    while (i < header.len and header[i] >= '0' and header[i] <= '9') i += 1;
+    if (i == digits_start) {
+        try out.appendSlice(alloc, header);
+        return;
+    }
+
+    var digits: [24]u8 = undefined;
+    try out.appendSlice(alloc, header[0..digits_start]);
+    try out.appendSlice(alloc, std.fmt.bufPrint(&digits, "{d}", .{length}) catch
+        return error.LengthTooLarge);
+    try out.appendSlice(alloc, header[i..]);
+}
+
+test "a scrubbed envelope still parses" {
+    // The regression this exists for: scrubbing shortens `code_file`, and an
+    // envelope item is length-prefixed, so a scrub that rewrites the payload
+    // without correcting the header leaves every report unreadable by our own
+    // parser and by anything else that reads the format. Substring assertions
+    // over a bare JSON fragment cannot see it; only a round trip can.
+    const alloc = std.testing.allocator;
+
+    const payload =
+        \\{"images":[{"code_file":"C:\\Users\\alex\\wintty.dll","type":"pe"}]}
+    ;
+    var raw: std.ArrayList(u8) = .empty;
+    defer raw.deinit(alloc);
+    var head: [64]u8 = undefined;
+    try raw.appendSlice(alloc, "{}\n");
+    try raw.appendSlice(alloc, try std.fmt.bufPrint(
+        &head,
+        "{{\"type\":\"event\",\"length\":{d}}}\n",
+        .{payload.len},
+    ));
+    try raw.appendSlice(alloc, payload);
+    try raw.appendSlice(alloc, "\n");
+
+    const scrubbed = try scrubEnvelope(alloc, raw.items);
+    defer if (scrubbed.ptr != raw.items.ptr) alloc.free(scrubbed);
+
+    try std.testing.expect(std.mem.indexOf(u8, scrubbed, "wintty.dll") != null);
+    try std.testing.expect(std.mem.indexOf(u8, scrubbed, "alex") == null);
+
+    var reader: std.Io.Reader = .fixed(scrubbed);
+    var parsed = try crash.Envelope.parse(alloc, &reader);
+    defer parsed.deinit();
+    try std.testing.expectEqual(@as(usize, 1), parsed.items.items.len);
 }
 
 test "scrubImagePaths keeps the file name and drops the directory" {
@@ -465,7 +687,7 @@ pub const Transport = struct {
         defer file.close(single_threaded.io());
         var buf: [4096]u8 = undefined;
         var file_writer = file.writer(single_threaded.io(), &buf);
-        try file_writer.interface.writeAll(try scrubImagePaths(alloc, json));
+        try file_writer.interface.writeAll(try scrubEnvelope(alloc, json));
         try file_writer.end();
 
         log.warn("crash report written to disk path={s}", .{path});

--- a/src/crash/sentry.zig
+++ b/src/crash/sentry.zig
@@ -375,7 +375,7 @@ pub const Transport = struct {
         // Build our final path and write to it.
         const path = try std.fs.path.join(alloc, &.{
             state_dir,
-            try std.fmt.allocPrint(alloc, "{s}.ghosttycrash", .{uuid.string()}),
+            try std.fmt.allocPrint(alloc, "{s}.winttycrash", .{uuid.string()}),
         });
         const file = try std.Io.Dir.cwd().createFile(single_threaded.io(), path, .{});
         defer file.close(single_threaded.io());

--- a/src/crash/sentry.zig
+++ b/src/crash/sentry.zig
@@ -202,6 +202,37 @@ fn cacheDir(io: std.Io, alloc: Allocator, environ_map: *const std.process.Enviro
 
 /// Process-wide deinitialization of our Sentry client. This ensures all
 /// our data is flushed.
+/// Set once a panic has been reported, so a panic raised while reporting a
+/// panic cannot recurse into the reporter.
+var panic_reported: bool = false;
+
+/// Report a panic to sentry, best effort, before the process goes down.
+///
+/// This exists because a Zig panic on Windows raises no exception that the
+/// in-process backend can see. `std.debug.defaultPanic` ends in
+/// `std.process.abort`, and on Windows that is `ntdll.RtlExitUserProcess`, a
+/// clean process exit. sentry-native's inproc backend hooks
+/// `SetUnhandledExceptionFilter`, which a clean exit never invokes, so without
+/// this the panic is invisible: no exception, no WER record, no envelope.
+///
+/// POSIX needs nothing here. There `abort` is `posix.raise(.ABRT)` and the
+/// backend's SIGABRT handler already captures the panic, so reporting again
+/// would duplicate every crash report.
+pub fn capturePanic(msg: []const u8) void {
+    if (comptime !build_options.sentry) return;
+    if (comptime builtin.os.tag != .windows) return;
+
+    // Reporting runs in an already broken process, so keep it to the one
+    // call and let anything it touches fail silently.
+    if (@atomicRmw(bool, &panic_reported, .Xchg, true, .seq_cst)) return;
+
+    _ = sentry.captureEvent(sentry.Value.initMessageEvent(
+        .fatal,
+        "panic",
+        msg,
+    ));
+}
+
 pub fn deinit() void {
     if (comptime !build_options.sentry) return;
 

--- a/src/crash/sentry.zig
+++ b/src/crash/sentry.zig
@@ -226,11 +226,14 @@ pub fn capturePanic(msg: []const u8) void {
     // call and let anything it touches fail silently.
     if (@atomicRmw(bool, &panic_reported, .Xchg, true, .seq_cst)) return;
 
-    _ = sentry.captureEvent(sentry.Value.initMessageEvent(
-        .fatal,
-        "panic",
-        msg,
-    ));
+    const event = sentry.Value.initMessageEvent(.fatal, "panic", msg);
+
+    // A panic report without frames says what happened but not where, which
+    // is most of the value gone. The frames start inside the panic handler,
+    // so the crash site is a few frames up.
+    event.addStacktrace();
+
+    _ = sentry.captureEvent(event);
 }
 
 pub fn deinit() void {

--- a/src/crash/sentry.zig
+++ b/src/crash/sentry.zig
@@ -100,7 +100,20 @@ pub fn init(gpa: Allocator, environ_map: std.process.Environ.Map) !void {
     init_thread = thr;
 }
 
-fn initThread(gpa: Allocator, environ_map_: std.process.Environ.Map) !void {
+fn initThread(gpa: Allocator, environ_map_: std.process.Environ.Map) void {
+    // Report here rather than returning the error. std.Thread.spawn swallows a
+    // thread function's error into std.debug.print, which is raw stderr: not
+    // logFn, not the app's log sink. In a NativeAOT windowed process there is
+    // no stderr at all, so an unwritable database directory produced a silent
+    // failure, waitReady burning its whole timeout, and "reporter did not arm"
+    // with nothing to diagnose it from. global.zig's catch only ever covered
+    // the spawn, which practically never fails.
+    initThreadImpl(gpa, environ_map_) catch |err| {
+        log.warn("sentry init failed, no crash capture available err={}", .{err});
+    };
+}
+
+fn initThreadImpl(gpa: Allocator, environ_map_: std.process.Environ.Map) !void {
     var environ_map = environ_map_;
     defer environ_map.deinit();
 
@@ -173,19 +186,23 @@ fn initThread(gpa: Allocator, environ_map_: std.process.Environ.Map) !void {
     // Initialize
     if (sentry.c.sentry_init(opts) != 0) return error.SentryInitFailed;
 
+    // Setup some basic tags that we always want present
+    sentry.setTag("build-mode", build_config.mode_string);
+    sentry.setTag("app-runtime", @tagName(build_config.app_runtime));
+    sentry.setTag("font-backend", @tagName(build_config.font_backend));
+    sentry.setTag("renderer", @tagName(build_config.renderer));
+
     // Only once sentry_init has returned is the backend's exception handler
     // installed. Anything that means to provoke a crash and watch it be
     // captured has to wait for this, and cannot infer it from the database
     // directory appearing: sentry creates that during init, before the
     // handler exists, and it outlives the process, so on every run after the
     // first it is already there before we start.
+    //
+    // Stored AFTER the tags, not before. A trigger that waits for ready and
+    // crashes at once would otherwise race them and produce a report missing
+    // all four, which reads as a flaky row rather than as a race.
     init_done.store(true, .release);
-
-    // Setup some basic tags that we always want present
-    sentry.setTag("build-mode", build_config.mode_string);
-    sentry.setTag("app-runtime", @tagName(build_config.app_runtime));
-    sentry.setTag("font-backend", @tagName(build_config.font_backend));
-    sentry.setTag("renderer", @tagName(build_config.renderer));
 
     // Log some information about sentry
     log.debug("sentry initialized database={s}", .{cache_dir});
@@ -239,12 +256,27 @@ pub fn capturePanic(msg: []const u8) void {
     if (comptime !build_options.sentry) return;
     if (comptime builtin.os.tag != .windows) return;
 
+    // Re-entry on THIS thread means reporting the panic itself panicked, and
+    // there is nothing left to try: return immediately so panicImpl falls
+    // through to defaultPanic.
+    //
+    // Checked before the cross-thread latch, and it has to be. The earlier
+    // version relied on the latch alone and claimed the re-entry "loses the
+    // exchange and falls through". It does lose it, and then waits on a flag
+    // that only the winner sets, which on a same-thread re-entry is this
+    // thread, still inside captureEvent. That is not a fall-through, it is a
+    // deadlock: the process hangs with no report, no abort, and no WER
+    // record, which is strictly worse than having no hook at all.
+    //
+    // Reachable, not theoretical. beforeSend runs synchronously on this
+    // thread and dereferences a surface whose data the comment there already
+    // admits may be torn; a zero cell width makes GridSize.update divide to
+    // inf, and @intFromFloat(inf) is a safety panic in Debug and ReleaseSafe.
+    if (in_capture) return;
+    in_capture = true;
+
     // Reporting runs in an already broken process, so keep it to the one
     // call and let anything it touches fail silently.
-    //
-    // The latch also stops a panic inside captureEvent from recursing: the
-    // exchange happens before any sentry call, so the re-entry loses it and
-    // falls through to defaultPanic.
     if (@atomicRmw(bool, &panic_reported, .Xchg, true, .seq_cst)) {
         // A second thread panicking concurrently must not race us to
         // abort(). std.debug.defaultPanic serialises panics against each
@@ -253,7 +285,18 @@ pub fn capturePanic(msg: []const u8) void {
         // the winner is in the middle of writing. Wait for the winner to
         // finish, then let this thread continue into defaultPanic, which
         // takes over the serialising from there.
-        while (!panic_capture_done.load(.acquire)) std.Thread.yield() catch {};
+        //
+        // Bounded, because the winner can stall rather than finish:
+        // sendInternal creates a directory and writes a file, and a hung or
+        // redirected state directory turns "wait for the winner" into "hang
+        // the process". A truncated report is a worse report; a hung process
+        // is no report and no exit. Prefer the truncated one.
+        var spins: usize = 0;
+        while (!panic_capture_done.load(.acquire)) {
+            if (spins >= panic_wait_spins) break;
+            spins += 1;
+            std.Thread.yield() catch {};
+        }
         return;
     }
 
@@ -264,10 +307,28 @@ pub fn capturePanic(msg: []const u8) void {
     // so the crash site is a few frames up.
     event.addStacktrace();
 
-    _ = sentry.captureEvent(event);
+    // Nil means the event was dropped rather than captured: the SDK is not
+    // initialised yet, before_send returned null, or it was rate limited.
+    // Discarding that turns "the panic hook fired and the event went nowhere"
+    // into something indistinguishable from "Zig panics are not captured on
+    // Windows", which is the conclusion this whole hook exists to overturn.
+    // defaultPanic is about to write to stderr regardless, so saying so costs
+    // nothing.
+    if (sentry.captureEvent(event) == null) {
+        log.warn("panic report was dropped rather than captured", .{});
+    }
 
     panic_capture_done.store(true, .release);
 }
+
+/// Set for the duration of a panic capture on the capturing thread, so a
+/// panic raised while reporting a panic is recognised as re-entry rather than
+/// waiting on itself.
+threadlocal var in_capture: bool = false;
+
+/// How long a thread that lost the panic latch will wait for the winner. Not
+/// a duration: a panicking process is the wrong place to ask for a clock.
+const panic_wait_spins: usize = 100_000;
 
 pub fn deinit() void {
     if (comptime !build_options.sentry) return;
@@ -279,6 +340,11 @@ pub fn deinit() void {
     init_thread = null;
     thr.join();
     _ = sentry.c.sentry_close();
+
+    // The handler is gone, so stop telling callers it is armed. Without this
+    // a trigger fired during shutdown is told the reporter is ready when it
+    // is not, which is precisely the lie waitReady exists to prevent.
+    init_done.store(false, .release);
 }
 
 /// Block until the crash reporter is armed, or until `timeout_ms` elapses.
@@ -298,11 +364,18 @@ pub fn waitReady(timeout_ms: u64) bool {
     defer io_threaded.deinit();
     const io = io_threaded.io();
 
-    var waited: u64 = 0;
+    // Measured against the clock, not by counting sleeps. Adding 5 per
+    // iteration assumes the scheduler returns on time, so an overshooting one
+    // makes the real wait longer than the caller asked for, and the caller
+    // then reports the timeout it believed it used.
+    //
+    // `.awake` rather than `.real`: this is an elapsed-time question, and a
+    // wall clock that steps backwards would extend the wait indefinitely.
+    const start = std.Io.Timestamp.now(io, .awake).toMilliseconds();
     while (!init_done.load(.acquire)) {
-        if (waited >= timeout_ms) return false;
+        const elapsed = std.Io.Timestamp.now(io, .awake).toMilliseconds() - start;
+        if (elapsed >= timeout_ms) return false;
         std.Io.sleep(io, .fromMilliseconds(5), .awake) catch return false;
-        waited += 5;
     }
 
     return true;
@@ -404,6 +477,11 @@ fn beforeSend(
 fn scrubImagePaths(alloc: Allocator, json: []const u8) ![]const u8 {
     var out: []const u8 = json;
     var owned = false;
+    // Without this, a key that fails after an earlier one allocated leaks the
+    // earlier buffer. sendInternal runs on an arena so production does not
+    // notice, but this function documents itself as returning owned memory,
+    // and a leak that only an arena hides is still a leak in the contract.
+    errdefer if (owned) alloc.free(out);
     for (image_path_keys) |key| {
         const next = try scrubKey(alloc, out, key);
         if (owned and next.ptr != out.ptr) alloc.free(out);
@@ -411,6 +489,15 @@ fn scrubImagePaths(alloc: Allocator, json: []const u8) ![]const u8 {
         out = next;
     }
     return out;
+}
+
+/// Whether any key in `image_path_keys` appears, so the envelope-level fast
+/// path cannot fall out of step with the list it is supposed to enforce.
+fn containsAnyPathKey(bytes: []const u8) bool {
+    inline for (image_path_keys) |key| {
+        if (std.mem.indexOf(u8, bytes, "\"" ++ key ++ "\":\"") != null) return true;
+    }
+    return false;
 }
 
 /// Every module field that carries a filesystem path.
@@ -422,10 +509,24 @@ fn scrubImagePaths(alloc: Allocator, json: []const u8) ![]const u8 {
 /// forgetting one visible.
 const image_path_keys = [_][]const u8{ "code_file", "debug_file" };
 
+/// Sized for `"<key>":"`, asserted against `image_path_keys` in `scrubKey`.
+const needle_buf_len = 64;
+
 fn scrubKey(alloc: Allocator, json: []const u8, key: []const u8) ![]const u8 {
-    var needle_buf: [64]u8 = undefined;
+    // The keys are compile-time constants, so a key too long for the buffer
+    // is a build-time mistake, not a runtime condition. Asserting it says so;
+    // the earlier `catch return json` turned it into "leak the paths quietly",
+    // which is the one outcome this function must never choose.
+    comptime {
+        for (image_path_keys) |k| {
+            if (k.len + 4 > needle_buf_len) @compileError(
+                "image_path_keys entry too long for scrubKey's needle buffer",
+            );
+        }
+    }
+    var needle_buf: [needle_buf_len]u8 = undefined;
     const needle = std.fmt.bufPrint(&needle_buf, "\"{s}\":\"", .{key}) catch
-        return json;
+        unreachable;
     if (std.mem.indexOf(u8, json, needle) == null) return json;
 
     var out: std.ArrayList(u8) = .empty;
@@ -455,13 +556,17 @@ fn scrubKey(alloc: Allocator, json: []const u8, key: []const u8) ![]const u8 {
 
         const value = rest[value_start..value_end];
 
-        // Backslashes arrive escaped in JSON, so the separator is two bytes.
-        const cut = if (std.mem.lastIndexOf(u8, value, "\\\\")) |b|
-            b + 2
-        else if (std.mem.lastIndexOfScalar(u8, value, '/')) |b|
-            b + 1
-        else
-            0;
+        // Backslashes arrive escaped in JSON, so that separator is two bytes.
+        //
+        // The LAST separator of either kind, not the last backslash falling
+        // back to the last slash. Preferring one kind keeps whatever follows
+        // the other: "C:\\Program Files\\x/Users/alex/a.dll" cut at the
+        // backslash leaves "x/Users/alex/a.dll", username intact. Contrived
+        // on Windows, but this is the function whose whole job is not to
+        // fail open.
+        const back = if (std.mem.lastIndexOf(u8, value, "\\\\")) |b| b + 2 else 0;
+        const fwd = if (std.mem.lastIndexOfScalar(u8, value, '/')) |b| b + 1 else 0;
+        const cut = @max(back, fwd);
 
         if (cut == 0) {
             try out.appendSlice(alloc, value);
@@ -491,7 +596,14 @@ fn scrubKey(alloc: Allocator, json: []const u8, key: []const u8) ![]const u8 {
 /// Returns a slice owned by `alloc`, or the input unchanged when there is
 /// nothing to rewrite.
 fn scrubEnvelope(alloc: Allocator, bytes: []const u8) ![]const u8 {
-    if (std.mem.indexOf(u8, bytes, "\"code_file\":\"") == null) return bytes;
+    // The fast path has to agree with image_path_keys, or the list is not
+    // authoritative and its doc comment lies. This used to test `code_file`
+    // alone, so an envelope whose only path field was `debug_file` was
+    // returned byte-identical with the username in it: exactly the bug
+    // adding `debug_file` to the list was meant to fix, surviving one layer
+    // up. sentry_modulefinder_windows.c happens to always emit both today,
+    // which is what made it latent rather than shipping.
+    if (!containsAnyPathKey(bytes)) return bytes;
 
     var out: std.ArrayList(u8) = .empty;
     errdefer out.deinit(alloc);
@@ -626,6 +738,68 @@ test "a scrubbed envelope still parses" {
     var parsed = try crash.Envelope.parse(alloc, &reader);
     defer parsed.deinit();
     try std.testing.expectEqual(@as(usize, 1), parsed.items.items.len);
+}
+
+test "every path key is scrubbed at the envelope level, not just code_file" {
+    // scrubEnvelope had its own fast path keyed on `code_file` alone, so an
+    // envelope whose only path field was `debug_file` was returned
+    // byte-identical with the username in it. image_path_keys said otherwise
+    // and the guard below could not see it, because that one calls
+    // scrubImagePaths directly and never goes through the gate.
+    //
+    // Driven off image_path_keys so a key added to the list is covered here
+    // the day it is added, rather than the day someone remembers.
+    const alloc = std.testing.allocator;
+
+    inline for (image_path_keys) |key| {
+        var payload_buf: [128]u8 = undefined;
+        const payload = try std.fmt.bufPrint(
+            &payload_buf,
+            "{{\"images\":[{{\"{s}\":\"C:\\\\\\\\Users\\\\\\\\alex\\\\\\\\a.bin\"}}]}}",
+            .{key},
+        );
+
+        var raw: std.ArrayList(u8) = .empty;
+        defer raw.deinit(alloc);
+        var head: [64]u8 = undefined;
+        try raw.appendSlice(alloc, "{}\n");
+        try raw.appendSlice(alloc, try std.fmt.bufPrint(
+            &head,
+            "{{\"type\":\"event\",\"length\":{d}}}\n",
+            .{payload.len},
+        ));
+        try raw.appendSlice(alloc, payload);
+        try raw.appendSlice(alloc, "\n");
+
+        const scrubbed = try scrubEnvelope(alloc, raw.items);
+        defer if (scrubbed.ptr != raw.items.ptr) alloc.free(scrubbed);
+
+        try std.testing.expect(std.mem.indexOf(u8, scrubbed, "a.bin") != null);
+        try std.testing.expect(std.mem.indexOf(u8, scrubbed, "alex") == null);
+        try std.testing.expect(std.mem.indexOf(u8, scrubbed, "Users") == null);
+
+        // And it still parses, so the gate fix did not shorten a payload
+        // without correcting its header.
+        var reader: std.Io.Reader = .fixed(scrubbed);
+        var parsed = try crash.Envelope.parse(alloc, &reader);
+        defer parsed.deinit();
+        try std.testing.expectEqual(@as(usize, 1), parsed.items.items.len);
+    }
+}
+
+test "the last separator wins, whichever kind it is" {
+    // Preferring backslashes kept everything after the last one when a
+    // forward slash came later, which on a mixed path leaves the username in.
+    const alloc = std.testing.allocator;
+    const input =
+        \\{"code_file":"C:\\Program Files\\x/Users/alex/a.dll"}
+    ;
+    const out = try scrubImagePaths(alloc, input);
+    defer if (out.ptr != input.ptr) alloc.free(out);
+
+    try std.testing.expect(std.mem.indexOf(u8, out, "a.dll") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "alex") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "Users") == null);
 }
 
 test "scrubImagePaths keeps the file name and drops the directory" {

--- a/src/crash/sentry.zig
+++ b/src/crash/sentry.zig
@@ -402,7 +402,30 @@ fn beforeSend(
 /// Returns a slice owned by `alloc`, or the input unchanged if there is
 /// nothing to rewrite.
 fn scrubImagePaths(alloc: Allocator, json: []const u8) ![]const u8 {
-    const needle = "\"code_file\":\"";
+    var out: []const u8 = json;
+    var owned = false;
+    for (image_path_keys) |key| {
+        const next = try scrubKey(alloc, out, key);
+        if (owned and next.ptr != out.ptr) alloc.free(out);
+        owned = owned or next.ptr != out.ptr;
+        out = next;
+    }
+    return out;
+}
+
+/// Every module field that carries a filesystem path.
+///
+/// `debug_file` is here because leaving it out is what shipped: `code_file`
+/// was scrubbed, the report was checked for a username, and it passed,
+/// because the username had moved next door into the PDB path. Any new
+/// path-bearing field belongs in this list, and the test below is what makes
+/// forgetting one visible.
+const image_path_keys = [_][]const u8{ "code_file", "debug_file" };
+
+fn scrubKey(alloc: Allocator, json: []const u8, key: []const u8) ![]const u8 {
+    var needle_buf: [64]u8 = undefined;
+    const needle = std.fmt.bufPrint(&needle_buf, "\"{s}\":\"", .{key}) catch
+        return json;
     if (std.mem.indexOf(u8, json, needle) == null) return json;
 
     var out: std.ArrayList(u8) = .empty;
@@ -609,15 +632,35 @@ test "scrubImagePaths keeps the file name and drops the directory" {
     const alloc = std.testing.allocator;
     // Multiline: contents are literal, so these backslashes are the
     // doubled ones real JSON carries.
+    //
+    // Both path fields, because a real module entry carries both and only
+    // one of them used to be scrubbed. The report then passed a username
+    // check on code_file while debug_file still spelled it out.
     const input =
-        \\{"images":[{"code_file":"C:\\Users\\alex\\conpty.dll"}]}
+        \\{"images":[{"code_file":"C:\\Users\\alex\\conpty.dll","debug_file":"C:\\Users\\alex\\conpty.pdb"}]}
     ;
     const out = try scrubImagePaths(alloc, input);
     defer alloc.free(out);
 
     try std.testing.expect(std.mem.indexOf(u8, out, "conpty.dll") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "conpty.pdb") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "alex") == null);
     try std.testing.expect(std.mem.indexOf(u8, out, "Users") == null);
+}
+
+test "no module field carries a path out of the scrub" {
+    // A standing check rather than a case: the leak was not a wrong rule, it
+    // was a field nobody had listed. This fails the day a module entry gains
+    // another path field and image_path_keys does not.
+    const alloc = std.testing.allocator;
+    const input =
+        \\{"images":[{"code_file":"C:\\Users\\alex\\a.dll","debug_file":"C:\\Users\\alex\\a.pdb","code_id":"abc","type":"pe"}]}
+    ;
+    const out = try scrubImagePaths(alloc, input);
+    defer alloc.free(out);
+
+    // Nothing that still looks like an absolute Windows path survives.
+    try std.testing.expect(std.mem.indexOf(u8, out, ":\\\\") == null);
 }
 
 test "scrubImagePaths leaves an envelope with no module paths alone" {

--- a/src/crash/sentry.zig
+++ b/src/crash/sentry.zig
@@ -63,13 +63,6 @@ pub fn init(gpa: Allocator, environ_map: std.process.Environ.Map) !void {
         return;
     }
 
-    // Not supported on Windows currently, doesn't build.
-    if (comptime builtin.os.tag == .windows) {
-        var map = environ_map;
-        map.deinit();
-        return;
-    }
-
     // Must only start once
     assert(init_thread == null);
 
@@ -211,8 +204,6 @@ fn cacheDir(io: std.Io, alloc: Allocator, environ_map: *const std.process.Enviro
 /// our data is flushed.
 pub fn deinit() void {
     if (comptime !build_options.sentry) return;
-
-    if (comptime builtin.os.tag == .windows) return;
 
     // If we're still initializing then wait for init to finish. This
     // is highly unlikely since init is a very fast operation but we want

--- a/src/crash/sentry.zig
+++ b/src/crash/sentry.zig
@@ -257,14 +257,6 @@ fn beforeSend(
     // handler to set thread-specific data such as window size, grid size,
     // etc. that we can use to debug crashes.
 
-    // If we don't have thread state we can't reliably determine
-    // metadata such as surface dimensions. In the future we can probably
-    // drop full app state (all surfaces, all windows, etc.).
-    const thr_state = thread_state orelse {
-        log.debug("no thread state, skipping crash metadata", .{});
-        return event_val;
-    };
-
     // Get our event contexts. At this point Sentry has already merged
     // all the contexts so we should have this key. If not, we create it.
     const event: sentry.Value = .{ .value = event_val };
@@ -277,6 +269,17 @@ fn beforeSend(
         const obj = sentry.Value.initObject();
         event.set("tags", obj);
         break :tags obj;
+    };
+
+    // If we have no thread state we cannot determine surface dimensions.
+    // Record that rather than returning: a missing tag is indistinguishable
+    // from a crash that never reached this code, and every call that arrives
+    // through the C API in src/apprt/embedded.zig has no thread state, which
+    // for an embedder is most of them.
+    const thr_state = thread_state orelse {
+        tags.set("thread-type", sentry.Value.initString("unknown"));
+        log.debug("no thread state, crash metadata limited", .{});
+        return event_val;
     };
 
     // Store our thread type
@@ -319,6 +322,87 @@ fn beforeSend(
     }
 
     return event_val;
+}
+
+/// Rewrite `"code_file":"<dir>/<name>"` to `"code_file":"<dir>/name"` in a
+/// serialized envelope, keeping only the file name.
+///
+/// sentry records the runtime path of every loaded module. Wintty installs
+/// under `%LOCALAPPDATA%`, so on a real machine those read
+/// `C:\Users\<name>\AppData\Local\Wintty\...`: the report we ask the user to
+/// send us would carry their username. Symbolication needs the file name to
+/// match a module, not the directory it happened to load from.
+///
+/// This runs on the serialized bytes rather than on the event, because the
+/// module list cannot be edited: `sentry_modulefinder_windows.c` calls
+/// `sentry_value_freeze` on it, so `set` from a `before_send` hook is silently
+/// a no-op. The bytes are ours; the value is not.
+///
+/// Returns a slice owned by `alloc`, or the input unchanged if there is
+/// nothing to rewrite.
+fn scrubImagePaths(alloc: Allocator, json: []const u8) ![]const u8 {
+    const needle = "\"code_file\":\"";
+    if (std.mem.indexOf(u8, json, needle) == null) return json;
+
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(alloc);
+
+    var rest = json;
+    while (std.mem.indexOf(u8, rest, needle)) |at| {
+        const value_start = at + needle.len;
+        try out.appendSlice(alloc, rest[0..value_start]);
+
+        // The value ends at the first quote that is not escaped. Paths carry
+        // no escaped quotes in practice, but a filename legally could.
+        var i: usize = value_start;
+        const value_end = while (i < rest.len) : (i += 1) {
+            if (rest[i] == '"' and (i == 0 or rest[i - 1] != '\\')) break i;
+        } else rest.len;
+
+        const value = rest[value_start..value_end];
+
+        // Backslashes arrive escaped in JSON, so the separator is two bytes.
+        const cut = if (std.mem.lastIndexOf(u8, value, "\\\\")) |b|
+            b + 2
+        else if (std.mem.lastIndexOfScalar(u8, value, '/')) |b|
+            b + 1
+        else
+            0;
+
+        if (cut == 0) {
+            try out.appendSlice(alloc, value);
+        } else {
+            try out.appendSlice(alloc, "<dir>/");
+            try out.appendSlice(alloc, value[cut..]);
+        }
+
+        rest = rest[value_end..];
+    }
+    try out.appendSlice(alloc, rest);
+
+    return try out.toOwnedSlice(alloc);
+}
+
+test "scrubImagePaths keeps the file name and drops the directory" {
+    const alloc = std.testing.allocator;
+    // Multiline: contents are literal, so these backslashes are the
+    // doubled ones real JSON carries.
+    const input =
+        \\{"images":[{"code_file":"C:\\Users\\alex\\conpty.dll"}]}
+    ;
+    const out = try scrubImagePaths(alloc, input);
+    defer alloc.free(out);
+
+    try std.testing.expect(std.mem.indexOf(u8, out, "conpty.dll") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "alex") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "Users") == null);
+}
+
+test "scrubImagePaths leaves an envelope with no module paths alone" {
+    const alloc = std.testing.allocator;
+    const input = "{\"level\":\"fatal\"}";
+    const out = try scrubImagePaths(alloc, input);
+    try std.testing.expectEqualStrings(input, out);
 }
 
 pub const Transport = struct {
@@ -381,7 +465,7 @@ pub const Transport = struct {
         defer file.close(single_threaded.io());
         var buf: [4096]u8 = undefined;
         var file_writer = file.writer(single_threaded.io(), &buf);
-        try file_writer.interface.writeAll(json);
+        try file_writer.interface.writeAll(try scrubImagePaths(alloc, json));
         try file_writer.end();
 
         log.warn("crash report written to disk path={s}", .{path});

--- a/src/main.zig
+++ b/src/main.zig
@@ -21,6 +21,22 @@ pub const std_options: std.Options = if (@hasDecl(entrypoint, "std_options"))
 else
     .{};
 
+/// Panic handler for the executable, for the same reason `src/main_c.zig` has
+/// one: a Zig panic on Windows ends in `RtlExitUserProcess`, a clean exit that
+/// raises nothing, so the in-process backend's `SetUnhandledExceptionFilter`
+/// never runs and the panic is invisible.
+///
+/// The library root got this and the executable root did not, which left the
+/// gap this whole change exists to close open on one of the two artifacts.
+/// `capturePanic` is a no-op off Windows, where `abort` is `raise(.ABRT)` and
+/// the backend's own handler already sees it.
+pub const panic = std.debug.FullPanic(panicImpl);
+
+fn panicImpl(msg: []const u8, first_trace_addr: ?usize) noreturn {
+    @import("crash/main.zig").sentry.capturePanic(msg);
+    std.debug.defaultPanic(msg, first_trace_addr);
+}
+
 comptime {
     // Force-reference our memset override so its export is emitted.
     // See quirks_memset.zig for details on why this exists.

--- a/src/main_c.zig
+++ b/src/main_c.zig
@@ -16,7 +16,26 @@ const main = @import("main_ghostty.zig");
 const global = @import("global.zig");
 const apprt = @import("apprt.zig");
 const internal_os = @import("os/main.zig");
+const crash = @import("crash/main.zig");
 const windows = @import("os/windows.zig");
+
+/// Panic handler for the library.
+///
+/// A Zig panic on Windows raises no exception the in-process crash backend can
+/// observe: `std.debug.defaultPanic` ends in `std.process.abort`, which on
+/// Windows is `ntdll.RtlExitUserProcess`, a clean exit. sentry hooks
+/// `SetUnhandledExceptionFilter`, which a clean exit never invokes, so a panic
+/// would otherwise leave no exception, no WER record and no crash report.
+/// Report it explicitly, then panic exactly as the default handler would.
+///
+/// `capturePanic` is a no-op off Windows, where the backend's SIGABRT handler
+/// already sees the panic and reporting again would duplicate it.
+pub const panic = std.debug.FullPanic(panicImpl);
+
+fn panicImpl(msg: []const u8, first_trace_addr: ?usize) noreturn {
+    crash.sentry.capturePanic(msg);
+    std.debug.defaultPanic(msg, first_trace_addr);
+}
 
 // Some comptime assertions that our C API depends on.
 comptime {

--- a/src/main_c.zig
+++ b/src/main_c.zig
@@ -319,16 +319,47 @@ pub const DllMain = if (builtin.os.tag == .windows) struct {
     const __acrt_initialize = @extern(*const fn () callconv(.c) c_int, .{ .name = "__acrt_initialize" });
     const __acrt_uninitialize = @extern(*const fn (c_int) callconv(.c) c_int, .{ .name = "__acrt_uninitialize" });
 
+    // `__acrt_initialize` runs only the `__acrt_initializers` table: heap,
+    // locks, ptd, lowio, command line. It does NOT run the `.CRT$XI` C
+    // initializer table, and `__acrt_initialize_stdio` lives there. Skipping
+    // it leaves `__piob` NULL and every `_iob[i]._lock` critical section
+    // zeroed, so the first C stdio call anywhere in this DLL access violates
+    // inside ntdll on a NULL `DebugInfo`. Zig's std never touches `FILE*`, so
+    // nothing noticed until sentry's logger called vfprintf(stderr, ...).
+    //
+    // A real MSVC DllMain runs these through
+    // `__scrt_dllmain_after_initialize_c`. `.CRT$XI` also carries fmode,
+    // timeset, fma3 and multibyte init, so this is not sentry-specific.
+    const PIFV = *const fn () callconv(.c) c_int;
+    const PVFV = *const fn () callconv(.c) void;
+    const _initterm_e = @extern(*const fn ([*]?PIFV, [*]?PIFV) callconv(.c) c_int, .{ .name = "_initterm_e" });
+    const _initterm = @extern(*const fn ([*]?PVFV, [*]?PVFV) callconv(.c) void, .{ .name = "_initterm" });
+    const __xi_a = @extern([*]?PIFV, .{ .name = "__xi_a" });
+    const __xi_z = @extern([*]?PIFV, .{ .name = "__xi_z" });
+    const __xc_a = @extern([*]?PVFV, .{ .name = "__xc_a" });
+    const __xc_z = @extern([*]?PVFV, .{ .name = "__xc_z" });
+    const __xp_a = @extern([*]?PVFV, .{ .name = "__xp_a" });
+    const __xp_z = @extern([*]?PVFV, .{ .name = "__xp_z" });
+    const __xt_a = @extern([*]?PVFV, .{ .name = "__xt_a" });
+    const __xt_z = @extern([*]?PVFV, .{ .name = "__xt_z" });
+
     pub fn handler(_: HINSTANCE, fdwReason: DWORD, _: LPVOID) callconv(.winapi) BOOL {
         // Only MSVC needs to bootstrap the CRT; MinGW handles it via dllcrt2.obj.
         if (builtin.abi != .msvc) return TRUE;
         switch (fdwReason) {
             DLL_PROCESS_ATTACH => {
-                if (__vcrt_initialize() < 0) return FALSE;
-                if (__acrt_initialize() < 0) return FALSE;
+                // Both return 1 on success and 0 on failure, never a
+                // negative value, so a `< 0` test let a failed CRT init
+                // through silently.
+                if (__vcrt_initialize() == 0) return FALSE;
+                if (__acrt_initialize() == 0) return FALSE;
+                if (_initterm_e(__xi_a, __xi_z) != 0) return FALSE;
+                _initterm(__xc_a, __xc_z);
                 return TRUE;
             },
             DLL_PROCESS_DETACH => {
+                _initterm(__xp_a, __xp_z);
+                _initterm(__xt_a, __xt_z);
                 _ = __acrt_uninitialize(1);
                 _ = __vcrt_uninitialize(1);
                 return TRUE;

--- a/src/main_c.zig
+++ b/src/main_c.zig
@@ -362,6 +362,16 @@ pub const DllMain = if (builtin.os.tag == .windows) struct {
     const __xt_a = @extern([*]?PVFV, .{ .name = "__xt_a" });
     const __xt_z = @extern([*]?PVFV, .{ .name = "__xt_z" });
 
+    /// Whether attach brought the CRT all the way up.
+    ///
+    /// Windows calls DllMain(DLL_PROCESS_DETACH) after an attach that
+    /// returned FALSE, so without this a partial init is torn down as though
+    /// it were a complete one: uninitializers run against a CRT that was
+    /// never finished, and the `.CRT$XP`/`.CRT$XT` tables are walked when no
+    /// constructor ever ran. Real MSVC guards the same window with
+    /// `__scrt_current_native_startup_state` in `dll_dllmain.cpp`.
+    var crt_up: bool = false;
+
     pub fn handler(_: HINSTANCE, fdwReason: DWORD, _: LPVOID) callconv(.winapi) BOOL {
         // Only MSVC needs to bootstrap the CRT; MinGW handles it via dllcrt2.obj.
         if (builtin.abi != .msvc) return TRUE;
@@ -371,12 +381,22 @@ pub const DllMain = if (builtin.os.tag == .windows) struct {
                 // negative value, so a `< 0` test let a failed CRT init
                 // through silently.
                 if (__vcrt_initialize() == 0) return FALSE;
-                if (__acrt_initialize() == 0) return FALSE;
-                if (_initterm_e(__xi_a, __xi_z) != 0) return FALSE;
+                if (__acrt_initialize() == 0) {
+                    _ = __vcrt_uninitialize(1);
+                    return FALSE;
+                }
+                if (_initterm_e(__xi_a, __xi_z) != 0) {
+                    _ = __acrt_uninitialize(1);
+                    _ = __vcrt_uninitialize(1);
+                    return FALSE;
+                }
                 _initterm(__xc_a, __xc_z);
+                crt_up = true;
                 return TRUE;
             },
             DLL_PROCESS_DETACH => {
+                if (!crt_up) return TRUE;
+                crt_up = false;
                 _initterm(__xp_a, __xp_z);
                 _initterm(__xt_a, __xt_z);
                 _ = __acrt_uninitialize(1);

--- a/src/renderer/directx12/shaders.zig
+++ b/src/renderer/directx12/shaders.zig
@@ -457,7 +457,13 @@ pub const Shaders = struct {
         // Uses CBV at b0 (binding shifted to b0 by zioshade), 1 SRV at t0,
         // 1 sampler at s0.
         const post_root_sig = if (custom_shaders.len > 0)
-            Pipeline.createPostRootSignature(dev) catch null
+            Pipeline.createPostRootSignature(dev) catch |err| root_sig: {
+                // Every other custom-shader failure path logs its reason.
+                // Without this one the user sees pipeline_failed with no
+                // explanation anywhere.
+                log.warn("custom shader post root signature failed: {}", .{err});
+                break :root_sig null;
+            }
         else
             null;
         errdefer {

--- a/windows/Ghostty.Core/Diagnostics/CrashKinds.cs
+++ b/windows/Ghostty.Core/Diagnostics/CrashKinds.cs
@@ -198,4 +198,18 @@ internal static class CrashKinds
 
     /// <summary>Every id, comma-separated, for a CLI usage line.</summary>
     internal static string Ids => string.Join(", ", All.Select(k => k.Id));
+
+    /// <summary>
+    /// The ids the CLI can actually run, comma-separated.
+    ///
+    /// Printed alongside <see cref="Ids"/> so a third consumer can read the
+    /// catalogue rather than keep its own copy of it. That third consumer is
+    /// <c>windows/scripts/crash-matrix.ps1</c>: it is a .ps1, so no wiring
+    /// test can scan it, and it hardcoded these five. A kind added to the
+    /// catalogue got a palette row and a working `+crash`, and the harness
+    /// went on reporting five green rows without ever running it. The row
+    /// nobody measured is the one that regresses.
+    /// </summary>
+    internal static string CliIds =>
+        string.Join(", ", All.Where(k => !k.NeedsSurface).Select(k => k.Id));
 }

--- a/windows/Ghostty.Core/Diagnostics/CrashKinds.cs
+++ b/windows/Ghostty.Core/Diagnostics/CrashKinds.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Ghostty.Core.Diagnostics;
+
+/// <summary>
+/// Which layer of the stack a crash kind actually faults in.
+///
+/// The point of the coverage matrix is that different layers are seen by
+/// different handlers, so the layer is the thing worth writing down: two
+/// kinds in the same layer prove the same row twice.
+/// </summary>
+internal enum CrashLayer
+{
+    /// <summary>
+    /// The managed shell, in-process, on whichever thread invoked the
+    /// trigger. Covers the NativeAOT runtime's own failure paths.
+    /// </summary>
+    Managed,
+
+    /// <summary>
+    /// Zig, inside libghostty. Reached through a libghostty binding
+    /// action, so the fault is raised by libghostty's own code rather than
+    /// by a P/Invoke shim on the managed side.
+    /// </summary>
+    LibGhostty,
+
+    /// <summary>
+    /// The render thread, whichever backend is live. Deliberately not
+    /// named after a backend: the panic sits in the shared renderer thread
+    /// (<c>src/renderer/Thread.zig</c>), above the DirectX12 / DirectX11 /
+    /// Metal / OpenGL split, so the same kind exercises whatever backend
+    /// the build selected.
+    /// </summary>
+    Renderer,
+}
+
+/// <summary>
+/// One deliberate crash trigger: what it is called, what it says on the
+/// tin, and how it is reached.
+/// </summary>
+internal sealed record CrashKind
+{
+    /// <summary>
+    /// The CLI spelling (<c>wintty +crash &lt;id&gt;</c>) and the stable
+    /// half of the palette command id. Kebab-case, matching the CLI's
+    /// other multi-word spellings.
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// The palette row's title. Carries the "Debug:" prefix and the word
+    /// "crash" so a destructive developer action cannot be mistaken for an
+    /// ordinary command in a list that is sorted by frecency.
+    /// </summary>
+    public required string Title { get; init; }
+
+    /// <summary>One line, shown under the title and by the CLI listing.</summary>
+    public required string Description { get; init; }
+
+    public required CrashLayer Layer { get; init; }
+
+    /// <summary>
+    /// The libghostty binding action this kind dispatches, or null when it
+    /// is raised in-process by the managed trigger itself.
+    ///
+    /// Non-null is also what makes a kind need a live surface: a binding
+    /// action has nowhere to go before a window exists, which is why the
+    /// CLI cannot run these and the palette can.
+    /// </summary>
+    public string? BindingAction { get; init; }
+
+    /// <summary>
+    /// False for the one kind that is deliberately NOT a crash. It is in
+    /// the set because "nothing is captured" is a result the matrix needs,
+    /// and a probe that quietly took the process down instead would report
+    /// the opposite of what it measured.
+    /// </summary>
+    public bool Crashes { get; init; } = true;
+
+    /// <summary>
+    /// Whether this kind can only run inside a window with a live surface.
+    /// </summary>
+    public bool NeedsSurface => BindingAction is not null;
+}
+
+/// <summary>
+/// Every crash kind, once.
+///
+/// The CLI (<c>+crash</c>) and the command palette are two front doors on
+/// one mechanism, and the failure this exists to prevent is the two
+/// drifting: a kind added for the palette that <c>+crash</c> does not
+/// know, or a CLI-only kind a developer cannot reach from inside a running
+/// window. Both read this list; neither keeps its own.
+///
+/// Metadata only. Nothing here crashes anything, and nothing here is
+/// wrapped in <c>#if DEBUG</c>: the mechanisms are (see
+/// <c>Ghostty.Cli.CrashTrigger</c>) and so is the palette source that
+/// offers them, so a Release build carries these strings with nothing able
+/// to invoke them. Keeping the catalogue unconditional is what lets the
+/// parity tests exercise the real list in any configuration, rather than
+/// asserting against an empty one and passing.
+/// </summary>
+internal static class CrashKinds
+{
+    internal static readonly IReadOnlyList<CrashKind> All =
+    [
+        new()
+        {
+            Id = "native-seh",
+            Title = "Debug: Crash (native SEH exception)",
+            Description =
+                "Raise a native SEH exception, which Windows dispatches through "
+                + "the unhandled exception filter",
+            Layer = CrashLayer.Managed,
+        },
+        new()
+        {
+            Id = "managed-unhandled",
+            Title = "Debug: Crash (unhandled managed exception)",
+            Description =
+                "Throw an unhandled managed exception, which NativeAOT turns into "
+                + "a fail-fast",
+            Layer = CrashLayer.Managed,
+        },
+        new()
+        {
+            Id = "env-failfast",
+            Title = "Debug: Crash (Environment.FailFast)",
+            Description = "Fail fast, bypassing every user-mode handler by design",
+            Layer = CrashLayer.Managed,
+        },
+        new()
+        {
+            Id = "stack-overflow",
+            Title = "Debug: Crash (stack overflow)",
+            Description =
+                "Recurse until the thread's stack is exhausted, leaving no stack "
+                + "for a handler to run on",
+            Layer = CrashLayer.Managed,
+        },
+        new()
+        {
+            Id = "handled-storm",
+            Title = "Debug: Handled exception storm (does not crash)",
+            Description =
+                "Throw and catch a thousand exceptions. Expected result: no crash "
+                + "report at all",
+            Layer = CrashLayer.Managed,
+            Crashes = false,
+        },
+        new()
+        {
+            Id = "libghostty-main",
+            Title = "Debug: Crash libghostty (main thread)",
+            Description =
+                "Panic inside libghostty on the thread that owns the surface, via "
+                + "the crash binding action",
+            Layer = CrashLayer.LibGhostty,
+            BindingAction = "crash:main",
+        },
+        new()
+        {
+            Id = "libghostty-io",
+            Title = "Debug: Crash libghostty (IO thread)",
+            Description =
+                "Panic on the terminal IO thread, which owns the pty and the "
+                + "terminal state",
+            Layer = CrashLayer.LibGhostty,
+            BindingAction = "crash:io",
+        },
+        new()
+        {
+            Id = "renderer-thread",
+            Title = "Debug: Crash the renderer (active backend)",
+            Description =
+                "Panic on the render thread, whichever GPU backend this build "
+                + "selected",
+            Layer = CrashLayer.Renderer,
+            BindingAction = "crash:render",
+        },
+    ];
+
+    /// <summary>
+    /// The kind with this id, or null. Ordinal: these are wire spellings
+    /// off a command line, not display text, and a culture-sensitive
+    /// compare is how "native-seh" starts matching something else under a
+    /// Turkish locale.
+    /// </summary>
+    internal static CrashKind? Find(string id) =>
+        All.FirstOrDefault(k => string.Equals(k.Id, id, StringComparison.Ordinal));
+
+    /// <summary>Every id, comma-separated, for a CLI usage line.</summary>
+    internal static string Ids => string.Join(", ", All.Select(k => k.Id));
+}

--- a/windows/Ghostty.Core/Diagnostics/CrashKinds.cs
+++ b/windows/Ghostty.Core/Diagnostics/CrashKinds.cs
@@ -94,13 +94,18 @@ internal sealed record CrashKind
 /// know, or a CLI-only kind a developer cannot reach from inside a running
 /// window. Both read this list; neither keeps its own.
 ///
-/// Metadata only. Nothing here crashes anything, and nothing here is
-/// wrapped in <c>#if DEBUG</c>: the mechanisms are (see
-/// <c>Ghostty.Cli.CrashTrigger</c>) and so is the palette source that
-/// offers them, so a Release build carries these strings with nothing able
-/// to invoke them. Keeping the catalogue unconditional is what lets the
-/// parity tests exercise the real list in any configuration, rather than
-/// asserting against an empty one and passing.
+/// Metadata only: nothing here crashes anything. Nothing here is wrapped in
+/// <c>#if DEBUG</c>, and neither are the mechanisms
+/// (<c>Ghostty.Cli.CrashTrigger</c>) or the palette source that offers them.
+/// A Release build carries these strings AND can invoke them, deliberately:
+/// capture has to be provable in the configuration users install, and a
+/// trigger compiled out of Release leaves that as the one configuration
+/// nobody can test.
+///
+/// What keeps them out of the way is not the compiler. The rows are
+/// <c>CommandCategory.Debug</c>, which sorts last and matches only on its
+/// title, so a destructive row has to be asked for by name. See
+/// <c>CommandPaletteViewModel.ApplyFilter</c>.
 /// </summary>
 internal static class CrashKinds
 {

--- a/windows/Ghostty.Tests/Diagnostics/CrashKindsTests.cs
+++ b/windows/Ghostty.Tests/Diagnostics/CrashKindsTests.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Ghostty.Core.Diagnostics;
+using Xunit;
+
+namespace Ghostty.Tests.Diagnostics;
+
+/// <summary>
+/// The crash-trigger catalogue, which the CLI (<c>+crash</c>) and the
+/// command palette both read.
+///
+/// Nothing here runs a trigger, and nothing here can: the catalogue is
+/// metadata and the mechanisms live in the shell assembly, which no test
+/// host loads. That separation is deliberate rather than a limitation.
+/// It is what lets the shape of the set be asserted against the real list
+/// in a process that is not allowed to die.
+/// </summary>
+public class CrashKindsTests
+{
+    [Fact]
+    public void Catalogue_IsNotEmpty()
+    {
+        // Load-bearing: every other test here reads "nothing to check" out
+        // of an empty list and passes.
+        Assert.NotEmpty(CrashKinds.All);
+    }
+
+    [Fact]
+    public void Ids_AreUniqueAndWireShaped()
+    {
+        var ids = CrashKinds.All.Select(k => k.Id).ToList();
+        Assert.Equal(ids.Count, ids.Distinct(StringComparer.Ordinal).Count());
+
+        foreach (var id in ids)
+        {
+            // These are typed on a command line and stored as frecency keys.
+            // Kebab-case lowercase matches the CLI's other multi-word
+            // spellings and leaves no room for a casing variant that only
+            // works on one of the two front doors.
+            Assert.Matches(new Regex("^[a-z][a-z0-9]*(-[a-z0-9]+)*$"), id);
+        }
+    }
+
+    [Fact]
+    public void EveryTitle_SaysItIsADebugAction()
+    {
+        // The palette sorts by frecency, so a crash trigger can surface next
+        // to New Tab. The prefix is the only thing standing between a
+        // developer and an accidental fail-fast, and it has to be in the
+        // title: the palette renders Title and Description and nothing else
+        // (Badge and Emphasis on CommandItem are unbound today).
+        foreach (var kind in CrashKinds.All)
+        {
+            Assert.StartsWith("Debug: ", kind.Title, StringComparison.Ordinal);
+            Assert.False(string.IsNullOrWhiteSpace(kind.Description));
+        }
+    }
+
+    [Fact]
+    public void NeedsSurface_IsExactlyTheBindingActionKinds()
+    {
+        // NeedsSurface is what the CLI refuses on. If it could be true for a
+        // kind with no binding action, +crash would start refusing a kind it
+        // can perfectly well run.
+        foreach (var kind in CrashKinds.All)
+            Assert.Equal(kind.BindingAction is not null, kind.NeedsSurface);
+    }
+
+    [Fact]
+    public void BindingActions_AreTheCrashActionLibghosttyDefines()
+    {
+        // libghostty's `crash` binding action takes a CrashThread value:
+        // main, io or render (src/input/Binding.zig). Anything else is
+        // silently rejected by ghostty_surface_binding_action, which the
+        // trigger reports as "not accepted" rather than as a crash, so the
+        // failure is loud but only at runtime. Pin the spellings here.
+        var actions = CrashKinds.All
+            .Where(k => k.BindingAction is not null)
+            .Select(k => k.BindingAction!)
+            .ToList();
+
+        Assert.NotEmpty(actions);
+        Assert.Equal(actions.Count, actions.Distinct(StringComparer.Ordinal).Count());
+        foreach (var action in actions)
+            Assert.Contains(action, new[] { "crash:main", "crash:io", "crash:render" });
+    }
+
+    [Fact]
+    public void EveryLayer_IsCovered()
+    {
+        // The point of the matrix is one probe per capture boundary. A layer
+        // with no kind is a row nobody can run.
+        foreach (var layer in Enum.GetValues<CrashLayer>())
+            Assert.Contains(CrashKinds.All, k => k.Layer == layer);
+    }
+
+    [Fact]
+    public void TheRendererKind_IsNotTiedToABackend()
+    {
+        // The renderer probe faults on the shared render thread
+        // (src/renderer/Thread.zig), above the DirectX12 / DirectX11 split,
+        // so the pro-legacy DX11 tier gets it without a tier-specific patch.
+        // A kind named after a backend is the regression: it would have to
+        // be forked per tier.
+        var renderer = Assert.Single(CrashKinds.All.Where(k => k.Layer == CrashLayer.Renderer));
+        foreach (var backend in new[] { "dx11", "dx12", "directx", "d3d", "metal", "opengl" })
+        {
+            Assert.DoesNotContain(backend, renderer.Id, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain(backend, renderer.Title, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
+    public void ExactlyOneKind_IsDeliberatelyNotACrash()
+    {
+        // handled-storm measures that a flood of caught exceptions produces
+        // no report. A second non-crashing kind is fine in principle, but it
+        // has not been thought about; making it fail here is cheaper than
+        // discovering that a probe named "crash" never crashed.
+        Assert.Single(CrashKinds.All.Where(k => !k.Crashes));
+    }
+
+    [Fact]
+    public void Find_MatchesOrdinallyAndExactly()
+    {
+        var first = CrashKinds.All[0];
+        Assert.Same(first, CrashKinds.Find(first.Id));
+        Assert.Null(CrashKinds.Find("no-such-kind"));
+        Assert.Null(CrashKinds.Find(""));
+        // Case-sensitive on purpose: an id is a wire spelling, and a loose
+        // compare is how a locale-dependent uppercase starts matching.
+        Assert.Null(CrashKinds.Find(first.Id.ToUpperInvariant()));
+    }
+
+    [Fact]
+    public void Ids_ListsEveryKind()
+    {
+        // The CLI prints this when it is handed an unknown kind, so a kind
+        // missing from it is a kind nobody can discover.
+        var listed = CrashKinds.Ids.Split(", ");
+        Assert.Equal(CrashKinds.All.Select(k => k.Id).ToArray(), listed);
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/CrashTriggerWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/CrashTriggerWiringTests.cs
@@ -87,39 +87,61 @@ public class CrashTriggerWiringTests
         Assert.DoesNotContain("Environment.FailFast", text, StringComparison.Ordinal);
     }
 
-    // -- Gating ----------------------------------------------------------
+    // -- Availability ----------------------------------------------------
+    //
+    // These guards were inverted deliberately. They used to assert the
+    // triggers were Debug-only. Capture has to be provable in the build
+    // users actually install, and a trigger compiled out of Release leaves
+    // the one configuration that matters as the one nobody can test. So the
+    // invariant now is the opposite: the triggers must reach every build.
 
     [Fact]
-    public void PaletteSource_IsWhollyDebugGated()
+    public void PaletteSource_IsNotBuildGated()
     {
         var lines = ShellText("Commands.CrashCommandSource.cs")
-            .Split('\n')
-            .Select(l => l.TrimEnd('\r').Trim())
+            .Split('
+')
+            .Select(l => l.TrimEnd('').Trim())
             .Where(l => l.Length > 0)
             .ToList();
 
-        // Not "contains an #if DEBUG": a file whose first half is gated and
-        // whose second half is not would satisfy that.
-        Assert.Equal("#if DEBUG", lines[0]);
-        Assert.Equal("#endif", lines[^1]);
-        Assert.Single(lines.Where(l => l.StartsWith("#if", StringComparison.Ordinal)));
+        Assert.DoesNotContain(lines, l => l.StartsWith("#if", StringComparison.Ordinal));
         Assert.DoesNotContain("#else", lines);
     }
 
     [Fact]
-    public void NothingConstructsThePaletteSourceOutsideADebugRegion()
+    public void TheTriggerItselfIsNotBuildGated()
     {
-        // The claim that matters: no Release build can offer these rows.
+        // The palette rows are worth nothing if Run() stubs itself out: the
+        // entries would appear in a shipped build and quietly do nothing,
+        // which is worse than not shipping them.
+        var lines = ShellText("Cli.CrashTrigger.cs")
+            .Split('
+')
+            .Select(l => l.TrimEnd('').Trim())
+            .Where(l => l.Length > 0)
+            .ToList();
+
+        Assert.DoesNotContain(lines, l => l.StartsWith("#if", StringComparison.Ordinal));
+        Assert.DoesNotContain(
+            "crash-trigger is compiled out of Release builds",
+            ShellText("Cli.CrashTrigger.cs"),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NothingGatesThePaletteSourceRegistration()
+    {
         // Swept over the whole shell rather than over MainWindow, because a
         // second registration site added later is exactly the one nobody
-        // would think to gate.
+        // would think about.
         var sites = new List<string>();
         foreach (var (tail, text) in ShellSource.AllUnder(ShellPrefix))
         {
             foreach (var conditions in EnclosingConditions(text, "new CrashCommandSource("))
             {
                 sites.Add(tail);
-                Assert.Equal(new[] { "DEBUG" }, conditions);
+                Assert.Empty(conditions);
             }
         }
 

--- a/windows/Ghostty.Tests/Wiring/CrashTriggerWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/CrashTriggerWiringTests.cs
@@ -7,16 +7,21 @@ using Xunit;
 namespace Ghostty.Tests.Wiring;
 
 /// <summary>
-/// That the crash triggers are reachable from both front doors, and only
-/// from a Debug build.
+/// That the crash triggers are reachable from both front doors, in every
+/// build.
 ///
 /// Text-level rather than parsed, which is the exception <c>ShellSource</c>
-/// describes rather than a shortcut. The trigger's real body and the whole
-/// palette source live inside <c>#if DEBUG</c>, and the half a parse cannot
-/// see is decided by which symbols the parse defines; a rule about "is this
-/// inside a DEBUG region" cannot be written against a tree that has already
-/// resolved the regions away. The lines are what carry the claim, so the
-/// lines are what is read.
+/// describes rather than a shortcut. The claim here is about preprocessor
+/// directives themselves: that the trigger and the palette source contain
+/// none. A parse cannot make that claim, because which half of a conditional
+/// it can see is decided by the symbols it defines, and the regions are
+/// resolved away before any rule could read them. The lines are what carry
+/// the claim, so the lines are what is read.
+///
+/// The direction is deliberate. These guards used to assert the opposite,
+/// that the triggers were Debug-only. Capture has to be provable in the
+/// build users install, and a trigger compiled out of Release leaves the one
+/// configuration that matters as the one nobody can test.
 ///
 /// What this cannot see: whether a case arm does what its comment says, and
 /// whether the palette rows reach a live surface. Neither is observable
@@ -99,9 +104,8 @@ public class CrashTriggerWiringTests
     public void PaletteSource_IsNotBuildGated()
     {
         var lines = ShellText("Commands.CrashCommandSource.cs")
-            .Split('
-')
-            .Select(l => l.TrimEnd('').Trim())
+            .Split('\n')
+            .Select(l => l.TrimEnd('\r').Trim())
             .Where(l => l.Length > 0)
             .ToList();
 
@@ -116,9 +120,8 @@ public class CrashTriggerWiringTests
         // entries would appear in a shipped build and quietly do nothing,
         // which is worse than not shipping them.
         var lines = ShellText("Cli.CrashTrigger.cs")
-            .Split('
-')
-            .Select(l => l.TrimEnd('').Trim())
+            .Split('\n')
+            .Select(l => l.TrimEnd('\r').Trim())
             .Where(l => l.Length > 0)
             .ToList();
 

--- a/windows/Ghostty.Tests/Wiring/CrashTriggerWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/CrashTriggerWiringTests.cs
@@ -139,6 +139,81 @@ public class CrashTriggerWiringTests
     }
 
     [Fact]
+    public void TheCliFrontDoorIsNotBuildGated()
+    {
+        // Program.cs, not just CrashTrigger.cs. The line-level scans above
+        // cover the trigger and the palette source; the `+crash` interception
+        // that reaches the trigger was covered by nothing. Wrapping that one
+        // `if` in `#if DEBUG` compiles `+crash` out of Release, makes
+        // crash-matrix.ps1 unrunnable against the shipped build, and left
+        // every test in this file green.
+        //
+        // Text, not a parse, for the reason at the top of this file: which
+        // half of a conditional a parse can see depends on the symbols it
+        // defines, and the claim here is about the directives themselves.
+        var text = ShellText("Program.cs");
+        var needle = "args[0] == \"+crash\"";
+        Assert.Contains(needle, text, StringComparison.Ordinal);
+
+        foreach (var conditions in EnclosingConditions(text, needle))
+        {
+            Assert.Empty(conditions);
+        }
+    }
+
+    [Fact]
+    public void NoMSBuildConditionRemovesTheCrashSourcesFromABuild()
+    {
+        // The scans in this file read EMBEDDED resources, and the embedding
+        // is an unconditional wildcard over ..\Ghostty\**\*.cs. So a
+        // <Compile Remove> under a Configuration condition takes the triggers
+        // out of the shipped build without touching a single line those scans
+        // can see. Not hypothetical: Ghostty.csproj already does exactly that
+        // for Demo\**\*.cs, and this project's own comments describe the
+        // mismatch.
+        var csproj = ShellSource.AllUnder(ShellPrefix)
+            .Any(f => f.Tail == "Program.cs");
+        Assert.True(csproj, "the shell corpus is empty; this test proves nothing");
+
+        var text = System.IO.File.ReadAllText(ShellProjectPath);
+        foreach (var name in new[]
+                 {
+                     "Cli\\CrashTrigger.cs",
+                     "Commands\\CrashCommandSource.cs",
+                     "Diagnostics\\CrashKinds.cs",
+                 })
+        {
+            Assert.DoesNotContain(
+                $"Compile Remove=\"{name}\"",
+                text,
+                StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    /// <summary>
+    /// The shell project file, located from the test assembly rather than
+    /// embedded, because the claim is about the build rules themselves.
+    /// </summary>
+    private static string ShellProjectPath
+    {
+        get
+        {
+            var dir = new System.IO.DirectoryInfo(AppContext.BaseDirectory);
+            while (dir is not null)
+            {
+                var candidate = System.IO.Path.Combine(
+                    dir.FullName, "windows", "Ghostty", "Ghostty.csproj");
+                if (System.IO.File.Exists(candidate)) return candidate;
+                dir = dir.Parent;
+            }
+
+            throw new System.IO.FileNotFoundException(
+                "could not locate windows/Ghostty/Ghostty.csproj from "
+                + AppContext.BaseDirectory);
+        }
+    }
+
+    [Fact]
     public void NothingGatesThePaletteSourceRegistration()
     {
         // Swept over the whole shell rather than over MainWindow, because a

--- a/windows/Ghostty.Tests/Wiring/CrashTriggerWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/CrashTriggerWiringTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Ghostty.Core.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Xunit;
 
 namespace Ghostty.Tests.Wiring;
@@ -10,13 +11,17 @@ namespace Ghostty.Tests.Wiring;
 /// That the crash triggers are reachable from both front doors, in every
 /// build.
 ///
-/// Text-level rather than parsed, which is the exception <c>ShellSource</c>
-/// describes rather than a shortcut. The claim here is about preprocessor
-/// directives themselves: that the trigger and the palette source contain
-/// none. A parse cannot make that claim, because which half of a conditional
-/// it can see is decided by the symbols it defines, and the regions are
-/// resolved away before any rule could read them. The lines are what carry
-/// the claim, so the lines are what is read.
+/// The availability guards are text-level, which is the exception
+/// <c>ShellSource</c> describes rather than a shortcut. Their claim is about
+/// preprocessor directives themselves: that the trigger and the palette
+/// source contain none. A parse cannot make that claim, because which half of
+/// a conditional it can see is decided by the symbols it defines, and the
+/// regions are resolved away before any rule could read them. The lines are
+/// what carry the claim, so the lines are what is read.
+///
+/// The palette guards at the bottom are parsed, because their claim is the
+/// opposite kind: which expression guards which, where a substring match
+/// cannot tell a live guard from one inside a comment.
 ///
 /// The direction is deliberate. These guards used to assert the opposite,
 /// that the triggers were Debug-only. Capture has to be provable in the
@@ -171,22 +176,28 @@ public class CrashTriggerWiringTests
             var line = raw.TrimEnd('\r');
             var trimmed = line.TrimStart();
 
-            if (trimmed.StartsWith("#if ", StringComparison.Ordinal))
+            // Matched without requiring the trailing space, and closed
+            // without requiring an exact line. `#if(DEBUG)` is legal C# and
+            // walked straight through a `"#if "` prefix test, leaving the
+            // registration reading as ungated while Release lost it. So did
+            // `#endif // DEBUG`, in the other direction: the condition stayed
+            // on the stack and every later line read as gated.
+            if (trimmed.StartsWith("#if", StringComparison.Ordinal))
             {
-                stack.Add(trimmed[4..].Trim());
+                stack.Add(trimmed[3..].Trim());
                 continue;
             }
-            if (trimmed.StartsWith("#elif ", StringComparison.Ordinal) && stack.Count > 0)
+            if (trimmed.StartsWith("#elif", StringComparison.Ordinal) && stack.Count > 0)
             {
-                stack[^1] = trimmed[6..].Trim();
+                stack[^1] = trimmed[5..].Trim();
                 continue;
             }
-            if (trimmed == "#else" && stack.Count > 0)
+            if (trimmed.StartsWith("#else", StringComparison.Ordinal) && stack.Count > 0)
             {
                 stack[^1] = "!(" + stack[^1] + ")";
                 continue;
             }
-            if (trimmed == "#endif" && stack.Count > 0)
+            if (trimmed.StartsWith("#endif", StringComparison.Ordinal) && stack.Count > 0)
             {
                 stack.RemoveAt(stack.Count - 1);
                 continue;
@@ -201,4 +212,84 @@ public class CrashTriggerWiringTests
 
         return found;
     }
+
+    // -- Keeping a destructive row out of reach ---------------------------
+    //
+    // These triggers ship in Release, so the compiler is not what stands
+    // between a user and a deliberate crash. Two properties of the palette
+    // are, and both were absent when the rows first landed: a fresh profile,
+    // the query "select", and Enter took the window down, because Debug rows
+    // matched on their description ("...this build selected") and the default
+    // ordering ignored Category entirely.
+    //
+    // Parsed, not text: the claim is about which expressions guard which, and
+    // a substring match cannot tell a live guard from one inside a comment.
+
+    [Fact]
+    public void DebugRows_MatchOnTitleOnly()
+    {
+        var filter = ShellSource
+            .Load("Commands.CommandPaletteViewModel.cs")
+            .Method("ApplyFilter");
+
+        var descriptionMatches = filter.DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .Where(i => i.Expression.ToString().EndsWith(
+                "Description.Contains", StringComparison.Ordinal))
+            .ToList();
+        Assert.True(
+            descriptionMatches.Count > 0,
+            "ApplyFilter no longer matches on Description at all. If that is "
+                + "deliberate, delete this test; it exists to prove the match "
+                + "excludes Debug rows, not to require the match.");
+
+        foreach (var match in descriptionMatches)
+        {
+            var guarded = match.Ancestors()
+                .OfType<BinaryExpressionSyntax>()
+                .Any(b => b.ToString().Contains(
+                    "Category != CommandCategory.Debug", StringComparison.Ordinal));
+            Assert.True(
+                guarded,
+                "a Description match in ApplyFilter is not behind "
+                    + "'Category != CommandCategory.Debug'. Debug rows describe "
+                    + "what they destroy in ordinary words, so matching their "
+                    + "descriptions puts 'crash the renderer' in front of "
+                    + "someone who typed 'select'.");
+        }
+    }
+
+    [Fact]
+    public void DebugRows_SortLastInBothBranches()
+    {
+        var filter = ShellSource
+            .Load("Commands.CommandPaletteViewModel.cs")
+            .Method("ApplyFilter");
+
+        // Every ordering chain built in this method, whether or not grouping
+        // is on. The grouped branch sorts by Category directly; the other has
+        // to name Debug explicitly, and used not to.
+        var chains = filter.DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .Where(i => i.Expression.ToString().EndsWith(".OrderBy", StringComparison.Ordinal)
+                || i.Expression.ToString().EndsWith(".OrderByDescending", StringComparison.Ordinal))
+            .ToList();
+        Assert.True(chains.Count >= 2, $"expected both ordering branches, found {chains.Count}");
+
+        foreach (var chain in chains)
+        {
+            var key = chain.ArgumentList.Arguments.ToString();
+            var demotesDebug =
+                key.Contains("c.Category", StringComparison.Ordinal)
+                && (key.Contains("CommandCategory.Debug", StringComparison.Ordinal)
+                    || key.Trim() == "c => c.Category");
+            Assert.True(
+                demotesDebug,
+                $"an ordering branch leads with '{key}', which does not put "
+                    + "Debug last. Frecency cannot be the first key for these: "
+                    + "executing one records the use before the process dies, "
+                    + "so one accident promotes that row for every later launch.");
+        }
+    }
+
 }

--- a/windows/Ghostty.Tests/Wiring/CrashTriggerWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/CrashTriggerWiringTests.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Ghostty.Core.Diagnostics;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// That the crash triggers are reachable from both front doors, and only
+/// from a Debug build.
+///
+/// Text-level rather than parsed, which is the exception <c>ShellSource</c>
+/// describes rather than a shortcut. The trigger's real body and the whole
+/// palette source live inside <c>#if DEBUG</c>, and the half a parse cannot
+/// see is decided by which symbols the parse defines; a rule about "is this
+/// inside a DEBUG region" cannot be written against a tree that has already
+/// resolved the regions away. The lines are what carry the claim, so the
+/// lines are what is read.
+///
+/// What this cannot see: whether a case arm does what its comment says, and
+/// whether the palette rows reach a live surface. Neither is observable
+/// without running a build that is allowed to die.
+/// </summary>
+public class CrashTriggerWiringTests
+{
+    private const string ShellPrefix = "Ghostty.Tests.Interop.Sources.Ghostty.";
+
+    private static string ShellText(string tail)
+    {
+        var matches = ShellSource.AllUnder(ShellPrefix)
+            .Where(f => f.Tail == tail)
+            .ToList();
+        Assert.True(
+            matches.Count == 1,
+            $"expected exactly one embedded shell source '{tail}', found {matches.Count}");
+        return matches[0].Text;
+    }
+
+    // -- One implementation, one catalogue -------------------------------
+
+    [Fact]
+    public void CrashTrigger_DispatchesOffTheCatalogue()
+    {
+        // The whole point of CrashKinds is that neither front door keeps its
+        // own list. A trigger that went back to matching the raw argument
+        // would let a kind exist for the CLI and not the palette.
+        Assert.Contains("CrashKinds.Find(kind)", ShellText("Cli.CrashTrigger.cs"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EveryInProcessKind_HasItsOwnArm()
+    {
+        // A catalogue entry with no mechanism reaches the default arm and
+        // exits 2, which looks like an unknown kind rather than a gap.
+        var text = ShellText("Cli.CrashTrigger.cs");
+        foreach (var kind in CrashKinds.All.Where(k => !k.NeedsSurface))
+        {
+            Assert.Contains($"case \"{kind.Id}\":", text, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void NoSurfaceBoundKind_AlsoHasAnArm()
+    {
+        // A surface-bound kind must go through the binding action and
+        // nothing else. A second mechanism behind the same id is how a probe
+        // ends up reporting on a layer it did not touch: a managed fault
+        // dressed up as a libghostty one.
+        var text = ShellText("Cli.CrashTrigger.cs");
+        foreach (var kind in CrashKinds.All.Where(k => k.NeedsSurface))
+        {
+            Assert.DoesNotContain($"case \"{kind.Id}\":", text, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void PaletteSource_ProjectsTheCatalogue()
+    {
+        var text = ShellText("Commands.CrashCommandSource.cs");
+        Assert.Contains("CrashKinds.All", text, StringComparison.Ordinal);
+        // Its own category, so grouped mode sorts them away from the
+        // commands a user reaches for.
+        Assert.Contains("CommandCategory.Debug", text, StringComparison.Ordinal);
+        // And no second opinion about what a kind does: the row hands the id
+        // back to the one implementation.
+        Assert.DoesNotContain("Environment.FailFast", text, StringComparison.Ordinal);
+    }
+
+    // -- Gating ----------------------------------------------------------
+
+    [Fact]
+    public void PaletteSource_IsWhollyDebugGated()
+    {
+        var lines = ShellText("Commands.CrashCommandSource.cs")
+            .Split('\n')
+            .Select(l => l.TrimEnd('\r').Trim())
+            .Where(l => l.Length > 0)
+            .ToList();
+
+        // Not "contains an #if DEBUG": a file whose first half is gated and
+        // whose second half is not would satisfy that.
+        Assert.Equal("#if DEBUG", lines[0]);
+        Assert.Equal("#endif", lines[^1]);
+        Assert.Single(lines.Where(l => l.StartsWith("#if", StringComparison.Ordinal)));
+        Assert.DoesNotContain("#else", lines);
+    }
+
+    [Fact]
+    public void NothingConstructsThePaletteSourceOutsideADebugRegion()
+    {
+        // The claim that matters: no Release build can offer these rows.
+        // Swept over the whole shell rather than over MainWindow, because a
+        // second registration site added later is exactly the one nobody
+        // would think to gate.
+        var sites = new List<string>();
+        foreach (var (tail, text) in ShellSource.AllUnder(ShellPrefix))
+        {
+            foreach (var conditions in EnclosingConditions(text, "new CrashCommandSource("))
+            {
+                sites.Add(tail);
+                Assert.Equal(new[] { "DEBUG" }, conditions);
+            }
+        }
+
+        // An empty sweep is a query that stopped matching, and reads as a
+        // pass.
+        Assert.Single(sites);
+    }
+
+    /// <summary>
+    /// For every line containing <paramref name="needle"/>, the stack of
+    /// <c>#if</c> conditions enclosing it, outermost first.
+    ///
+    /// A line inside an <c>#else</c> reports the condition negated, so a
+    /// registration that moved into the Release half of a conditional does
+    /// not read as gated.
+    /// </summary>
+    private static List<List<string>> EnclosingConditions(string text, string needle)
+    {
+        var found = new List<List<string>>();
+        var stack = new List<string>();
+
+        foreach (var raw in text.Split('\n'))
+        {
+            var line = raw.TrimEnd('\r');
+            var trimmed = line.TrimStart();
+
+            if (trimmed.StartsWith("#if ", StringComparison.Ordinal))
+            {
+                stack.Add(trimmed[4..].Trim());
+                continue;
+            }
+            if (trimmed.StartsWith("#elif ", StringComparison.Ordinal) && stack.Count > 0)
+            {
+                stack[^1] = trimmed[6..].Trim();
+                continue;
+            }
+            if (trimmed == "#else" && stack.Count > 0)
+            {
+                stack[^1] = "!(" + stack[^1] + ")";
+                continue;
+            }
+            if (trimmed == "#endif" && stack.Count > 0)
+            {
+                stack.RemoveAt(stack.Count - 1);
+                continue;
+            }
+
+            // Comments mentioning the type are not registrations. Only a
+            // line that is not a comment counts.
+            if (trimmed.StartsWith("//", StringComparison.Ordinal)) continue;
+            if (line.Contains(needle, StringComparison.Ordinal))
+                found.Add([.. stack]);
+        }
+
+        return found;
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/CrashTriggerWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/CrashTriggerWiringTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Ghostty.Core.Diagnostics;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Xunit;
 
@@ -232,31 +233,142 @@ public class CrashTriggerWiringTests
             .Load("Commands.CommandPaletteViewModel.cs")
             .Method("ApplyFilter");
 
-        var descriptionMatches = filter.DescendantNodes()
+        // Every field a query is matched against EXCEPT Title. Title is the
+        // one a Debug row is allowed to match on, which is the whole rule.
+        //
+        // Classified by the property the call hangs off, not by the callee
+        // text: `c.Subtitle?.Contains(...)` is a conditional access, so the
+        // invocation's own Expression is a bare `.Contains` and matching on
+        // "Subtitle?.Contains" silently found nothing.
+        // By the invoked member's name, not by the node's text. The enclosing
+        // `Where(...)` is itself an invocation and stringifies to the whole
+        // lambda, so a text match picked it up and then reported it as an
+        // unguarded Contains.
+        var matches = filter.DescendantNodes()
             .OfType<InvocationExpressionSyntax>()
-            .Where(i => i.Expression.ToString().EndsWith(
-                "Description.Contains", StringComparison.Ordinal))
+            .Where(i => CalleeName(i.Expression) == "Contains")
+            .Select(i => (Node: (SyntaxNode)i, Owner: MatchOwner(i)))
+            .ToList();
+
+        var secondaryMatches = matches
+            .Where(m => !m.Owner.StartsWith("c.Title", StringComparison.Ordinal))
             .ToList();
         Assert.True(
-            descriptionMatches.Count > 0,
-            "ApplyFilter no longer matches on Description at all. If that is "
-                + "deliberate, delete this test; it exists to prove the match "
-                + "excludes Debug rows, not to require the match.");
+            secondaryMatches.Count >= 3,
+            "ApplyFilter no longer matches on Description, Subtitle and "
+                + "ActionKey. If that is deliberate, delete this test; it "
+                + $"exists to prove those matches exclude Debug rows. Found "
+                + $"{secondaryMatches.Count}.");
 
-        foreach (var match in descriptionMatches)
+        // The guard, located exactly: the '&&' whose LEFT side is the Debug
+        // check. Anything the rule protects has to sit in its RIGHT side.
+        //
+        // The earlier version walked every BinaryExpressionSyntax ancestor and
+        // passed if ANY of them stringified to something containing the Debug
+        // check. The whole lambda body is one '||' chain, so the outermost
+        // expression always contains it, and the test passed no matter where
+        // the match sat. Hoisting the Description match up a level, which is
+        // precisely the regression, left it green.
+        var debugGuards = filter.DescendantNodes()
+            .OfType<BinaryExpressionSyntax>()
+            .Where(b => b.OperatorToken.Text == "&&"
+                && b.Left.ToString().Replace(" ", "")
+                    == "c.Category!=CommandCategory.Debug")
+            .ToList();
+        Assert.True(
+            debugGuards.Count == 1,
+            $"expected exactly one 'c.Category != CommandCategory.Debug &&' "
+                + $"guard in ApplyFilter, found {debugGuards.Count}. The tests "
+                + "below locate the protected matches by it.");
+        var guardedRegion = debugGuards[0].Right;
+
+        foreach (var match in secondaryMatches)
         {
-            var guarded = match.Ancestors()
-                .OfType<BinaryExpressionSyntax>()
-                .Any(b => b.ToString().Contains(
-                    "Category != CommandCategory.Debug", StringComparison.Ordinal));
             Assert.True(
-                guarded,
-                "a Description match in ApplyFilter is not behind "
-                    + "'Category != CommandCategory.Debug'. Debug rows describe "
-                    + "what they destroy in ordinary words, so matching their "
-                    + "descriptions puts 'crash the renderer' in front of "
-                    + "someone who typed 'select'.");
+                guardedRegion.Contains(match.Node),
+                $"'{match.Owner}' in ApplyFilter is not inside the right side "
+                    + "of 'c.Category != CommandCategory.Debug &&'. Debug rows "
+                    + "describe what they destroy in ordinary words, so "
+                    + "matching their descriptions puts 'crash the renderer' "
+                    + "in front of someone who typed 'select'.");
         }
+    }
+
+    /// <summary>
+    /// The `c.&lt;Property&gt;...` expression a Contains call hangs off, found by
+    /// walking up rather than by reading the callee, so a conditional access
+    /// is classified the same way a plain member access is.
+    /// </summary>
+    /// <summary>
+    /// The name of the member being invoked, for a plain member access
+    /// (<c>c.Title.Contains</c>) or a conditional one (<c>?.Contains</c>).
+    /// Null for anything else.
+    /// </summary>
+    private static string? CalleeName(ExpressionSyntax callee) => callee switch
+    {
+        MemberAccessExpressionSyntax m => m.Name.Identifier.Text,
+        MemberBindingExpressionSyntax m => m.Name.Identifier.Text,
+        _ => null,
+    };
+
+    private static string MatchOwner(SyntaxNode node)
+    {
+        for (var cur = node; cur is not null; cur = cur.Parent)
+        {
+            var text = cur.ToString();
+            if (text.StartsWith("c.", StringComparison.Ordinal)) return text;
+        }
+
+        return node.ToString();
+    }
+
+    [Fact]
+    public void TheUnfilteredList_ExcludesDebugRows()
+    {
+        var filter = ShellSource
+            .Load("Commands.CommandPaletteViewModel.cs")
+            .Method("ApplyFilter");
+
+        // Sorting Debug last governs position, and title-only matching needs a
+        // query, so neither reaches the empty-query branch. Without an
+        // exclusion here, opening the palette and pressing End then Enter
+        // takes the window down on a shipped build with no confirmation.
+        var emptyBranch = filter.DescendantNodes()
+            .OfType<IfStatementSyntax>()
+            .FirstOrDefault(i => i.Condition.ToString()
+                .Contains("IsNullOrEmpty", StringComparison.Ordinal));
+        Assert.True(
+            emptyBranch is not null,
+            "ApplyFilter no longer has an empty-query branch; this test "
+                + "locates the unfiltered list by it.");
+
+        Assert.Contains(
+            "c.Category != CommandCategory.Debug",
+            emptyBranch!.Statement.ToString().Replace("  ", " "));
+    }
+
+    [Fact]
+    public void DebugIsLastInTheCategoryEnum()
+    {
+        // The grouped ordering branch sorts by Category directly, so its
+        // entire correctness rests on Debug being the last member. Nothing
+        // else asserts it, and moving Debug above Demo silently puts crash
+        // rows at the top of every grouped list.
+        var text = ShellText("Commands.CommandItem.cs");
+        var body = text[text.IndexOf("enum CommandCategory", StringComparison.Ordinal)..];
+        body = body[..body.IndexOf('}')];
+
+        var members = body
+            .Split(',', '\n')
+            .Select(s => s.Trim())
+            .Where(s => s.Length > 0
+                && !s.StartsWith("//", StringComparison.Ordinal)
+                && !s.StartsWith("enum", StringComparison.Ordinal)
+                && !s.StartsWith("{", StringComparison.Ordinal))
+            .ToList();
+
+        Assert.NotEmpty(members);
+        Assert.Equal("Debug", members[^1]);
     }
 
     [Fact]
@@ -276,19 +388,38 @@ public class CrashTriggerWiringTests
             .ToList();
         Assert.True(chains.Count >= 2, $"expected both ordering branches, found {chains.Count}");
 
+        // Exact shapes, not substrings. The earlier version asked whether the
+        // key text mentioned c.Category and CommandCategory.Debug, which is
+        // as true of `? 0 : 1` as of `? 1 : 0`, and it accepted
+        // OrderByDescending(c => c.Category) because that trims to the same
+        // string as the ascending form. Both inversions put Debug FIRST and
+        // both left the test green.
+        //
+        // Brittle on purpose. A reformulated guard on destructive rows should
+        // stop and make someone look, not pattern-match its way through.
         foreach (var chain in chains)
         {
-            var key = chain.ArgumentList.Arguments.ToString();
-            var demotesDebug =
-                key.Contains("c.Category", StringComparison.Ordinal)
-                && (key.Contains("CommandCategory.Debug", StringComparison.Ordinal)
-                    || key.Trim() == "c => c.Category");
+            var ascending = chain.Expression.ToString()
+                .EndsWith(".OrderBy", StringComparison.Ordinal);
+            var key = chain.ArgumentList.Arguments.ToString().Replace(" ", "");
+
+            var demotesDebug = ascending && (
+                // Ungrouped: name Debug explicitly, sort it after the rest.
+                key == "c=>c.Category==CommandCategory.Debug?1:0"
+                // Grouped: sort by the enum, which puts Debug last only
+                // because it is the last member. DebugIsLastInTheCategoryEnum
+                // is what holds up this half.
+                || key == "c=>c.Category");
+
             Assert.True(
                 demotesDebug,
-                $"an ordering branch leads with '{key}', which does not put "
+                $"an ordering branch orders {(ascending ? "ascending" : "descending")} "
+                    + $"by '{key}', which is not one of the two shapes known to put "
                     + "Debug last. Frecency cannot be the first key for these: "
-                    + "executing one records the use before the process dies, "
-                    + "so one accident promotes that row for every later launch.");
+                    + "executing one records the use before the process dies, so one "
+                    + "accident promotes that row for every later launch. If this is "
+                    + "a deliberate reformulation, verify it demotes Debug and add "
+                    + "its shape here.");
         }
     }
 

--- a/windows/Ghostty.Tests/Wiring/ShellSource.cs
+++ b/windows/Ghostty.Tests/Wiring/ShellSource.cs
@@ -31,6 +31,24 @@ internal sealed class ShellSource
     private ShellSource(CompilationUnitSyntax root) => _root = root;
 
     /// <summary>
+    /// The configuration these scans read the shell in.
+    ///
+    /// DEMO, because demo mode is a configuration that ships and a scan
+    /// that cannot see it reports full coverage of a file it only partly
+    /// read. DEBUG, because that is the branch this test assembly is itself
+    /// built in, and because the debug-only regions are where the
+    /// destructive developer actions live: those are precisely the ones a
+    /// gating guard has to be able to see.
+    ///
+    /// Both symbols hide their opposite branch, and <see cref="Load"/>'s
+    /// refusal of any remaining disabled text is what keeps that from
+    /// widening silently. A file whose Release half needs checking needs a
+    /// text-level rule, the way <c>ParseForCorpusScan</c> describes.
+    /// </summary>
+    private static readonly CSharpParseOptions ParseOptions =
+        new(preprocessorSymbols: new[] { "DEMO", "DEBUG" });
+
+    /// <summary>
     /// Load an embedded shell source by its dotted path tail, e.g.
     /// "Controls.CommandPalette.CommandPaletteControl.xaml.cs".
     ///
@@ -58,14 +76,14 @@ internal sealed class ShellSource
         // with, because it reports full coverage of a file it only partly
         // read, and DEMO is a configuration that ships.
         //
-        // Defining the symbol reveals that branch. It cannot be the whole
-        // answer, because it hides the other one: an `#else` or `#if !DEMO`
-        // becomes the disabled region instead. So the assertion below refuses
-        // any tree that still has disabled text, which turns adding a new
-        // conditional into a decision someone has to make rather than a
-        // silent widening of the blind spot.
-        var options = new CSharpParseOptions(preprocessorSymbols: new[] { "DEMO" });
-        var tree = CSharpSyntaxTree.ParseText(reader.ReadToEnd(), options);
+        // Defining the symbol reveals that branch (see ParseOptions, which
+        // defines DEMO and DEBUG). It cannot be the whole answer, because it
+        // hides the other one: an `#else` or `#if !DEMO` becomes the disabled
+        // region instead. So the assertion below refuses any tree that still
+        // has disabled text, which turns adding a new conditional into a
+        // decision someone has to make rather than a silent widening of the
+        // blind spot.
+        var tree = CSharpSyntaxTree.ParseText(reader.ReadToEnd(), ParseOptions);
         var root = (CompilationUnitSyntax)tree.GetRoot();
 
         var hidden = root.DescendantTrivia()
@@ -123,8 +141,7 @@ internal sealed class ShellSource
     /// </summary>
     public static ShellSource ParseForCorpusScan(string text)
     {
-        var options = new CSharpParseOptions(preprocessorSymbols: new[] { "DEMO" });
-        return new ShellSource((CompilationUnitSyntax)CSharpSyntaxTree.ParseText(text, options).GetRoot());
+        return new ShellSource((CompilationUnitSyntax)CSharpSyntaxTree.ParseText(text, ParseOptions).GetRoot());
     }
 
     // MSBuild substitutes the host's directory separator into the logical
@@ -155,7 +172,6 @@ internal sealed class ShellSource
     public static IReadOnlyList<(string Resource, CompilationUnitSyntax Root)> AllShellSources()
     {
         var asm = Assembly.GetExecutingAssembly();
-        var options = new CSharpParseOptions(preprocessorSymbols: new[] { "DEMO" });
         var found = new List<(string Resource, CompilationUnitSyntax Root)>();
         foreach (var name in asm.GetManifestResourceNames())
         {
@@ -166,7 +182,7 @@ internal sealed class ShellSource
 
             using var stream = asm.GetManifestResourceStream(name)!;
             using var reader = new StreamReader(stream);
-            var tree = CSharpSyntaxTree.ParseText(reader.ReadToEnd(), options);
+            var tree = CSharpSyntaxTree.ParseText(reader.ReadToEnd(), ParseOptions);
             found.Add((dotted, (CompilationUnitSyntax)tree.GetRoot()));
         }
 

--- a/windows/Ghostty/Cli/CrashTrigger.cs
+++ b/windows/Ghostty/Cli/CrashTrigger.cs
@@ -126,7 +126,9 @@ internal static partial class CrashTrigger
                         "crash-trigger: deliberate unhandled managed exception"));
                 unhandled.Start();
                 unhandled.Join();
-                return (int)ExitCode.ManagedUnhandled;
+                // Unreachable: the runtime tears the process down before the
+                // join returns. Present because the compiler cannot know it.
+                return 5;
 
             // Explicit fail-fast. Bypasses all handlers by design.
             case "env-failfast":

--- a/windows/Ghostty/Cli/CrashTrigger.cs
+++ b/windows/Ghostty/Cli/CrashTrigger.cs
@@ -1,6 +1,10 @@
 using System;
+using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Threading;
+using Ghostty.Core.Diagnostics;
+using Ghostty.Interop;
 
 namespace Ghostty.Cli;
 
@@ -15,6 +19,12 @@ namespace Ghostty.Cli;
 /// Each kind uses the exact mechanism its matrix row names. Do not
 /// substitute a convenient proxy: the whole value of the harness is that
 /// a result says something about the real mechanism.
+///
+/// The set of kinds is <see cref="CrashKinds"/>, not the switch below.
+/// Two front doors reach this: <c>wintty +crash &lt;kind&gt;</c> from
+/// <c>Program.cs</c>, and the palette entries built by
+/// <c>CrashCommandSource</c>. They share one catalogue and one
+/// implementation so a kind cannot exist for one and not the other.
 /// </summary>
 internal static partial class CrashTrigger
 {
@@ -30,15 +40,57 @@ internal static partial class CrashTrigger
         IntPtr lpArguments);
 
     /// <summary>
-    /// Runs the named trigger. Never returns for a crashing kind.
-    /// Returns a non-zero exit code for an unknown kind.
+    /// Runs the named trigger. Never returns for a crashing kind that runs
+    /// in-process. Returns a non-zero exit code for an unknown kind, and
+    /// for a kind this caller cannot reach.
     /// </summary>
-    internal static int Run(string kind)
+    /// <param name="bindingAction">
+    /// Dispatches a libghostty binding action against the active surface,
+    /// returning whether it reached one. Null from the CLI, where no
+    /// window exists yet, which is exactly why the surface-bound kinds are
+    /// refused there rather than silently doing nothing.
+    /// </param>
+    internal static int Run(string kind, Func<string, bool>? bindingAction = null)
     {
-        Console.Error.WriteLine($"crash-trigger: {kind}");
+        var entry = CrashKinds.Find(kind);
+        if (entry is null)
+        {
+            Console.Error.WriteLine($"crash-trigger: unknown kind '{kind}'");
+            Console.Error.WriteLine($"crash-trigger: kinds: {CrashKinds.Ids}");
+            return 2;
+        }
+
+        Console.Error.WriteLine($"crash-trigger: {entry.Id}");
         Console.Error.Flush();
 
-        switch (kind)
+        if (entry.BindingAction is { } action)
+        {
+            if (bindingAction is null)
+            {
+                Console.Error.WriteLine(
+                    $"crash-trigger: '{entry.Id}' faults inside libghostty and needs "
+                    + "a live surface. Run it from the command palette in a running "
+                    + "window; the CLI has no surface to dispatch it against.");
+                return 3;
+            }
+
+            // Reporting a crash for a call that reached no surface is the one
+            // outcome a crash probe must not produce: the operator would read
+            // the absent envelope as "the reporter missed it".
+            if (!bindingAction(action))
+            {
+                Console.Error.WriteLine(
+                    $"crash-trigger: libghostty did not accept '{action}'");
+                return 4;
+            }
+
+            // Only crash:main panics on this thread. crash:io and crash:render
+            // are mailbox pushes, so control comes back here and the panic
+            // lands on the other thread a moment later.
+            return 0;
+        }
+
+        switch (entry.Id)
         {
             // A genuine native SEH exception, dispatched by Windows through
             // normal exception handling, so sentry's
@@ -99,11 +151,82 @@ internal static partial class CrashTrigger
                 Console.Error.WriteLine("crash-trigger: handled-storm survived");
                 return 0;
 
+            // A catalogue entry with no binding action and no arm here. A
+            // parity test in Ghostty.Tests fails before this can ship, so
+            // reaching it means the catalogue was edited and the test was
+            // not run; say so rather than crashing in a way that looks like
+            // a result.
             default:
                 Console.Error.WriteLine(
-                    $"crash-trigger: unknown kind '{kind}'");
+                    $"crash-trigger: '{entry.Id}' is in the catalogue but has no "
+                    + "mechanism here");
                 return 2;
         }
+    }
+
+    /// <summary>
+    /// Bring libghostty's crash reporting up before a trigger fires.
+    /// </summary>
+    /// <remarks>
+    /// Without this the matrix measures nothing: every crash kind is
+    /// intercepted in Program.MainImpl before ghostty_init runs, and
+    /// ghostty_init is what reaches crash.init and so sentry_init (see
+    /// src/global.zig). A trigger fired first crashes a process that has no
+    /// reporter attached, so an absent envelope says nothing about what the
+    /// backend can capture.
+    ///
+    /// The command line passed here is synthetic, and deliberately not this
+    /// process's own. libghostty parses argv, and "+crash" is not one of its
+    /// actions, so handing it the real command line fails init and exits
+    /// before the trigger ever runs.
+    ///
+    /// sentry_init happens on a background thread (the "sentry-init" thread
+    /// in src/crash/sentry.zig), so returning from ghostty_init does not mean
+    /// the reporter is armed. Wait for the database directory sentry is
+    /// configured with, and give up rather than hang: a trigger that fires a
+    /// little early is a visible failed row, a trigger that never fires is a
+    /// stuck harness.
+    /// </remarks>
+    internal static void ArmCrashReporting(TimeSpan timeout)
+    {
+        // argv[0] only, so there is no action for libghostty to reject.
+        // A real Windows command line leads with the executable path, and
+        // the args iterator skips that first token before looking for an
+        // action. A bare word is not a valid command line in that shape.
+        var cmdline = "\"" + Environment.ProcessPath + "\"";
+        var buf = Marshal.StringToHGlobalUni(cmdline);
+        var status = NativeMethods.InitWide(buf, (UIntPtr)cmdline.Length);
+        if (status != 0)
+        {
+            Console.Error.WriteLine(
+                $"crash-trigger: ghostty_init failed (status {status}); " +
+                "continuing with no reporter attached");
+            return;
+        }
+
+        var dir = Path.Combine(
+            Environment.GetFolderPath(
+                Environment.SpecialFolder.LocalApplicationData),
+            "wintty",
+            // sentry's database path, set by cacheDir in src/crash/sentry.zig.
+            // Not "crash": that is where the managed-side crash.log goes.
+            "sentry");
+
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (Directory.Exists(dir))
+            {
+                Console.Error.WriteLine($"crash-trigger: reporter armed ({dir})");
+                return;
+            }
+
+            Thread.Sleep(50);
+        }
+
+        Console.Error.WriteLine(
+            $"crash-trigger: reporter did not arm within {timeout.TotalSeconds:0.#}s " +
+            $"({dir} never appeared); triggering anyway");
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -116,7 +239,7 @@ internal static partial class CrashTrigger
         return Recurse(depth + 1) + pad[0];
     }
 #else
-    internal static int Run(string kind)
+    internal static int Run(string kind, Func<string, bool>? bindingAction = null)
     {
         Console.Error.WriteLine(
             "crash-trigger is compiled out of Release builds");

--- a/windows/Ghostty/Cli/CrashTrigger.cs
+++ b/windows/Ghostty/Cli/CrashTrigger.cs
@@ -111,9 +111,22 @@ internal static partial class CrashTrigger
             // handler, so NO envelope is expected. The existing handlers in
             // App.xaml.cs are what capture this class, with a managed stack
             // trace, which is more useful than a dump would be.
+            // Thrown from a thread of its own, deliberately. Program.Main
+            // runs MainImpl inside a catch-all that turns any exception into
+            // ReportFatal and a clean exit, so throwing here would exercise
+            // the CLI's error path and never be unhandled at all. The palette
+            // path IS unhandled (App.xaml.cs leaves Handled = false), and the
+            // two front doors have to mean the same thing.
+            //
+            // Join is unreachable: an unhandled exception on any thread tears
+            // the process down.
             case "managed-unhandled":
-                throw new InvalidOperationException(
-                    "crash-trigger: deliberate unhandled managed exception");
+                var unhandled = new Thread(
+                    () => throw new InvalidOperationException(
+                        "crash-trigger: deliberate unhandled managed exception"));
+                unhandled.Start();
+                unhandled.Join();
+                return (int)ExitCode.ManagedUnhandled;
 
             // Explicit fail-fast. Bypasses all handlers by design.
             case "env-failfast":
@@ -205,29 +218,21 @@ internal static partial class CrashTrigger
             return;
         }
 
-        var dir = Path.Combine(
-            Environment.GetFolderPath(
-                Environment.SpecialFolder.LocalApplicationData),
-            "wintty",
-            // sentry's database path, set by cacheDir in src/crash/sentry.zig.
-            // Not "crash": that is where the managed-side crash.log goes.
-            "sentry");
-
-        var deadline = DateTime.UtcNow + timeout;
-        while (DateTime.UtcNow < deadline)
+        // Ask libghostty, rather than watching for sentry's database
+        // directory to appear. That directory is created during init, before
+        // the backend's handler is installed, and it outlives the process, so
+        // on every run after the first it is already there and the wait
+        // returns instantly with the reporter not yet armed. Every "no
+        // envelope" row measured that way says nothing.
+        if (NativeMethods.CrashWaitReady((uint)timeout.TotalMilliseconds))
         {
-            if (Directory.Exists(dir))
-            {
-                Console.Error.WriteLine($"crash-trigger: reporter armed ({dir})");
-                return;
-            }
-
-            Thread.Sleep(50);
+            Console.Error.WriteLine("crash-trigger: reporter armed");
+            return;
         }
 
         Console.Error.WriteLine(
-            $"crash-trigger: reporter did not arm within {timeout.TotalSeconds:0.#}s " +
-            $"({dir} never appeared); triggering anyway");
+            $"crash-trigger: reporter did not arm within {timeout.TotalSeconds:0.#}s; " +
+            "triggering anyway, and any absent report below is unproven");
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/windows/Ghostty/Cli/CrashTrigger.cs
+++ b/windows/Ghostty/Cli/CrashTrigger.cs
@@ -12,9 +12,11 @@ namespace Ghostty.Cli;
 /// Deliberate crash triggers, one per class in the coverage matrix of
 /// docs/2026-08-25-crash-reporting-and-diagnostics-design.md.
 ///
-/// Compiled out of Release entirely: this exists to prove which crash
-/// classes the in-process sentry backend can and cannot see, and several
-/// of the expected results are deliberately "nothing is captured".
+/// Present in every build, including shipped installers. This exists to
+/// prove which crash classes the in-process sentry backend can and cannot
+/// see, and several of the expected results are deliberately "nothing is
+/// captured". A trigger compiled out of Release would leave the one
+/// configuration users actually run as the one nobody can verify.
 ///
 /// Each kind uses the exact mechanism its matrix row names. Do not
 /// substitute a convenient proxy: the whole value of the harness is that
@@ -28,7 +30,6 @@ namespace Ghostty.Cli;
 /// </summary>
 internal static partial class CrashTrigger
 {
-#if DEBUG
     private const uint EXCEPTION_NONCONTINUABLE = 0x1;
     private const uint FACILITY_TEST_EXCEPTION = 0xE0000001;
 
@@ -238,12 +239,4 @@ internal static partial class CrashTrigger
         pad[0] = (byte)depth;
         return Recurse(depth + 1) + pad[0];
     }
-#else
-    internal static int Run(string kind, Func<string, bool>? bindingAction = null)
-    {
-        Console.Error.WriteLine(
-            "crash-trigger is compiled out of Release builds");
-        return 2;
-    }
-#endif
 }

--- a/windows/Ghostty/Cli/CrashTrigger.cs
+++ b/windows/Ghostty/Cli/CrashTrigger.cs
@@ -31,7 +31,29 @@ namespace Ghostty.Cli;
 internal static partial class CrashTrigger
 {
     private const uint EXCEPTION_NONCONTINUABLE = 0x1;
-    private const uint FACILITY_TEST_EXCEPTION = 0xE0000001;
+
+    /// <summary>
+    /// The exception code <c>native-seh</c> raises. Customer bit set, so it
+    /// cannot collide with a system code or with the CLR's 0xE0434352.
+    /// </summary>
+    /// <remarks>
+    /// Named for what it is. It was <c>FACILITY_TEST_EXCEPTION</c>, which
+    /// misdirects: this is a whole exception code, not a facility, and the
+    /// harness reads the value back as a process exit code.
+    /// </remarks>
+    private const uint CRASH_TEST_EXCEPTION_CODE = 0xE0000001;
+
+    // The trigger's own exit codes, kept clear of Program.ExitCode, which
+    // uses 1, 2 and 3. They collided: ReportFatal returns 3 for anything
+    // escaping MainImpl, and 3 here meant "the CLI refused a surface-bound
+    // kind", so a developer reading exit 3 could not tell a refusal from a
+    // trigger the catch-all had eaten from a failure to load ghostty.dll.
+    // 64+ follows sysexits, purely to be somewhere nothing else is.
+    private const int ExitUnknownKind = 64;
+    private const int ExitNeedsSurface = 65;
+    private const int ExitBindingRefused = 66;
+    private const int ExitTriggerReturned = 67;
+    private const int ExitNoMechanism = 68;
 
     [LibraryImport("kernel32.dll")]
     private static partial void RaiseException(
@@ -58,7 +80,11 @@ internal static partial class CrashTrigger
         {
             Console.Error.WriteLine($"crash-trigger: unknown kind '{kind}'");
             Console.Error.WriteLine($"crash-trigger: kinds: {CrashKinds.Ids}");
-            return 2;
+            // The subset this front door can run, so the acceptance harness
+            // can read the catalogue instead of keeping its own copy. It is a
+            // .ps1, so no wiring test can scan it for drift.
+            Console.Error.WriteLine($"crash-trigger: cli-kinds: {CrashKinds.CliIds}");
+            return ExitUnknownKind;
         }
 
         Console.Error.WriteLine($"crash-trigger: {entry.Id}");
@@ -72,7 +98,7 @@ internal static partial class CrashTrigger
                     $"crash-trigger: '{entry.Id}' faults inside libghostty and needs "
                     + "a live surface. Run it from the command palette in a running "
                     + "window; the CLI has no surface to dispatch it against.");
-                return 3;
+                return ExitNeedsSurface;
             }
 
             // Reporting a crash for a call that reached no surface is the one
@@ -82,7 +108,7 @@ internal static partial class CrashTrigger
             {
                 Console.Error.WriteLine(
                     $"crash-trigger: libghostty did not accept '{action}'");
-                return 4;
+                return ExitBindingRefused;
             }
 
             // Only crash:main panics on this thread. crash:io and crash:render
@@ -101,20 +127,23 @@ internal static partial class CrashTrigger
             //
             // Raised from a thread of its own, for the same reason
             // managed-unhandled is. Measured, not assumed: raising it inline
-            // produced no crash at all. NativeAOT wraps the P/Invoke in an SEH
-            // frame that translates the exception into a managed
-            // SEHException, Program.Main's catch-all caught it, ReportFatal
-            // wrote a log, and the process exited 3. The row went red for
-            // "no envelope" while the reporter had never been given anything
-            // to capture.
+            // produced no crash at all under CoreCLR, which is what
+            // `dotnet build` and `dotnet run` give you. There the runtime
+            // wraps the P/Invoke in an SEH frame that translates the exception
+            // into a managed SEHException, Program.Main's catch-all caught it,
+            // ReportFatal wrote a log, and the process exited 3. The row went
+            // red for "no envelope" while the reporter had never been given
+            // anything to capture.
             //
-            // What this row measures, then, is a native fault as it reaches a
-            // NativeAOT process: translated, and unhandled from there on. A
-            // fault in a frame the runtime is NOT wrapping is a different
-            // path, and the libghostty kinds are the ones that measure it.
+            // Naming the runtime matters here. Under NativeAOT, which is what
+            // ships, the exception is NOT translated: it goes unhandled and
+            // exits 0xE0000001, which is what the harness expects. A reader
+            // who believed the CoreCLR behaviour was the AOT one could
+            // reasonably conclude the catch-all covers native faults and
+            // delete this thread. The thread is correct under both.
             case "native-seh":
                 var seh = new Thread(() => RaiseException(
-                    FACILITY_TEST_EXCEPTION,
+                    CRASH_TEST_EXCEPTION_CODE,
                     EXCEPTION_NONCONTINUABLE,
                     0,
                     IntPtr.Zero));
@@ -126,15 +155,24 @@ internal static partial class CrashTrigger
 
             // An unhandled managed exception. In NativeAOT this reaches
             // RaiseFailFastException, which bypasses every user-mode
-            // handler, so NO envelope is expected. The existing handlers in
-            // App.xaml.cs are what capture this class, with a managed stack
-            // trace, which is more useful than a dump would be.
-            // Thrown from a thread of its own, deliberately. Program.Main
-            // runs MainImpl inside a catch-all that turns any exception into
+            // handler, so NO envelope is expected.
+            //
+            // Thrown from a thread of its own, deliberately. Program.Main runs
+            // MainImpl inside a catch-all that turns any exception into
             // ReportFatal and a clean exit, so throwing here would exercise
-            // the CLI's error path and never be unhandled at all. The palette
-            // path IS unhandled (App.xaml.cs leaves Handled = false), and the
-            // two front doors have to mean the same thing.
+            // the CLI's error path and never be unhandled at all.
+            //
+            // What that thread does and does NOT reach, stated precisely
+            // because an earlier version of this comment got it wrong. A bare
+            // Thread is not the XAML UI thread, so
+            // Application.UnhandledException in App.xaml.cs never fires for
+            // it; only AppDomain.CurrentDomain.UnhandledException can see it,
+            // and that one cannot mark the exception handled. So this row
+            // measures the AppDomain path and the AOT fail-fast, on both front
+            // doors, and it does NOT measure the XAML handler that covers a
+            // UI-thread throw in the shipped app. That path has no automated
+            // coverage; it needs a throw dispatched onto the DispatcherQueue,
+            // which only the palette can do.
             //
             // Join is unreachable: an unhandled exception on any thread tears
             // the process down.
@@ -146,7 +184,7 @@ internal static partial class CrashTrigger
                 unhandled.Join();
                 // Unreachable: the runtime tears the process down before the
                 // join returns. Present because the compiler cannot know it.
-                return 5;
+                return ExitTriggerReturned;
 
             // Explicit fail-fast. Bypasses all handlers by design.
             case "env-failfast":
@@ -194,7 +232,7 @@ internal static partial class CrashTrigger
                 Console.Error.WriteLine(
                     $"crash-trigger: '{entry.Id}' is in the catalogue but has no "
                     + "mechanism here");
-                return 2;
+                return ExitNoMechanism;
         }
     }
 
@@ -227,11 +265,30 @@ internal static partial class CrashTrigger
         // A real Windows command line leads with the executable path, and
         // the args iterator skips that first token before looking for an
         // action. A bare word is not a valid command line in that shape.
-        var cmdline = "\"" + Environment.ProcessPath + "\"";
+        // ProcessPath is nullable, and this is the one path whose entire job
+        // is not to fail silently: a null would build `""`, hand libghostty an
+        // empty argv[0], and the args iterator would skip a token that is not
+        // there.
+        var exe = Environment.ProcessPath;
+        if (string.IsNullOrEmpty(exe))
+        {
+            Console.Error.WriteLine(
+                "crash-trigger: Environment.ProcessPath is unavailable; " +
+                "continuing with no reporter attached");
+            return;
+        }
+
+        var cmdline = "\"" + exe + "\"";
         var buf = Marshal.StringToHGlobalUni(cmdline);
         var status = NativeMethods.InitWide(buf, (UIntPtr)cmdline.Length);
         if (status != 0)
         {
+            // Freed only on the failure path. On success libghostty borrows
+            // this buffer for the process lifetime (see InitWideFromProcess,
+            // which spends eleven lines saying so), so the leak there is
+            // required rather than an oversight. Here global.init's errdefer
+            // has already unwound and nothing borrows it any more.
+            Marshal.FreeHGlobal(buf);
             Console.Error.WriteLine(
                 $"crash-trigger: ghostty_init failed (status {status}); " +
                 "continuing with no reporter attached");
@@ -244,7 +301,13 @@ internal static partial class CrashTrigger
         // on every run after the first it is already there and the wait
         // returns instantly with the reporter not yet armed. Every "no
         // envelope" row measured that way says nothing.
-        if (NativeMethods.CrashWaitReady((uint)timeout.TotalMilliseconds))
+        // checked: a negative or absurd TimeSpan wraps rather than throwing,
+        // and a wrapped timeout silently turns the wait into a no-op, which
+        // is the failure this whole method exists to prevent.
+        uint timeoutMs;
+        checked { timeoutMs = (uint)timeout.TotalMilliseconds; }
+
+        if (NativeMethods.CrashWaitReady(timeoutMs))
         {
             Console.Error.WriteLine("crash-trigger: reporter armed");
             return;

--- a/windows/Ghostty/Cli/CrashTrigger.cs
+++ b/windows/Ghostty/Cli/CrashTrigger.cs
@@ -98,13 +98,31 @@ internal static partial class CrashTrigger
             // SetUnhandledExceptionFilter WILL see it. This is the one row
             // that must go green for the in-process backend to be worth
             // anything at all.
+            //
+            // Raised from a thread of its own, for the same reason
+            // managed-unhandled is. Measured, not assumed: raising it inline
+            // produced no crash at all. NativeAOT wraps the P/Invoke in an SEH
+            // frame that translates the exception into a managed
+            // SEHException, Program.Main's catch-all caught it, ReportFatal
+            // wrote a log, and the process exited 3. The row went red for
+            // "no envelope" while the reporter had never been given anything
+            // to capture.
+            //
+            // What this row measures, then, is a native fault as it reaches a
+            // NativeAOT process: translated, and unhandled from there on. A
+            // fault in a frame the runtime is NOT wrapping is a different
+            // path, and the libghostty kinds are the ones that measure it.
             case "native-seh":
-                RaiseException(
+                var seh = new Thread(() => RaiseException(
                     FACILITY_TEST_EXCEPTION,
                     EXCEPTION_NONCONTINUABLE,
                     0,
-                    IntPtr.Zero);
-                return 1; // unreachable
+                    IntPtr.Zero));
+                seh.Start();
+                seh.Join();
+                // Unreachable: the translated exception is unhandled on that
+                // thread and tears the process down before the join returns.
+                return 1;
 
             // An unhandled managed exception. In NativeAOT this reaches
             // RaiseFailFastException, which bypasses every user-mode

--- a/windows/Ghostty/Cli/CrashTrigger.cs
+++ b/windows/Ghostty/Cli/CrashTrigger.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Ghostty.Cli;
+
+/// <summary>
+/// Deliberate crash triggers, one per class in the coverage matrix of
+/// docs/2026-08-25-crash-reporting-and-diagnostics-design.md.
+///
+/// Compiled out of Release entirely: this exists to prove which crash
+/// classes the in-process sentry backend can and cannot see, and several
+/// of the expected results are deliberately "nothing is captured".
+///
+/// Each kind uses the exact mechanism its matrix row names. Do not
+/// substitute a convenient proxy: the whole value of the harness is that
+/// a result says something about the real mechanism.
+/// </summary>
+internal static partial class CrashTrigger
+{
+#if DEBUG
+    private const uint EXCEPTION_NONCONTINUABLE = 0x1;
+    private const uint FACILITY_TEST_EXCEPTION = 0xE0000001;
+
+    [LibraryImport("kernel32.dll")]
+    private static partial void RaiseException(
+        uint dwExceptionCode,
+        uint dwExceptionFlags,
+        uint nNumberOfArguments,
+        IntPtr lpArguments);
+
+    /// <summary>
+    /// Runs the named trigger. Never returns for a crashing kind.
+    /// Returns a non-zero exit code for an unknown kind.
+    /// </summary>
+    internal static int Run(string kind)
+    {
+        Console.Error.WriteLine($"crash-trigger: {kind}");
+        Console.Error.Flush();
+
+        switch (kind)
+        {
+            // A genuine native SEH exception, dispatched by Windows through
+            // normal exception handling, so sentry's
+            // SetUnhandledExceptionFilter WILL see it. This is the one row
+            // that must go green for the in-process backend to be worth
+            // anything at all.
+            case "native-seh":
+                RaiseException(
+                    FACILITY_TEST_EXCEPTION,
+                    EXCEPTION_NONCONTINUABLE,
+                    0,
+                    IntPtr.Zero);
+                return 1; // unreachable
+
+            // An unhandled managed exception. In NativeAOT this reaches
+            // RaiseFailFastException, which bypasses every user-mode
+            // handler, so NO envelope is expected. The existing handlers in
+            // App.xaml.cs are what capture this class, with a managed stack
+            // trace, which is more useful than a dump would be.
+            case "managed-unhandled":
+                throw new InvalidOperationException(
+                    "crash-trigger: deliberate unhandled managed exception");
+
+            // Explicit fail-fast. Bypasses all handlers by design.
+            case "env-failfast":
+                Environment.FailFast("crash-trigger: deliberate FailFast");
+                return 1; // unreachable
+
+            // Stack overflow. The thread has no stack left to run a handler
+            // on, and sentry's inproc backend sets no stack guarantee and
+            // uses no alternate stack.
+            case "stack-overflow":
+                return Recurse(0);
+
+            // NOT a crash. Throws and catches many times, including a null
+            // dereference, which NativeAOT delivers as a hardware fault
+            // translated by the runtime's own handler. If sentry's filter is
+            // misordered this floods the crash directory. Expected result:
+            // zero envelopes, exit 0.
+            case "handled-storm":
+                for (var i = 0; i < 1000; i++)
+                {
+                    try
+                    {
+                        if (i % 2 == 0)
+                        {
+                            string? nothing = null;
+                            _ = nothing!.Length;
+                        }
+                        else
+                        {
+                            throw new InvalidOperationException("handled");
+                        }
+                    }
+                    catch (NullReferenceException) { }
+                    catch (InvalidOperationException) { }
+                }
+                Console.Error.WriteLine("crash-trigger: handled-storm survived");
+                return 0;
+
+            default:
+                Console.Error.WriteLine(
+                    $"crash-trigger: unknown kind '{kind}'");
+                return 2;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int Recurse(int depth)
+    {
+        // The buffer keeps each frame large enough that the overflow arrives
+        // promptly, and blocks tail-call optimization from flattening it.
+        Span<byte> pad = stackalloc byte[512];
+        pad[0] = (byte)depth;
+        return Recurse(depth + 1) + pad[0];
+    }
+#else
+    internal static int Run(string kind)
+    {
+        Console.Error.WriteLine(
+            "crash-trigger is compiled out of Release builds");
+        return 2;
+    }
+#endif
+}

--- a/windows/Ghostty/Commands/CommandItem.cs
+++ b/windows/Ghostty/Commands/CommandItem.cs
@@ -13,6 +13,9 @@ internal enum CommandCategory
     Custom,
     About,
     Demo,
+    // Destructive developer actions. Last so that grouped mode sorts them
+    // to the bottom, away from anything a user could hit by accident.
+    Debug,
 }
 
 internal record CommandItem

--- a/windows/Ghostty/Commands/CommandPaletteViewModel.cs
+++ b/windows/Ghostty/Commands/CommandPaletteViewModel.cs
@@ -215,13 +215,26 @@ internal partial class CommandPaletteViewModel : INotifyPropertyChanged
         }
         else
         {
+            // Debug rows match on their title only. Their descriptions
+            // explain what they destroy, in ordinary words, so matching those
+            // puts "crash the renderer" in front of someone who typed
+            // "select" and meant Select All. A destructive row has to be
+            // asked for by name.
             filtered = _allCommands.Where(c =>
                 c.Title.Contains(query, StringComparison.OrdinalIgnoreCase) ||
-                c.Description.Contains(query, StringComparison.OrdinalIgnoreCase) ||
-                (c.Subtitle?.Contains(query, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                (c.ActionKey?.Contains(query, StringComparison.OrdinalIgnoreCase) ?? false));
+                (c.Category != CommandCategory.Debug && (
+                    c.Description.Contains(query, StringComparison.OrdinalIgnoreCase) ||
+                    (c.Subtitle?.Contains(query, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                    (c.ActionKey?.Contains(query, StringComparison.OrdinalIgnoreCase) ?? false))));
         }
 
+        // Debug sorts last in BOTH branches. Category ordering used to apply
+        // only when grouping was on, and grouping defaults off, so the one
+        // thing keeping a crash row away from the top was its title's
+        // alphabetical luck. Frecency cannot be the first key for these
+        // either: executing one records the use before it takes the process
+        // down, so a single accident promotes that row for every later
+        // launch.
         FilteredCommands = _groupByCategory
             ? filtered
                 .OrderBy(c => c.Category)
@@ -229,7 +242,8 @@ internal partial class CommandPaletteViewModel : INotifyPropertyChanged
                 .ThenBy(c => c.Title, StringComparer.OrdinalIgnoreCase)
                 .ToList()
             : filtered
-                .OrderByDescending(c => _frecency.Score(c.Id))
+                .OrderBy(c => c.Category == CommandCategory.Debug ? 1 : 0)
+                .ThenByDescending(c => _frecency.Score(c.Id))
                 .ThenBy(c => c.Title, StringComparer.OrdinalIgnoreCase)
                 .ToList();
 

--- a/windows/Ghostty/Commands/CommandPaletteViewModel.cs
+++ b/windows/Ghostty/Commands/CommandPaletteViewModel.cs
@@ -211,7 +211,17 @@ internal partial class CommandPaletteViewModel : INotifyPropertyChanged
 
         if (string.IsNullOrEmpty(query))
         {
-            filtered = _allCommands;
+            // Debug rows are absent from the unfiltered list, not merely last
+            // in it. Sorting them last governs position, and title-only
+            // matching needs a query to apply, so both mitigations miss this
+            // branch by construction: open the palette, press End, press
+            // Enter, and the window goes down with whatever was in the
+            // terminal, on a shipped build, with no confirmation.
+            //
+            // The invariant is that a destructive row has to be asked for by
+            // name. Excluding them here is what makes it true. Typing any part
+            // of the title still finds them, and `+crash` is untouched.
+            filtered = _allCommands.Where(c => c.Category != CommandCategory.Debug);
         }
         else
         {

--- a/windows/Ghostty/Commands/CrashCommandSource.cs
+++ b/windows/Ghostty/Commands/CrashCommandSource.cs
@@ -1,0 +1,58 @@
+#if DEBUG
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Ghostty.Core.Diagnostics;
+
+namespace Ghostty.Commands;
+
+/// <summary>
+/// The deliberate crash triggers, as palette entries.
+///
+/// Same set and same implementation as <c>wintty +crash &lt;kind&gt;</c>:
+/// the rows are projected from <see cref="CrashKinds.All"/> and each one
+/// calls straight back into <c>CrashTrigger.Run</c>. The palette is the
+/// only way to reach the surface-bound kinds at all, because a binding
+/// action has no surface to land on before a window exists.
+///
+/// The whole file is <c>#if DEBUG</c>, matching <c>CrashTrigger</c>
+/// itself. There is no Release build in which these rows can be built, so
+/// no runtime gate is needed and none is offered: a flag a user could flip
+/// is a flag that ends up flipped.
+/// </summary>
+internal sealed class CrashCommandSource : ICommandSource
+{
+    // Segoe Fluent "Warning" (E7BA). Built from the code point rather than
+    // embedded, matching DemoCommandSource: private-use-area characters in
+    // source survive an editor round trip only by luck.
+    private static readonly string WarningGlyph = ((char)0xE7BA).ToString();
+
+    private readonly IReadOnlyList<CommandItem> _commands;
+
+    /// <param name="run">
+    /// Runs one kind by its <see cref="CrashKind.Id"/>. Takes the id rather
+    /// than a prepared delegate so the mechanism stays in one place, and so
+    /// this source cannot grow a second opinion about what a kind does.
+    /// </param>
+    public CrashCommandSource(Action<string> run)
+    {
+        _commands = CrashKinds.All
+            .Select(kind => new CommandItem
+            {
+                // Namespaced so a kind id can never collide with a binding
+                // action id in the frecency store, which keys off this.
+                Id = $"crash:{kind.Id}",
+                Title = kind.Title,
+                Description = kind.Description,
+                Category = CommandCategory.Debug,
+                LeadingIcon = WarningGlyph,
+                Execute = _ => run(kind.Id),
+            })
+            .ToList();
+    }
+
+    public IReadOnlyList<CommandItem> GetCommands() => _commands;
+
+    public void Refresh() { /* static entries */ }
+}
+#endif

--- a/windows/Ghostty/Commands/CrashCommandSource.cs
+++ b/windows/Ghostty/Commands/CrashCommandSource.cs
@@ -18,10 +18,11 @@ namespace Ghostty.Commands;
 /// verifiable in the builds users actually run, and a trigger that is
 /// compiled out of Release makes the one configuration that matters the one
 /// configuration nobody can test. The entries are prefixed "Debug:" and sort
-/// last, so reaching one takes a deliberate search.
-/// itself. There is no Release build in which these rows can be built, so
-/// no runtime gate is needed and none is offered: a flag a user could flip
-/// is a flag that ends up flipped.
+/// last, and they match only on their title, so reaching one takes a
+/// deliberate search rather than a word that happens to appear in a
+/// description. There is no runtime gate and none is offered: a flag a user
+/// could flip is a flag that ends up flipped, and a gate would put the
+/// shipped build back out of reach of the harness.
 /// </summary>
 internal sealed class CrashCommandSource : ICommandSource
 {

--- a/windows/Ghostty/Commands/CrashCommandSource.cs
+++ b/windows/Ghostty/Commands/CrashCommandSource.cs
@@ -1,4 +1,3 @@
-#if DEBUG
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -15,7 +14,11 @@ namespace Ghostty.Commands;
 /// only way to reach the surface-bound kinds at all, because a binding
 /// action has no surface to land on before a window exists.
 ///
-/// The whole file is <c>#if DEBUG</c>, matching <c>CrashTrigger</c>
+/// Present in every build, including shipped installers. Capture has to be
+/// verifiable in the builds users actually run, and a trigger that is
+/// compiled out of Release makes the one configuration that matters the one
+/// configuration nobody can test. The entries are prefixed "Debug:" and sort
+/// last, so reaching one takes a deliberate search.
 /// itself. There is no Release build in which these rows can be built, so
 /// no runtime gate is needed and none is offered: a flag a user could flip
 /// is a flag that ends up flipped.
@@ -55,4 +58,3 @@ internal sealed class CrashCommandSource : ICommandSource
 
     public void Refresh() { /* static entries */ }
 }
-#endif

--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -480,12 +480,21 @@
     <NativeLibrary Include="d3d12.lib" />
     <NativeLibrary Include="dxgi.lib" />
     <NativeLibrary Include="dcomp.lib" />
-    <!--
-      sentry-native's Windows sources arrive inside ghostty-static.lib, and
-      pkg/sentry/build.zig declares no system libraries of its own:
-        dbghelp.lib - symbolizer, dbghelp unwinder, modulefinder
-        version.lib - sentry_os.c
-    -->
+  </ItemGroup>
+
+  <!--
+    sentry-native's Windows sources arrive inside ghostty-static.lib, and
+    pkg/sentry/build.zig declares no system libraries of its own:
+      dbghelp.lib - symbolizer, dbghelp unwinder, modulefinder
+      version.lib - sentry_os.c
+
+    A separate ItemGroup rather than two more lines in the one above, which
+    is deliberate. The pro-legacy patch stack rewrites that group to add
+    d3d11.lib and matches on its closing lines, and tools/materialize.py
+    applies patches with plain git apply, so appending inside it takes the
+    tier build down. MSBuild treats consecutive ItemGroups as one.
+  -->
+  <ItemGroup>
     <NativeLibrary Include="dbghelp.lib" />
     <NativeLibrary Include="version.lib" />
   </ItemGroup>

--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -469,6 +469,14 @@
     <NativeLibrary Include="d3d12.lib" />
     <NativeLibrary Include="dxgi.lib" />
     <NativeLibrary Include="dcomp.lib" />
+    <!--
+      sentry-native's Windows sources arrive inside ghostty-static.lib, and
+      pkg/sentry/build.zig declares no system libraries of its own:
+        dbghelp.lib - symbolizer, dbghelp unwinder, modulefinder
+        version.lib - sentry_os.c
+    -->
+    <NativeLibrary Include="dbghelp.lib" />
+    <NativeLibrary Include="version.lib" />
   </ItemGroup>
 
   <!--

--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -31,6 +31,17 @@
          version it was built against (the referenced package) instead of
          whatever Windows App Runtime happens to be installed system-wide. -->
     <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+    <!--
+      IconGen is referenced only to run it as a build-time tool
+      (ReferenceOutputAssembly="false"), but the SDK still validates it as an
+      executable reference and fails a RID publish with NETSDK1150, because a
+      self-contained executable may not reference a non self-contained one.
+      Nothing links IconGen, so the invariant the check protects does not
+      apply. Without this, `dotnet publish -r win-x64` cannot run at all,
+      which means the NativeAOT build that the installer ships is the one
+      build nobody can test.
+    -->
+    <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -317,6 +317,23 @@ internal static partial class NativeMethods
     internal static partial int InitWide(IntPtr cmdline, UIntPtr len);
 
     /// <summary>
+    /// Block until the crash reporter is armed, returning whether it is.
+    /// </summary>
+    /// <remarks>
+    /// Only for the deliberate crash triggers. The reporter initialises on
+    /// its own thread, so a trigger fired straight after init can beat the
+    /// handler into place; the missing report then reads as "this class
+    /// cannot be captured" when nobody was listening yet. Do not substitute
+    /// a check that sentry's database directory exists: it is created during
+    /// init, before the handler, and it outlives the process, so after the
+    /// first run it is always already there.
+    /// </remarks>
+    [LibraryImport(Dll, EntryPoint = "ghostty_crash_wait_ready")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    [return: MarshalAs(UnmanagedType.U1)]
+    internal static partial bool CrashWaitReady(uint timeoutMs);
+
+    /// <summary>
     /// Initialize libghostty from this process's own command line.
     /// </summary>
     /// <remarks>

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -3537,6 +3537,20 @@ public sealed partial class MainWindow : Window
 
         var sources = new List<ICommandSource> { builtIn, jump, config, version };
 
+#if DEBUG
+        // Deliberate crash triggers, the same kinds and the same
+        // implementation as `wintty +crash <kind>`. CrashCommandSource and
+        // CrashTrigger are both #if DEBUG in their entirety, so a Release
+        // build has nothing here to gate at runtime.
+        //
+        // Deferred to the next tick like every other source: the fault then
+        // lands after the palette popup has torn down, so the captured stack
+        // is the trigger's own rather than WinUI's teardown on top of it.
+        sources.Add(new CrashCommandSource(
+            kind => DispatcherQueue.TryEnqueue(
+                () => Cli.CrashTrigger.Run(kind, TryExecuteBindingAction))));
+#endif
+
 #if DEMO
         // Demo entries appear only when WINTTY_DEMO is set, so a demo build with
         // the var unset leaves the palette unchanged. Defer to the next tick so
@@ -3641,14 +3655,28 @@ public sealed partial class MainWindow : Window
         window.Activate();
     }
 
-    private void ExecuteBindingAction(string actionKey)
+    // Every caller but one passes this as an Action<string>, and a
+    // bool-returning method group does not convert to that, so the void
+    // wrapper stays and the answer lives next door.
+    private void ExecuteBindingAction(string actionKey) =>
+        _ = TryExecuteBindingAction(actionKey);
+
+    /// <summary>
+    /// Dispatch a binding action against the active surface, reporting
+    /// whether it reached one.
+    ///
+    /// The crash triggers are what need the answer: "crash:render" that
+    /// found no surface is a no-op, and reporting a crash for it would have
+    /// the operator read the absent report as a miss by the reporter.
+    /// </summary>
+    private bool TryExecuteBindingAction(string actionKey)
     {
         var leaf = _tabManager.ActiveTab?.PaneHost?.ActiveLeaf;
-        if (leaf is null) return;
+        if (leaf is null) return false;
 
         var terminal = leaf.Terminal();
         var surfaceHandle = terminal.SurfaceHandle;
-        if (surfaceHandle == IntPtr.Zero) return;
+        if (surfaceHandle == IntPtr.Zero) return false;
 
         var surface = new GhosttySurface(surfaceHandle);
         var actionBytes = Encoding.UTF8.GetBytes(actionKey);
@@ -3656,7 +3684,8 @@ public sealed partial class MainWindow : Window
         {
             fixed (byte* p = actionBytes)
             {
-                NativeMethods.SurfaceBindingAction(surface, p, (UIntPtr)actionBytes.Length);
+                return NativeMethods.SurfaceBindingAction(
+                    surface, p, (UIntPtr)actionBytes.Length);
             }
         }
     }

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -3653,19 +3653,28 @@ public sealed partial class MainWindow : Window
         window.Activate();
     }
 
-    // Every caller but one passes this as an Action<string>, and a
-    // bool-returning method group does not convert to that, so the void
-    // wrapper stays and the answer lives next door.
-    private void ExecuteBindingAction(string actionKey) =>
+    private void ExecuteBindingAction(string actionKey)
+    {
+        var leaf = _tabManager.ActiveTab?.PaneHost?.ActiveLeaf;
+        if (leaf is null) return;
         _ = TryExecuteBindingAction(actionKey);
+    }
 
     /// <summary>
     /// Dispatch a binding action against the active surface, reporting
-    /// whether it reached one.
+    /// whether it was performed.
     ///
     /// The crash triggers are what need the answer: "crash:render" that
-    /// found no surface is a no-op, and reporting a crash for it would have
-    /// the operator read the absent report as a miss by the reporter.
+    /// found no surface, or that libghostty did not recognise, is a no-op,
+    /// and reporting a crash for it would have the operator read the absent
+    /// report as a miss by the reporter.
+    ///
+    /// The split is shaped by the tier machinery rather than by taste. Three
+    /// patch stacks carry hunks whose context is
+    /// <see cref="ExecuteBindingAction"/>'s opening three lines, and plain
+    /// `git apply` is what materialises them, so those three lines cannot
+    /// move. Everything below them can, which is why the body lives here and
+    /// the original method keeps its signature and its first three lines.
     /// </summary>
     private bool TryExecuteBindingAction(string actionKey)
     {

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -3537,11 +3537,10 @@ public sealed partial class MainWindow : Window
 
         var sources = new List<ICommandSource> { builtIn, jump, config, version };
 
-#if DEBUG
         // Deliberate crash triggers, the same kinds and the same
-        // implementation as `wintty +crash <kind>`. CrashCommandSource and
-        // CrashTrigger are both #if DEBUG in their entirety, so a Release
-        // build has nothing here to gate at runtime.
+        // implementation as `wintty +crash <kind>`. Registered in every
+        // build: the shipped installer is the configuration whose capture
+        // most needs proving, and a Debug-only trigger cannot prove it.
         //
         // Deferred to the next tick like every other source: the fault then
         // lands after the palette popup has torn down, so the captured stack
@@ -3549,7 +3548,6 @@ public sealed partial class MainWindow : Window
         sources.Add(new CrashCommandSource(
             kind => DispatcherQueue.TryEnqueue(
                 () => Cli.CrashTrigger.Run(kind, TryExecuteBindingAction))));
-#endif
 
 #if DEMO
         // Demo entries appear only when WINTTY_DEMO is set, so a demo build with

--- a/windows/Ghostty/Program.cs
+++ b/windows/Ghostty/Program.cs
@@ -532,9 +532,22 @@ public static partial class Program
         // before the libghostty CLI dispatcher. Deliberately not a
         // CliAliases entry, because that set is parity-tested against the
         // Action enum in src/cli/ghostty.zig.
-        if (args.Length > 1 && args[0] == "+crash")
+        // A bare `+crash` is handled too: without it the argument falls
+        // through to the libghostty dispatcher, which reports an unknown
+        // action rather than the list of kinds the caller was reaching for.
+        if (args.Length > 0 && args[0] == "+crash")
         {
-            Environment.Exit(Cli.CrashTrigger.Run(args[1]));
+            // Arm crash reporting first. This interception happens before
+            // InitGhostty, and ghostty_init is what brings sentry up, so a
+            // trigger fired here would otherwise crash a process with no
+            // reporter attached and every envelope row would read as absent
+            // for a reason that has nothing to do with the backend.
+            if (args.Length > 1)
+            {
+                Cli.CrashTrigger.ArmCrashReporting(TimeSpan.FromSeconds(10));
+            }
+
+            Environment.Exit(Cli.CrashTrigger.Run(args.Length > 1 ? args[1] : ""));
         }
 
         // Does the command line lead with a bare Windows subcommand, e.g.

--- a/windows/Ghostty/Program.cs
+++ b/windows/Ghostty/Program.cs
@@ -526,6 +526,17 @@ public static partial class Program
             Environment.Exit(Cli.CliActions.PrintVersion());
         }
 
+        // +crash <kind> is a debug-only probe for the crash coverage matrix
+        // in docs/2026-08-25-crash-reporting-and-diagnostics-design.md.
+        // Intercepted here for the same reason +version is: it must run
+        // before the libghostty CLI dispatcher. Deliberately not a
+        // CliAliases entry, because that set is parity-tested against the
+        // Action enum in src/cli/ghostty.zig.
+        if (args.Length > 1 && args[0] == "+crash")
+        {
+            Environment.Exit(Cli.CrashTrigger.Run(args[1]));
+        }
+
         // Does the command line lead with a bare Windows subcommand, e.g.
         // `wintty list-themes`? This is the same call InitWideFromProcess
         // makes to perform the rewrite, over the same input, so the gate

--- a/windows/Ghostty/Program.cs
+++ b/windows/Ghostty/Program.cs
@@ -526,7 +526,7 @@ public static partial class Program
             Environment.Exit(Cli.CliActions.PrintVersion());
         }
 
-        // +crash <kind> is a debug-only probe for the crash coverage matrix
+        // +crash <kind> is the probe behind the crash coverage matrix
         // in docs/2026-08-25-crash-reporting-and-diagnostics-design.md.
         // Intercepted here for the same reason +version is: it must run
         // before the libghostty CLI dispatcher. Deliberately not a

--- a/windows/scripts/crash-canary.ps1
+++ b/windows/scripts/crash-canary.ps1
@@ -18,7 +18,7 @@
 #>
 param(
     [Parameter(Mandatory)][string]$ExePath,
-    [string]$CrashDir = "$env:LOCALAPPDATA\wintty\sentry"
+    [string]$CrashDir = "$env:LOCALAPPDATA\wintty\crash"
 )
 
 $ErrorActionPreference = 'Stop'

--- a/windows/scripts/crash-canary.ps1
+++ b/windows/scripts/crash-canary.ps1
@@ -1,0 +1,86 @@
+#requires -Version 7
+<#
+.SYNOPSIS
+  Crashes Wintty with known canary strings in play, then greps the resulting
+  envelope for them.
+
+.DESCRIPTION
+  Answers one question: does a Wintty crash envelope actually contain
+  terminal-adjacent process strings? If it does, the opt-in split in section 7
+  of docs/2026-08-25-crash-reporting-and-diagnostics-design.md is justified. If
+  it does not, that split costs a support round trip for no privacy gain and
+  the sealed-envelope decision (D3) should be revisited.
+
+  This is a MEASUREMENT, not a gate: it exits 0 whether or not canaries are
+  found, and only fails if it could not measure at all.
+
+  Requires a DEBUG build: +crash is compiled out of Release.
+#>
+param(
+    [Parameter(Mandatory)][string]$ExePath,
+    [string]$CrashDir = "$env:LOCALAPPDATA\wintty\crash"
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $ExePath)) {
+    throw "ExePath not found: $ExePath"
+}
+
+# Two independent channels into the child's process memory: the environment
+# block (inherited by Start-Process) and argv (the +crash handler reads only
+# args[1] as the kind, so a third argument rides along unused but present).
+$canaryEnv = 'CANARY_ENV_8f3a1c'
+$canaryArg = 'CANARY_ARG_5d9e2b'
+
+function Get-EnvelopeSet {
+    if (-not (Test-Path $CrashDir)) { return @() }
+    @(Get-ChildItem $CrashDir -File -ErrorAction SilentlyContinue |
+        Select-Object -ExpandProperty Name)
+}
+
+$before = Get-EnvelopeSet
+
+$env:WINTTY_CANARY = $canaryEnv
+try {
+    Start-Process -FilePath $ExePath `
+        -ArgumentList '+crash', 'native-seh', $canaryArg `
+        -PassThru -Wait -NoNewWindow | Out-Null
+} finally {
+    Remove-Item Env:\WINTTY_CANARY -ErrorAction SilentlyContinue
+}
+
+# The envelope is written by the crashing process before it dies; give the
+# filesystem a beat to settle before enumerating.
+Start-Sleep -Milliseconds 500
+
+$after = Get-EnvelopeSet
+$new   = @($after | Where-Object { $_ -notin $before })
+
+if ($new.Count -eq 0) {
+    throw 'canary: no envelope was produced, so nothing could be measured. Run crash-matrix.ps1 first to confirm native-seh is captured at all.'
+}
+
+# Envelopes are part text, part binary; scan raw bytes decoded as Latin1
+# rather than reading as UTF-8 text, which would choke on non-text spans.
+$path  = Join-Path $CrashDir $new[0]
+$bytes = [System.IO.File]::ReadAllBytes($path)
+$text  = [System.Text.Encoding]::Latin1.GetString($bytes)
+
+$findings = foreach ($c in @($canaryEnv, $canaryArg)) {
+    [pscustomobject]@{
+        Canary = $c
+        Found  = $text.Contains($c)
+    }
+}
+
+Write-Host "envelope: $path ($($bytes.Length) bytes)"
+$findings | Format-Table -AutoSize
+
+if (@($findings | Where-Object { $_.Found }).Count -gt 0) {
+    Write-Host 'RESULT: envelopes DO carry process strings. The opt-in split in section 7 is justified.' -ForegroundColor Yellow
+} else {
+    Write-Host 'RESULT: no canary found. Revisit decision D3 before building the opt-in split.' -ForegroundColor Cyan
+}
+
+exit 0

--- a/windows/scripts/crash-canary.ps1
+++ b/windows/scripts/crash-canary.ps1
@@ -18,7 +18,7 @@
 #>
 param(
     [Parameter(Mandatory)][string]$ExePath,
-    [string]$CrashDir = "$env:LOCALAPPDATA\wintty\crash"
+    [string]$CrashDir = "$env:LOCALAPPDATA\wintty\sentry"
 )
 
 $ErrorActionPreference = 'Stop'

--- a/windows/scripts/crash-canary.ps1
+++ b/windows/scripts/crash-canary.ps1
@@ -14,7 +14,9 @@
   This is a MEASUREMENT, not a gate: it exits 0 whether or not canaries are
   found, and only fails if it could not measure at all.
 
-  Requires a DEBUG build: +crash is compiled out of Release.
+  Runs against any configuration. +crash used to be compiled out of Release;
+  it now ships everywhere, and pointing this at a published build is the
+  point, because that is the one whose reports users would be sending.
 #>
 param(
     [Parameter(Mandatory)][string]$ExePath,
@@ -39,6 +41,29 @@ function Get-EnvelopeSet {
         Select-Object -ExpandProperty Name)
 }
 
+# A launch that arms the reporter, does not crash, and exits. See below for
+# why this is needed twice.
+function Invoke-Drain {
+    Start-Process -FilePath $ExePath -ArgumentList '+crash', 'handled-storm' `
+        -PassThru -Wait -NoNewWindow | Out-Null
+    Start-Sleep -Milliseconds 300
+}
+
+# A crash report arrives ONE LAUNCH LATE. sentry-native's inproc backend does
+# not call our transport at crash time; it writes into its own run directory,
+# and only the next sentry_init replays it. So a canary-carrying crash leaves
+# NOTHING in the crash directory when its process dies.
+#
+# This script used to snapshot around the crash alone and read $new[0]. What
+# it actually read was whatever the crashing launch DRAINED on the way up,
+# i.e. the report from whichever crash came before it. Run after
+# crash-matrix.ps1, or after any real crash, it opened a canary-free envelope
+# and printed "no canary found" -- which is the input to decision D3, so the
+# answer would have been arrived at from the wrong file.
+#
+# Drain first so the directory is quiet, then crash, then drain again to bring
+# THIS crash's report through.
+Invoke-Drain
 $before = Get-EnvelopeSet
 
 $env:WINTTY_CANARY = $canaryEnv
@@ -50,15 +75,19 @@ try {
     Remove-Item Env:\WINTTY_CANARY -ErrorAction SilentlyContinue
 }
 
-# The envelope is written by the crashing process before it dies; give the
-# filesystem a beat to settle before enumerating.
-Start-Sleep -Milliseconds 500
+Invoke-Drain
 
 $after = Get-EnvelopeSet
 $new   = @($after | Where-Object { $_ -notin $before })
 
 if ($new.Count -eq 0) {
     throw 'canary: no envelope was produced, so nothing could be measured. Run crash-matrix.ps1 first to confirm native-seh is captured at all.'
+}
+if ($new.Count -gt 1) {
+    # More than one means something else crashed alongside this, and $new[0]
+    # would be an arbitrary pick. Say so rather than measure the wrong file.
+    throw ("canary: {0} envelopes appeared, so which one belongs to this " +
+        "crash is ambiguous: {1}" -f $new.Count, ($new -join ', '))
 }
 
 # Envelopes are part text, part binary; scan raw bytes decoded as Latin1

--- a/windows/scripts/crash-matrix.ps1
+++ b/windows/scripts/crash-matrix.ps1
@@ -9,7 +9,9 @@
   NO envelope are load-bearing: they pin known gaps so a future change cannot
   silently widen them, and they are why this harness asserts absence.
 
-  Requires a DEBUG build: +crash is compiled out of Release.
+  Runs against any configuration. +crash used to be compiled out of Release,
+  which left the build users install as the one nobody could measure; it now
+  ships everywhere, and pointing this at a Release build is the point.
 #>
 # Two directories are easy to confuse. Crash envelopes are written by
 # ghostty's own transport (src/crash/sentry.zig sendInternal) to the STATE

--- a/windows/scripts/crash-matrix.ps1
+++ b/windows/scripts/crash-matrix.ps1
@@ -6,12 +6,40 @@
 .DESCRIPTION
   Expected results come from the verified coverage map in section 3 of
   docs/2026-08-25-crash-reporting-and-diagnostics-design.md. Rows that expect
-  NO envelope are load-bearing: they pin known gaps so a future change cannot
+  NO report are load-bearing: they pin known gaps so a future change cannot
   silently widen them, and they are why this harness asserts absence.
 
   Runs against any configuration. +crash used to be compiled out of Release,
   which left the build users install as the one nobody could measure; it now
   ships everywhere, and pointing this at a Release build is the point.
+
+  POINT IT AT A PUBLISHED BUILD, not at bin/x64/Release. Ghostty.csproj sets
+  PublishAot, so `dotnet build` produces a CoreCLR binary and `dotnet publish`
+  produces the NativeAOT one that ships, and they do not agree about crashes.
+  Measured on both: an unhandled managed exception is CAPTURED under CoreCLR,
+  which dispatches it as SEH 0xE0434352 through the unhandled filter, and is
+  NOT captured under NativeAOT, which fail-fasts with 0xC0000409. A native SEH
+  raised from a P/Invoke is caught and swallowed by Program.Main's catch-all
+  under CoreCLR, and crashes the process under NativeAOT. Every row here is
+  the NativeAOT answer.
+
+    dotnet publish windows/Ghostty/Ghostty.csproj -c Release -r win-x64 `
+      -p:Platform=x64 --self-contained true -o <dir>
+    pwsh windows/scripts/crash-matrix.ps1 -ExePath <dir>/Wintty.exe
+
+.NOTES
+  A crash report arrives ONE LAUNCH LATE, and the harness is built around
+  that. sentry-native's inproc backend does not call our transport at crash
+  time; it writes the envelope into its own run directory under the database.
+  Only the next sentry_init picks it up (sentry__process_old_runs) and pushes
+  it through the transport, which is what writes to the crash directory.
+
+  So each row drains before and after: a clean launch that arms the reporter,
+  crashes at nothing, and exits. The drain AFTER the trigger is what makes the
+  report appear; the drain BEFORE the next row is what proves the previous
+  row's drain was enough. An earlier version of this script snapshotted the
+  directory around the trigger alone, and so credited every capture to the row
+  after the one that produced it.
 #>
 # Two directories are easy to confuse. Crash envelopes are written by
 # ghostty's own transport (src/crash/sentry.zig sendInternal) to the STATE
@@ -25,7 +53,10 @@ param(
     [string]$CrashDir = "$env:LOCALAPPDATA\wintty\crash",
     # The managed handler writes next to the binary, not under LOCALAPPDATA:
     # Program.cs uses Path.Combine(AppContext.BaseDirectory, "ghostty-crash.log").
-    [string]$CrashLog = (Join-Path (Split-Path -Parent $ExePath) 'ghostty-crash.log')
+    [string]$CrashLog = (Join-Path (Split-Path -Parent $ExePath) 'ghostty-crash.log'),
+    # Report what happened without asserting it against the coverage map.
+    # Use this when re-measuring; use the default when gating a change.
+    [switch]$Discover
 )
 
 $ErrorActionPreference = 'Stop'
@@ -34,7 +65,10 @@ if (-not (Test-Path $ExePath)) {
     throw "ExePath not found: $ExePath"
 }
 
-# Kind, whether a crash envelope is expected, whether crash.log should grow.
+# Kind, and whether a crash EVENT envelope and a managed crash log are
+# expected. "Envelope" means an envelope carrying an event item: the transport
+# discards anything else (Transport.shouldDiscard), so a session-only envelope
+# never reaches disk no matter how many sentry sends the logs show.
 #
 # Only the kinds that run in-process. The surface-bound kinds
 # (libghostty-main, libghostty-io, renderer-thread) fault inside libghostty
@@ -44,28 +78,113 @@ if (-not (Test-Path $ExePath)) {
 # trigger that never ran, which is the one result this harness must not
 # produce. See CrashKinds in windows/Ghostty.Core/Diagnostics.
 $matrix = @(
-    # native-seh surfaces as a managed SEHException, so the CLR claims it
-    # before sentry's unhandled filter runs and the managed handler is what
-    # records it. Measured, not assumed: the design predicted an envelope here
-    # and was wrong.
-    @{ Kind = 'native-seh';        Envelope = $false; CrashLog = $true  }
-    # No crash log, and that is the CLI telling the truth rather than a gap.
-    # The handler that writes one is registered in App.xaml.cs, which is the
-    # GUI. The CLI path runs in Program.MainImpl before any App exists, so a
-    # genuinely unhandled exception reaches no handler of ours.
+    # The row the in-process backend has to win, and it does: exit 0xE0000001,
+    # a crash event and a session marked "crashed", both on the next launch.
+    # No managed crash log, and none is wanted: the filter takes the process
+    # down, and the CLI has no handler registered anyway.
+    @{ Kind = 'native-seh';        Envelope = $true;  CrashLog = $false }
+    # An unhandled managed exception, which NativeAOT turns into a fail-fast
+    # (exit 0xC0000409, STATUS_STACK_BUFFER_OVERRUN) rather than an exception,
+    # so SetUnhandledExceptionFilter never runs and nothing is captured. Same
+    # result as env-failfast, by the same mechanism.
+    #
+    # No crash log either, and that is the CLI telling the truth rather than a
+    # gap: the handler that writes one is registered in App.xaml.cs, which is
+    # the GUI, and the CLI path runs in Program.MainImpl before any App
+    # exists. That handler is what covers this class in the shipped app, with
+    # a managed stack trace, and it is measured through the palette the way
+    # the libghostty rows are.
     #
     # This row used to expect a log, and got one, because the throw was caught
     # by Main's catch-all and turned into ReportFatal: the process never
     # crashed and the row passed for the wrong reason. The trigger now throws
-    # from its own thread. Installing the GUI's handler here would make the
-    # row pass again while measuring a CLI that does not exist; what an
-    # unhandled exception does in the shipped app is measured through the
-    # palette, the way the libghostty rows are.
+    # from its own thread.
     @{ Kind = 'managed-unhandled'; Envelope = $false; CrashLog = $false }
     @{ Kind = 'env-failfast';      Envelope = $false; CrashLog = $false }
     @{ Kind = 'stack-overflow';    Envelope = $false; CrashLog = $false }
     @{ Kind = 'handled-storm';     Envelope = $false; CrashLog = $false }
 )
+
+# Parse the envelope framing rather than grepping the bytes. The framing is
+# exactly what a scrub that rewrites payloads can corrupt, and a report that
+# no parser will read is worth nothing, so reading it here is a second check
+# on the writer and not merely a convenience.
+function Read-Envelope([string]$path) {
+    $bytes = [System.IO.File]::ReadAllBytes($path)
+    $utf8  = [System.Text.Encoding]::UTF8
+    $items = @()
+    $pos   = 0
+
+    function Read-Line([byte[]]$b, [ref]$p) {
+        $nl = [Array]::IndexOf($b, [byte]10, $p.Value)
+        if ($nl -lt 0) { return $null }
+        $line = [System.Text.Encoding]::UTF8.GetString($b, $p.Value, $nl - $p.Value)
+        $p.Value = $nl + 1
+        $line
+    }
+
+    $header = Read-Line $bytes ([ref]$pos)
+    if ($null -eq $header) {
+        return [pscustomobject]@{ Malformed = 'no header line'; Items = @() }
+    }
+
+    while ($pos -lt $bytes.Length) {
+        $itemHeader = Read-Line $bytes ([ref]$pos)
+        if ([string]::IsNullOrWhiteSpace($itemHeader)) { break }
+
+        try { $parsedHeader = $itemHeader | ConvertFrom-Json }
+        catch {
+            return [pscustomobject]@{
+                Malformed = "item header is not JSON: $itemHeader"; Items = $items
+            }
+        }
+
+        $lenProp = $parsedHeader.PSObject.Properties['length']
+        if ($null -eq $lenProp) {
+            return [pscustomobject]@{
+                Malformed = "item header has no length: $itemHeader"; Items = $items
+            }
+        }
+        $len = [int]$lenProp.Value
+        if ($pos + $len -gt $bytes.Length) {
+            return [pscustomobject]@{
+                Malformed = ("item '{0}' claims {1} bytes, {2} remain" -f `
+                    $parsedHeader.type, $len, ($bytes.Length - $pos))
+                Items = $items
+            }
+        }
+
+        $payload = $utf8.GetString($bytes, $pos, $len)
+        $pos += $len
+        if ($pos -lt $bytes.Length -and $bytes[$pos] -eq 10) { $pos++ }
+
+        $body = $null
+        try { $body = $payload | ConvertFrom-Json } catch { }
+
+        # An event without an exception is normal (a message event has none),
+        # and so is an attachment that is not JSON at all, so reach for the
+        # exception only once it is known to be there.
+        $exc = $null
+        if ($null -ne $body -and $null -ne $body.PSObject.Properties['exception']) {
+            $values = $body.exception.PSObject.Properties['values']
+            if ($null -ne $values -and $values.Value.Count -gt 0) {
+                $exc = $values.Value[0]
+            }
+        }
+
+        $items += [pscustomobject]@{
+            Type    = $parsedHeader.type
+            Length  = $len
+            Level   = if ($null -ne $body) { $body.level } else { $null }
+            Status  = if ($null -ne $body) { $body.status } else { $null }
+            ExcType = if ($null -ne $exc)  { $exc.type } else { $null }
+            Mech    = if ($null -ne $exc)  { $exc.mechanism.type } else { $null }
+            Payload = $payload
+        }
+    }
+
+    [pscustomobject]@{ Malformed = $null; Items = $items }
+}
 
 function Get-EnvelopeSet {
     if (-not (Test-Path $CrashDir)) { return @() }
@@ -84,42 +203,133 @@ function Get-CrashLogStamp {
         (Get-FileHash $CrashLog -Algorithm SHA256).Hash
 }
 
-$results = @()
-foreach ($row in $matrix) {
-    $before    = Get-EnvelopeSet
-    $logBefore = Get-CrashLogStamp
-
-    $proc = Start-Process -FilePath $ExePath `
-        -ArgumentList '+crash', $row.Kind `
-        -PassThru -Wait -NoNewWindow
-    $exit = $proc.ExitCode
-
-    # The envelope is written by the crashing process before it dies; give
-    # the filesystem a beat to settle before enumerating.
-    Start-Sleep -Milliseconds 500
-
-    $after    = Get-EnvelopeSet
-    $newFiles = @($after | Where-Object { $_ -notin $before })
-    $gotEnv   = $newFiles.Count -gt 0
-    $gotLog   = (Get-CrashLogStamp) -ne $logBefore
-
-    $results += [pscustomobject]@{
-        Kind             = $row.Kind
-        ExitCode         = $exit
-        EnvelopeExpected = $row.Envelope
-        EnvelopeGot      = $gotEnv
-        CrashLogExpected = $row.CrashLog
-        CrashLogGot      = $gotLog
-        Pass             = (($gotEnv -eq $row.Envelope) -and ($gotLog -eq $row.CrashLog))
-        NewEnvelopes     = ($newFiles -join ',')
+function Invoke-Wintty([string]$kind) {
+    $err = [System.IO.Path]::GetTempFileName()
+    try {
+        $proc = Start-Process -FilePath $ExePath `
+            -ArgumentList '+crash', $kind `
+            -PassThru -Wait -NoNewWindow -RedirectStandardError $err
+        # The transport writes from within the launch; give the filesystem a
+        # beat to settle before enumerating.
+        Start-Sleep -Milliseconds 500
+        [pscustomobject]@{
+            ExitCode = $proc.ExitCode
+            Armed    = (Select-String -Path $err -Pattern 'reporter armed' -Quiet) -eq $true
+            Stderr   = (Get-Content $err -Raw)
+        }
+    } finally {
+        Remove-Item $err -Force -ErrorAction SilentlyContinue
     }
 }
 
-$results | Format-Table -AutoSize
+# A launch that arms the reporter, does not crash, and exits. handled-storm is
+# used deliberately rather than a mode invented for the harness: it is already
+# the row asserting that a thousand handled exceptions produce no report, so
+# if the drain were ever to emit one, that row fails and says so.
+function Invoke-Drain {
+    Invoke-Wintty 'handled-storm' | Out-Null
+}
+
+# Describe the envelopes that appeared, so a row says WHAT was captured rather
+# than only how many files exist.
+function Get-Report([string[]]$names) {
+    $events = @()
+    $sessions = @()
+    $bad = @()
+    foreach ($name in $names) {
+        $envelope = Read-Envelope (Join-Path $CrashDir $name)
+        if ($envelope.Malformed) { $bad += "$name`: $($envelope.Malformed)"; continue }
+        foreach ($item in $envelope.Items) {
+            switch ($item.Type) {
+                'event'   { $events   += ($item.ExcType ?? $item.Level ?? 'event') }
+                'session' { $sessions += ($item.Status ?? 'session') }
+                default   { }
+            }
+        }
+    }
+    [pscustomobject]@{
+        HasEvent = $events.Count -gt 0
+        Events   = ($events   -join ',')
+        Sessions = ($sessions -join ',')
+        Malformed = ($bad -join '; ')
+    }
+}
+
+$results = @()
+$notes   = @()
+
+foreach ($row in $matrix) {
+    # Drain first. Anything that shows up here belongs to the row before,
+    # arriving later than the design says it can, and is reported rather than
+    # folded into this row's baseline.
+    $preDrain = Get-EnvelopeSet
+    Invoke-Drain
+    $late = @((Get-EnvelopeSet) | Where-Object { $_ -notin $preDrain })
+    if ($late.Count -gt 0) {
+        $notes += ("before '{0}': {1} envelope(s) arrived more than one launch " +
+            "after the crash that produced them: {2}") -f `
+            $row.Kind, $late.Count, ($late -join ',')
+    }
+
+    $before    = Get-EnvelopeSet
+    $logBefore = Get-CrashLogStamp
+
+    $run = Invoke-Wintty $row.Kind
+    if (-not $run.Armed) {
+        $notes += ("'{0}': the reporter never armed, so an absent report " +
+            "below proves nothing") -f $row.Kind
+    }
+
+    # The crash log is written by the crashing process itself, so it is
+    # already there. The envelope is not: drain to bring it through.
+    $gotLog = (Get-CrashLogStamp) -ne $logBefore
+    Invoke-Drain
+
+    $newFiles = @((Get-EnvelopeSet) | Where-Object { $_ -notin $before })
+    $report   = Get-Report $newFiles
+    if ($report.Malformed) {
+        $notes += ("'{0}': {1}") -f $row.Kind, $report.Malformed
+    }
+
+    $results += [pscustomobject]@{
+        Kind             = $row.Kind
+        ExitCode         = $run.ExitCode
+        EnvelopeExpected = $row.Envelope
+        EnvelopeGot      = $report.HasEvent
+        Captured         = $report.Events
+        Sessions         = $report.Sessions
+        CrashLogExpected = $row.CrashLog
+        CrashLogGot      = $gotLog
+        Pass             = (($report.HasEvent -eq $row.Envelope) -and
+                            ($gotLog -eq $row.CrashLog) -and
+                            (-not $report.Malformed))
+    }
+}
+
+# The last row has no successor to prove its drain was enough, so prove it
+# here. Without this the final row is the one place the old bug could hide.
+$tailBefore = Get-EnvelopeSet
+Invoke-Drain
+$tailLate = @((Get-EnvelopeSet) | Where-Object { $_ -notin $tailBefore })
+if ($tailLate.Count -gt 0) {
+    $notes += ("after the last row: {0} envelope(s) arrived late: {1}") -f `
+        $tailLate.Count, ($tailLate -join ',')
+}
+
+$results | Format-Table -AutoSize Kind, ExitCode, EnvelopeExpected, EnvelopeGot,
+    Captured, Sessions, CrashLogExpected, CrashLogGot, Pass
+
+foreach ($note in $notes) { Write-Warning $note }
+
+if ($Discover) {
+    Write-Host 'crash matrix: discovery run, nothing asserted' -ForegroundColor Yellow
+    exit 0
+}
 
 $failed = @($results | Where-Object { -not $_.Pass })
-if ($failed.Count -gt 0) {
-    Write-Error "crash matrix: $($failed.Count) row(s) did not match the expected coverage map"
+if ($failed.Count -gt 0 -or $notes.Count -gt 0) {
+    Write-Error (("crash matrix: {0} row(s) did not match the expected coverage " +
+        "map, {1} note(s)") -f $failed.Count, $notes.Count)
     exit 1
 }
 

--- a/windows/scripts/crash-matrix.ps1
+++ b/windows/scripts/crash-matrix.ps1
@@ -11,10 +11,19 @@
 
   Requires a DEBUG build: +crash is compiled out of Release.
 #>
+# Two directories are easy to confuse. Crash envelopes are written by
+# ghostty's own transport (src/crash/sentry.zig sendInternal) to the STATE
+# dir, xdg.state with subdir "wintty/crash". The sentry database, which is
+# where sentry-native keeps its .run bookkeeping and session.json, is the
+# CACHE dir, %LOCALAPPDATA%\wintty\sentry. Watching the database counts a
+# new .run.lock on every launch and reports an envelope for runs that never
+# crashed.
 param(
     [Parameter(Mandatory)][string]$ExePath,
-    [string]$CrashDir = "$env:LOCALAPPDATA\wintty\sentry",
-    [string]$CrashLog = "$env:LOCALAPPDATA\Wintty\crash.log"
+    [string]$CrashDir = "$env:LOCALAPPDATA\wintty\crash",
+    # The managed handler writes next to the binary, not under LOCALAPPDATA:
+    # Program.cs uses Path.Combine(AppContext.BaseDirectory, "ghostty-crash.log").
+    [string]$CrashLog = (Join-Path (Split-Path -Parent $ExePath) 'ghostty-crash.log')
 )
 
 $ErrorActionPreference = 'Stop'

--- a/windows/scripts/crash-matrix.ps1
+++ b/windows/scripts/crash-matrix.ps1
@@ -1,0 +1,86 @@
+#requires -Version 7
+<#
+.SYNOPSIS
+  Runs each crash trigger in a child process and asserts what lands on disk.
+
+.DESCRIPTION
+  Expected results come from the verified coverage map in section 3 of
+  docs/2026-08-25-crash-reporting-and-diagnostics-design.md. Rows that expect
+  NO envelope are load-bearing: they pin known gaps so a future change cannot
+  silently widen them, and they are why this harness asserts absence.
+
+  Requires a DEBUG build: +crash is compiled out of Release.
+#>
+param(
+    [Parameter(Mandatory)][string]$ExePath,
+    [string]$CrashDir = "$env:LOCALAPPDATA\wintty\crash",
+    [string]$CrashLog = "$env:LOCALAPPDATA\Wintty\crash.log"
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $ExePath)) {
+    throw "ExePath not found: $ExePath"
+}
+
+# Kind, whether a crash envelope is expected, whether crash.log should grow.
+$matrix = @(
+    @{ Kind = 'native-seh';        Envelope = $true;  CrashLog = $false }
+    @{ Kind = 'managed-unhandled'; Envelope = $false; CrashLog = $true  }
+    @{ Kind = 'env-failfast';      Envelope = $false; CrashLog = $false }
+    @{ Kind = 'stack-overflow';    Envelope = $false; CrashLog = $false }
+    @{ Kind = 'handled-storm';     Envelope = $false; CrashLog = $false }
+)
+
+function Get-EnvelopeSet {
+    if (-not (Test-Path $CrashDir)) { return @() }
+    @(Get-ChildItem $CrashDir -File -ErrorAction SilentlyContinue |
+        Select-Object -ExpandProperty Name)
+}
+
+function Get-CrashLogLength {
+    if (-not (Test-Path $CrashLog)) { return 0 }
+    (Get-Item $CrashLog).Length
+}
+
+$results = @()
+foreach ($row in $matrix) {
+    $before    = Get-EnvelopeSet
+    $logBefore = Get-CrashLogLength
+
+    $proc = Start-Process -FilePath $ExePath `
+        -ArgumentList '+crash', $row.Kind `
+        -PassThru -Wait -NoNewWindow
+    $exit = $proc.ExitCode
+
+    # The envelope is written by the crashing process before it dies; give
+    # the filesystem a beat to settle before enumerating.
+    Start-Sleep -Milliseconds 500
+
+    $after    = Get-EnvelopeSet
+    $newFiles = @($after | Where-Object { $_ -notin $before })
+    $gotEnv   = $newFiles.Count -gt 0
+    $gotLog   = (Get-CrashLogLength) -gt $logBefore
+
+    $results += [pscustomobject]@{
+        Kind             = $row.Kind
+        ExitCode         = $exit
+        EnvelopeExpected = $row.Envelope
+        EnvelopeGot      = $gotEnv
+        CrashLogExpected = $row.CrashLog
+        CrashLogGot      = $gotLog
+        Pass             = (($gotEnv -eq $row.Envelope) -and ($gotLog -eq $row.CrashLog))
+        NewEnvelopes     = ($newFiles -join ',')
+    }
+}
+
+$results | Format-Table -AutoSize
+
+$failed = @($results | Where-Object { -not $_.Pass })
+if ($failed.Count -gt 0) {
+    Write-Error "crash matrix: $($failed.Count) row(s) did not match the expected coverage map"
+    exit 1
+}
+
+Write-Host 'crash matrix: all rows matched the expected coverage map' -ForegroundColor Green
+exit 0

--- a/windows/scripts/crash-matrix.ps1
+++ b/windows/scripts/crash-matrix.ps1
@@ -49,7 +49,19 @@ $matrix = @(
     # records it. Measured, not assumed: the design predicted an envelope here
     # and was wrong.
     @{ Kind = 'native-seh';        Envelope = $false; CrashLog = $true  }
-    @{ Kind = 'managed-unhandled'; Envelope = $false; CrashLog = $true  }
+    # No crash log, and that is the CLI telling the truth rather than a gap.
+    # The handler that writes one is registered in App.xaml.cs, which is the
+    # GUI. The CLI path runs in Program.MainImpl before any App exists, so a
+    # genuinely unhandled exception reaches no handler of ours.
+    #
+    # This row used to expect a log, and got one, because the throw was caught
+    # by Main's catch-all and turned into ReportFatal: the process never
+    # crashed and the row passed for the wrong reason. The trigger now throws
+    # from its own thread. Installing the GUI's handler here would make the
+    # row pass again while measuring a CLI that does not exist; what an
+    # unhandled exception does in the shipped app is measured through the
+    # palette, the way the libghostty rows are.
+    @{ Kind = 'managed-unhandled'; Envelope = $false; CrashLog = $false }
     @{ Kind = 'env-failfast';      Envelope = $false; CrashLog = $false }
     @{ Kind = 'stack-overflow';    Envelope = $false; CrashLog = $false }
     @{ Kind = 'handled-storm';     Envelope = $false; CrashLog = $false }

--- a/windows/scripts/crash-matrix.ps1
+++ b/windows/scripts/crash-matrix.ps1
@@ -42,7 +42,11 @@ if (-not (Test-Path $ExePath)) {
 # trigger that never ran, which is the one result this harness must not
 # produce. See CrashKinds in windows/Ghostty.Core/Diagnostics.
 $matrix = @(
-    @{ Kind = 'native-seh';        Envelope = $true;  CrashLog = $false }
+    # native-seh surfaces as a managed SEHException, so the CLR claims it
+    # before sentry's unhandled filter runs and the managed handler is what
+    # records it. Measured, not assumed: the design predicted an envelope here
+    # and was wrong.
+    @{ Kind = 'native-seh';        Envelope = $false; CrashLog = $true  }
     @{ Kind = 'managed-unhandled'; Envelope = $false; CrashLog = $true  }
     @{ Kind = 'env-failfast';      Envelope = $false; CrashLog = $false }
     @{ Kind = 'stack-overflow';    Envelope = $false; CrashLog = $false }
@@ -55,15 +59,21 @@ function Get-EnvelopeSet {
         Select-Object -ExpandProperty Name)
 }
 
-function Get-CrashLogLength {
-    if (-not (Test-Path $CrashLog)) { return 0 }
-    (Get-Item $CrashLog).Length
+# The managed handler uses File.WriteAllText, which OVERWRITES. Detecting a
+# crash log by growth therefore misses every row after the first: a shorter
+# exception replaces a longer one and the length goes down. Identify the file
+# by its contents instead, so "was it rewritten" is what gets measured.
+function Get-CrashLogStamp {
+    if (-not (Test-Path $CrashLog)) { return '<absent>' }
+    $item = Get-Item $CrashLog
+    "$($item.LastWriteTimeUtc.Ticks):$($item.Length):" +
+        (Get-FileHash $CrashLog -Algorithm SHA256).Hash
 }
 
 $results = @()
 foreach ($row in $matrix) {
     $before    = Get-EnvelopeSet
-    $logBefore = Get-CrashLogLength
+    $logBefore = Get-CrashLogStamp
 
     $proc = Start-Process -FilePath $ExePath `
         -ArgumentList '+crash', $row.Kind `
@@ -77,7 +87,7 @@ foreach ($row in $matrix) {
     $after    = Get-EnvelopeSet
     $newFiles = @($after | Where-Object { $_ -notin $before })
     $gotEnv   = $newFiles.Count -gt 0
-    $gotLog   = (Get-CrashLogLength) -gt $logBefore
+    $gotLog   = (Get-CrashLogStamp) -ne $logBefore
 
     $results += [pscustomobject]@{
         Kind             = $row.Kind

--- a/windows/scripts/crash-matrix.ps1
+++ b/windows/scripts/crash-matrix.ps1
@@ -78,11 +78,18 @@ if (-not (Test-Path $ExePath)) {
 # trigger that never ran, which is the one result this harness must not
 # produce. See CrashKinds in windows/Ghostty.Core/Diagnostics.
 $matrix = @(
+    # ExitCode is asserted, not merely printed. Without it the one row whose
+    # entire claim is "this does not crash" could not tell a clean exit from a
+    # fail-fast: both produce no envelope and no crash log, so handled-storm
+    # passed either way. Since the drain launch IS handled-storm, a mutation
+    # that made it crash would have taken down every drain in the run while
+    # the table reported all rows matching.
+    #
     # The row the in-process backend has to win, and it does: exit 0xE0000001,
     # a crash event and a session marked "crashed", both on the next launch.
     # No managed crash log, and none is wanted: the filter takes the process
     # down, and the CLI has no handler registered anyway.
-    @{ Kind = 'native-seh';        Envelope = $true;  CrashLog = $false }
+    @{ Kind = 'native-seh';        Envelope = $true;  CrashLog = $false; ExitCode = -536870911 }
     # An unhandled managed exception, which NativeAOT turns into a fail-fast
     # (exit 0xC0000409, STATUS_STACK_BUFFER_OVERRUN) rather than an exception,
     # so SetUnhandledExceptionFilter never runs and nothing is captured. Same
@@ -99,10 +106,13 @@ $matrix = @(
     # by Main's catch-all and turned into ReportFatal: the process never
     # crashed and the row passed for the wrong reason. The trigger now throws
     # from its own thread.
-    @{ Kind = 'managed-unhandled'; Envelope = $false; CrashLog = $false }
-    @{ Kind = 'env-failfast';      Envelope = $false; CrashLog = $false }
-    @{ Kind = 'stack-overflow';    Envelope = $false; CrashLog = $false }
-    @{ Kind = 'handled-storm';     Envelope = $false; CrashLog = $false }
+    @{ Kind = 'managed-unhandled'; Envelope = $false; CrashLog = $false; ExitCode = -1073740791 }
+    @{ Kind = 'env-failfast';      Envelope = $false; CrashLog = $false; ExitCode = -1073740791 }
+    @{ Kind = 'stack-overflow';    Envelope = $false; CrashLog = $false; ExitCode = -1073741571 }
+    # Zero, and it is load-bearing: this row exists to prove a thousand
+    # handled exceptions produce no report, which is only meaningful if the
+    # process survived to say so.
+    @{ Kind = 'handled-storm';     Envelope = $false; CrashLog = $false; ExitCode = 0 }
 )
 
 # Parse the envelope framing rather than grepping the bytes. The framing is
@@ -158,8 +168,25 @@ function Read-Envelope([string]$path) {
         $pos += $len
         if ($pos -lt $bytes.Length -and $bytes[$pos] -eq 10) { $pos++ }
 
+        # A payload that no JSON parser will read is a corrupted report, and
+        # this function exists to say so. Swallowing the failure and then
+        # classifying the item from its HEADER meant an event whose payload
+        # the scrub had mangled still counted as an event and the row passed.
+        # That is the one corruption class the writer can still produce, now
+        # that it always recomputes the length header.
+        #
+        # Attachments are exempt: they are not JSON and never claimed to be.
         $body = $null
-        try { $body = $payload | ConvertFrom-Json } catch { }
+        $jsonError = $null
+        try { $body = $payload | ConvertFrom-Json }
+        catch { $jsonError = $_.Exception.Message }
+        if ($jsonError -and $parsedHeader.type -ne 'attachment') {
+            return [pscustomobject]@{
+                Malformed = ("item '{0}' payload is not JSON: {1}" -f `
+                    $parsedHeader.type, $jsonError)
+                Items = $items
+            }
+        }
 
         # An event without an exception is normal (a message event has none),
         # and so is an attachment that is not JSON at all, so reach for the
@@ -252,11 +279,72 @@ function Get-Report([string[]]$names) {
         Events   = ($events   -join ',')
         Sessions = ($sessions -join ',')
         Malformed = ($bad -join '; ')
+        Leaks    = (Get-PrivacyLeaks $names)
     }
+}
+
+# Whether a report that actually got written carries anything it should not.
+#
+# Nothing in this branch checked a real envelope for a username. The scrub's
+# unit tests feed it hand-authored JSON containing exactly the keys someone
+# already thought of, which is why the shipped leak (`code_file` scrubbed,
+# `debug_file` next door still spelling out the home directory) passed a
+# "contains no username" check. Only bytes off disk can see that.
+#
+# Deliberately not keyed on the scrub's own list: this asks whether ANY
+# absolute path or the current username survived, so a field nobody has
+# thought of yet fails here rather than shipping.
+function Get-PrivacyLeaks([string[]]$names) {
+    $found = @()
+    foreach ($name in $names) {
+        $text = [System.IO.File]::ReadAllText((Join-Path $CrashDir $name))
+
+        if ($env:USERNAME -and $text.Contains($env:USERNAME)) {
+            $found += "$name carries the username"
+        }
+        # Both spellings: JSON escapes a backslash, so a Windows path arrives
+        # as "C:\\Users\\...", and a raw one would arrive as "C:\Users\...".
+        foreach ($pattern in @('[A-Za-z]:\\\\', '[A-Za-z]:\\[^\\]')) {
+            if ($text -match $pattern) {
+                $sample = ([regex]::Match($text, "$pattern[^`"]{0,40}")).Value
+                $found += "$name carries an absolute path ($sample)"
+                break
+            }
+        }
+    }
+
+    $found -join '; '
 }
 
 $results = @()
 $notes   = @()
+
+# The table above is a third copy of the catalogue, and the only one no test
+# can scan: CrashKinds guards the CLI and the palette against drifting apart,
+# but this is a .ps1. Ask the binary what it knows rather than trusting the
+# table. An unknown kind exits 2 after printing both lists.
+$probe = Invoke-Wintty '__list__'
+$cliKinds = @()
+if ($probe.Stderr -match 'crash-trigger: cli-kinds:\s*(.+)') {
+    $cliKinds = @($Matches[1] -split ',' | ForEach-Object { $_.Trim() } |
+        Where-Object { $_ })
+}
+if ($cliKinds.Count -eq 0) {
+    $notes += "could not read the kind catalogue from the binary, so this " +
+        "run cannot tell whether the table below still covers it"
+} else {
+    $tableKinds = @($matrix | ForEach-Object { $_.Kind })
+    $missing = @($cliKinds | Where-Object { $_ -notin $tableKinds })
+    $extra   = @($tableKinds | Where-Object { $_ -notin $cliKinds })
+    if ($missing.Count -gt 0) {
+        $notes += ("the catalogue has CLI kind(s) this table never runs: {0}" -f
+            ($missing -join ', '))
+    }
+    if ($extra.Count -gt 0) {
+        $notes += ("this table names kind(s) the catalogue does not: {0}" -f
+            ($extra -join ', '))
+    }
+}
 
 foreach ($row in $matrix) {
     # Drain first. Anything that shows up here belongs to the row before,
@@ -291,8 +379,13 @@ foreach ($row in $matrix) {
         $notes += ("'{0}': {1}") -f $row.Kind, $report.Malformed
     }
 
+    if ($report.Leaks) {
+        $notes += ("'{0}': {1}") -f $row.Kind, $report.Leaks
+    }
+
     $results += [pscustomobject]@{
         Kind             = $row.Kind
+        ExitExpected     = $row.ExitCode
         ExitCode         = $run.ExitCode
         EnvelopeExpected = $row.Envelope
         EnvelopeGot      = $report.HasEvent
@@ -302,7 +395,9 @@ foreach ($row in $matrix) {
         CrashLogGot      = $gotLog
         Pass             = (($report.HasEvent -eq $row.Envelope) -and
                             ($gotLog -eq $row.CrashLog) -and
-                            (-not $report.Malformed))
+                            ($run.ExitCode -eq $row.ExitCode) -and
+                            (-not $report.Malformed) -and
+                            (-not $report.Leaks))
     }
 }
 
@@ -316,8 +411,8 @@ if ($tailLate.Count -gt 0) {
         $tailLate.Count, ($tailLate -join ',')
 }
 
-$results | Format-Table -AutoSize Kind, ExitCode, EnvelopeExpected, EnvelopeGot,
-    Captured, Sessions, CrashLogExpected, CrashLogGot, Pass
+$results | Format-Table -AutoSize Kind, ExitExpected, ExitCode, EnvelopeExpected,
+    EnvelopeGot, Captured, Sessions, CrashLogExpected, CrashLogGot, Pass
 
 foreach ($note in $notes) { Write-Warning $note }
 

--- a/windows/scripts/crash-matrix.ps1
+++ b/windows/scripts/crash-matrix.ps1
@@ -13,7 +13,7 @@
 #>
 param(
     [Parameter(Mandatory)][string]$ExePath,
-    [string]$CrashDir = "$env:LOCALAPPDATA\wintty\crash",
+    [string]$CrashDir = "$env:LOCALAPPDATA\wintty\sentry",
     [string]$CrashLog = "$env:LOCALAPPDATA\Wintty\crash.log"
 )
 
@@ -24,6 +24,14 @@ if (-not (Test-Path $ExePath)) {
 }
 
 # Kind, whether a crash envelope is expected, whether crash.log should grow.
+#
+# Only the kinds that run in-process. The surface-bound kinds
+# (libghostty-main, libghostty-io, renderer-thread) fault inside libghostty
+# via a binding action, which has no surface to land on before a window
+# exists, so `+crash` refuses them with exit 3 and they are driven from the
+# command palette instead. Adding them here would assert absence for a
+# trigger that never ran, which is the one result this harness must not
+# produce. See CrashKinds in windows/Ghostty.Core/Diagnostics.
 $matrix = @(
     @{ Kind = 'native-seh';        Envelope = $true;  CrashLog = $false }
     @{ Kind = 'managed-unhandled'; Envelope = $false; CrashLog = $true  }


### PR DESCRIPTION
Wintty shipped with no crash capture on Windows at all. This makes it work.

## What

Four defects stood between sentry and a running Windows build. Three are in the vendored `pkg/sentry` build wiring and only bite on Windows: `SENTRY_BUILD_STATIC` was never defined though the library builds static, so every symbol came out `__declspec(dllimport)` and unresolved; no system libraries were declared, so `dbghelp` and `version` were missing from the link; and aro cannot parse `__ptr64` in the Windows SDK's `basetsd.h`, which `--zig-integration` was swallowing the diagnostic for.

The fourth was ours and predated sentry. `src/main_c.zig`'s hand-rolled MSVC `DllMain` never ran the `.CRT$XI` C initializer table, and `__acrt_initialize_stdio` lives there. That left `__piob` NULL and every `_iob[i]._lock` critical section zeroed, so the first C stdio call in the DLL faulted. Zig's std never touches `FILE*`, so nothing had noticed; sentry was simply the first vendored C dependency to call `vfprintf`. The fix repairs C stdio for every vendored C dependency, and it means `.CRT$XC` now runs too, so C++ static constructors in linked dependencies execute at attach for the first time.

A fifth defect blocked releases rather than the build. sentry's C sources were compiled with Zig's default sanitizer settings, and Zig cannot bundle its ubsan runtime on Windows, so every sentry object in `ghostty-static.lib` left `__ubsan_handle_*` undefined. `zig build` links its own artifacts and resolves them; `dotnet build` is CoreCLR and never links that archive; only `dotnet publish` reaches MSVC `link.exe`. It failed with 11 unresolved externals while every gate was green.

Then a structural problem no wiring fixes. `@panic` reaches `std.debug.defaultPanic`, whose last statement is `std.process.abort()`, which on Windows is `RtlExitUserProcess(3)`: a clean process exit that raises no structured exception. The inproc backend hooks `SetUnhandledExceptionFilter`, which such an exit never invokes, so the backend cannot observe a Zig panic on Windows even in principle. The same panic on Linux is caught through `SIGABRT`. Capture therefore needs an explicit panic hook calling `captureEvent`, which is what `capturePanic` is.

Also here: `+crash <kind>` and matching command palette entries for triggering each crash class, an acceptance harness that asserts what lands on disk, thread tagging on the C API path, and module paths scrubbed to `<dir>/<name>` in the transport so reports carry no username or absolute path.

## Two things worth knowing before reading the harness

**Point it at a published build.** `Ghostty.csproj` sets `PublishAot`, so `dotnet build` gives CoreCLR and `dotnet publish` gives what ships, and they disagree about every row that matters. Under CoreCLR an unhandled managed exception is captured and a native SEH raised through a P/Invoke never crashes at all; under NativeAOT it is the other way round. An earlier revision of this branch measured the wrong one and wrote the result into three documents.

**A report arrives one launch late.** The inproc backend does not call our transport at crash time; it writes into its own run directory, and only the next `sentry_init` replays it. The crash directory is empty immediately after a crash. A report from `captureEvent`, which is how panics are captured, arrives in the same launch.

## Coverage, on the build that ships

| Crash class | Exit | Captured by | Evidence |
| --- | --- | --- | --- |
| Native SEH, unhandled | `0xE0000001` | **sentry**, next launch | measured |
| Unhandled managed exception, CLI | `0xC0000409` | nobody | measured |
| `Environment.FailFast` | `0xC0000409` | nobody | measured |
| Stack overflow | `0xC00000FD` | nobody | measured |
| Handled exception storm | 0 | nobody, correctly | measured |
| libghostty panic (main, io, renderer) | n/a | **sentry**, same launch | argued: a Zig panic raises nothing, so the runtime is not in its path |
| Unhandled managed exception, GUI | `0xC0000409` | `App.xaml.cs`, writing `%LOCALAPPDATA%\Wintty\crash.log` | argued: the GUI cannot be driven headlessly |

Fail-fast and stack overflow are captured by nobody in process by Windows design, and under NativeAOT an unhandled managed exception is a fail-fast too. Both are visible to WER, which needs administrator (tracked on the release side).

## Why this shape

The two reporters are disjoint and should stay that way. The managed handler owns anything the runtime surfaces as a managed exception; sentry owns faults inside libghostty and native exceptions the runtime does not claim.

The triggers ship in every build rather than under `#if DEBUG`. A trigger compiled out of Release leaves the one configuration that matters as the one nobody can test. Destructive palette rows are excluded from the unfiltered list, match on their title only, and sort last, so one has to be asked for by name.

## Test plan

Four tiers, Release, x64, `-p:ProVariant=Desktop` for the pro family, from a replay of this branch onto the tier pin:

| Tier | Renderer | Tests |
| --- | --- | --- |
| oss | dx12 | 2422 passed, 0 failed |
| sponsor | dx12 | 3448 passed, 0 failed |
| pro | dx12 | 3887 passed, 0 failed |
| pro-legacy | dx11 | 3887 passed, 0 failed |

`ghostty.dll` imports `dbghelp.dll` and `VERSION.dll` in every tier; pro-legacy's also imports `d3d11.dll`.

On the branch itself, rebased onto `origin/windows`: `zig build` and `zig build test` green, 2407 C# tests passing, `dotnet publish` green (which is what proves the link), and `windows/scripts/crash-matrix.ps1` matching all five rows against the published binary. The harness now asserts exit codes, reads the kind catalogue from the binary rather than hardcoding it, rejects an envelope whose payload no JSON parser will read, and fails any row whose report contains the current username or an absolute path.

Guards were mutation-tested rather than assumed: inverting either ordering key, hoisting the description match out of its guard, removing the empty-query exclusion, moving `Debug` off the end of the enum, and six weakenings of the symbol-archival gate are each killed by a named test.
