### PR TITLE
build: assert containment and unreviewed work at sync-publish time

### DIFF
--- a/.agents/scripts/syncflow-selftest.sh
+++ b/.agents/scripts/syncflow-selftest.sh
@@ -113,7 +113,11 @@ J sync
 check "series rebased onto upstream" git -C work merge-base --is-ancestor refs/remotes/upstream/main series-wip
 check_eq "series-wip stamped with its generation" "$(git -C work config --get branch.series-wip.seriesbase)" "series/v0"
 quiet "sync-verify fast (first sync)" J sync-verify fast
-J sync-publish
+if out=$(J sync-publish 2>&1) && ! printf '%s' "$out" | grep -q "REFUSING\|unreviewed"; then
+  ok "a clean publish is quiet about unreviewed work"
+else
+  nope "a clean publish is quiet about unreviewed work"
+fi
 M1=$(git -C origin.git rev-parse refs/heads/windows)
 check_eq "snapshot M1 is a merge of old tip + upstream" \
   "$(git -C work rev-parse "$M1^1" "$M1^2" | tr '\n' ' ')" \
@@ -225,15 +229,66 @@ if git -C work rev-parse --verify -q refs/tags/series/v7 >/dev/null; then
 else
   ok "series/v7 not minted by a refused publish"
 fi
-J sync-publish fixture-direct-work-may-ride-the-snapshot
+J sync-publish yes
 check "series/v7 pushed on the acknowledged publish" git -C origin.git rev-parse --verify refs/tags/series/v7
 check "acknowledged work reached windows" git -C work cat-file -e 'refs/remotes/origin/windows:direct.txt'
 M8=$(git -C origin.git rev-parse refs/heads/windows)
 if git -C work log -1 --format=%B "$M8" | grep -q "w1: direct work"; then
-  ok "the ack is recorded in the snapshot merge message"
+  ok "the acknowledged commit is recorded in the snapshot merge message"
 else
-  nope "the ack is recorded in the snapshot merge message"
+  nope "the acknowledged commit is recorded in the snapshot merge message"
 fi
+if git -C work log -1 --format=%B "$M8" | grep -q "acknowledged at publish"; then
+  ok "the merge message marks the acknowledgement itself"
+else
+  nope "the merge message marks the acknowledgement itself"
+fi
+
+say "test 9: a hand-resolved fold-in still publishes (pairing, not patch-id)"
+( cd up && echo lib9 >> lib.txt && $G add -A && $G commit -qm "u10: resolved-fold era" )
+J sync
+( cd work
+  git checkout -q windows
+  printf 'base1\nbase2\nbase3\nbase4\nbase5\nbase6\nbase7\nbase8\nfork1\nfork2\nfork3\nfork4\nfork5\nfork6\np4-line\n' > a.txt
+  $G add -A && $G commit -qm "p4: PR that conflicts with the stack's f2"
+  git push -q origin windows
+)
+# The fold-in of p4 onto the standing replay conflicts (the recovery path
+# SKILL.md documents); resolve by hand and continue the pick. The resolved
+# carry has a different patch-id than p4 - patch-id containment would refuse
+# this publish forever; range-diff pairing must let it through.
+( cd work
+  git checkout -q series-wip
+  git cherry-pick refs/remotes/origin/windows >/dev/null 2>&1 || true
+  printf 'base1\nbase2\nbase3\nbase4\nbase5\nbase6\nbase7\nbase8\nfork1\nfork2\nfork3\nfork4\nfork5\nfork6\np4-line\n' > a.txt
+  $G add a.txt
+  GIT_EDITOR=true $G cherry-pick --continue >/dev/null 2>&1 || true
+)
+if out=$(J sync-publish 2>&1) && ! printf '%s' "$out" | grep -q "REFUSING"; then
+  ok "a hand-resolved fold-in publishes"
+else
+  nope "a hand-resolved fold-in publishes ($(printf '%s' "$out" | tail -3 | tr '\n' ' '))"
+fi
+check "the resolved fold's content reached windows" \
+  git -C work cat-file -e 'refs/remotes/origin/windows:a.txt'
+if git -C work show 'refs/remotes/origin/windows:a.txt' | grep -q "p4-line"; then
+  ok "the resolved fold's change is in the published tree"
+else
+  nope "the resolved fold's change is in the published tree"
+fi
+
+say "test 10: new work cannot hide behind an old fork commit's subject"
+( cd up && echo lib10 >> lib.txt && $G add -A && $G commit -qm "u11: sneaky era" )
+J sync
+( cd work
+  git checkout -q series-wip
+  echo sneaky > sneaky.txt
+  $G add -A && $G commit -qm "f1: fork file"
+)
+expect_fail "a reused deep-history subject is still refused" "f1: fork file" J sync-publish
+( cd work && git checkout -q windows && git branch -q -D series-wip )
+# The guards below need a standing wip; rebuild one without the sneaky work.
+J sync
 
 say "guards"
 ( cd work && git checkout -q -b random "$M4" )

