### PR TITLE
windows: restore what the sync series-v2 merge reverted (#705, #729, #742)

### DIFF
--- a/windows/Ghostty.Core/Windows/ActiveWindowTarget.cs
+++ b/windows/Ghostty.Core/Windows/ActiveWindowTarget.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+
+namespace Ghostty.Core.Windows;
+
+/// <summary>
+/// Picks the window a process-wide request should act on. Pure, and public
+/// for the same reason <c>PipeServerRetryPolicy</c> is: the decision belongs
+/// to a service the test project cannot construct (it does not reference the
+/// WinUI shell at all), so leaving it inline in the shell means it is never
+/// exercised by anything but a human with two windows open.
+///
+/// The rule is "the window the user last looked at, if it can still take the
+/// request; otherwise any other that can". Falling back matters more than it
+/// looks: the last-activated window is remembered across its own close on
+/// some paths, and a request routed to it then reaches a window whose
+/// surfaces are already gone.
+/// </summary>
+public static class ActiveWindowTarget
+{
+    /// <summary>
+    /// <paramref name="lastActivated"/> when it passes
+    /// <paramref name="eligible"/>, otherwise the first of
+    /// <paramref name="all"/> that does, otherwise null.
+    /// </summary>
+    /// <param name="lastActivated">
+    /// The window that most recently received activation, or null when the
+    /// process has never had one (or the last one closed).
+    /// </param>
+    /// <param name="all">Every live window, in no particular order.</param>
+    /// <param name="eligible">
+    /// Whether a window can take the request right now. Both halves are
+    /// filtered through it, so an ineligible <paramref name="lastActivated"/>
+    /// does not short-circuit the search.
+    /// </param>
+    public static T? Choose<T>(T? lastActivated, IEnumerable<T> all, Func<T, bool> eligible)
+        where T : class
+    {
+        ArgumentNullException.ThrowIfNull(all);
+        ArgumentNullException.ThrowIfNull(eligible);
+
+        if (lastActivated is not null && eligible(lastActivated)) return lastActivated;
+
+        foreach (var candidate in all)
+        {
+            if (candidate is null) continue;
+            // Skipped rather than returned: it already failed the predicate
+            // above, and the enumeration is the only place it can reappear.
+            if (ReferenceEquals(candidate, lastActivated)) continue;
+            if (eligible(candidate)) return candidate;
+        }
+
+        return null;
+    }
+}

--- a/windows/Ghostty.Tests/Commands/PaletteSelectionWiringTests.cs
+++ b/windows/Ghostty.Tests/Commands/PaletteSelectionWiringTests.cs
@@ -85,25 +85,13 @@ public class PaletteSelectionWiringTests
         Assert.Equal(2, ShellSource.Load(ViewModel).Root.Calls("PaletteSelection.Step").Count);
     }
 
-    /// <summary>
-    /// The parser runs with no preprocessor symbols, so a disabled `#if`
-    /// region is trivia and every guard above looks straight through it.
-    /// This file has a live `#if DEMO` block, so a demo path that touched
-    /// the list would ship unguarded in DEMO builds.
-    /// </summary>
-    [Fact]
-    public void NoDisabledRegionTouchesTheList()
-    {
-        var hidden = ShellSource.Load(ViewModel).Root
-            .DescendantTrivia()
-            .Where(t => t.IsKind(SyntaxKind.DisabledTextTrivia))
-            .Select(t => t.ToString())
-            .Where(t => t.Contains("FilteredCommands"))
-            .ToList();
-
-        Assert.True(hidden.Count == 0,
-            "A conditionally compiled region assigns FilteredCommands. It is trivia to "
-            + "the parser, so the guards in this file cannot see it: "
-            + string.Join("\n", hidden));
-    }
+    // The guard that used to live here -- "no disabled #if region assigns
+    // FilteredCommands" -- moved into ShellSource.Load, which now parses with
+    // the symbol defined and refuses outright to hand back a tree that still
+    // has disabled regions. So the demo block in this file is real syntax to
+    // the guards above rather than trivia they look through, and the same now
+    // holds for every file a test reads through Load rather than for this one
+    // alone. It is not corpus-wide: AllUnder hands back raw text, and
+    // ParseForCorpusScan and AllShellSources each skip that refusal on
+    // purpose, for the reason each of them documents.
 }

