### PR TITLE
tests: restore #741, the fourth PR the sync series-v2 merge reverted

### DIFF
--- a/windows/Ghostty.Core/Profiles/IProcessRunner.cs
+++ b/windows/Ghostty.Core/Profiles/IProcessRunner.cs
@@ -5,14 +5,32 @@ using System.Threading.Tasks;
 namespace Ghostty.Core.Profiles;
 
 /// <summary>
-/// Result of running an external process. ExitCode is -1 if the
-/// process did not start (e.g. file not found).
+/// How a process run ended. ExitCode alone cannot tell "never spawned"
+/// apart from "spawned and was killed on timeout" -- both report -1 --
+/// which lets a machine where nothing can spawn look identical to a
+/// machine where the subject merely timed out.
+/// </summary>
+public enum ProcessOutcome
+{
+    Exited,       // Ran to completion; ExitCode is the child's own.
+    DidNotStart,  // Never spawned: file not found, not executable.
+    TimedOut,     // Spawned, then killed when the timeout elapsed.
+    Canceled,     // Spawned, then killed because the caller's token fired.
+}
+
+/// <summary>
+/// Result of running an external process. ExitCode is -1 for every ending
+/// but Exited, so callers that only read it are unaffected; Outcome says
+/// which ending it was. Canceled is separate from TimedOut because a
+/// pipeline that abandons its probes says nothing about how long the child
+/// was going to take.
 /// </summary>
 public sealed record ProcessResult(
     int ExitCode,
     string Stdout,
     string Stderr,
-    System.TimeSpan Duration);
+    System.TimeSpan Duration,
+    ProcessOutcome Outcome = ProcessOutcome.Exited);
 
 /// <summary>
 /// Runs an external process and returns its result. Production wrapper

--- a/windows/Ghostty.Core/Profiles/WindowsProcessRunner.cs
+++ b/windows/Ghostty.Core/Profiles/WindowsProcessRunner.cs
@@ -43,13 +43,13 @@ internal sealed class WindowsProcessRunner : IProcessRunner
         try
         {
             if (!process.Start())
-                return new ProcessResult(-1, "", "", sw.Elapsed);
+                return new ProcessResult(-1, "", "", sw.Elapsed, ProcessOutcome.DidNotStart);
         }
         catch (System.ComponentModel.Win32Exception)
         {
             // File not found / not executable. Match the interface
             // contract: ExitCode = -1 means "did not start".
-            return new ProcessResult(-1, "", "", sw.Elapsed);
+            return new ProcessResult(-1, "", "", sw.Elapsed, ProcessOutcome.DidNotStart);
         }
 
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
@@ -72,13 +72,13 @@ internal sealed class WindowsProcessRunner : IProcessRunner
             // immediately.
             try { await Task.WhenAll(stdoutTask, stderrTask).ConfigureAwait(false); }
             catch { }
-            return new ProcessResult(-1, "", "", sw.Elapsed);
+            return new ProcessResult(-1, "", "", sw.Elapsed, Ended(ct));
         }
 
         // Process exited cleanly; drain the read tasks. If cts was
         // cancelled in the tiny window between WaitForExit returning and
-        // the awaits completing (e.g. token raced the exit), treat as a
-        // timeout — same shape as the WaitForExit cancellation branch.
+        // the awaits completing (e.g. token raced the exit), report it the
+        // same way as the WaitForExit cancellation branch.
         string stdout;
         string stderr;
         try
@@ -88,8 +88,17 @@ internal sealed class WindowsProcessRunner : IProcessRunner
         }
         catch (OperationCanceledException)
         {
-            return new ProcessResult(-1, "", "", sw.Elapsed);
+            return new ProcessResult(-1, "", "", sw.Elapsed, Ended(ct));
         }
-        return new ProcessResult(process.ExitCode, stdout, stderr, sw.Elapsed);
+        return new ProcessResult(process.ExitCode, stdout, stderr, sw.Elapsed, ProcessOutcome.Exited);
     }
