### PR TITLE
build: bump the zioshade pin to v0.8.4

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -95,8 +95,8 @@
         // between zioshade versions on unchanged input (lowering and
         // identifier fixes); regenerate any golden outputs.
         .zioshade = .{
-            .url = "https://github.com/zioShade/zioshade/archive/refs/tags/v0.8.3.tar.gz",
-            .hash = "zioshade-0.8.3-8s3a2iYpUgAhs9iKuHeZxih1_anDBa1eFX1zjlHjCU6T",
+            .url = "https://github.com/zioShade/zioshade/archive/refs/tags/v0.8.4.tar.gz",
+            .hash = "zioshade-0.8.4-8s3a2kNFVAA2mZkIZq45NvtR1fRSG-tKMIAHaFNZajS1",
             .lazy = true,
         },
 


### PR DESCRIPTION
Repoints build.zig.zon at the v0.8.4 tarball (hash from zig fetch).

v0.8.4 is the v0.8.3 tip plus the compiler campaign merged this week:

- optimizer: store-forwarding order checks (#694), scatter-store-to-composite block guards
- wgsl: uniformity prepass extracted to its own module (#704), flow-sensitive store reachability + function-return uniformity (#700), derivative builtins refused in non-uniform control flow (#701), 128-bit selector stride guard (#696)
- tests: gallery re-vendor with renamed shaders, tint probe corpus

Verified locally: zig fetch resolves the new hash, lib ghostty + all 54 deps compile on Zig 0.16.0 (the only failing build steps are the macOS Metal artifacts, unavailable on this CommandLineTools-only machine, pre-existing and unrelated). Signoff legs zig-fmt + zig-tests running.