--- a/windows/Ghostty.Tests/Windows/ActiveWindowTargetTests.cs
+++ b/windows/Ghostty.Tests/Windows/ActiveWindowTargetTests.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using Ghostty.Core.Windows;
+using Xunit;
+
+namespace Ghostty.Tests.Windows;
+
+/// <summary>
+/// Routing a process-wide request to one window.
+///
+/// The real callers pass MainWindow, which this project cannot reference, so
+/// the window here is a record with the two flags the shell's predicate reads.
+/// That is the whole reason the decision lives in Ghostty.Core: inline in App
+/// it would only ever be exercised by a person with two windows open.
+/// </summary>
+public sealed class ActiveWindowTargetTests
+{
+    private sealed record FakeWindow(string Name, bool Quake = false, bool Closing = false);
+
+    // The shell's predicate, verbatim in shape. The closing half is the one
+    // that fires in the shell; the quake half is a backstop, since the shell
+    // keeps the quake window out of the registry and out of last-activated
+    // both. This helper lives in Core and can see neither, so it has to
+    // answer for a quake window it is handed anyway.
+    private static bool Eligible(FakeWindow w) => !w.Quake && !w.Closing;
+
+    private static FakeWindow? Choose(FakeWindow? lastActivated, params FakeWindow[] all) =>
+        ActiveWindowTarget.Choose(lastActivated, all, Eligible);
+
+    [Fact]
+    public void NoWindowsAtAllChoosesNothing()
+    {
+        Assert.Null(Choose(null));
+    }
+
+    [Fact]
+    public void TheOnlyEligibleWindowIsChosen()
+    {
+        var only = new FakeWindow("only");
+        Assert.Same(only, Choose(null, only));
+    }
+
+    [Fact]
+    public void TheLastActivatedWindowWinsOverListOrder()
+    {
+        var first = new FakeWindow("first");
+        var last = new FakeWindow("last");
+
+        // Enumeration order would hand back `first`; the point of tracking
+        // activation is that it does not.
+        Assert.Same(last, Choose(last, first, last));
+    }
+
+    [Fact]
+    public void AClosingLastActivatedWindowGivesWayToTheNextEligibleOne()
+    {
+        var closing = new FakeWindow("closing", Closing: true);
+        var open = new FakeWindow("open");
+
+        Assert.Same(open, Choose(closing, closing, open));
+    }
+
+    [Fact]
+    public void AQuakeOnlySessionChoosesNothing()
+    {
+        // "Some window exists" is not the same question as "some window can
+        // take this". The shell excludes the quake window upstream, so this
+        // is the backstop being exercised rather than a state the shell
+        // produces.
+        var quake = new FakeWindow("quake", Quake: true);
+
+        Assert.Null(Choose(quake, quake));
+        Assert.Null(Choose(null, quake));
+    }
+
+    [Fact]
+    public void AClosingLastActivatedWindowWithNoEligibleRestChoosesNothing()
+    {
+        // The failure this guards: falling back to the last-activated window
+        // anyway because it is the only one there is.
+        var closing = new FakeWindow("closing", Closing: true);
+        var quake = new FakeWindow("quake", Quake: true);
+
+        Assert.Null(Choose(closing, closing, quake));
+    }
+
+    [Fact]
+    public void ALastActivatedWindowMissingFromTheListIsStillChosenWhenEligible()
+    {
+        // The two arguments come from different places in App (a field and a
+        // dictionary's values), and there is no moment where they are read
+        // atomically. Preferring the field when it is eligible is the
+        // documented rule, not an accident of it appearing in the list.
+        var detached = new FakeWindow("detached");
+        var other = new FakeWindow("other");
+
+        Assert.Same(detached, Choose(detached, other));
+    }
+
+    [Fact]
+    public void TheEligiblePredicateIsAskedAboutTheLastActivatedWindowOnlyOnce()
+    {
+        // The fallback scan skips the last-activated window rather than
+        // re-testing it. A predicate that is expensive or that changes its
+        // answer would otherwise be able to return a window it just rejected.
+        var last = new FakeWindow("last", Closing: true);
+        var asked = new List<string>();
+
+        var chosen = ActiveWindowTarget.Choose<FakeWindow>(
+            last,
+            new[] { last },
+            w => { asked.Add(w.Name); return Eligible(w); });
+
+        Assert.Null(chosen);
+        Assert.Equal(new[] { "last" }, asked);
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/ThemePreviewOwnershipWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/ThemePreviewOwnershipWiringTests.cs
@@ -1,0 +1,716 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// Who owns the +list-themes pipe server.
+///
+/// ThemePreviewService serves a named pipe whose name carries the process id,
+/// created with FirstPipeInstance. There is exactly one of that name in the
+/// process, and the second service to ask for it does not get a degraded
+/// server -- it gets an IOException at construction, which the retry policy
+/// correctly calls permanent, and its accept loop exits before it has ever
+/// accepted anything. Constructing one per window therefore left windows 2..N
+/// with a service that was never going to serve, and left the whole feature
+/// riding on window 1. When window 1's close later learned to dispose its
+/// service, the pipe name was released with nothing reclaiming it and
+/// `wintty +list-themes` went dead for the rest of the session instead.
+///
+/// So the shape to hold is one service for the process, built where the
+/// bootstrap host is built and torn down where it is torn down, with the
+/// request routed to whichever window can currently show a picker.
+///
+/// The load-bearing difference from <see cref="AppActionOwnershipWiringTests"/>
+/// is that CONSTRUCTION is the ownership fact here, not subscription. There,
+/// a service per window was fine and only the subscription had to be unique.
+/// Here the singleton is the pipe, which is claimed by the constructor: a
+/// rule that counted only subscriptions would pass a second
+/// `new ThemePreviewService` that subscribes to nothing, and that is exactly
+/// what windows 2..N were.
+///
+/// What this cannot prove: that no window reaches the request through some
+/// further indirection. <see cref="TheHandlerShowsThePickerOnTheOneWindowItChose"/>
+/// closes the shape that is cheap to write and invisible in review -- App
+/// handling the request once and then reaching more than one window with it --
+/// by pinning what the handler must do rather than listing what it must not.
+/// The rest is left to the reader.
+/// </summary>
+public class ThemePreviewOwnershipWiringTests
+{
+    /// <summary>The event the pipe server raises when a LIST_THEMES arrives.</summary>
+    private const string ListThemes = "ListThemesRequested";
+
+    /// <summary>The service whose constructor claims the pipe name.</summary>
+    private const string ServiceType = "ThemePreviewService";
+
+    /// <summary>The field App holds the one service in.</summary>
+    private const string ServiceField = "_themePreview";
+
+    /// <summary>The member that puts a window into the registry.</summary>
+    private const string Registration = "NoteRegularWindowRegistered";
+
+    /// <summary>The registry a window is registered into.</summary>
+    private const string Registry = "WindowsByRoot";
+
+    /// <summary>The one verb a routed request performs on its window.</summary>
+    private const string Picker = "ShowInlineThemePicker";
+
+    /// <summary>The file that owns the one construction and the one subscription.</summary>
+    private const string App = ".Ghostty.App.xaml.cs";
+
+    /// <summary>The file that declares the service and raises the event.</summary>
+    private const string Service = ".Ghostty.Services.ThemePreviewService.cs";
+
+    /// <summary>
+    /// The only two files that may name the event at all. Deliberately not an
+    /// extensible allow-list -- a third entry is the bug this file exists to
+    /// catch. Both are exempt from the text rule below and therefore read by
+    /// parse instead, which is why
+    /// <see cref="OwnerFilesHideNothingInAConditionalRegion"/> exists.
+    /// </summary>
+    private static readonly string[] Owners = { App, Service };
+
+    /// <summary>
+    /// Every embedded C# source, not one of the blocks the test project
+    /// happens to embed. Two shell files (NativeMethods.cs,
+    /// LibGhosttyBuildInfo.cs) sit outside the Interop.Sources wildcard and
+    /// are re-embedded under Interop.Imports, so a corpus keyed on the
+    /// Sources prefix silently never reads them.
+    /// </summary>
+    private const string Corpus = "Ghostty.Tests.";
+
+    private static ShellSource AppSource() => ShellSource.Load("Ghostty.App.xaml.cs");
+
+    private static ShellSource ServiceSource() =>
+        ShellSource.Load("Services.ThemePreviewService.cs");
+
+    private sealed record Wire(string Event, string Receiver, string Handler);
+
+    /// <summary>
+    /// Every subscription or detach whose left-hand side names the event, read
+    /// off the parsed tree so a mention in a comment or a string is not one.
+    /// Matched on the event's own name rather than on the receiver: a
+    /// subscription taken out through some other spelling of the service is
+    /// the same subscription.
+    /// </summary>
+    private static List<Wire> Wires(SyntaxNode scope, SyntaxKind kind) =>
+        Assignments(scope, kind)
+            .Select(a => new Wire(
+                ListThemes,
+                a.Left is MemberAccessExpressionSyntax m ? Receiver(m.Expression) : "this",
+                a.Right.ToString()))
+            .ToList();
+
+    private static List<AssignmentExpressionSyntax> Assignments(SyntaxNode scope, SyntaxKind kind) =>
+        scope.DescendantNodes()
+            .OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.IsKind(kind) && EventName(a.Left) == ListThemes)
+            .ToList();
+
+    /// <summary>
+    /// The receiver as written, with a null-forgiving operator dropped: `x!`
+    /// and `x` are the same field, and telling them apart would be pinning
+    /// punctuation.
+    /// </summary>
+    private static string Receiver(ExpressionSyntax expression) =>
+        expression is PostfixUnaryExpressionSyntax
+            { RawKind: (int)SyntaxKind.SuppressNullableWarningExpression } bang
+            ? bang.Operand.ToString()
+            : expression.ToString();
+
+    /// <summary>The event's own identifier, receiver stripped.</summary>
+    private static string? EventName(ExpressionSyntax left) => left switch
+    {
+        MemberAccessExpressionSyntax member => member.Name.Identifier.ValueText,
+        IdentifierNameSyntax name => name.Identifier.ValueText,
+        _ => null,
+    };
+
+    /// <summary>
+    /// Every construction of the service under <paramref name="scope"/>,
+    /// matched on the simple type name so a fully-qualified spelling counts.
+    ///
+    /// Both spellings of `new`. A target-typed `new(...)` parses as
+    /// ImplicitObjectCreationExpressionSyntax, which is a sibling of
+    /// ObjectCreationExpressionSyntax under BaseObjectCreationExpressionSyntax
+    /// rather than a subtype of it, so a filter on the latter reads a file
+    /// full of `= new()` -- which this codebase writes freely -- as
+    /// constructing nothing at all. It carries no type of its own either, so
+    /// the type has to come from what it initialises: a declaration that
+    /// names it, or a field or property in the same file that does.
+    /// </summary>
+    private static List<BaseObjectCreationExpressionSyntax> Constructions(SyntaxNode scope)
+    {
+        var typed = MembersDeclaredAsTheService(scope);
+
+        return scope.DescendantNodes()
+            .OfType<BaseObjectCreationExpressionSyntax>()
+            .Where(n => n is ObjectCreationExpressionSyntax spelled
+                ? SimpleName(spelled.Type.ToString()) == ServiceType
+                : BuildsTheService(n, typed))
+            .ToList();
+    }
+
+    /// <summary>The type name with any qualifier and `?` dropped.</summary>
+    private static string SimpleName(string type) =>
+        type.Trim().TrimEnd('?').Split('.').Last();
+
+    /// <summary>
+    /// The fields and properties in this file declared as the service, which
+    /// is what gives `_themePreview = new(...)` a type to be read against.
+    /// </summary>
+    private static HashSet<string> MembersDeclaredAsTheService(SyntaxNode scope)
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var field in scope.DescendantNodes().OfType<FieldDeclarationSyntax>())
+            if (SimpleName(field.Declaration.Type.ToString()) == ServiceType)
+                foreach (var variable in field.Declaration.Variables)
+                    names.Add(variable.Identifier.ValueText);
+
+        foreach (var property in scope.DescendantNodes().OfType<PropertyDeclarationSyntax>())
+            if (SimpleName(property.Type.ToString()) == ServiceType)
+                names.Add(property.Identifier.ValueText);
+
+        return names;
+    }
+
+    /// <summary>
+    /// Whether a target-typed `new(...)` is building the service: either the
+    /// declaration it initialises names the type, or it is assigned to a
+    /// member of this file that was declared with it.
+    /// </summary>
+    private static bool BuildsTheService(SyntaxNode creation, HashSet<string> typed)
+    {
+        if (creation.Parent is EqualsValueClauseSyntax { Parent: VariableDeclaratorSyntax declarator }
+            && declarator.Parent is VariableDeclarationSyntax declaration)
+            return SimpleName(declaration.Type.ToString()) == ServiceType;
+
+        if (creation.Parent is AssignmentExpressionSyntax assignment)
+            return typed.Contains(LastIdentifier(assignment.Left));
+
+        return false;
+    }
+
+    /// <summary>The last identifier of a dotted expression, or empty.</summary>
+    private static string LastIdentifier(ExpressionSyntax expression) => expression switch
+    {
+        MemberAccessExpressionSyntax member => member.Name.Identifier.ValueText,
+        IdentifierNameSyntax name => name.Identifier.ValueText,
+        _ => string.Empty,
+    };
+
+    /// <summary>The last dotted segment of a callee, `?` dropped.</summary>
+    private static string LastSegment(string callee)
+    {
+        var dot = callee.LastIndexOf('.');
+        return (dot < 0 ? callee : callee[(dot + 1)..]).Trim();
+    }
+
+    /// <summary>
+    /// The identifier a call is made on. `target.Show()` and `target?.Show()`
+    /// are the same receiver; a call on anything that is not a plain
+    /// identifier comes back as written, which is enough to fail a
+    /// comparison against one.
+    /// </summary>
+    private static string ReceiverIdentifier(InvocationExpressionSyntax call)
+    {
+        var callee = call.CalleeText();
+        var dot = callee.LastIndexOf('.');
+        return dot < 0 ? string.Empty : callee[..dot].TrimEnd('?', ' ');
+    }
+
+    /// <summary>
+    /// Every call of <paramref name="verb"/> on something that names the
+    /// service. Matched on the receiver rather than on the one field, so an
+    /// accessor handing the service back out is covered by the same rule.
+    /// </summary>
+    private static List<InvocationExpressionSyntax> ServiceCalls(SyntaxNode scope, string verb) =>
+        scope.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(call => LastSegment(call.CalleeText()) == verb
+                && ReceiverIdentifier(call).Contains("themePreview", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+    /// <summary>
+    /// The same rule by text, which is the half that sees a call parked in a
+    /// disabled conditional region. Returns the files that match.
+    /// </summary>
+    private static List<string> ServiceCallText(
+        string verb, IReadOnlyList<(string Tail, string Text)> corpus)
+    {
+        var pattern = new Regex(
+            @"[Tt]hemePreview\w*\s*\??\.\s*" + verb + @"\s*\(", RegexOptions.Compiled);
+        return corpus.Where(f => pattern.IsMatch(f.Text)).Select(f => f.Tail).ToList();
+    }
+
+    /// <summary>
+    /// How many times <paramref name="scope"/> writes the window registry:
+    /// an insert through the indexer, or a mutating dictionary call on it.
+    /// </summary>
+    private static int RegistryWrites(SyntaxNode scope)
+    {
+        var inserts = scope.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Count(a => a.Left is ElementAccessExpressionSyntax element
+                && LastIdentifier(element.Expression) == Registry);
+
+        var mutations = scope.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Count(call => LastSegment(call.CalleeText())
+                    is "Add" or "TryAdd" or "Remove" or "Clear"
+                && ReceiverIdentifier(call).Split('.').Last().TrimEnd('!') == Registry);
+
+        return inserts + mutations;
+    }
+
+    /// <summary>
+    /// The rule the subscription-shaped guard next door cannot express: the
+    /// pipe is claimed by the constructor, so a second construction is a
+    /// second claim on it whether or not anybody subscribes to the result.
+    ///
+    /// Checked over the whole corpus twice, by parse and by text, because the
+    /// two owner files are exempt from nothing here and every other file is
+    /// read through a parse that cannot see a disabled conditional region.
+    /// </summary>
+    [Fact]
+    public void TheProcessConstructsExactlyOneThemePreviewService()
+    {
+        var corpus = ShellSource.AllUnder(Corpus);
+
+        // Load-bearing: a prefix that stopped matching would pass this test
+        // while reading nothing at all.
+        Assert.True(
+            corpus.Count > 100,
+            $"expected the shell source corpus under '{Corpus}', got {corpus.Count} files");
+        Assert.Single(corpus.Where(f => f.Tail.EndsWith(App, StringComparison.Ordinal)));
+        Assert.Single(corpus.Where(f => f.Tail.EndsWith(Service, StringComparison.Ordinal)));
+
+        var built = corpus
+            .Where(f => Constructions(ShellSource.ParseForCorpusScan(f.Text).Root).Count > 0)
+            .Select(f => f.Tail)
+            .ToList();
+
+        Assert.True(
+            built.Count == 1 && built[0].EndsWith(App, StringComparison.Ordinal),
+            "expected exactly one file to construct " + ServiceType + ", App; found "
+            + (built.Count == 0 ? "none" : string.Join(", ", built))
+            + ". The constructor is what claims the per-process pipe name, so a second "
+            + "construction gets an IOException and a server loop that stands down before it "
+            + "has served anything -- which is what a service per window was.");
+
+        Assert.Single(Constructions(AppSource().Root));
+
+        // And by text, which is the half that sees a construction parked in a
+        // disabled `#if` region. That region ships in the configuration that
+        // defines the symbol, and no parse in this file can read it.
+        //
+        // Three spellings, because a target-typed `new(...)` never writes the
+        // type next to the `new`: the explicit form, a declaration that names
+        // the type and defers, and an assignment to the field App holds it
+        // in. The alternatives cannot both match one construction, so a count
+        // stays a count.
+        var pattern = new Regex(
+            @"\bnew\s+(?:[\w]+\s*\.\s*)*" + ServiceType + @"\b"
+            + @"|\b" + ServiceType + @"\b\??\s+\w+\s*=\s*new\s*\("
+            + @"|\b" + ServiceField + @"\s*=\s*new\s*\(",
+            RegexOptions.Compiled);
+        var mentions = corpus
+            .SelectMany(f => pattern.Matches(f.Text).Select(_ => f.Tail))
+            .ToList();
+        Assert.True(
+            mentions.Count == 1 && mentions[0].EndsWith(App, StringComparison.Ordinal),
+            "expected one `new " + ServiceType + "` in the whole corpus, found "
+            + mentions.Count + ": " + string.Join(", ", mentions));
+    }
+
+    /// <summary>
+    /// The one construction runs once per process, on the framework's entry
+    /// point, unconditionally.
+    ///
+    /// OnLaunched by name, not by whatever member happens to build the
+    /// bootstrap host. Anchoring on a landmark proves only that the
+    /// construction sits beside that landmark, and both move together for
+    /// free: hoist the pair into one helper, call it from a per-window path,
+    /// and every count here still reads one while a service accumulates per
+    /// window.
+    /// </summary>
+    [Fact]
+    public void TheServiceIsBuiltOnTheStartupPathAndNotUnderAnyBranch()
+    {
+        var app = AppSource();
+        var startup = app.Method("OnLaunched");
+        var construction = Assert.Single(Constructions(app.Root));
+
+        Assert.Same(startup, construction.FirstAncestorOrSelf<MemberDeclarationSyntax>());
+
+        // Unconditional within it, too. A guarded construction on OnLaunched
+        // satisfies a count of one whenever the branch is taken once, and a
+        // condition that reads as "the first window only" selecting more than
+        // one window is the defect this file is about.
+        var nested = construction.Ancestors()
+            .TakeWhile(n => n != startup)
+            .FirstOrDefault(n => n is IfStatementSyntax or SwitchStatementSyntax or ElseClauseSyntax
+                or ForStatementSyntax or ForEachStatementSyntax or WhileStatementSyntax
+                or DoStatementSyntax or TryStatementSyntax or LambdaExpressionSyntax
+                or LocalFunctionStatementSyntax);
+
+        Assert.True(
+            nested is null,
+            $"the {ServiceType} construction is inside a {nested?.Kind()}. It has to happen once, "
+            + "unconditionally, on the one path that builds the bootstrap host.");
+    }
+
+    [Fact]
+    public void AppSubscribesExactlyOnceWithANamedMethod()
+    {
+        var app = AppSource();
+        var wires = Wires(app.Root, SyntaxKind.AddAssignmentExpression);
+
+        Assert.True(
+            wires.Count == 1,
+            $"expected exactly one `+= {ListThemes}` in App; found {wires.Count}. A second "
+            + "subscriber opens a second picker on the same request.");
+        Assert.Equal(ServiceField, wires[0].Receiver);
+
+        // A method group, so the teardown has something to name. An anonymous
+        // lambda cannot be unsubscribed at all, and this subscription lasts as
+        // long as the process.
+        Assert.True(
+            SyntaxFactory.ParseExpression(wires[0].Handler) is IdentifierNameSyntax,
+            $"{ListThemes} must be handled by a named method, not `{wires[0].Handler}`: a lambda "
+            + "cannot be detached, and the shutdown has to take this one back.");
+
+        // Method() asserts there is exactly one, so a detach cannot name a
+        // method that no longer exists and two overloads cannot make "the
+        // handler" ambiguous.
+        var handler = app.Method(wires[0].Handler);
+        Assert.True(
+            handler.Body is not null || handler.ExpressionBody is not null,
+            $"{wires[0].Handler} has no body");
+    }
+
+    /// <summary>
+    /// Both halves of the teardown, before the bootstrap host is freed.
+    ///
+    /// Detach and dispose are separate claims. The detach is what stops a
+    /// LIST_THEMES that beat the cancel from reaching a window that is already
+    /// tearing down; the dispose is what ends the accept loop and releases the
+    /// pipe name. Ordering them before `_bootstrapHost?.Dispose` is the same
+    /// requirement the app-action handlers have: work started during teardown
+    /// must not reach native state the host is about to free.
+    /// </summary>
+    [Fact]
+    public void TheSubscriptionAndTheServiceAreTornDownBeforeTheHostIsFreed()
+    {
+        var app = AppSource();
+        var subscribes = Wires(app.Root, SyntaxKind.AddAssignmentExpression);
+        var detaches = Wires(app.Root, SyntaxKind.SubtractAssignmentExpression);
+
+        // The (event, receiver, handler) triple, not the event: a detach of
+        // null, or of some other handler, satisfies a match on the event
+        // alone.
+        Assert.Equal(subscribes, detaches);
+
+        var shutdown = app.Root.DescendantNodes().OfType<BlockSyntax>()
+            .Where(b => b.Calls("_bootstrapHost?.Dispose").Count == 1)
+            .OrderBy(b => b.Span.Length)
+            .First()
+            .Statements;
+
+        var free = shutdown.TakeWhile(s => !s.Calls("_bootstrapHost?.Dispose").Any()).Count();
+        Assert.True(free < shutdown.Count, "expected the shutdown block to dispose the bootstrap host");
+
+        var detach = shutdown
+            .TakeWhile(s => Assignments(s, SyntaxKind.SubtractAssignmentExpression).Count == 0)
+            .Count();
+        Assert.True(
+            detach < shutdown.Count,
+            $"{ListThemes} is detached somewhere other than the shutdown that disposes the host. "
+            + "It is attached for the life of the process, so nothing else will.");
+        Assert.True(detach < free, $"{ListThemes} must be detached before the ghostty app is freed");
+
+        var dispose = shutdown.TakeWhile(s => !s.Calls("_themePreview.Dispose").Any()).Count();
+        Assert.True(
+            dispose < shutdown.Count,
+            "the shutdown must dispose _themePreview: detaching alone leaves the accept loop "
+            + "running and the per-process pipe name held with nobody listening on it");
+        Assert.True(dispose < free, "the pipe server must be stopped before the ghostty app is freed");
+    }
+
+    /// <summary>
+    /// The handler shows the picker on the one window it chose, and on no
+    /// other.
+    ///
+    /// Stated as a shape the handler must have rather than as a list of
+    /// shapes it must not. The defect wearing another name is a fan-out: App
+    /// keeps the one real subscription and reaches every window anyway, by
+    /// re-broadcasting through an event of its own, by calling a delegate it
+    /// stashed, or by looping the registry next to the one legitimate call.
+    /// A blacklist catches whichever spelling it was written against and none
+    /// of the others -- a delegate invoked through a local reads as
+    /// `relay(e)`, which is not the word "Invoke" anywhere. Pinning the
+    /// positive shape (one picker call, on the identifier Choose's result
+    /// went into) refuses the fan-out without having to have anticipated how
+    /// it was spelled, because a second recipient is a second call site by
+    /// construction.
+    /// </summary>
+    [Fact]
+    public void TheHandlerShowsThePickerOnTheOneWindowItChose()
+    {
+        var app = AppSource();
+        var handler = app.Method(Wires(app.Root, SyntaxKind.AddAssignmentExpression).Single().Handler);
+
+        // It picks the window through the decision that has real unit tests
+        // rather than re-deriving one inline, where it would be exercised
+        // only by a person with two windows open.
+        var chosen = handler.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(call => call.CalleeText().EndsWith("ActiveWindowTarget.Choose", StringComparison.Ordinal))
+            .ToList();
+        Assert.True(
+            chosen.Count == 1,
+            handler.Identifier.ValueText + " must route through ActiveWindowTarget.Choose; found "
+            + chosen.Count + " call(s).");
+
+        // Into a local, which is what the picker call then has to name. A
+        // Choose whose result is used inline leaves nothing for the call
+        // below to be checked against.
+        var target = chosen[0].FirstAncestorOrSelf<VariableDeclaratorSyntax>();
+        Assert.True(
+            target is not null,
+            "the ActiveWindowTarget.Choose result must be held in a local, so the picker call "
+            + "can be checked against it.");
+
+        var shown = handler.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(call => LastSegment(call.CalleeText()) == Picker)
+            .ToList();
+        Assert.True(
+            shown.Count == 1,
+            handler.Identifier.ValueText + " makes " + shown.Count + " " + Picker
+            + " call(s), expected one: " + string.Join(", ", shown.Select(c => c.CalleeText()))
+            + ". One process-wide request opens one picker; a second call site is the fan-out "
+            + "this file exists to prevent.");
+
+        Assert.Equal(target!.Identifier.ValueText, ReceiverIdentifier(shown[0]));
+    }
+
+    /// <summary>
+    /// App is the only place that disposes the service.
+    ///
+    /// The inverse of the census entry that came out with the per-window
+    /// field. Disposing this from a window's close is one line, it compiles,
+    /// and every other rule in this file stays green -- but it ends the
+    /// accept loop and drops the subscription for every window still open,
+    /// which is the defect the ownership move removed. Written against any
+    /// receiver that names the service rather than against the one field, so
+    /// re-exposing the service through an accessor and disposing that is
+    /// caught too.
+    /// </summary>
+    [Fact]
+    public void OnlyAppDisposesTheService()
+    {
+        var corpus = ShellSource.AllUnder(Corpus);
+        Assert.True(
+            corpus.Count > 100,
+            $"expected the shell source corpus under '{Corpus}', got {corpus.Count} files");
+
+        var disposers = corpus
+            .Where(f => ServiceCalls(ShellSource.ParseForCorpusScan(f.Text).Root, "Dispose").Count > 0)
+            .Select(f => f.Tail)
+            .ToList();
+
+        Assert.True(
+            disposers.Count == 1 && disposers[0].EndsWith(App, StringComparison.Ordinal),
+            "expected only App to dispose " + ServiceType + "; found "
+            + (disposers.Count == 0 ? "nobody" : string.Join(", ", disposers))
+            + ". One service serves the process, so a dispose anywhere else takes the pipe "
+            + "away from every window that is still open.");
+
+        // And by text, for the call parked in a disabled `#if` region that no
+        // parse in this file can read.
+        var mentions = ServiceCallText("Dispose", corpus);
+        Assert.True(
+            mentions.Count == 1 && mentions[0].EndsWith(App, StringComparison.Ordinal),
+            "expected one dispose of " + ServiceType + " in the whole corpus, found "
+            + mentions.Count + ": " + string.Join(", ", mentions));
+    }
+
+    /// <summary>
+    /// The pipe opens when a window registers, and not before.
+    ///
+    /// The pipe's existence is the readiness signal: `wintty +list-themes`
+    /// probes for it with File.Exists and counts a successful write as
+    /// delivery, never waiting for an answer. Opened at construction it
+    /// exists within milliseconds of OnLaunched, which returns before the
+    /// message loop can raise any window's Loaded -- so for the whole of
+    /// startup the CLI connects, writes, exits 0, and the app logs that it
+    /// had no window to draw on. The user gets no picker and no fallback
+    /// either, because finding no pipe is exactly what sends the CLI to
+    /// libghostty's own TUI picker.
+    ///
+    /// Pinned to the registration member by NAME, for the reason the
+    /// construction rule pins OnLaunched: anchoring on a landmark proves only
+    /// that the call sits beside that landmark, and both move together for
+    /// free.
+    /// </summary>
+    [Fact]
+    public void TheServerStartsWhenAWindowRegistersAndNotBefore()
+    {
+        var corpus = ShellSource.AllUnder(Corpus);
+        Assert.True(
+            corpus.Count > 100,
+            $"expected the shell source corpus under '{Corpus}', got {corpus.Count} files");
+
+        var starters = corpus
+            .Where(f => ServiceCalls(ShellSource.ParseForCorpusScan(f.Text).Root, "Start").Count > 0)
+            .Select(f => f.Tail)
+            .ToList();
+        Assert.True(
+            starters.Count == 1 && starters[0].EndsWith(App, StringComparison.Ordinal),
+            "expected exactly one file to start " + ServiceType + ", App; found "
+            + (starters.Count == 0 ? "none" : string.Join(", ", starters)));
+
+        var mentions = ServiceCallText("Start", corpus);
+        Assert.True(
+            mentions.Count == 1 && mentions[0].EndsWith(App, StringComparison.Ordinal),
+            "expected one start of " + ServiceType + " in the whole corpus, found "
+            + mentions.Count + ": " + string.Join(", ", mentions));
+
+        var start = Assert.Single(ServiceCalls(AppSource().Root, "Start"));
+        var member = start.Ancestors().OfType<MethodDeclarationSyntax>().FirstOrDefault();
+        Assert.True(
+            member?.Identifier.ValueText == Registration,
+            "the " + ServiceType + " start is in " + (member?.Identifier.ValueText ?? "no method")
+            + ", not " + Registration + ". The pipe may not exist before some window can host a "
+            + "picker, and registering is the moment one can.");
+    }
+
+    /// <summary>
+    /// App is the only writer of the window registry.
+    ///
+    /// Registering a window is what opens the pipe, so a window that inserts
+    /// itself directly registers without the side effect -- and the rule
+    /// above would still find its one start call, in App, in the right
+    /// member, never reached. Reads are left alone: several files resolve
+    /// their owning window through this dictionary and always have.
+    /// </summary>
+    [Fact]
+    public void OnlyAppWritesTheWindowRegistry()
+    {
+        var corpus = ShellSource.AllUnder(Corpus);
+        Assert.True(
+            corpus.Count > 100,
+            $"expected the shell source corpus under '{Corpus}', got {corpus.Count} files");
+
+        var writers = corpus
+            .Where(f => RegistryWrites(ShellSource.ParseForCorpusScan(f.Text).Root) > 0)
+            .Select(f => f.Tail)
+            .ToList();
+        Assert.True(
+            writers.Count == 1 && writers[0].EndsWith(App, StringComparison.Ordinal),
+            "expected only App to write " + Registry + "; found "
+            + (writers.Count == 0 ? "nobody" : string.Join(", ", writers))
+            + ". Registering a window is also what opens the +list-themes pipe, so an insert "
+            + "that goes around App is a window the pipe never learns about.");
+
+        // And by text, for the insert parked in a disabled `#if` region.
+        var pattern = new Regex(
+            @"\b" + Registry + @"\s*\[[^\]]*\]\s*=(?!=)"
+            + @"|\b" + Registry + @"\s*\??\.\s*(?:Add|TryAdd|Remove|Clear)\s*\(",
+            RegexOptions.Compiled);
+        var mentions = corpus
+            .Where(f => !f.Tail.EndsWith(App, StringComparison.Ordinal) && pattern.IsMatch(f.Text))
+            .Select(f => f.Tail)
+            .ToList();
+        Assert.True(
+            mentions.Count == 0,
+            "these files write " + Registry + ": " + string.Join(", ", mentions));
+    }
+
+    /// <summary>
+    /// The owner files are exempt from the text rule below, so a parse is all
+    /// that reads them -- and a parse cannot see inside a disabled conditional
+    /// region. Wrapping a second construction or a subscription in `#if !DEMO`
+    /// would hide it from both rules at once while shipping in every non-DEMO
+    /// build.
+    ///
+    /// <see cref="ShellSource.Load"/> refuses a file that still has disabled
+    /// text after DEMO is defined, which is the check that closes it. Both
+    /// owners go through Load rather than through the corpus scan's relaxed
+    /// parse.
+    /// </summary>
+    [Fact]
+    public void OwnerFilesHideNothingInAConditionalRegion()
+    {
+        // App is loaded by every other test here. The service is not, and it
+        // is the one file where subscribing to its own event would not look
+        // out of place.
+        var service = ServiceSource();
+
+        var wires = Wires(service.Root, SyntaxKind.AddAssignmentExpression);
+        Assert.True(
+            wires.Count == 0,
+            ServiceType + " subscribes to its own " + ListThemes
+            + ". It declares and raises this; a subscription here is a handler nobody detaches.");
+        Assert.Empty(Constructions(service.Root));
+
+        // Load-bearing: Load is what makes the above meaningful, and it is
+        // silently satisfied by a file that parses to nothing.
+        Assert.NotEmpty(service.Root.DescendantNodes().OfType<MethodDeclarationSyntax>());
+    }
+
+    /// <summary>
+    /// The corpus rule: no file other than the service and App may so much as
+    /// name the event.
+    ///
+    /// Text rather than syntax, deliberately. A parse cannot see inside a
+    /// disabled conditional region, and a subscription reintroduced there is
+    /// live in the configuration that defines the symbol. Matching the token
+    /// in the raw source has no such blind spot. The cost is that a comment
+    /// naming the event also fails -- including a comment explaining why a
+    /// file must not subscribe. Reword it; the rule is worth more than the
+    /// sentence.
+    /// </summary>
+    [Fact]
+    public void NoOtherFileNamesTheThemePickerRequest()
+    {
+        var corpus = ShellSource.AllUnder(Corpus);
+
+        Assert.True(
+            corpus.Count > 100,
+            $"expected the shell source corpus under '{Corpus}', got {corpus.Count} files");
+
+        // The two files that live outside the Interop.Sources wildcard are in
+        // the corpus, because a corpus keyed on that prefix alone silently
+        // skipped them and they are shell sources like any other.
+        Assert.Contains(corpus, f => f.Tail.EndsWith(".NativeMethods.cs", StringComparison.Ordinal));
+
+        var pattern = new Regex(@"\b" + ListThemes + @"\b", RegexOptions.Compiled);
+        var offenders = corpus
+            .Where(f => !Owners.Any(o => f.Tail.EndsWith(o, StringComparison.Ordinal)) && pattern.IsMatch(f.Text))
+            .Select(f => f.Tail)
+            .ToList();
+
+        Assert.True(
+            offenders.Count == 0,
+            "these files name " + ListThemes + ": " + string.Join(", ", offenders)
+            + ". One service serves the whole process and App owns the one subscription; a "
+            + "per-window subscriber is a window rooted on a service that outlives it, and a "
+            + "per-window service is one that never gets the pipe. If the name is only in a "
+            + "comment, reword the comment.");
+
+        // And the parsed view agrees. It reads the owner files too, which the
+        // text rule exempts, so this is not a second copy of the rule above:
+        // it is the half that covers what the exemption opens up.
+        foreach (var file in corpus.Where(f => !f.Tail.EndsWith(App, StringComparison.Ordinal)))
+        {
+            var wires = Wires(
+                ShellSource.ParseForCorpusScan(file.Text).Root, SyntaxKind.AddAssignmentExpression);
+            Assert.True(wires.Count == 0, $"{file.Tail} subscribes to {ListThemes}");
+        }
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/WindowTeardownWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/WindowTeardownWiringTests.cs
@@ -173,7 +173,23 @@ public class WindowTeardownWiringTests
         Class: "MainWindow",
         File: "Ghostty.MainWindow.xaml.cs",
         ClosedFlag: "_isClosed",
-        ClosePath: Array.Empty<string>(),
+        // OnClosedAsync's first teardown act, called unconditionally, and the
+        // only place the picker's per-control subscription is taken back --
+        // the control can outlive this window, so nothing on the control's
+        // side can answer for it.
+        //
+        // Naming it here unions its whole body into the detach set for the
+        // WHOLE census, which is a stronger claim than it looks. ClosePicker
+        // is called unconditionally from the close, but the `-=` inside it is
+        // reached CONDITIONALLY: it bails first on a zero handle. And the
+        // close is not its only caller -- the poll tick and a second
+        // ShowInlineThemePicker both run it. So "the close takes this back"
+        // holds only because a subscription exists only while the handle is
+        // non-zero, which is exactly when ClosePicker runs past that bail.
+        // ThePickerIsClosedWhenTheSurfaceUnderItGoes is what pins that
+        // invariant; widening this list further needs the same argument made
+        // again for whatever is added.
+        ClosePath: new[] { "ClosePicker" },
         AtLeast: 40,
         Owned: MainWindowOwned,
         Exempt: MainWindowExempt);
@@ -735,6 +751,289 @@ public class WindowTeardownWiringTests
             + "ClosePicker bails on the zero handle before it reaches those same clears, so the "
             + "stale surface pointer and the pane subtree behind _pickerTerminal are held until "
             + "the next successful picker or the window's close.");
+    }
+
+    /// <summary>The control that owns the surface the picker installs itself on.</summary>
+    private const string TerminalControlFile = "Controls.TerminalControl.xaml.cs";
+
+    /// <summary>The control event that warns its holders the surface is going.</summary>
+    private const string SurfaceDisposing = "SurfaceDisposing";
+
+    /// <summary>The window's handler for it.</summary>
+    private const string PickerDisposingHandler = "OnPickerSurfaceDisposing";
+
+    /// <summary>
+    /// Matched on the event's own name, whatever the receiver is spelled as: a
+    /// subscription taken out through a local and detached through a field is
+    /// the same subscription, and the census above is what insists the two
+    /// spellings agree.
+    /// </summary>
+    private static bool NamesSurfaceDisposing(string flattened) =>
+        flattened == SurfaceDisposing
+        || flattened.EndsWith("." + SurfaceDisposing, StringComparison.Ordinal);
+
+    /// <summary>
+    /// <c>if (!ReferenceEquals(sender, _pickerTerminal)) return;</c>, either
+    /// argument order and however ReferenceEquals is qualified.
+    ///
+    /// The shape, not the text: the operands are what carry the meaning, and a
+    /// guard comparing the sender against anything else -- `this` is the one
+    /// that reads plausibly -- is never true for a control, so the handler
+    /// returns before ClosePicker on every raise and the picker is stranded
+    /// exactly as it was before this event existed. Same style as
+    /// <see cref="IsClosedGuard"/> and
+    /// <see cref="TestsSurfaceHandleAgainstZero"/>, so the file keeps one idea
+    /// of what a guard is.
+    /// </summary>
+    private static bool IsPickerIdentityGuard(StatementSyntax statement)
+    {
+        if (statement is not IfStatementSyntax guard) return false;
+        if (guard.Condition is not PrefixUnaryExpressionSyntax negation) return false;
+        if (!negation.IsKind(SyntaxKind.LogicalNotExpression)) return false;
+        if (negation.Operand is not InvocationExpressionSyntax call) return false;
+        if (!call.CalleeText().EndsWith("ReferenceEquals", StringComparison.Ordinal)) return false;
+
+        var operands = call.ArgumentList.Arguments.Select(a => Flatten(a.Expression)).ToList();
+        return operands.Count == 2
+            && operands.Contains("sender")
+            && operands.Contains("_pickerTerminal")
+            && guard.Statement.DescendantNodesAndSelf().OfType<ReturnStatementSyntax>().Any();
+    }
+
+    /// <summary>
+    /// The warning a control gives before it frees its surface.
+    ///
+    /// The picker's cleanup writes through the surface pointer it saved -- it
+    /// clears three redirects and pushes pty input -- so it is only meaningful
+    /// while the surface is alive. Raised after SurfaceFree it would be
+    /// useless: the liveness check the window makes would already be false and
+    /// the picker, its theme arena, its 50ms poll and the control's whole
+    /// visual subtree would leak for the life of the window, which is exactly
+    /// what a tab close did before this event existed.
+    ///
+    /// Once-only and never-for-a-surface-that-was-not-created are the other
+    /// half. The disposed latch buys the first (DisposeSurface is idempotent
+    /// and callable from both PaneHost and the window's close), the handle
+    /// check the second -- a subscriber told about a surface that never
+    /// existed would be comparing its saved pointer against a zero handle.
+    /// </summary>
+    [Fact]
+    public void TheSurfaceDisposingWarningComesBeforeTheFree()
+    {
+        var source = ShellSource.Load(TerminalControlFile);
+        var dispose = source.Method("DisposeSurface");
+        var statements = dispose.Body!.Statements;
+
+        // Exactly one raise in the whole file: a second one somewhere else
+        // would fire without the latch below and could reach a subscriber
+        // twice, or reach one after the surface is already gone.
+        var raises = source.Root.Calls(SurfaceDisposing + "?.Invoke");
+        Assert.True(
+            raises.Count == 1,
+            $"expected exactly one `{SurfaceDisposing}?.Invoke` in {TerminalControlFile}, found "
+            + $"{raises.Count}; only the raise guarded by the disposed latch is once-only");
+
+        int IndexOfCall(string call) => statements.TakeWhile(s => !s.Calls(call).Any()).Count();
+        var raise = IndexOfCall(SurfaceDisposing + "?.Invoke");
+        var free = IndexOfCall("NativeMethods.SurfaceFree");
+
+        // Both have to be found, or TakeWhile hands back the full count and
+        // the ordering comparison below passes while pinning nothing.
+        Assert.True(raise < statements.Count, "DisposeSurface must raise " + SurfaceDisposing);
+        Assert.True(free < statements.Count, "expected DisposeSurface to free the surface");
+        Assert.True(
+            raise < free,
+            SurfaceDisposing + " must be raised before SurfaceFree: it exists so a holder of "
+            + "surface-keyed native state can hand it back, and after the free there is nothing "
+            + "left to hand back to");
+
+        // The latch, in the two statements that make the raise once-only.
+        Assert.True(
+            IsClosedGuard(statements[0], "_surfaceDisposed"),
+            "DisposeSurface must return early on _surfaceDisposed as its first statement");
+        Assert.True(
+            SetsLatch(statements[1], "_surfaceDisposed"),
+            "DisposeSurface must set _surfaceDisposed before anything else, so the raise below "
+            + "cannot fire twice for one control");
+        Assert.True(raise > 1, "the raise must sit below the latch, or it is not once-only");
+
+        // And the guard that keeps it off a control that never made a surface.
+        //
+        // Every `if` between the raise and the method, not the nearest one:
+        // the nearest-ancestor question is answered just as well by an outer
+        // condition that is never true, and wrapping the handle test in one
+        // leaves every count and every index above intact while the event
+        // stops being raised at all. One enclosing `if`, and it is the handle
+        // test, is the only shape that says the raise runs whenever the
+        // surface exists.
+        var enclosing = raises[0].Ancestors()
+            .OfType<IfStatementSyntax>()
+            .Where(node => dispose.Span.Contains(node.Span))
+            .ToList();
+        Assert.True(
+            enclosing.Count == 1,
+            "expected the raise to sit under exactly one `if` inside DisposeSurface, found "
+            + $"{enclosing.Count}; a second condition around it decides whether the warning is "
+            + "given at all, and nothing here can say what that condition is worth");
+        Assert.True(
+            TestsSurfaceHandleAgainstZero(enclosing[0].Condition),
+            "the raise must be guarded on _surface.Handle != IntPtr.Zero: a control whose surface "
+            + "was never created has nothing installed on it, and a subscriber told about one "
+            + "would be matching its saved pointer against a zero handle");
+
+        // A subscriber that throws must not stop the teardown: everything
+        // below the raise frees native memory, and PaneHost walks the leaves
+        // in a loop, so an escaping exception strands this surface and skips
+        // every leaf after it.
+        var contained = raises[0].Ancestors().OfType<TryStatementSyntax>().FirstOrDefault();
+        Assert.True(
+            contained is not null && contained.Catches.Count > 0,
+            "the raise must be wrapped in try/catch; DisposeSurface is a teardown path and an "
+            + "exception out of a subscriber would leak this surface and every leaf after it");
+        Assert.DoesNotContain(
+            contained!.Catches.SelectMany(c => c.Block.DescendantNodesAndSelf()),
+            n => n.IsKind(SyntaxKind.ThrowStatement));
+    }
+
+    /// <summary>
+    /// <c>_surface.Handle != IntPtr.Zero</c>, either way round.
+    /// </summary>
+    private static bool TestsSurfaceHandleAgainstZero(ExpressionSyntax condition)
+    {
+        if (condition is not BinaryExpressionSyntax comparison) return false;
+        if (!comparison.IsKind(SyntaxKind.NotEqualsExpression)) return false;
+
+        var sides = new[] { Flatten(comparison.Left), Flatten(comparison.Right) };
+        return sides.Contains("_surface.Handle") && sides.Contains("IntPtr.Zero");
+    }
+
+    /// <summary>
+    /// The window following its picker's surface into teardown.
+    ///
+    /// Closing the tab the picker is open in frees the surface through
+    /// TabManager.CloseTab, which calls DisposeAllLeaves BEFORE it raises
+    /// TabRemoved -- so no tab-level notification is early enough, and the
+    /// deinit that clears the picker's redirects and returns its allocation
+    /// was simply skipped, forever, with the poll still ticking every 50ms at
+    /// a picker no key could ever quit.
+    ///
+    /// The subscription is per-control, and the control can outlive this
+    /// window: a detached tab carries it to another window. So it is taken
+    /// back explicitly, and taken out only once the open has succeeded, which
+    /// is what makes that one detach enough -- a subscription exists only
+    /// while _pickerHandle is non-zero, and that is exactly when ClosePicker
+    /// runs past its early return.
+    /// </summary>
+    [Fact]
+    public void ThePickerIsClosedWhenTheSurfaceUnderItGoes()
+    {
+        var source = ShellSource.Load(MainWindow.File);
+
+        var subscribed = Subscriptions(source).Where(s => NamesSurfaceDisposing(s.Event)).ToList();
+        Assert.True(
+            subscribed.Count == 1,
+            $"expected exactly one `{SurfaceDisposing} +=` in {MainWindow.Class}, found "
+            + $"{subscribed.Count}; a second one would outlive the picker it was taken out for");
+        var wire = subscribed[0];
+        Assert.True(
+            wire.Handler == PickerDisposingHandler,
+            $"expected `{SurfaceDisposing} += {PickerDisposingHandler}`; an inline lambda here "
+            + "cannot be detached, and the control outlives this window on a tab detach");
+
+        // Detached, spelled the same way on both sides so the census can pair
+        // them. Nothing on the control's side can answer for this one: nulling
+        // the event during its own disposal is too late for the control that
+        // is carried to another window instead.
+        Assert.Contains(
+            (wire.Event, wire.Handler),
+            Unsubscribes(MainWindow, source).Select(u => (u.Event, u.Handler)));
+
+        // In ClosePicker itself, not merely somewhere the close reaches: every
+        // way the picker ends -- the poll seeing should_quit, a second picker
+        // opening, this very handler -- goes through there, and each of them
+        // has to leave the control clean.
+        var detached = Assignments(source.Method("ClosePicker"), SyntaxKind.SubtractAssignmentExpression)
+            .Where(u => NamesSurfaceDisposing(u.Event))
+            .ToList();
+        Assert.True(
+            detached.Count == 1,
+            $"ClosePicker must take back the one {SurfaceDisposing} subscription, found "
+            + $"{detached.Count}; it is the single exit every picker close funnels through");
+
+        // Taken out after the open SUCCEEDS, which is the invariant behind
+        // that single detach: ClosePicker returns on a zero handle before it
+        // reaches the detach, so a subscription that can survive a failed open
+        // has nothing left able to remove it.
+        //
+        // Measured against the zero-handle bail, not against the native call.
+        // "Below SurfaceListThemes" is satisfied by a `+=` sitting between the
+        // call and the bail, and that is the failing open: a null return then
+        // leaves a subscription on the control with _pickerTerminal null and
+        // the handle zero, and detaching that tab to another window leaves the
+        // closed window reachable from a live control.
+        var statements = source.Method("ShowInlineThemePicker").Body!.Statements;
+        var opened = statements
+            .TakeWhile(s => !s.Calls("NativeMethods.SurfaceListThemes").Any())
+            .Count();
+        var bail = statements
+            .Select((s, i) => (s, i))
+            .Where(x => x.i > opened)
+            .Where(x => x.s is IfStatementSyntax guard
+                        && TestsPickerHandleAgainstZero(guard.Condition)
+                        && guard.Statement.DescendantNodesAndSelf()
+                            .OfType<ReturnStatementSyntax>().Any())
+            .Select(x => x.i)
+            .DefaultIfEmpty(statements.Count)
+            .First();
+        var wired = statements
+            .TakeWhile(s => !Assignments(s, SyntaxKind.AddAssignmentExpression)
+                .Any(a => NamesSurfaceDisposing(a.Event)))
+            .Count();
+        Assert.True(
+            opened < statements.Count,
+            "expected ShowInlineThemePicker to open the picker through NativeMethods.SurfaceListThemes");
+        Assert.True(
+            bail < statements.Count,
+            "expected ShowInlineThemePicker to return on a zero handle after the open; without "
+            + "that statement there is no failure path to measure the subscription against");
+        Assert.True(
+            wired < statements.Count,
+            $"ShowInlineThemePicker must subscribe to the surface's {SurfaceDisposing}");
+        Assert.True(
+            bail < wired,
+            $"the {SurfaceDisposing} subscription must be taken out below the zero-handle return, "
+            + "not merely below the open: ClosePicker bails on a zero handle before it reaches "
+            + "the detach, so one a failed open can reach is stranded on the control for good");
+
+        // Unconditionally, as a statement of the method rather than something
+        // reached through a branch. Every count and every index above survives
+        // wrapping the `+=` in an `if` that is never taken, and the picker
+        // would then have no subscription at all.
+        var wireStatement = wire.Rhs.FirstAncestorOrSelf<StatementSyntax>();
+        Assert.True(
+            wireStatement is not null && statements.Any(s => s.Span == wireStatement.Span),
+            $"the `{SurfaceDisposing} +=` must be a top-level statement of ShowInlineThemePicker; "
+            + "nested inside a branch it is a subscription that may never be taken out while "
+            + "everything here still reads as wired");
+
+        // And the handler hands the picker back rather than doing its own
+        // half of the cleanup, so there is one teardown to keep correct.
+        Assert.Single(source.Method(PickerDisposingHandler).Calls("ClosePicker"));
+
+        // Guarded on the control this picker was opened on, as the handler's
+        // first act. Nothing else reads that condition, and the mutation that
+        // matters is small: compare the sender against `this` instead and the
+        // handler returns on every raise, ClosePicker never runs, and the
+        // picker, its arena, the poll and the control's subtree are stranded
+        // for the life of the window -- which is the defect this whole event
+        // exists to fix, back with every rule above still green.
+        var handler = source.Method(PickerDisposingHandler).Body!.Statements;
+        Assert.True(
+            handler.Count > 0 && IsPickerIdentityGuard(handler[0]),
+            $"{PickerDisposingHandler} must open with "
+            + "`if (!ReferenceEquals(sender, _pickerTerminal)) return;`: it is what keeps a stale "
+            + "raise from tearing down a picker it does not belong to, and what makes the raise "
+            + "for the current one get through");
     }
 
     /// <summary>