+
+    /// <summary>
+    /// Which cancellation ended the run. The linked source fires for both the
+    /// caller's token and CancelAfter, so only the caller's own token can tell
+    /// them apart -- and they are not the same event: a timeout is evidence
+    /// about the child, a cancelled pipeline is evidence about the caller.
+    /// </summary>
+    private static ProcessOutcome Ended(CancellationToken ct) =>
+        ct.IsCancellationRequested ? ProcessOutcome.Canceled : ProcessOutcome.TimedOut;
 }

--- a/windows/Ghostty.Tests.Windows/SpawnFactAttribute.cs
+++ b/windows/Ghostty.Tests.Windows/SpawnFactAttribute.cs
@@ -1,0 +1,58 @@
+using System;
+using Xunit;
+
+namespace Ghostty.Tests.Windows;
+
+/// <summary>
+/// A Fact that skips itself when this host cannot spawn cmd.exe.
+/// xunit 2.x has no dynamic skip, so the decision is made where the
+/// framework does look: Skip is read off the attribute at discovery.
+/// That is why SpawnProbe caches -- discovery instantiates one of these
+/// per decorated test.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+public sealed class SpawnFactAttribute : FactAttribute
+{
+    public SpawnFactAttribute()
+    {
+        var unavailable = SpawnProbe.Cmd.Unavailable;
+        if (unavailable is not null)
+            Skip = unavailable;
+    }
+}
+
+/// <summary>
+/// SpawnFact for tests that spawn pwsh.exe. Separate because pwsh is not
+/// in-box on Windows and, where it is installed, pays a runtime cold start
+/// that a cmd.exe measurement does not predict: a host that clears the cmd
+/// gate can still be far too slow for a test whose budget is spent on
+/// pwsh starting up.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+public sealed class PwshFactAttribute : FactAttribute
+{
+    public PwshFactAttribute()
+    {
+        var unavailable = SpawnProbe.Pwsh.Unavailable;
+        if (unavailable is not null)
+            Skip = unavailable;
+    }
+}
+
+/// <summary>
+/// PwshFact plus a working wsl installation with at least one distro. The
+/// two gates are separate observations and the reason says which one fired:
+/// the wsl check spawns a process itself, so on a host where nothing spawns
+/// it could not otherwise tell "wsl is not installed" from "wsl could not
+/// be asked". Checking pwsh first removes that ambiguity.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+public sealed class WslFactAttribute : FactAttribute
+{
+    public WslFactAttribute()
+    {
+        var unavailable = SpawnProbe.Pwsh.Unavailable ?? WslDistro.Unavailable;
+        if (unavailable is not null)
+            Skip = unavailable;
+    }
+}