--- a/.agents/scripts/syncflow-selftest.sh
+++ b/.agents/scripts/syncflow-selftest.sh
@@ -4,8 +4,10 @@
 # working clones in a temp dir and drives the real recipes from this repo's
 # justfile through: bootstrap, a plain sync, a fold-in sync, a publish that
 # loses a race to a mid-sync PR merge, a conflicted replay, a second clone
-# joining mid-series with stale tags, and a stale leftover replay that must
-# be refused rather than published. The fixture upstream carries a merge
+# joining mid-series with stale tags, a stale leftover replay that must
+# be refused rather than published, and a publish carrying work no PR
+# reviewed that must be named, refused, and only land with an acknowledgement
+# recorded in the merge message. The fixture upstream carries a merge
 # commit on purpose: the snapshot detection must not mistake upstream's own
 # PR merges for the fork's snapshots.
 #
@@ -148,7 +150,7 @@ git clone -q "$ROOT/origin.git" "$ROOT/rc"
   $G add -A && $G commit -qm "p2: raced PR"
   git push -q origin windows
 )
-expect_fail "raced publish rejected" "Push rejected" J sync-publish
+expect_fail "raced publish refused before the push, naming the PR" "p2: raced PR" J sync-publish
 if git -C work rev-parse --verify -q refs/tags/series/v3 >/dev/null; then nope "series/v3 rolled back after rejection"; else ok "series/v3 rolled back after rejection"; fi
 J sync
 check "p2 folded on resume" git -C work cat-file -e 'series-wip:late.txt'
@@ -207,6 +209,30 @@ if out=$(J sync-publish 2>&1) && printf '%s' "$out" | grep -q "nothing to publis
   ok "publish no-ops when windows already carries the tree"
 else
   nope "publish no-ops when windows already carries the tree"
+fi
+
+say "test 8: unreviewed work on the wip is named, refused, and needs an ack"
+( cd up && echo lib8 >> lib.txt && $G add -A && $G commit -qm "u9: unreviewed era" )
+J sync
+( cd work
+  git checkout -q series-wip
+  echo direct > direct.txt
+  $G add -A && $G commit -qm "w1: direct work, never through a PR"
+)
+expect_fail "unreviewed publish refused and the commit named" "w1: direct work" J sync-publish
+if git -C work rev-parse --verify -q refs/tags/series/v7 >/dev/null; then
+  nope "series/v7 not minted by a refused publish"
+else
+  ok "series/v7 not minted by a refused publish"
+fi
+J sync-publish fixture-direct-work-may-ride-the-snapshot
+check "series/v7 pushed on the acknowledged publish" git -C origin.git rev-parse --verify refs/tags/series/v7
+check "acknowledged work reached windows" git -C work cat-file -e 'refs/remotes/origin/windows:direct.txt'
+M8=$(git -C origin.git rev-parse refs/heads/windows)
+if git -C work log -1 --format=%B "$M8" | grep -q "w1: direct work"; then
+  ok "the ack is recorded in the snapshot merge message"
+else
+  nope "the ack is recorded in the snapshot merge message"
 fi
 
 say "guards"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,8 +47,11 @@ The rules above are upstream's. They do not describe how work lands here.
 Issues and PRs against `deblasis/wintty` are the normal, required workflow:
 branch from `windows`, open a PR with `--repo deblasis/wintty`, get it
 reviewed, run `just signoff` green against the exact head sha, and squash