--- a/windows/Ghostty.Tests/Wiring/WindowTeardownWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/WindowTeardownWiringTests.cs
@@ -657,6 +657,86 @@ public class WindowTeardownWiringTests
         }
     }
 
+    private static readonly string[] PickerFields =
+        { "_pickerSurface", "_pickerTerminal", "_inlineThemeCb" };
+
+    /// <summary>
+    /// <c>_pickerHandle == IntPtr.Zero</c>, either way round.
+    /// </summary>
+    private static bool TestsPickerHandleAgainstZero(ExpressionSyntax condition)
+    {
+        if (condition is not BinaryExpressionSyntax equality) return false;
+        if (!equality.IsKind(SyntaxKind.EqualsExpression)) return false;
+
+        var sides = new[] { Flatten(equality.Left), Flatten(equality.Right) };
+        return sides.Contains("_pickerHandle") && sides.Contains("IntPtr.Zero");
+    }
+
+    /// <summary>
+    /// The fields <paramref name="scope"/> assigns null or default to. Read
+    /// off the right-hand side, because an assignment that puts something
+    /// back is not a clear.
+    /// </summary>
+    private static HashSet<string> ClearedIn(SyntaxNode scope) =>
+        scope.DescendantNodesAndSelf()
+            .OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.IsKind(SyntaxKind.SimpleAssignmentExpression))
+            .Where(a => a.Right.IsKind(SyntaxKind.NullLiteralExpression)
+                        || a.Right.IsKind(SyntaxKind.DefaultLiteralExpression)
+                        || a.Right is DefaultExpressionSyntax)
+            .Select(a => Flatten(a.Left))
+            .ToHashSet(StringComparer.Ordinal);
+
+    /// <summary>
+    /// The picker open, on the path where libghostty declines to open one.
+    ///
+    /// The three fields the close reads -- the surface copy, the control it
+    /// was opened on, and the callback field that is the only GC root for the
+    /// delegate whose function pointer goes across -- are assigned before the
+    /// native call, and have to be: a local would be collectable while the
+    /// call is still running. So a null return leaves all three set with no
+    /// picker behind them, and ClosePicker returns on the zero handle before
+    /// it reaches the clears. The window is then holding a raw pointer to a
+    /// surface that whoever owns it may free, plus a strong reference to a
+    /// control and its whole pane subtree, until a later picker succeeds.
+    /// ghostty_surface_list_themes returns null on four separate paths, so
+    /// this is not a branch that needs a fault to reach.
+    /// </summary>
+    [Fact]
+    public void AFailedPickerOpenClearsWhatTheCloseWillNotReach()
+    {
+        var source = ShellSource.Load(MainWindow.File);
+        var statements = source.Method("OnListThemesRequested").Body!.Statements;
+
+        var opened = statements
+            .TakeWhile(s => !s.Calls("NativeMethods.SurfaceListThemes").Any())
+            .Count();
+        Assert.True(
+            opened < statements.Count,
+            "expected OnListThemesRequested to open the picker through "
+            + "NativeMethods.SurfaceListThemes; without that call there is no failure path "
+            + "here and this test would pass while reading nothing");
+
+        // After the call only: the same condition written before it would be
+        // testing the previous picker's handle, which is a different claim.
+        var cleared = statements
+            .Skip(opened + 1)
+            .OfType<IfStatementSyntax>()
+            .Where(guard => TestsPickerHandleAgainstZero(guard.Condition))
+            .Where(guard => guard.Statement.DescendantNodesAndSelf()
+                .OfType<ReturnStatementSyntax>().Any())
+            .Where(guard => ClearedIn(guard.Statement).IsSupersetOf(PickerFields))
+            .ToList();
+
+        Assert.True(
+            cleared.Count == 1,
+            "OnListThemesRequested must clear " + string.Join(", ", PickerFields)
+            + " and return when SurfaceListThemes hands back a zero handle. Nothing else will: "
+            + "ClosePicker bails on the zero handle before it reaches those same clears, so the "
+            + "stale surface pointer and the pane subtree behind _pickerTerminal are held until "
+            + "the next successful picker or the window's close.");
+    }
+
     /// <summary>
     /// ThemePreviewService, the one gap #694 named and did not close.
     ///