--- a/windows/Ghostty.Tests.Windows/SpawnProbe.cs
+++ b/windows/Ghostty.Tests.Windows/SpawnProbe.cs
@@ -1,0 +1,321 @@
+using System;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Ghostty.Tests.Windows;
+
+/// <summary>
+/// Answers "can this environment spawn <em>this</em> executable with
+/// redirected pipes, quickly enough to test with?". Some hosts (locked-down
+/// sandboxes, aggressive AV, job objects that deny process creation) fail,
+/// hang, or take seconds over every spawn from the test host, which makes any
+/// spawn-dependent test report a failure of the subject rather than of
+/// the machine.
+///
+/// The executable and the latency budget are per-instance because the answer
+/// is not the same for every child. cmd.exe is in-box and starts in
+/// milliseconds; pwsh.exe may be absent entirely, and where it is present it
+/// pays a runtime cold start that a cmd measurement says nothing about. A
+/// test is gated on the probe for the exe it actually spawns.
+///
+/// The probe deliberately drives System.Diagnostics.Process itself rather
+/// than going through IProcessRunner / WindowsProcessRunner. If it used the
+/// code under test, a real regression in that code would make the probe
+/// fail, the tests would skip, and the regression would ship unnoticed. On
+/// an independent path the two causes stay separable: environment broken
+/// means skip, product broken means the tests still run and fail.
+///
+/// Each instance caches its own result for the lifetime of the test host
+/// because xunit reads Skip at discovery time, once per test.
+/// </summary>
+internal sealed class SpawnProbe
+{
+    /// <summary>
+    /// Exit code the probe child is asked to produce. An arbitrary non-zero
+    /// value, so "the child really ran our command" cannot be confused with
+    /// a process that failed and happened to report 0 or 1.
+    /// </summary>
+    private const int ExpectedExitCode = 42;
+
+    /// <summary>
+    /// Hard cap on one sample, covering the spawn as well as the wait, so a
+    /// host where Process.Start itself blocks inside a filter driver cannot
+    /// hang discovery with it.
+    /// </summary>
+    private const int TimeoutMs = 10_000;
+
+    /// <summary>
+    /// Latency a host must beat before the tests that spawn cmd.exe mean
+    /// anything. A no-op child is milliseconds of work; a host that needs
+    /// seconds for it (anti-malware scanning every image, a throttled
+    /// sandbox) cannot honour the sub-second and few-second timeouts those
+    /// tests assert, so they would fail for the host's reason -- exactly the
+    /// confusion this probe removes. Well clear of a healthy runner, which
+    /// lands in the low hundreds of ms.
+    /// </summary>
+    private const int CmdBudgetMs = 2_000;
+
+    /// <summary>
+    /// The same question for pwsh.exe, derived from what the tests that spawn
+    /// it actually assert: the tracker smoke tests allow themselves 8000 ms
+    /// end to end. 750 ms of that is fixed tracker cost (500 ms tick +
+    /// 250 ms debounce) and is available to no spawn at all. The remaining
+    /// 7250 ms has to cover pwsh getting to the point of running its command
+    /// AND everything it is then asked to do -- launch cmd, cmd exec ping,
+    /// and a tracker snapshot that catches them alive. This probe measures
+    /// only the first half, so it gets half the budget: 3625 ms, taken as
+    /// 3500. A host slower than that cannot pass those tests for a reason
+    /// that has nothing to do with the tracker.
+    /// </summary>
+    private const int PwshBudgetMs = 3_500;
+
+    /// <summary>
+    /// The diagnosis that fits every verdict about creating or waiting on the
+    /// child. It deliberately does not fit "the child exited with the wrong
+    /// code": that one observed a process that started fine.
+    /// </summary>
+    private const string BlockedOrStalling =
+        "Process creation from the test host is blocked or stalling "
+        + "(sandbox, anti-malware, or job-object limits)";
+
+    /// <summary>
+    /// The diagnosis for a start Win32 refused outright, which covers a host
+    /// that denies process creation and an executable that is simply not
+    /// installed. Nothing observable from here separates the two.
+    /// </summary>
+    private const string NotFoundOrRefused =
+        "That executable is not installed on this host, or process creation "
+        + "was refused (sandbox, anti-malware, or job-object limits)";
+
+    /// <summary>
+    /// Gate for tests that spawn cmd.exe (or anything else in-box and cheap).
+    /// </summary>
+    internal static SpawnProbe Cmd { get; } = new(
+        "cmd.exe",
+        new[] { "/c", $"exit {ExpectedExitCode}" },
+        CmdBudgetMs);
+
+    /// <summary>
+    /// Gate for tests that spawn pwsh.exe. PowerShell 7 is not in-box on
+    /// Windows, so "absent" is a verdict this probe has to reach on its own:
+    /// Process.Start throws for a missing image, which is a refused start,
+    /// not a timing problem.
+    /// </summary>
+    internal static SpawnProbe Pwsh { get; } = new(
+        "pwsh.exe",
+        new[] { "-NoLogo", "-NoProfile", "-Command", $"exit {ExpectedExitCode}" },
+        PwshBudgetMs);
+
+    private readonly string _fileName;
+    private readonly string[] _args;
+    private readonly int _budgetMs;
+    private readonly Lazy<string?> _verdict;
+
+    private SpawnProbe(string fileName, string[] args, int budgetMs)
+    {
+        _fileName = fileName;
+        _args = args;
+        _budgetMs = budgetMs;
+        _verdict = new Lazy<string?>(Decide, LazyThreadSafetyMode.ExecutionAndPublication);
+    }
+
+    /// <summary>
+    /// Null when this executable can be spawned here with redirected pipes,
+    /// promptly. Otherwise a reason naming what was probed and what the probe
+    /// observed, suitable for a CI log.
+    /// </summary>
+    internal string? Unavailable => _verdict.Value;
+
+    /// <summary>
+    /// Best of three, decided as soon as two agree.
+    /// </summary>
+    /// <remarks>
+    /// One sample is not enough to answer this. The hosts worth detecting are
+    /// not uniformly slow: the same machine has produced a trivial spawn in
+    /// tens of ms and, minutes later, in several seconds. A single sample
+    /// therefore skips a host that is mostly fine, or clears one that is about
+    /// to make the timing assertions fail -- and both of those are the
+    /// ambiguity this probe exists to remove.
+    ///
+    /// Two agreeing samples settle it, so a healthy host pays two trivial
+    /// spawns and stops. Anything that is not a timing verdict -- a refused
+    /// start, a wrong exit code, no exit at all -- is decisive on its own and
+    /// short-circuits, because repeating it would only cost the hard cap
+    /// again.
+    /// </remarks>
+    private string? Decide()
+    {
+        string? slow = null;
+        var fast = 0;
+
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            var (verdict, isTiming) = Run();
+            if (verdict is not null && !isTiming) return verdict;
+
+            if (verdict is null)
+            {
+                if (++fast == 2) return null;
+            }
+            else
+            {
+                if (slow is not null) return slow;
+                slow = verdict;
+            }
+        }
+
+        // Not reachable: a sample is fast, slow-on-timing, or decisive, and a
+        // decisive one has already returned. Two samples that did not decide
+        // are therefore one fast and one slow, so whichever of the three the
+        // third turns out to be completes a pair and returns above.
+        throw new UnreachableException(
+            $"spawn probe for {_fileName} ran three samples without deciding");
+    }
+
+    /// <summary>
+    /// One sample, bounded by the hard cap.
+    /// </summary>
+    /// <remarks>
+    /// The sample runs on a worker because Process.Start is itself one of the
+    /// things that hangs on the hosts this probe detects -- CreateProcessW
+    /// blocks inside an anti-malware filter driver and never returns -- and a
+    /// cap that only covered the waits would not cover that. Discovery is
+    /// single-file behind an ExecutionAndPublication Lazy, so a sample that
+    /// blocks forever would block every other test's discovery too.
+    ///
+    /// The bool says whether a non-null verdict is about timing: timing
+    /// verdicts are worth a second opinion, the rest are not.
+    /// </remarks>
+    private (string? Verdict, bool IsTiming) Run()
+    {
+        var sample = Task.Run(Sample);
+        // An abandoned worker still finishes eventually, and its failure is
+        // not the caller's problem by then. Observe it here so it cannot
+        // resurface as an unobserved task exception on the finalizer thread.
+        sample.ContinueWith(
+            static t => _ = t.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted,
+            TaskScheduler.Default);
+
+        try
+        {
+            if (sample.Wait(TimeoutMs)) return sample.Result;
+        }
+        catch (Exception ex)
+        {
+            return (Reason($"threw {ex.GetType().Name}: {ex.Message}", BlockedOrStalling), false);
+        }
+
+        return (
+            Reason(
+                $"had not finished after {TimeoutMs} ms, spawn included",
+                BlockedOrStalling),
+            false);
+    }
+
+    private (string? Verdict, bool IsTiming) Sample()
+    {
+        try
+        {
+            // Same shape WindowsProcessRunner uses, because that shape is what
+            // fails on the hosts this probe exists to detect: no shell execute,
+            // no window, both output pipes redirected, UTF-8 on both, and an
+            // environment variable set. That last one is not cosmetic: touching
+            // EnvironmentVariables makes .NET hand CreateProcessW an explicit
+            // environment block instead of NULL, which is a different Win32
+            // path from the one an untouched ProcessStartInfo takes.
+            var psi = new ProcessStartInfo
+            {
+                FileName = _fileName,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8,
+            };
+            psi.EnvironmentVariables["WSL_UTF8"] = "1";
+            foreach (var a in _args) psi.ArgumentList.Add(a);
+
+            var sw = Stopwatch.StartNew();
+            using var process = Process.Start(psi);
+            if (process is null)
+                return (Reason("returned no process from Process.Start", BlockedOrStalling), false);
+
+            // Drain before waiting; the reverse order deadlocks if the child
+            // ever fills a pipe.
+            var stdout = process.StandardOutput.ReadToEndAsync();
+            var stderr = process.StandardError.ReadToEndAsync();
+
+            if (!process.WaitForExit(Remaining(sw)))
+            {
+                try { process.Kill(entireProcessTree: true); } catch { }
+                Drain(stdout, stderr, sw);
+                return (Reason($"had not exited within the {TimeoutMs} ms cap", BlockedOrStalling), false);
+            }
+            sw.Stop();
+
+            Drain(stdout, stderr, sw);
+
+            if (process.ExitCode != ExpectedExitCode)
+                return (
+                    Reason(
+                        $"exited with {process.ExitCode}, not {ExpectedExitCode}",
+                        "Something on this host intercepted or replaced that executable: "
+                            + "it started, but it did not run what it was asked to"),
+                    false);
+
+            return sw.ElapsedMilliseconds > _budgetMs
+                ? (Reason($"took {sw.ElapsedMilliseconds} ms, over the {_budgetMs} ms this host must beat", BlockedOrStalling), true)
+                : (null, false);
+        }
+        catch (System.ComponentModel.Win32Exception ex)
+        {
+            // Win32 refused the image. Not necessarily a locked-down host:
+            // pwsh.exe is not in-box on Windows, so "absent" arrives here too,
+            // and the two are indistinguishable from out here.
+            return (Reason($"threw Win32Exception: {ex.Message}", NotFoundOrRefused), false);
+        }
+        catch (Exception ex)
+        {
+            return (Reason($"threw {ex.GetType().Name}: {ex.Message}", BlockedOrStalling), false);
+        }
+    }
+
+    /// <summary>
+    /// Waits for the stdout/stderr reads before the caller's
+    /// <c>using var process</c> disposes underneath them, so they do not run
+    /// as unobserved continuations against a disposed Process. Killing the
+    /// child closes the pipes, so after a kill these return at once.
+    /// </summary>
+    private static void Drain(Task stdout, Task stderr, Stopwatch sw)
+    {
+        var tasks = new[] { stdout, stderr };
+        foreach (var t in tasks)
+        {
+            t.ContinueWith(
+                static x => _ = x.Exception,
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted,
+                TaskScheduler.Default);
+        }
+        try { Task.WaitAll(tasks, Remaining(sw)); } catch { }
+    }
+
+    /// <summary>
+    /// What is left of the hard cap. The worker inherits the same budget the
+    /// caller is waiting on, so an abandoned sample stops shortly after the
+    /// caller has given up on it rather than sitting on a live child.
+    /// </summary>
+    private static int Remaining(Stopwatch sw) =>
+        (int)Math.Clamp(TimeoutMs - sw.ElapsedMilliseconds, 0, TimeoutMs);
+
+    private string Reason(string observed, string diagnosis) =>
+        $"Spawn probe for `{_fileName} {string.Join(' ', _args)}` "
+        + $"(UseShellExecute=false, CreateNoWindow=true, both pipes redirected): "
+        + $"it {observed}. {diagnosis}, so tests that spawn {_fileName} would "
+        + $"report this host's problem as the subject's.";
+}