-merge. The `pr_gate` hook refuses a merge without that signoff, so there is no
-path that skips it.
+merge. The `pr_gate` hook refuses a merge without that signoff. The one
+deliberate exception is `just sync-publish`, which lands the upstream
+snapshot merge without a PR; in exchange it runs its own assertions at
+publish time: nothing windows merged may be missing from the replay, and
+work no PR reviewed may ride along unnamed or unacknowledged.
 
 Always pass `--repo deblasis/wintty`. Never open anything against
 `ghostty-org/ghostty`.

--- a/justfile
+++ b/justfile
@@ -553,14 +553,21 @@ sync-bootstrap:
 # would re-merge and could resolve differently than the replay did - so the
 # commit is built directly with commit-tree.
 #
-# The push is deliberately not forced. If windows gained a PR mid-sync the
-# push is rejected as non-fast-forward, the tag is rolled back, and re-running
-# 'just sync' folds the new commits into the standing replay. It is atomic
-# across the branch and the series tag so a half-published sync cannot exist
-# on the remote.
+# Because the tree arrives wholesale, two assertions gate the stamp itself:
+# containment (windows holds nothing the replay lacks, else the stamp drops
+# it forever) and unreviewed work (the replay carries nothing windows has
+# never seen through a PR, unless acknowledged with a reason that is written
+# into the merge message). Both re-run here at publish time; the replay being
+# hours old is the normal case, not an anomaly.
+#
+# The push is deliberately not forced. If windows gained a PR between the
+# publish-time fetch and the push, the push is rejected as non-fast-forward,
+# the tag is rolled back, and re-running 'just sync' folds the new commits
+# into the standing replay. It is atomic across the branch and the series tag
+# so a half-published sync cannot exist on the remote.
 #
 # Publish the verified replay onto windows as a snapshot merge.
-sync-publish:
+sync-publish ack="":
     #!/usr/bin/env bash
     set -euo pipefail
     if [ "$(git branch --show-current)" != "series-wip" ]; then
@@ -581,6 +588,12 @@ sync-publish:
     # Same explicit namespace fetch as sync: the next generation is numbered
     # from these tags, and a stale set would mint a duplicate number.
     git fetch origin 'refs/tags/series/*:refs/tags/series/*'
+    # Fetched here, not inherited from the last 'just sync', because both
+    # assertions below measure against the windows the remote actually has.
+    # The push rejects a race that lands between this fetch and the push; the
+    # gap these checks close is the one that cannot be caught at push time -
+    # a replay built hours ago that a PR merged in between would stamp out.
+    git fetch origin windows
     prev_n=$(git tag --list 'series/v*' | sed 's|^series/v||' | grep -E '^[0-9]+$' | sort -n | tail -1 || true)
     if [ -z "$prev_n" ]; then
         echo "REFUSING: no series/v* tag; run 'just sync-bootstrap' first."
@@ -601,12 +614,89 @@ sync-publish:
         echo "newer generation folded in. Re-run 'just sync'."
         exit 1
     fi