--- a/windows/Ghostty.Tests/Wiring/WindowTeardownWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/WindowTeardownWiringTests.cs
@@ -706,14 +706,14 @@ public class WindowTeardownWiringTests
     public void AFailedPickerOpenClearsWhatTheCloseWillNotReach()
     {
         var source = ShellSource.Load(MainWindow.File);
-        var statements = source.Method("OnListThemesRequested").Body!.Statements;
+        var statements = source.Method("ShowInlineThemePicker").Body!.Statements;
 
         var opened = statements
             .TakeWhile(s => !s.Calls("NativeMethods.SurfaceListThemes").Any())
             .Count();
         Assert.True(
             opened < statements.Count,
-            "expected OnListThemesRequested to open the picker through "
+            "expected ShowInlineThemePicker to open the picker through "
             + "NativeMethods.SurfaceListThemes; without that call there is no failure path "
             + "here and this test would pass while reading nothing");
 
@@ -730,35 +730,11 @@ public class WindowTeardownWiringTests
 
         Assert.True(
             cleared.Count == 1,
-            "OnListThemesRequested must clear " + string.Join(", ", PickerFields)
+            "ShowInlineThemePicker must clear " + string.Join(", ", PickerFields)
             + " and return when SurfaceListThemes hands back a zero handle. Nothing else will: "
             + "ClosePicker bails on the zero handle before it reaches those same clears, so the "
             + "stale surface pointer and the pane subtree behind _pickerTerminal are held until "
             + "the next successful picker or the window's close.");
-    }
-
-    /// <summary>
-    /// ThemePreviewService, the one gap #694 named and did not close.
-    ///
-    /// It is not an event source the census can see: it owns a named-pipe
-    /// server running on a background task, and the close only detached the
-    /// window from its ListThemesRequested. The task then ran for the life of
-    /// the process, holding the per-process pipe name with nobody left
-    /// listening to what arrived on it. Disposing cancels the loop, waits for
-    /// it, and drops the subscribers, so the window is neither rooted by it
-    /// nor outlived by it.
-    /// </summary>
-    [Fact]
-    public void TheThemePreviewServiceIsDisposedByTheClose()
-    {
-        var source = ShellSource.Load(MainWindow.File);
-        var statements = source.Method("OnClosedAsync").Body!.Statements;
-
-        var disposed = statements.TakeWhile(s => !s.Calls("_themePreview.Dispose").Any()).Count();
-        Assert.True(
-            disposed < statements.Count,
-            "OnClosedAsync must dispose _themePreview: unsubscribing alone leaves its pipe server "
-            + "task running for the life of the process");
     }
 
     /// <summary>

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -79,6 +79,10 @@ public partial class App : Application
     /// </summary>
     internal Window? SettingsWindow => _settingsWindow;
 