--- a/windows/Ghostty.Tests.Windows/Tracking/WindowsActiveProcessTrackerSmokeTests.cs
+++ b/windows/Ghostty.Tests.Windows/Tracking/WindowsActiveProcessTrackerSmokeTests.cs
@@ -17,7 +17,10 @@ public sealed class WindowsActiveProcessTrackerSmokeTests
         _output = output;
     }
 
-    [Fact]
+    // PwshFact, not SpawnFact: this spawns pwsh, which is not in-box on
+    // Windows and pays a runtime cold start that the whole 8s budget below is
+    // sized around. A cmd.exe measurement predicts neither.
+    [PwshFact]
     public async Task Track_PwshThenCmd_ReportsTransition()
     {
         // Spawn pwsh and have it run a long-lived cmd child that waits on

--- a/windows/Ghostty.Tests.Windows/Tracking/WindowsActiveProcessTrackerWslSmokeTests.cs
+++ b/windows/Ghostty.Tests.Windows/Tracking/WindowsActiveProcessTrackerWslSmokeTests.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Ghostty.Core.Profiles;
 using Ghostty.Core.Profiles.Tracking;
@@ -20,17 +18,15 @@ public sealed class WindowsActiveProcessTrackerWslSmokeTests
         _output = output;
     }
 