+    # Both assertions below are re-evaluated HERE, at publish time, because the
+    # gap that bit series v2 was the hours between 'just sync' and this
+    # command: four merged PRs were stamped out by a replay that predated
+    # them, and once stamped they became ancestors of the snapshot merge, so
+    # no later sync ever re-folded them. A publish joins two surfaces that
+    # moved independently since the replay was built, and must prove two
+    # things about them:
+    #
+    #   containment  windows holds nothing this replay lacks. This is the
+    #                fold-in computation from 'just sync', pointed at the
+    #                replay: anything sync would fold in right now is exactly
+    #                what this publish would drop.
+    #   unreviewed   the replay carries nothing windows has never reviewed.
+    #                This command lands on windows without passing pr_gate -
+    #                that is its design - so it pays a toll instead: every
+    #                commit entering windows that is not a replay of an
+    #                already-merged PR and not a patch upstream absorbed is
+    #                named, and the publish refuses unless each is explicitly
+    #                acknowledged with a reason that lands in history.
+    prev="refs/tags/series/v${prev_n}"
+    mprev=$(git rev-list --min-parents=2 --first-parent -1 refs/remotes/upstream/main..refs/remotes/origin/windows)
+    if [ -z "$mprev" ]; then
+        mprev=$(git rev-parse "${prev}^{commit}")
+    fi
+    dropped=$(git cherry HEAD refs/remotes/origin/windows "$mprev" | awk '$1 == "+" { print $2 }')
+    if [ -n "$dropped" ]; then
+        echo "REFUSING: windows has commits this replay does not carry. Publishing now"
+        echo "would stamp a tree without them, and after the stamp they are ancestors"
+        echo "of the merge, so no later sync re-folds them. Re-run 'just sync' (it"
+        echo "folds these in), verify, then publish again:"
+        git log --no-walk --oneline $dropped
+        exit 1
+    fi
+    # Patch-id flags every hand-resolved replay as new, because resolving
+    # changes the patch, so equivalence is established by name instead: a
+    # replay keeps the subject of the commit it replays, and squash-merged
+    # subjects are unique per PR. Only commits newer than the last snapshot
+    # are considered; the previous series stack is excluded by the limit.
+    # Upstream's own commits are skipped outright: they enter windows through
+    # the merge's second parent, which is the entire point of the publish.
+    unreviewed=""
+    entering=""
+    for sha in $(git cherry refs/remotes/origin/windows HEAD "$prev" | awk '$1 == "+" { print $2 }'); do
+        if git merge-base --is-ancestor "$sha" refs/remotes/upstream/main 2>/dev/null; then
+            continue
+        elif [ "$(git cherry refs/remotes/upstream/main "$sha" "${sha}^" 2>/dev/null | cut -c1)" = "-" ]; then
+            entering="${entering}$(git log -1 --oneline "$sha") [absorbed upstream]"$'\n'
+        elif git log --format=%s "refs/remotes/upstream/main..refs/remotes/origin/windows" \
+                | grep -Fxq "$(git log -1 --format=%s "$sha")"; then
+            entering="${entering}$(git log -1 --oneline "$sha") [replay of a merged PR]"$'\n'
+        else
+            unreviewed="${unreviewed}$(git log -1 --oneline "$sha")"$'\n'
+        fi
+    done
+    if [ -n "$entering" ]; then
+        echo "rewritten patches entering windows (each reviewed where it first landed):"
+        printf '%s' "$entering"
+    fi
+    if [ -n "$unreviewed" ]; then
+        if [ -n "{{ ack }}" ]; then
+            echo ""
+            echo "ACKNOWLEDGED unreviewed work entering windows (reason: {{ ack }}):"
+            printf '%s' "$unreviewed"
+            echo "Recorded in the snapshot merge message."
+        else
+            echo "REFUSING: this publish would carry commits into windows that no PR"
+            echo "reviewed (not replays of merged PRs, not absorbed upstream):"
+            printf '%s' "$unreviewed"
+            echo "Land them through a PR, or acknowledge explicitly - the reason is"
+            echo "recorded permanently in the snapshot merge message:"
+            echo "  just sync-publish ack=\"<reason>\""
+            exit 1
+        fi
+    fi
     next=$((10#$prev_n + 1))
     base=$(git rev-parse refs/remotes/origin/windows)
     up=$(git rev-parse refs/remotes/upstream/main)
     tree=$(git rev-parse 'HEAD^{tree}')
-    m=$(git commit-tree "$tree" -p "$base" -p "$up" \
-        -m "sync: merge upstream $(git rev-parse --short "$up") (series v${next})")
+    msg=(-m "sync: merge upstream $(git rev-parse --short "$up") (series v${next})")
+    if [ -n "$unreviewed" ]; then
+        msg+=(-m "unreviewed work entering windows (ack: {{ ack }}):$(printf '\n%s' "$unreviewed" | sed 's/^/  /')")
+    fi
+    m=$(git commit-tree "$tree" -p "$base" -p "$up" "${msg[@]}")
     # By construction, and still checked: tier pins, the next sync's fold-in,
     # and sync-verify all ride on this equality.
     if [ "$(git rev-parse "${m}^{tree}")" != "$tree" ]; then

--- a/justfile
+++ b/justfile
@@ -638,53 +638,113 @@ sync-publish ack="":
     if [ -z "$mprev" ]; then
         mprev=$(git rev-parse "${prev}^{commit}")
     fi
-    dropped=$(git cherry HEAD refs/remotes/origin/windows "$mprev" | awk '$1 == "+" { print $2 }')
+    # The same baseline sync validates, re-checked here because publish
+    # reads it after its own fetch: a bogus snapshot marker would make the
+    # containment check below measure nothing while appearing to pass.
+    if ! git merge-base --is-ancestor "$mprev" refs/remotes/origin/windows; then
+        echo "REFUSING: the snapshot baseline (${mprev:0:9}) is not on origin/windows."
+        exit 1
+    fi
+    if [ "$(git rev-parse "${mprev}^{tree}")" != "$(git rev-parse "${prev}^{tree}")" ]; then
+        echo "REFUSING: the last snapshot on windows (${mprev:0:9}) does not carry the"
+        echo "tree of series/v${prev_n}. The published branch and the series diverged."
+        exit 1
+    fi
+    # Containment: windows holds nothing this replay lacks. Pairing is by
+    # range-diff, not patch-id, because a fold-in resolved by hand carries a
+    # different patch than the PR it folds, and patch-id alone would refuse
+    # that publish forever while its own remedy ('re-run just sync') re-folds
+    # the same conflict - an impassable release path. range-diff is the one
+    # instrument that pairs hand-resolved work; it is what sync-verify
+    # already trusts for its dropped-commit check.
+    dropped=""
+    if [ "$(git rev-list --count "${mprev}..refs/remotes/origin/windows")" -gt 0 ]; then
+        if ! rd_windows=$(git range-diff --no-color \
+                "${mprev}..refs/remotes/origin/windows" \
+                "refs/remotes/upstream/main..HEAD" 2>&1); then
+            echo "REFUSING: range-diff could not pair the replay against windows:"
+            printf '%s\n' "$rd_windows" | head -3
+            exit 1
+        fi
+        while IFS= read -r line; do
+            [ -n "$line" ] || continue
+            sha=$(printf '%s' "$line" | awk '{print $2}')
+            # Upstream absorbing a fork PR legitimately removes it from the
+            # fold set: the patch is already arriving through parent 2.
+            if [ "$(git cherry refs/remotes/upstream/main "$sha" "${sha}^" 2>/dev/null | cut -c1)" = "-" ]; then
+                continue
+            fi
+            dropped="${dropped}$(git log -1 --oneline "$sha")"$'\n'
+        done <<< "$(printf '%s\n' "$rd_windows" | grep -E '^ *[0-9]+: *[0-9a-f]+ *< ' || true)"
+    fi
     if [ -n "$dropped" ]; then
         echo "REFUSING: windows has commits this replay does not carry. Publishing now"
         echo "would stamp a tree without them, and after the stamp they are ancestors"
         echo "of the merge, so no later sync re-folds them. Re-run 'just sync' (it"
         echo "folds these in), verify, then publish again:"
-        git log --no-walk --oneline $dropped
+        printf '%s' "$dropped"
         exit 1
     fi
-    # Patch-id flags every hand-resolved replay as new, because resolving
-    # changes the patch, so equivalence is established by name instead: a
-    # replay keeps the subject of the commit it replays, and squash-merged
-    # subjects are unique per PR. Only commits newer than the last snapshot
-    # are considered; the previous series stack is excluded by the limit.
-    # Upstream's own commits are skipped outright: they enter windows through
-    # the merge's second parent, which is the entire point of the publish.
+    # Unreviewed: the replay carries nothing windows has never reviewed.
+    # Candidates come from patch-id (git cherry over commits newer than the
+    # last series tag). Classification then runs, in order: upstream's own
+    # commits are skipped (they enter through parent 2 by design); patches
+    # upstream absorbed pass (the absorbed mark only fires when upstream
+    # carries the patch under a different sha, which is why reachability is
+    # checked first); commits whose subject matches a PR windows merged
+    # since the last snapshot pass (the pool is RECENT commits only, read
+    # into a variable once - piping git log into grep under pipefail flips
+    # the test false when git log SIGPIPEs, and matches near the top are
+    # exactly the folded-PR case; a full-history pool would let new work
+    # hide behind any old subject); and finally commits range-diff pairs
+    # with the standing series stack pass, which is what clears a
+    # hand-resolved replay of an old patch. Anything left is named.
+    recent_subjects=$(git log --format=%s "${mprev}..refs/remotes/origin/windows")
+    old_base=$(git merge-base "${prev}^{commit}" refs/remotes/upstream/main 2>/dev/null || true)
+    paired=""
+    if [ -n "$old_base" ]; then
+        # range-diff prints abbreviated shas; resolved to full ones so the
+        # membership test below compares like with like.
+        paired=$(git range-diff --no-color \
+                "${old_base}..${prev}^{commit}" \
+                "refs/remotes/upstream/main..HEAD" 2>/dev/null \
+            | awk '$3 == "=" || $3 == "!" { print $5 }' \
+            | while IFS= read -r p; do git rev-parse "$p"; done \
+            || true)
+    fi
     unreviewed=""
-    entering=""
+    reviewed_rewrites=0
     for sha in $(git cherry refs/remotes/origin/windows HEAD "$prev" | awk '$1 == "+" { print $2 }'); do
         if git merge-base --is-ancestor "$sha" refs/remotes/upstream/main 2>/dev/null; then
             continue
         elif [ "$(git cherry refs/remotes/upstream/main "$sha" "${sha}^" 2>/dev/null | cut -c1)" = "-" ]; then
-            entering="${entering}$(git log -1 --oneline "$sha") [absorbed upstream]"$'\n'
-        elif git log --format=%s "refs/remotes/upstream/main..refs/remotes/origin/windows" \
-                | grep -Fxq "$(git log -1 --format=%s "$sha")"; then
-            entering="${entering}$(git log -1 --oneline "$sha") [replay of a merged PR]"$'\n'
+            reviewed_rewrites=$((reviewed_rewrites + 1))
+        elif [ -n "$(printf '%s\n' "$recent_subjects" | grep -Fx "$(git log -1 --format=%s "$sha")" || true)" ]; then
+            reviewed_rewrites=$((reviewed_rewrites + 1))
+        elif [ -n "$(printf '%s\n' "$paired" | grep -Fx "$sha" || true)" ]; then
+            reviewed_rewrites=$((reviewed_rewrites + 1))
         else
             unreviewed="${unreviewed}$(git log -1 --oneline "$sha")"$'\n'
         fi
     done
-    if [ -n "$entering" ]; then
-        echo "rewritten patches entering windows (each reviewed where it first landed):"
-        printf '%s' "$entering"
+    if [ "$reviewed_rewrites" -gt 0 ]; then
+        echo "${reviewed_rewrites} rewritten patch(es) entering windows (each reviewed where it first landed)."
     fi
     if [ -n "$unreviewed" ]; then
-        if [ -n "{{ ack }}" ]; then
+        # ack is a fixed token, not freeform prose: just interpolates
+        # arguments into the script text verbatim, so a prose reason would
+        # be code the recipe executes. The named commits below are the
+        # permanent record; the token only says the operator read them.
+        if [ '{{ ack }}' = yes ]; then
             echo ""
-            echo "ACKNOWLEDGED unreviewed work entering windows (reason: {{ ack }}):"
+            echo "ACKNOWLEDGED unreviewed work entering windows; recorded in the merge message:"
             printf '%s' "$unreviewed"
-            echo "Recorded in the snapshot merge message."
         else
             echo "REFUSING: this publish would carry commits into windows that no PR"
             echo "reviewed (not replays of merged PRs, not absorbed upstream):"
             printf '%s' "$unreviewed"
-            echo "Land them through a PR, or acknowledge explicitly - the reason is"
-            echo "recorded permanently in the snapshot merge message:"
-            echo "  just sync-publish ack=\"<reason>\""
+            echo "Land them through a PR, or acknowledge explicitly after reading them:"
+            echo "  just sync-publish yes"
             exit 1
         fi
     fi
@@ -694,7 +754,7 @@ sync-publish ack="":
     tree=$(git rev-parse 'HEAD^{tree}')
     msg=(-m "sync: merge upstream $(git rev-parse --short "$up") (series v${next})")
     if [ -n "$unreviewed" ]; then
-        msg+=(-m "unreviewed work entering windows (ack: {{ ack }}):$(printf '\n%s' "$unreviewed" | sed 's/^/  /')")
+        msg+=(-m "unreviewed work entering windows, acknowledged at publish:"$'\n'"$(printf '%s' "$unreviewed" | sed 's/^/  /')")
     fi
     m=$(git commit-tree "$tree" -p "$base" -p "$up" "${msg[@]}")
     # By construction, and still checked: tier pins, the next sync's fold-in,


### PR DESCRIPTION
Implements #774. Redesigned after adversarial review found the first cut both impassable (patch-id containment refuses any hand-resolved fold-in forever, while its remedy re-folds the same conflict) and bypassable (the subject-twin pool spanned all fork history, so new work titled like an old commit rode the snapshot labeled as reviewed).

Two assertions run at publish time, against the windows the remote actually has (fetched at publish, not inherited from the last sync):

- **Containment**: windows holds nothing the replay lacks. Pairing is by range-diff (the instrument sync-verify already trusts for its dropped-commit check) with the absorbed-upstream exemption, so a fold-in resolved by hand still pairs with its PR. The snapshot-baseline validations sync runs are copied here too.
- **Unreviewed**: the replay carries nothing windows has never reviewed. Candidates by patch-id (commits newer than the last series tag); classification in order: upstream's own commits skip (parent 2), absorbed-upstream passes, subject match against the PRs windows merged since the last snapshot passes, range-diff pairing against the standing stack passes (which is what clears a hand-resolved replay of an old patch). The remainder is named and refused unless acknowledged with the fixed token `just sync-publish yes` (not freeform prose: just interpolates arguments into the script verbatim, so prose would be code the recipe executes). The merge message records the named commits and the acknowledgement marker.

Selftest: 50 checks green against real git fixture repos driving the real recipes (no mocking): both refusals fire and name their commits, a hand-resolved fold-in publishes, a reused deep-history subject is still refused, the ack marker lands in the merge message, a refused publish mints no series tag, and a clean publish stays quiet. Validated against an independently-built deadlock fixture from the review.

Signoff: gates-selftest on the Windows box (needs pwsh).