+    // The +list-themes pipe server. One per process, because the pipe name it
+    // claims is per process; see OnLaunched.
+    private Ghostty.Services.ThemePreviewService? _themePreview;
+
     private Ghostty.Session.SessionManager? _sessionManager;
     private Ghostty.Hosting.WindowsGlobalHotKey? _quakeHotKey;
     private Ghostty.Hosting.WindowsSystemMenuHook? _systemMenuHook;
@@ -125,6 +129,28 @@ public partial class App : Application
     internal static void NoteRegularWindowActivated(MainWindow window)
         => LastRegularWindow = window;
 
+    /// <summary>
+    /// A regular window has become able to host process-wide work: its
+    /// XamlRoot is live and it is going into the registry. Called from the
+    /// window's one-shot content Loaded handler.
+    /// </summary>
+    internal static void NoteRegularWindowRegistered(MainWindow window)
+    {
+        if (window.RegisteredRoot is not { } root) return;
+        WindowsByRoot[root] = window;
+
+        // Only now may the +list-themes pipe exist. `wintty +list-themes`
+        // probes for it with File.Exists and counts a successful write as
+        // delivery, never waiting for an answer, so a pipe advertised before
+        // any window can draw a picker makes the CLI exit 0 having done
+        // nothing -- and skips the libghostty TUI picker it falls back to
+        // when it finds no pipe. The service is built in OnLaunched, which
+        // returns before the message loop can raise any window's Loaded, so
+        // construction is always too early to start listening. Start is
+        // idempotent, so every window may say this.
+        (Application.Current as App)?._themePreview?.Start();
+    }
+
     // How many recently-closed tabs / windows the reopen stacks retain.
     private const int ClosedItemCapacity = 25;
 