-    [Fact]
+    // WslFact rather than an early-out inside the body: CI runners often lack
+    // wsl, and a test that returns early is recorded as a pass, which is the
+    // same green as a test that proved something. The gate also spawns pwsh
+    // first, so "wsl is not installed" stays distinct from "nothing spawns on
+    // this host" -- the two the old check could not tell apart.
+    [WslFact]
     public async Task Track_WslWithDistribution_ReportsAutoForWslDistro()
     {
-        // Probe wsl: CI runners often lack it. Silent early-out keeps CI green
-        // while still exercising the full path on a dev machine with wsl set up.
-        var (ok, distro) = ProbeWsl();
-        if (!ok || string.IsNullOrEmpty(distro))
-        {
-            _output.WriteLine("wsl not available - skipping");
-            return;
-        }
+        var distro = WslDistro.Name!;
         _output.WriteLine($"probed distro: {distro}");
 
         // Spawn pwsh -> wsl.exe --distribution <distro> -- sleep 5
@@ -95,42 +91,6 @@ public sealed class WindowsActiveProcessTrackerWslSmokeTests
         finally
         {
             try { pwsh.Kill(entireProcessTree: true); } catch { }
-        }
-    }
-
-    /// <summary>
-    /// Probes whether wsl is installed and at least one distro exists.
-    /// <c>wsl --list --quiet</c> emits UTF-16 LE with a BOM on Windows, so the
-    /// raw stdout has interleaved null bytes when read as the default encoding.
-    /// We strip those before splitting; the result is the first non-empty line.
-    /// </summary>
-    private static (bool ok, string? distro) ProbeWsl()
-    {
-        try
-        {
-            var p = Process.Start(new ProcessStartInfo
-            {
-                FileName = "wsl.exe",
-                Arguments = "--list --quiet",
-                RedirectStandardOutput = true,
-                UseShellExecute = false,
-                CreateNoWindow = true,
-            });
-            if (p is null) return (false, null);
-            if (!p.WaitForExit(2000)) return (false, null);
-            if (p.ExitCode != 0) return (false, null);
-
-            var raw = p.StandardOutput.ReadToEnd();
-            var cleaned = new string(raw.Where(c => c != '\0' && c != '﻿').ToArray());
-            var first = cleaned
-                .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
-                .Select(s => s.Trim())
-                .FirstOrDefault(s => !string.IsNullOrWhiteSpace(s));
-            return string.IsNullOrEmpty(first) ? (false, null) : (true, first);
-        }
-        catch
-        {
-            return (false, null);
         }
     }
 }

--- a/windows/Ghostty.Tests.Windows/WindowsProcessRunnerTests.cs
+++ b/windows/Ghostty.Tests.Windows/WindowsProcessRunnerTests.cs
@@ -7,25 +7,37 @@ namespace Ghostty.Tests.Windows;
 
 public sealed class WindowsProcessRunnerTests
 {
-    [Fact]
+    [SpawnFact]
     public async System.Threading.Tasks.Task Run_CmdExit42_ReturnsExitCode42()
     {
         var runner = new WindowsProcessRunner();
         var result = await runner.RunAsync("cmd.exe", new[] { "/c", "exit 42" },
             TimeSpan.FromSeconds(5), CancellationToken.None);
+        // Assert the outcome first: a host where the spawn hangs reports
+        // ExitCode -1, and "expected Exited, got TimedOut" is the diagnosis,
+        // where "expected 42, got -1" only looks like a wrong exit code.
+        Assert.Equal(ProcessOutcome.Exited, result.Outcome);
         Assert.Equal(42, result.ExitCode);
     }
 
+    // Plain Fact: nothing here ever spawns successfully, and there is no
+    // elapsed assertion, so spawn latency cannot change the answer. A host
+    // that denies process creation outright reaches DidNotStart down the same
+    // catch as a missing file. Gating it would delete the only coverage of
+    // that path on exactly the hosts the gate fires on.
     [Fact]
     public async System.Threading.Tasks.Task Run_MissingExe_ReturnsMinusOne()
     {
         var runner = new WindowsProcessRunner();
         var result = await runner.RunAsync("no_such_exe_xyz.exe",
             new string[0], TimeSpan.FromSeconds(2), CancellationToken.None);
+        // -1 alone would also be satisfied by a spawn that hung and was
+        // killed, which is exactly what this test must not accept.
+        Assert.Equal(ProcessOutcome.DidNotStart, result.Outcome);
         Assert.Equal(-1, result.ExitCode);
     }
 
-    [Fact]
+    [SpawnFact]
     public async System.Threading.Tasks.Task Run_LongPing_TimeoutKills()
     {
         // Plan originally used `cmd.exe /c pause`, but WindowsProcessRunner
@@ -39,7 +51,43 @@ public sealed class WindowsProcessRunnerTests
             new[] { "-n", "60", "127.0.0.1" },
             TimeSpan.FromMilliseconds(500), CancellationToken.None);
         sw.Stop();
+        // The elapsed range alone is also satisfied by a spawn that never
+        // started and stalled; only the outcome proves the kill path ran.
+        Assert.Equal(ProcessOutcome.TimedOut, result.Outcome);
         Assert.Equal(-1, result.ExitCode);
         Assert.InRange(sw.ElapsedMilliseconds, 400, 3000);
+    }
+
+    [SpawnFact]
+    public async System.Threading.Tasks.Task Run_CallerCancelsMidFlight_ReportsCanceled()
+    {
+        // The timeout is two orders of magnitude past the cancel, so nothing
+        // but the caller's token can be what ended this run. Reporting TimedOut
+        // here would assert the child was too slow, which it was not.
+        var runner = new WindowsProcessRunner();
+        using var cts = new CancellationTokenSource();
+        var run = runner.RunAsync("ping.exe", new[] { "-n", "60", "127.0.0.1" },
+            TimeSpan.FromSeconds(60), cts.Token);
+        cts.CancelAfter(TimeSpan.FromMilliseconds(200));
+        var result = await run;
+        Assert.Equal(ProcessOutcome.Canceled, result.Outcome);
+        // Cancelled runs stay -1 like every other non-Exited ending, so
+        // callers that only read ExitCode see no change.
+        Assert.Equal(-1, result.ExitCode);
+    }
+
+    [SpawnFact]
+    public async System.Threading.Tasks.Task Run_CallerTokenAlreadyCanceled_ReportsCanceled()
+    {
+        // Same distinction without the race: the token is dead before the
+        // runner is called, so the elapsed time cannot be mistaken for a
+        // timeout by anything downstream either.
+        var runner = new WindowsProcessRunner();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var result = await runner.RunAsync("ping.exe", new[] { "-n", "60", "127.0.0.1" },
+            TimeSpan.FromSeconds(60), cts.Token);
+        Assert.Equal(ProcessOutcome.Canceled, result.Outcome);
+        Assert.Equal(-1, result.ExitCode);
     }
 }