@@ -140,6 +166,20 @@ public partial class App : Application
     internal static readonly Core.Panes.ClosedStack<Core.Session.WindowSession> ClosedWindows = new(ClosedItemCapacity);
 
     internal static GhosttyHost? BootstrapHost { get; private set; }
+
+    /// <summary>
+    /// Apply a browsed theme's colors, from the process-wide preview
+    /// service. Null before OnLaunched runs; null again once the shutdown's
+    /// finally block has cleared it.
+    /// </summary>
+    // The one verb the inline theme picker needs, rather than the service
+    // itself. A window that can reach the service can also Dispose it, and a
+    // dispose on one window's close ends the accept loop and drops the
+    // subscription for every window still open -- exactly the defect this
+    // ownership move removed, and it would go back in a single line with
+    // every rule in ThemePreviewOwnershipWiringTests still green.
+    internal static Action<string>? ApplyThemePreview { get; private set; }
+
     internal static ConfigService? ConfigService { get; private set; }
     internal static Ghostty.Core.Profiles.IProfileRegistry? ProfileRegistry { get; private set; }
     internal static Ghostty.Session.SessionManager? SessionManager { get; private set; }
@@ -726,6 +766,25 @@ public partial class App : Application
         // the teardown below can take them back.
         _bootstrapHost.OpenConfigRequested += OnAppOpenConfigRequested;
         _bootstrapHost.ReloadConfigRequested += OnAppReloadConfigRequested;
+
+        // The +list-themes server, one for the process. The pipe name it
+        // claims carries the process id and it is created with
+        // FirstPipeInstance, so a second service in this process cannot open
+        // the pipe at all: it stood down at construction and never came back.
+        // A service per window therefore meant only the first window served
+        // `wintty +list-themes`, and closing that window released the name
+        // without anything reclaiming it, leaving the rest of the session with
+        // no server for the CLI to find. Constructed unconditionally and
+        // subscribed to a named method, so the shutdown can take it back.
+        // Built here but not started here: NoteRegularWindowRegistered opens
+        // the pipe, because the pipe is what the CLI reads as "a window is
+        // ready to show you a picker".
+        _themePreview = new Ghostty.Services.ThemePreviewService(
+            _configService,
+            DispatcherQueue.GetForCurrentThread(),
+            factory.CreateLogger<Ghostty.Services.ThemePreviewService>());
+        _themePreview.ListThemesRequested += OnAppListThemesRequested;
+        ApplyThemePreview = _themePreview.ApplyThemePreview;
 
         // App-level: High Contrast is a system-wide state and config is
         // applied app-wide, so a single monitor drives the surface override.
@@ -1443,6 +1502,32 @@ public partial class App : Application
         _configService?.Reload();
 
     /// <summary>
+    /// A LIST_THEMES arriving on the preview pipe. The picker is drawn by
+    /// libghostty into a surface, so it needs a window even though the
+    /// request is process-wide: it goes to the one the user was last in,
+    /// skipping any window whose close has started, because its surfaces are
+    /// on their way out. The predicate also refuses the quake window, which
+    /// the shell never registers and never records as last-activated -- that
+    /// half is a backstop for a helper in Core that cannot see either fact.
+    /// ThemePreviewService raises this on the UI thread.
+    /// </summary>
+    private void OnAppListThemesRequested(object? sender, EventArgs e)
+    {
+        var target = Ghostty.Core.Windows.ActiveWindowTarget.Choose(
+            LastRegularWindow, AllWindows, w => !w.IsQuickTerminal && !w.IsClosing);
+        if (target is null)
+        {
+            // Every window is closing. Nothing to draw the picker on, and
+            // the CLI already wrote its line and moved on, so there is
+            // nobody to tell.
+            Ghostty.Logging.StaticLoggers.App.LogNoWindowForThemePicker();
+            return;
+        }
+
+        target.ShowInlineThemePicker();
+    }
+
+    /// <summary>
     /// Show the app-wide settings window, or focus the existing one if it is
     /// already open. One settings window serves the whole process, so opening
     /// it from any window reuses the same instance. The caller guards on
@@ -1707,6 +1792,17 @@ public partial class App : Application
                 // a native access violation (issue #208 switch-then-close).
                 _configService.BeginShutdown();
 
+                // Same reason, one line down: the preview pipe server runs on
+                // a background task and can still enqueue a picker onto a
+                // window that is already tearing down. Detach first so a
+                // LIST_THEMES that beat the cancel finds no handler, then
+                // dispose, which cancels the accept loop and waits for it.
+                if (_themePreview is not null)
+                {
+                    _themePreview.ListThemesRequested -= OnAppListThemesRequested;
+                    _themePreview.Dispose();
+                }
+
                 // Stop the process tracker before any tab teardown could
                 // race its Timer callback. Dispose unsubscribes the
                 // Changed handler in addition to cancelling the timer,
@@ -1871,6 +1967,8 @@ public partial class App : Application
                 NotificationService = null;
                 _configEditor = null;
                 ConfigFileEditor = null;
+                _themePreview = null;
+                ApplyThemePreview = null;
                 _bootstrapHost = null;
                 BootstrapHost = null;
                 _lifetimeSupervisor = null;
@@ -1929,6 +2027,11 @@ internal static partial class AppLogExtensions
                    Message = "Failed to open config file {ConfigPath}")]
     internal static partial void LogConfigOpenFailed(
         this ILogger<App> logger, System.Exception ex, string configPath);
+
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.ThemePreview.NoWindowForThemePicker,
+                   Level = LogLevel.Debug,
+                   Message = "LIST_THEMES arrived with no window able to host the picker")]
+    internal static partial void LogNoWindowForThemePicker(this ILogger<App> logger);
 
     [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Startup.StaleAumidRemoved,
                    Level = LogLevel.Information,

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -660,6 +660,20 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     /// glow.</summary>
     public event EventHandler? FirstRender;
 
+    /// <summary>Raised from <see cref="DisposeSurface"/> while the surface is
+    /// still valid, for holders of native state keyed on this control's
+    /// surface pointer -- the window's inline theme picker keeps input,
+    /// scroll and resize redirects installed on it, and handing those back
+    /// writes through the pointer.
+    ///
+    /// Nothing at the tab level can serve them: TabManager.CloseTab frees the
+    /// tab's leaves before it announces the tab is gone, so a TabRemoved
+    /// subscriber already holds a dangling pointer by the time it runs.
+    ///
+    /// Fires at most once per control, and never for a control whose surface
+    /// was never created.</summary>
+    internal event EventHandler? SurfaceDisposing;
+
     // Distance the search bar floats from the terminal's top-right, on
     // top of whatever gutter the pane chrome reserves.
     private const double SearchBarInset = 8;
@@ -1011,6 +1025,33 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         if (_surfaceDisposed) return;
         _surfaceDisposed = true;
 
+        // Tell the holders of surface-keyed native state first, while nothing
+        // has been unwound yet: what they have to hand back is written through
+        // this surface pointer, so after SurfaceFree below there is no safe
+        // moment left. The latch above is what makes this fire exactly once,
+        // and the handle check is what keeps it from firing for a control
+        // whose surface was never created -- there is nothing installed on a
+        // surface that does not exist, and a subscriber told about one would
+        // be comparing its saved pointer against a zero handle.
+        if (_surface.Handle != IntPtr.Zero)
+        {
+            try
+            {
+                SurfaceDisposing?.Invoke(this, EventArgs.Empty);
+            }
+            catch (Exception ex)
+            {
+                // Swallowed on purpose. Everything below this point frees
+                // native memory, and PaneHost walks the leaves in a loop, so
+                // an escaping exception would strand this surface and skip
+                // every leaf after it. A subscriber that failed to clean up
+                // after itself is a smaller problem than a teardown that
+                // stops half way, so log it and keep tearing down.
+                Ghostty.Logging.StaticLoggers.App.LogWarning(
+                    "SurfaceDisposing subscriber threw during teardown: {Message}", ex.Message);
+            }
+        }
+
         _bellAudio?.Dispose();
         _bellAudio = null;
 
@@ -1047,6 +1088,9 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         FirstRender = null;
         BellRang = null;
         BellAcknowledged = null;
+        // Already raised above; dropping it here is for a subscriber that did
+        // not detach itself in its handler.
+        SurfaceDisposing = null;
     }
 
     private static IntPtr AllocEmptyUtf8()

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -781,6 +781,11 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         // Surface creation runs exactly once per control instance,
         // even across multiple reparents. Subsequent Loaded events
         // skip this entire block.
+        //
+        // MainWindow's picker cleanup leans on that: comparing SurfaceHandle
+        // against the pointer it saved only proves reachability while a
+        // control's handle can be that pointer or zero and never a recycled
+        // third one.
         if (_surfaceCreated) return;
         _surfaceCreated = true;
 

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -802,8 +802,11 @@ internal static partial class NativeMethods
 
     // ---- inline theme picker ---------------------------------------------
 
-    // Callback for the inline theme picker. Fired from the Zig/apprt
-    // thread for each preview/confirm event.
+    // Callback for the inline theme picker, fired for each preview/confirm
+    // event. Synchronous, on the calling thread: the picker only ever runs
+    // from the surface's input and scroll redirects, so this arrives inside
+    // the key or scroll call the embedder made -- the UI thread, not an
+    // apprt one.
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate void InlineThemeCallback(IntPtr namePtr, byte confirmed);
 

--- a/windows/Ghostty/Logging/LogEvents.cs
+++ b/windows/Ghostty/Logging/LogEvents.cs
@@ -41,6 +41,7 @@ internal static class LogEvents
         public const int PipeError         = 2204;
         public const int InvalidThemeName  = 2205;
         public const int PipeServerUnavailable = 2206;
+        public const int NoWindowForThemePicker = 2207;
     }
 
     // 2300-2399: WindowState + migration

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -3866,13 +3866,13 @@ public sealed partial class MainWindow : Window
     private IntPtr _pickerHandle;
 
     /// <summary>
-    /// The control and tab the picker's surface belongs to.
+    /// The control whose surface the picker was opened on.
     /// <see cref="_pickerSurface"/> is a copy of a raw pointer and nothing
-    /// zeroes it when that surface is freed, so these are what make the
-    /// liveness check in <see cref="ClosePicker"/> possible.
+    /// zeroes it when that surface is freed, so this is what makes the
+    /// liveness check in <see cref="ClosePicker"/> possible: the control
+    /// clears its own handle on disposal.
     /// </summary>
     private Ghostty.Controls.TerminalControl? _pickerTerminal;
-    private Ghostty.Core.Tabs.TabModel? _pickerTab;
     // Held rather than left local to StartPickerPoll: the dispatcher drives
     // the poll, so the window's teardown has no other way to reach it.
     private Microsoft.UI.Dispatching.DispatcherQueueTimer? _pickerPoll;
@@ -3895,7 +3895,6 @@ public sealed partial class MainWindow : Window
 
         _pickerSurface = new GhosttySurface(surfaceHandle);
         _pickerTerminal = terminal;
-        _pickerTab = _tabManager.ActiveTab;
 
         // Theme callback: apply preview/confirm colors on the UI thread.
         _inlineThemeCb = (namePtr, confirmed) =>
@@ -3905,9 +3904,14 @@ public sealed partial class MainWindow : Window
                 var name = Marshal.PtrToStringUTF8(namePtr);
                 if (name is null) return;
 
-                // The callback fires from the Zig/apprt thread. Dispatch
-                // to the UI thread so ConfigService and ShellThemeService
-                // updates happen on the right thread.
+                // Not a thread hop: the picker calls this synchronously from
+                // the surface's input and scroll redirects, so it arrives
+                // inside the key or scroll call the terminal control made,
+                // on the UI thread. The enqueue earns its place for the
+                // other reason -- it keeps ConfigService and
+                // ShellThemeService off the stack of a native input
+                // callback, rather than re-entering libghostty while it is
+                // still handling the key that got us here.
                 DispatcherQueue.TryEnqueue(() =>
                 {
                     _themePreview.ApplyThemePreview(name);
@@ -3918,18 +3922,33 @@ public sealed partial class MainWindow : Window
         var cbPtr = Marshal.GetFunctionPointerForDelegate(_inlineThemeCb);
 
         _pickerHandle = NativeMethods.SurfaceListThemes(_pickerSurface, cbPtr);
+        if (_pickerHandle == IntPtr.Zero)
+        {
+            // No picker was installed -- no redirects, no allocation -- so
+            // there is nothing to hand back and ClosePicker returns on the
+            // zero handle before it reaches the clears below. Without this
+            // the window keeps a raw copy of a surface pointer that whoever
+            // owns that surface is free to release, and a strong reference
+            // to the control and its whole pane subtree, until some later
+            // picker opens or the window dies.
+            _pickerSurface = default;
+            _pickerTerminal = null;
+            _inlineThemeCb = null;
+            return;
+        }
+
         // Picker is now active. handleKey fires on each key event and
         // sets should_quit when the user confirms/cancels. We poll on
         // a timer to clean up, avoiding a thread that races with the
         // input redirect callback.
-        if (_pickerHandle != IntPtr.Zero)
-            StartPickerPoll();
+        StartPickerPoll();
     }
 
     private void StartPickerPoll()
     {
-        // Use a DispatcherQueue timer so cleanup runs on the UI thread
-        // with no race against the apprt thread's input redirect.
+        // A DispatcherQueue timer rather than a polling thread, so the
+        // cleanup lands on the same thread the input redirect runs the
+        // picker from and cannot tear it down mid-keystroke.
         //
         // One poll at a time: a second picker replaces _pickerHandle, and a
         // leftover timer would then be polling the new picker and could run
@@ -4000,25 +4019,30 @@ public sealed partial class MainWindow : Window
         // frees the surface without touching anything here.
         //
         // The control zeroes its own handle when it disposes the surface, so
-        // a mismatch means the surface is gone. The tab check answers the
-        // other direction: a detached tab carries its live surface to another
-        // window, and deiniting from here would strip the redirects of a
-        // window that never closed.
+        // a mismatch means the surface is gone and nothing can reach the
+        // picker any more. That is the only case where skipping is right, and
+        // it strands the picker allocation, which is what happened before this
+        // path existed at all. Leaking it beats writing through a dangling
+        // pointer.
         //
-        // When neither holds, the picker allocation is stranded, which is
-        // what happened before this path existed at all. Leaking it is the
-        // right trade against writing through a dangling pointer.
+        // Deliberately NOT conditioned on the tab still being ours. A detached
+        // tab carries its live surface to another window with this picker's
+        // input, scroll and resize redirects still installed on it, and this
+        // deinit is the only thing that clears them or frees the picker. Not
+        // running it leaves that window wedged in the picker's alt screen with
+        // its input redirected, and drops the last GC root for the delegate
+        // whose function pointer the picker still holds, so the next keystroke
+        // there is a callback on a collected delegate, which kills the process
+        // rather than throwing. Cleaning up after our own picker is a repair
+        // for that window, not damage to it.
         var live = _pickerTerminal is { } terminal
-            && terminal.SurfaceHandle == _pickerSurface.Handle
-            && _pickerTab is { } tab
-            && _tabManager.Tabs.Contains(tab);
+            && terminal.SurfaceHandle == _pickerSurface.Handle;
         if (live)
             NativeMethods.SurfaceListThemesDeinit(_pickerSurface, _pickerHandle);
 
         _pickerHandle = IntPtr.Zero;
         _pickerSurface = default;
         _pickerTerminal = null;
-        _pickerTab = null;
         _inlineThemeCb = null;
     }
 }

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -137,7 +137,6 @@ public sealed partial class MainWindow : Window
     private readonly TabBellAnnouncer _bellAnnouncer;
     private readonly WindowThemeManager _themeManager;
     private readonly ShellThemeService _shellTheme;
-    private readonly ThemePreviewService _themePreview;
 
     // Set at the top of OnClosedAsync. Theme callbacks route through the
     // dispatcher, so a switch-then-close can leave an ApplyTheme queued to
@@ -280,6 +279,13 @@ public sealed partial class MainWindow : Window
     /// </summary>
     internal bool IsQuickTerminal { get; }
 
+    /// <summary>
+    /// True once this window's close has started. Process-wide services that
+    /// route work to a window read this so they do not pick one whose panes
+    /// and surfaces are already being torn down.
+    /// </summary>
+    internal bool IsClosing => _isClosed;
+
     internal MainWindow(
         ConfigService configService,
         GhosttyHost bootstrapHost,
@@ -321,8 +327,7 @@ public sealed partial class MainWindow : Window
     /// shared-app ctor. <paramref name="loggerFactory"/> is the
     /// process-wide factory built in App.OnLaunched; MainWindow holds
     /// it to construct loggers for the per-window components it owns
-    /// (GhosttyHost's clipboard trio, TaskbarHost, AcrylicBackdrop,
-    /// ThemePreviewService).
+    /// (GhosttyHost's clipboard trio, TaskbarHost, AcrylicBackdrop).
     /// </summary>
     private MainWindow(
         ConfigService configService,
@@ -431,7 +436,10 @@ public sealed partial class MainWindow : Window
                 RegisteredRoot = fe.XamlRoot;
                 if (RegisteredRoot != null)
                 {
-                    App.WindowsByRoot[RegisteredRoot] = this;
+                    // App does the insert, because registering is also the
+                    // moment process-wide services may start acting on a
+                    // window and only App knows which those are.
+                    App.NoteRegularWindowRegistered(this);
                 }
             }
         }
@@ -509,11 +517,10 @@ public sealed partial class MainWindow : Window
 
         _shellTheme = new ShellThemeService(configService);
         _shellTheme.ThemeChanged += OnShellThemeChanged;
-        _themePreview = new ThemePreviewService(
-            configService,
-            DispatcherQueue,
-            loggerFactory.CreateLogger<ThemePreviewService>());
-        _themePreview.ListThemesRequested += OnListThemesRequested;
+
+        // The +list-themes pipe server is process-wide, not per window: its
+        // pipe name is per process. App owns the one service and routes the
+        // request here; see App.OnLaunched.
 
         _factory = new PaneHostFactory(_host, configService);
         // Restore a saved session into this window when one was passed and
@@ -1435,25 +1442,6 @@ public sealed partial class MainWindow : Window
         // toggle during teardown puts AppSetColorScheme through the app
         // pointer _host.Dispose is about to free at the end of this method.
         _systemUiSettings.ColorValuesChanged -= OnSystemColorValuesChanged;
-        // The preview service owns a named-pipe server on a background task,
-        // so it raises this from outside the window's own lifetime. Detaching
-        // keeps a LIST_THEMES arriving afterwards from starting a picker on a
-        // window whose surfaces are gone; disposing is what ends the task,
-        // which otherwise ran for the life of the process, holding the
-        // per-process pipe name with nobody listening on it. The cancel is
-        // observed by the awaits inside the accept loop, so the synchronous
-        // wait here is bounded.
-        //
-        // The service is per window and the pipe name is per process, so in a
-        // multi-window session only the first one to start ever owns the pipe
-        // (FirstPipeInstance stands the others down at construction). Closing
-        // that window therefore leaves the session with no server rather than
-        // with one whose only subscriber has detached. Both states are broken
-        // for `+list-themes`; this one at least does not leak. The real fix is
-        // to own the service where the bootstrap host lives, the same shape as
-        // the app-targeted config actions, which App owns for that reason.
-        _themePreview.ListThemesRequested -= OnListThemesRequested;
-        _themePreview.Dispose();
 
         // CompositionTarget.Rendering is static, so a window closed before
         // its first composed frame would otherwise stay subscribed.
@@ -3877,8 +3865,19 @@ public sealed partial class MainWindow : Window
     // the poll, so the window's teardown has no other way to reach it.
     private Microsoft.UI.Dispatching.DispatcherQueueTimer? _pickerPoll;
 
-    private void OnListThemesRequested(object? sender, EventArgs e)
+    /// <summary>
+    /// Open the inline theme picker on this window's active surface. Called
+    /// by App when a LIST_THEMES arrives on the preview pipe; App picks the
+    /// window. UI thread only.
+    /// </summary>
+    internal void ShowInlineThemePicker()
     {
+        // App filters closing windows out of the routing, but the request
+        // crosses a thread hop to get here, so one enqueued before this
+        // window's close is delivered after it -- and every surface the
+        // picker would install itself into is already freed by then.
+        if (_isClosed) return;
+
         var leaf = _tabManager.ActiveTab?.PaneHost?.ActiveLeaf;
         if (leaf is null) return;
 
@@ -3914,7 +3913,14 @@ public sealed partial class MainWindow : Window
                 // still handling the key that got us here.
                 DispatcherQueue.TryEnqueue(() =>
                 {
-                    _themePreview.ApplyThemePreview(name);
+                    // Null until OnLaunched builds the service and again
+                    // once the shutdown's finally block clears it; a picker
+                    // keystroke in flight across this dispatch can land in
+                    // either gap. Non-null is not proof the service is still
+                    // live -- the shutdown disposes it well before that
+                    // clearing -- but applying colors after the dispose is
+                    // fenced off by ConfigService's own shutdown flag.
+                    Ghostty.App.ApplyThemePreview?.Invoke(name);
                 });
             }
             catch { }

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -3943,11 +3943,40 @@ public sealed partial class MainWindow : Window
             return;
         }
 
+        // The only warning that this surface is about to go. Closing the
+        // picker's tab frees its leaves before it announces the tab is gone,
+        // so nothing tab-level runs early enough: by then the deinit below
+        // can no longer run, and the picker allocation, its theme arena, the
+        // 50ms poll and the control's whole visual subtree are stranded for
+        // the life of the window.
+        //
+        // Taken out after the open succeeds, not alongside the field
+        // assignments above, so the single detach in ClosePicker is enough: a
+        // subscription then only ever exists while _pickerHandle is non-zero,
+        // which is exactly when ClosePicker runs past its early return.
+        terminal.SurfaceDisposing += OnPickerSurfaceDisposing;
+
         // Picker is now active. handleKey fires on each key event and
         // sets should_quit when the user confirms/cancels. We poll on
         // a timer to clean up, avoiding a thread that races with the
         // input redirect callback.
         StartPickerPoll();
+    }
+
+    /// <summary>
+    /// The surface the picker is installed on is being freed. Close the picker
+    /// now, while the deinit can still reach it: this runs above
+    /// <c>SurfaceFree</c>, so the redirects come off and the allocation comes
+    /// back instead of being stranded.
+    /// </summary>
+    private void OnPickerSurfaceDisposing(object? sender, EventArgs e)
+    {
+        // Act on the control this picker was opened on, never on whatever
+        // raised the event: a stale subscription -- one taken out for a picker
+        // that has since been replaced -- must not tear down the current one.
+        if (!ReferenceEquals(sender, _pickerTerminal)) return;
+
+        ClosePicker();
     }
 
     private void StartPickerPoll()
@@ -4021,8 +4050,12 @@ public sealed partial class MainWindow : Window
         // A non-zero handle does not mean the surface behind it is still
         // there. Deinit writes through that pointer -- it clears three
         // redirects and pushes pty input -- so running it against a freed
-        // surface is a write into freed memory, and closing the picker's tab
-        // frees the surface without touching anything here.
+        // surface is a write into freed memory.
+        //
+        // The control now says so before it frees anything, which is what
+        // gets a tab close here while the deinit still means something. The
+        // mismatch below is the residual case: any path that reaches the free
+        // without this window being told.
         //
         // The control zeroes its own handle when it disposes the surface, so
         // a mismatch means the surface is gone and nothing can reach the
@@ -4041,12 +4074,30 @@ public sealed partial class MainWindow : Window
         // there is a callback on a collected delegate, which kills the process
         // rather than throwing. Cleaning up after our own picker is a repair
         // for that window, not damage to it.
-        var live = _pickerTerminal is { } terminal
-            && terminal.SurfaceHandle == _pickerSurface.Handle;
-        if (live)
-            NativeMethods.SurfaceListThemesDeinit(_pickerSurface, _pickerHandle);
-
+        //
+        // Ownership of the picker leaves this window here, before the deinit
+        // rather than after it. The native side only checks the pointer is
+        // non-null and then destroys the allocation, so it is not idempotent,
+        // and a second call through a handle the field was still holding is a
+        // double free. Anything that re-entered ClosePicker while the deinit
+        // was running would find a zero handle and turn back at the early
+        // return above instead.
+        var handle = _pickerHandle;
         _pickerHandle = IntPtr.Zero;