--- a/windows/Ghostty.Tests.Windows/WslDistro.cs
+++ b/windows/Ghostty.Tests.Windows/WslDistro.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+
+namespace Ghostty.Tests.Windows;
+
+/// <summary>
+/// Answers "is wsl installed here, with at least one distribution?", and
+/// hands back the distribution name so the gated test does not have to ask
+/// again.
+///
+/// This exists as a gate rather than as an early-out inside the test because
+/// an early-out that returns is recorded by xunit as a pass: a test that ran
+/// nothing reports the same green as a test that proved something. Skipping
+/// says what actually happened.
+///
+/// Cached for the lifetime of the test host: xunit reads Skip at discovery,
+/// once per decorated test.
+/// </summary>
+internal static class WslDistro
+{
+    /// <summary>
+    /// `wsl --list --quiet` on a host with a distro answers immediately;
+    /// anything slower than this is a host problem, and the pwsh spawn probe
+    /// that runs before this gate has already ruled that in or out.
+    /// </summary>
+    private const int TimeoutMs = 2_000;
+
+    /// <summary>
+    /// Byte-order mark. <c>wsl --list --quiet</c> emits UTF-16 LE with a BOM
+    /// on Windows, so read as the default encoding the stdout carries a
+    /// leading mark and interleaved nulls; both are stripped before splitting.
+    /// </summary>
+    private const char Bom = '\uFEFF';
+
+    private static readonly Lazy<(string? Distro, string? Unavailable)> Result =
+        new(Detect, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    /// <summary>
+    /// Null when a distribution was found. Otherwise a reason for a CI log.
+    /// </summary>
+    internal static string? Unavailable => Result.Value.Unavailable;
+
+    /// <summary>
+    /// The first distribution wsl reported. Non-null whenever
+    /// <see cref="Unavailable"/> is null.
+    /// </summary>
+    internal static string? Name => Result.Value.Distro;
+
+    private static (string? Distro, string? Unavailable) Detect()
+    {
+        try
+        {
+            using var p = Process.Start(new ProcessStartInfo
+            {
+                FileName = "wsl.exe",
+                Arguments = "--list --quiet",
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            });
+            if (p is null) return (null, Reason("Process.Start returned no process"));
+
+            // Read before waiting, so a distro list long enough to fill the
+            // pipe cannot deadlock the wait.
+            var stdout = p.StandardOutput.ReadToEndAsync();
+            if (!p.WaitForExit(TimeoutMs))
+            {
+                try { p.Kill(entireProcessTree: true); } catch { }
+                try { stdout.Wait(TimeoutMs); } catch { }
+                return (null, Reason($"it had not answered after {TimeoutMs} ms"));
+            }
+            string raw;
+            try { raw = stdout.Result; }
+            catch { raw = ""; }
+            if (p.ExitCode != 0)
+                return (null, Reason($"it exited with {p.ExitCode}"));
+
+            var cleaned = new string(raw.Where(c => c != '\0' && c != Bom).ToArray());
+            var first = cleaned
+                .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(s => s.Trim())
+                .FirstOrDefault(s => !string.IsNullOrWhiteSpace(s));
+            return string.IsNullOrEmpty(first)
+                ? (null, Reason("it listed no distributions"))
+                : (first, null);
+        }
+        catch (Exception ex)
+        {
+            return (null, Reason($"it threw {ex.GetType().Name}: {ex.Message}"));
+        }
+    }
+
+    private static string Reason(string observed) =>
+        $"No usable wsl installation: ran `wsl.exe --list --quiet` and {observed}. "
+        + $"The spawn probe already cleared this host, so this is wsl's absence "
+        + $"rather than a host that cannot start processes.";
+}

--- a/windows/Ghostty.Tests/Profiles/Fakes/FakeProcessRunner.cs
+++ b/windows/Ghostty.Tests/Profiles/Fakes/FakeProcessRunner.cs
@@ -32,7 +32,8 @@ internal sealed class FakeProcessRunner : IProcessRunner
         var key = Key(fileName, args);
         if (_canned.TryGetValue(key, out var result))
             return Task.FromResult(result);
-        return Task.FromResult(new ProcessResult(-1, "", "", TimeSpan.Zero));
+        return Task.FromResult(
+            new ProcessResult(-1, "", "", TimeSpan.Zero, ProcessOutcome.DidNotStart));
     }
 
     private static string Key(string fileName, IEnumerable<string> args)


### PR DESCRIPTION
Follow-up to #773. The series-v2 sync merge (ec7cc4ec9) stamped an 18-hour-stale series-wip tree over windows and reverted FOUR merged PRs, not three: #705, #729, #741, #742. #773 restored the other three; this restores #741 (6517eafda, tests: tell a broken spawn from a broken product) by cherry-pick.

Content: the spawn diagnostic machinery (SpawnProbe, SpawnFactAttribute, WslDistro) plus the IProcessRunner/WindowsProcessRunner distinction between a broken spawn and a broken product. All nine touched files are blob-identical to 6517eafda's merged state; zero conflicts.

Also corrects the record from #773/#774: the VerticalTabStrip.xaml.cs delta in the sync merge is direct-to-series-wip work, not a leaked unmerged fragment.