+
+        if (_pickerTerminal is { } terminal)
+        {
+            // Taken back here rather than left to the control to null when it
+            // disposes, because the control can outlive this window: a
+            // detached tab carries it to another window, and a subscription
+            // left on it would keep this closed window reachable from a
+            // control it no longer owns.
+            terminal.SurfaceDisposing -= OnPickerSurfaceDisposing;
+
+            if (terminal.SurfaceHandle == _pickerSurface.Handle)
+                NativeMethods.SurfaceListThemesDeinit(_pickerSurface, handle);
+        }
+
         _pickerSurface = default;
         _pickerTerminal = null;
         _inlineThemeCb = null;

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -998,6 +998,13 @@ internal sealed partial class ConfigService : IConfigService, Ghostty.Core.Profi
     /// </summary>
     internal void ApplyThemeColors(uint fg, uint bg, uint? cursor, uint? cursorText, uint[] palette)
     {
+        // The same fence Reload takes, for the same reason. The preview
+        // service reaches this from its pipe thread through TryEnqueue, so a
+        // preview or a revert enqueued just before teardown is pumped after
+        // it, and the fan-out below hands every subscriber a config the
+        // shutdown is already unwinding.
+        if (_shuttingDown) return;
+
         ForegroundColor = fg;
         BackgroundColor = bg;
         CursorColor = cursor ?? fg;

--- a/windows/Ghostty/Services/ThemePreviewService.cs
+++ b/windows/Ghostty/Services/ThemePreviewService.cs
@@ -22,7 +22,7 @@ namespace Ghostty.Services;
 ///   "CONFIRM:ThemeName\n"  -- user accepted the theme
 ///   (pipe closed)          -- user cancelled, revert to original
 /// </summary>
-internal sealed partial class ThemePreviewService : IAsyncDisposable, IDisposable
+internal sealed partial class ThemePreviewService : IDisposable
 {
     // Path.GetInvalidFileNameChars() allocates a fresh char[] on each
     // call (defensive copy); SearchValues caches the set once and picks
@@ -35,6 +35,7 @@ internal sealed partial class ThemePreviewService : IAsyncDisposable, IDisposabl
     private readonly ILogger<ThemePreviewService> _logger;
     private readonly CancellationTokenSource _cts = new();
     private Task? _serverTask;
+    private bool _disposed;
 
     /// <summary>
     /// Raised on the UI thread when a CLI process sends LIST_THEMES
@@ -58,31 +59,66 @@ internal sealed partial class ThemePreviewService : IAsyncDisposable, IDisposabl
         _configService = configService;
         _dispatcher = dispatcher;
         _logger = logger;
+    }
+
+    /// <summary>
+    /// Begin serving the pipe. Idempotent, and a no-op once
+    /// <see cref="Dispose"/> has run. UI thread only, like every other
+    /// call into this service from the shell.
+    /// </summary>
+    // Separate from construction because the pipe's existence is the
+    // readiness signal the CLI reads: `wintty +list-themes` probes for
+    // \\.\pipe\ghostty-theme-preview-{pid} with File.Exists, and treats a
+    // successful write to it as delivery -- it never waits for an answer. So
+    // a pipe opened before any window is able to draw a picker turns the
+    // CLI's fallback (libghostty's own TUI picker, which it runs when it
+    // finds no pipe) into a silent exit 0 that does nothing at all. The
+    // caller starts this when the first window registers.
+    internal void Start()
+    {
+        if (_disposed || _serverTask is not null) return;
         _serverTask = Task.Run(() => RunServer(_cts.Token));
     }
 
-    public async ValueTask DisposeAsync()
-    {
-        _cts.Cancel();
-        if (_serverTask is not null)
-        {
-            try { await _serverTask; }
-            catch (OperationCanceledException) { }
-            catch (Exception) { /* server loop handles its own errors */ }
-        }
-        _cts.Dispose();
-    }
-
+    /// <summary>
+    /// Ends the accept loop and drops subscribers. Called once, from the
+    /// process shutdown that runs after the last window closes.
+    /// </summary>
+    // Synchronous, and there is no DisposeAsync to prefer: the shutdown that
+    // calls this is a `void` event handler with nothing to await it, so an
+    // async variant would have had no caller able to use it.
+    //
+    // Waiting on the server task from the UI thread cannot deadlock. Every
+    // await in the loop -- WaitForConnectionAsync, ReadLineAsync, the backoff
+    // Delay -- takes the token, so the cancel below completes all three, and
+    // each is ConfigureAwait(false), so no continuation wants the thread that
+    // is blocked here. The loop also hands UI work over with TryEnqueue and
+    // does not wait for it.
+    //
+    // Bounded, but not instantly: the token reaches none of the synchronous
+    // work between those awaits, and the long piece of it is reading the
+    // theme file (File.Exists plus ParseThemeFile's File.ReadLines) for a
+    // PREVIEW that arrived just before the cancel. That is one small file
+    // from the config directory, which can be a redirected or UNC path, so
+    // the real bound is a file read that may have to time out. A timeout on
+    // the wait would not improve on that: it would return with the accept
+    // loop still running into the state this shutdown is freeing.
     public void Dispose()
     {
+        // Callers get a Dispose that can be called twice, per the BCL
+        // contract. Without this the second call cancels a disposed
+        // CancellationTokenSource and throws ObjectDisposedException.
+        if (_disposed) return;
+        _disposed = true;
+
         _cts.Cancel();
-        // Best-effort synchronous wait -- prefer DisposeAsync.
         try { _serverTask?.GetAwaiter().GetResult(); }
         catch { /* expected OCE or pipe error */ }
         _cts.Dispose();
 
-        // Drop subscribers so MainWindow is not rooted via this event
-        // after the service tears down at window-close.
+        // Drop subscribers. The loop is over by now, but the event is a root
+        // like any other and this service is only ever disposed on the way out
+        // of the process.
         ListThemesRequested = null;
     }
 
@@ -97,14 +133,14 @@ internal sealed partial class ThemePreviewService : IAsyncDisposable, IDisposabl
     {
         while (!ct.IsCancellationRequested)
         {
-            var outcome = await RunOneServerSession(ct);
+            var outcome = await RunOneServerSession(ct).ConfigureAwait(false);
             switch (_retryPolicy.Decide(outcome))
             {
                 case PipeLoopDecision.Stop:
                 case PipeLoopDecision.StandDown:
                     return;
                 case PipeLoopDecision.RetryAfterBackoff:
-                    try { await Task.Delay(_retryPolicy.Backoff, ct); }
+                    try { await Task.Delay(_retryPolicy.Backoff, ct).ConfigureAwait(false); }
                     catch (OperationCanceledException) { return; }
                     break;
                 case PipeLoopDecision.RetryImmediately:
@@ -116,17 +152,18 @@ internal sealed partial class ThemePreviewService : IAsyncDisposable, IDisposabl
 
     /// <summary>
     /// Runs one accept-serve cycle of the named-pipe server and classifies
-    /// how it ended. Never throws (cancellation and I/O faults are mapped to
-    /// outcomes); the caller's policy decides whether to retry, back off, or
-    /// stand down.
+    /// how it ended. Never throws -- cancellation and every fault, from
+    /// creating the server through serving it, are mapped to outcomes; the
+    /// caller's policy decides whether to retry, back off, or stand down.
     /// </summary>
     private async Task<PipeLoopOutcome> RunOneServerSession(CancellationToken ct)
     {
-        // Creating the server is its own failure mode. With FirstPipeInstance
-        // + a per-process PipeName, the ctor throws "All pipe instances are
-        // busy" when another ThemePreviewService in this process already owns
-        // the name -- permanent for this loop, so the policy stands it down
-        // rather than retrying.
+        // Creating the server is its own failure mode. FirstPipeInstance is
+        // what makes the name exclusive, so the ctor throws "All pipe
+        // instances are busy" when anything else already holds it -- another
+        // process squatting the name, or a handle from this process that has
+        // not been released yet. Neither clears by retrying on this loop, so
+        // the policy stands it down rather than spinning.
         NamedPipeServerStream server;
         try
         {
@@ -142,13 +179,28 @@ internal sealed partial class ThemePreviewService : IAsyncDisposable, IDisposabl
             _logger.LogPipeServerUnavailable(ex);
             return PipeLoopOutcome.ServerCreationFailed;
         }
+        catch (Exception ex)
+        {
+            // Everything else the ctor can raise -- an ACL that denies the
+            // create, a disposal race during teardown, an allocation failure
+            // -- is a creation failure too, and this try sits outside the
+            // broad catch below, so without this it escapes into the
+            // fire-and-forget server task instead. A faulted task there is
+            // silent: nothing observes it, .NET Core no longer tears the
+            // process down for it, and +list-themes is dead for the rest of
+            // the session with nothing in the log to say why. Logged through
+            // the general pipe-error message rather than the stand-down one,
+            // which describes the collision case and would misreport this.
+            _logger.LogPipeError(ex);
+            return PipeLoopOutcome.ServerCreationFailed;
+        }
 
         try
         {
             using (server)
             {
                 _logger.LogPipeWaiting(PipeName);
-                await server.WaitForConnectionAsync(ct);
+                await server.WaitForConnectionAsync(ct).ConfigureAwait(false);
                 _logger.LogClientConnected();
 
                 // Snapshot current colors for revert on cancel.
@@ -159,7 +211,7 @@ internal sealed partial class ThemePreviewService : IAsyncDisposable, IDisposabl
 
                 while (!ct.IsCancellationRequested)
                 {
-                    var line = await reader.ReadLineAsync(ct);
+                    var line = await reader.ReadLineAsync(ct).ConfigureAwait(false);
                     if (line is null) break; // pipe closed
 
                     if (line == "LIST_THEMES")

--- a/windows/docs/logging.md
+++ b/windows/docs/logging.md
@@ -79,7 +79,7 @@ at the message text.
 | 1100-1199 | FrecencyStore (command palette history) |
 | 2000-2099 | Startup (AUMID, jump list) |
 | 2100-2199 | Clipboard (backend + bridge + confirm dialog) |
-| 2200-2299 | ThemePreviewService |
+| 2200-2299 | Theme preview (pipe server, picker routing) |
 | 2300-2399 | WindowState + WindowStateMigration |
 | 2400-2499 | Shell (taskbar host, backdrop) |
 | 2500-2599 | MainWindow |


### PR DESCRIPTION
The sync series-v2 merge (ec7cc4ec9) has parents 400f3036a (the windows tip of the time) and 8867c37c5 (pure upstream, with no windows/ directory at all). A three-way merge of those trees could not have changed any windows/ file, since the upstream side contributed nothing there. Instead the merge rewrote 59 windows/ files with 2463 deletions, hand-resolving windows/ to a snapshot from before three already-merged PRs:

- #705 "windows: clean up after the theme picker even when its tab has moved" (527c28c5e)
- #729 "app: own the theme preview server on App, and route it to the active window" (f84f56614)
- #742 "windows: close the theme picker when the surface under it is freed" (400f3036a)

This branch cherry-picks those three commits back on top of the current windows tip (bd48bb72c), in that order. All three applied cleanly, one diff each, no conflicts; commit messages are the originals.

What came back:

- windows/Ghostty/App.xaml.cs: App-level theme preview ownership (ThemePreviewService on App, ApplyThemePreview). The merge had reverted the blob to the pre-#729 state (e2085c6ef became 00bc98995).
- windows/Ghostty.Core/Windows/ActiveWindowTarget.cs: deleted at the merge tip, restored, plus its tests.
- windows/Ghostty.Tests/Windows/ActiveWindowTargetTests.cs: deleted at the merge tip, restored.
- windows/Ghostty.Tests/Wiring/ThemePreviewOwnershipWiringTests.cs: deleted at the merge tip, restored.
- windows/Ghostty/Controls/TerminalControl.xaml.cs: the SurfaceDisposing event from #742 and the liveness comment from #705, after the merge reverted the blob to pre-#705 (c5d984a47 became 9a3355cd1).
- windows/Ghostty/MainWindow.xaml.cs: the picker cleanup from #705/#729 and the picker-close-on-surface-dispose handler from #742.
- WindowTeardownWiringTests.cs, PaletteSelectionWiringTests.cs, the NativeMethods.cs picker-callback comment, ThemePreviewService.cs, ConfigService.cs, LogEvents.cs, windows/docs/logging.md: the rest of the three diffs.

The sync merge's own work is untouched: the kitty clipboard C ABI rework in NativeMethods.cs and everything else it brought is byte-identical to the merge tip. The only NativeMethods delta versus the pre-merge windows tip 400f3036a is the clipboard ABI itself plus #705's comment reword, which auto-merged around it.

Left exactly as the merge left them, pending your call:

- the VerticalTabStrip.xaml.cs placement fix that arrived with the merge (the unmerged feat/folder-tab-seam fragment): blob identical to the windows tip.
- the fuzz scripts the merge added.

Verification: every restored file is byte-identical (same git blob) to the pre-merge windows tip 400f3036a, except NativeMethods.cs where the clipboard C ABI rework is kept and #705's comment change sits on top. The branch diff versus the windows tip is exactly the union of the three PR diffs: 13 files, 1651 insertions, 124 deletions.

Signoff: windows-tests PASS recorded for head f830c691b (Ghostty.Tests 2405 passed, 0 failed, 1 skipped; Ghostty.Tests.Windows 44 passed, 0 failed, 12 skipped). Run on the Windows host, since `just test-win` is a [windows]-host recipe and the mac has no .NET 10 SDK; the scoped plan was identical on both hosts (1 leg, windows-tests, 13 paths).

Size-override: mechanical restoration. This cherry-picks three already-reviewed, already-merged PRs (#705, #729, #742) that sync merge ec7cc4ec9 silently reverted; every restored file is the same git blob as its pre-revert state at 400f3036a, so the bulk is un-modification, not new review surface. Two exceptions, both benign tip-side kitty-clipboard coexistence: NativeMethods.cs (ABI rework plus #705 comment reword) and LogEvents.cs (two additive clipboard constants 2107 and 2108; #729 constant 2207 restored intact). Filed as #774.