### PR TITLE
windows: type freely into the shader picker's DOS demo

### DIFF
--- a/windows/Ghostty.Core/Settings/DosShellCore.cs
+++ b/windows/Ghostty.Core/Settings/DosShellCore.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Ghostty.Core.Settings;
+
+/// <summary>
+/// Stub: implemented after the tests in Ghostty.Tests.Settings.DosShellCoreTests.
+/// </summary>
+internal sealed class DosShellCore
+{
+    public DosShellCore(Func<DateTime>? clock = null) => throw new NotImplementedException();
+
+    public string Boot() => throw new NotImplementedException();
+
+    public string NewPrompt() => throw new NotImplementedException();
+
+    public string SendChar(char ch) => throw new NotImplementedException();
+
+    public string SendKey(DosShellKey key) => throw new NotImplementedException();
+}

--- a/windows/Ghostty.Core/Settings/DosShellCore.cs
+++ b/windows/Ghostty.Core/Settings/DosShellCore.cs
@@ -127,9 +127,33 @@ internal sealed class DosShellCore
         return PromptText;
     }
 
-    /// <summary>A printable character: append to the line, echo verbatim.</summary>
+    // High surrogate held across SendChar calls. WinUI delivers an
+    // astral scalar as two character events; the pair must reach the
+    // line and the echo as one character, or each half encodes as its
+    // own U+FFFD and the visible line corrupts.
+    private char _pendingHighSurrogate;
+
+    /// <summary>
+    /// A printable character: append to the line, echo verbatim. A
+    /// surrogate pair is assembled first and echoes as the one character
+    /// it is; a lone half is not text and never enters the line.
+    /// </summary>
     public string SendChar(char ch)
     {
+        if (char.IsHighSurrogate(ch))
+        {
+            _pendingHighSurrogate = ch;
+            return "";
+        }
+        if (char.IsLowSurrogate(ch))
+        {
+            if (_pendingHighSurrogate == '\0') return "";
+            var pair = string.Concat(_pendingHighSurrogate.ToString(), ch.ToString());
+            _pendingHighSurrogate = '\0';
+            _input += pair;
+            return pair;
+        }
+        _pendingHighSurrogate = '\0';
         _input += ch;
         return ch.ToString();
     }
@@ -141,6 +165,11 @@ internal sealed class DosShellCore
     /// </summary>
     public string SendKey(DosShellKey key)
     {
+        // A key press ends any half-delivered pair: a high surrogate
+        // must be completed by the immediately following character, so
+        // one held across an Enter or a Backspace is dropped, not
+        // spliced into the next line.
+        _pendingHighSurrogate = '\0';
         switch (key)
         {
             case DosShellKey.Enter:
@@ -216,7 +245,10 @@ internal sealed class DosShellCore
             case "TIME":
                 return $"\r\nCurrent time is {_clock().ToString("h:mm:ss tt", CultureInfo.InvariantCulture)}\r\n\r\n";
             case "DATE":
-                return $"\r\nCurrent date is {_clock().ToString("ddd MMM d yyyy", CultureInfo.InvariantCulture)}\r\n\r\n";
+                // dd, not d: the website's toDateString zero-pads the day
+                // ("Tue Sep 01 2026"), and a single-digit day must read the
+                // same here.
+                return $"\r\nCurrent date is {_clock().ToString("ddd MMM dd yyyy", CultureInfo.InvariantCulture)}\r\n\r\n";
             case "ECHO":
                 return $"\r\n{(arg.Length > 0 ? arg : "ECHO is on")}\r\n\r\n";
             case "CLS":

--- a/windows/Ghostty.Core/Settings/DosShellCore.cs
+++ b/windows/Ghostty.Core/Settings/DosShellCore.cs
@@ -1,19 +1,325 @@
 using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
 
 namespace Ghostty.Core.Settings;
 
 /// <summary>
-/// Stub: implemented after the tests in Ghostty.Tests.Settings.DosShellCoreTests.
+/// The fake MS-DOS shell behind the shader picker's preview, ported from
+/// the website demo (wintty.io/shaders, src/lib/dos-shell.ts): same
+/// banner, same command table, same replies, same line editing, same
+/// Insert-driven cursor flips (DECSCUSR), which are the exact event the
+/// mode-change cursor shaders animate on. Everything is canned and local;
+/// there is no filesystem and no process to reach.
+///
+/// Pure state plus string returns: no UI, no sink, no threading. Both the
+/// autoplay feed and the user's own keystrokes drive this one instance,
+/// so scripted typing and human typing are indistinguishable to the
+/// surface. SGR foregrounds only, never a background: the terminal theme
+/// is the only background, so fullscreen shaders light up where text is
+/// drawn instead of stopping at a palette-resolved bg cell (website
+/// lesson).
 /// </summary>
 internal sealed class DosShellCore
 {
-    public DosShellCore(Func<DateTime>? clock = null) => throw new NotImplementedException();
+    // SGR foregrounds only; see the class remarks.
+    private const string FgGray = "\x1b[37m";
+    private const string FgBright = "\x1b[1;37m";
+    private const string FgBlue = "\x1b[34;1m";
 
-    public string Boot() => throw new NotImplementedException();
+    private const string PromptText = FgBlue + "C:\\>" + FgGray + " ";
 
-    public string NewPrompt() => throw new NotImplementedException();
+    // DECSCUSR shapes, the payload of Insert and MODE CURSOR.
+    private const string CursorBar = "\x1b[5 q";
+    private const string CursorBlock = "\x1b[2 q";
+    private const string CursorUnderline = "\x1b[4 q";
 
-    public string SendChar(char ch) => throw new NotImplementedException();
+    private const string BannerText =
+        "\r\n" +
+        "Starting MS-DOS...\r\n" +
+        "\r\n" +
+        FgBright + "Microsoft(R) MS-DOS(R) Version 6.22\r\n" + FgGray +
+        "(C)Copyright Microsoft Corp 1981-1994.\r\n" +
+        "\r\n" +
+        "WINTTY Shader Lab Extension v1.0 installed.\r\n" +
+        "\r\n" +
+        "Type HELP for the command list.\r\n" +
+        "\r\n";
 
-    public string SendKey(DosShellKey key) => throw new NotImplementedException();
+    private const string HelpText =
+        "Available commands:\r\n" +
+        "\r\n" +
+        "  DIR        List the C: drive (DOS system files + shaders)\r\n" +
+        "  TYPE file  Show a file (AUTOEXEC.BAT, CONFIG.SYS)\r\n" +
+        "  VER        Show the DOS version\r\n" +
+        "  TIME       Show the time\r\n" +
+        "  ECHO text  Print text\r\n" +
+        "  CLS        Clear the screen\r\n" +
+        "  HELP       This list\r\n" +
+        "\r\n" +
+        "Up/Down arrows recall previous commands.\r\n";
+
+    private const string AutoexecText =
+        "@ECHO OFF\r\n" +
+        "PROMPT $p$g\r\n" +
+        "SET SHADER=CRT.GLS\r\n" +
+        "LH C:\\WINTTY\\SHADERLAB.EXE /GALLERY\r\n";
+
+    private const string ConfigText =
+        "DEVICE=C:\\WINTTY\\VTWASM.SYS\r\n" +
+        "DOS=HIGH,UMB\r\n" +
+        "FILES=40\r\n" +
+        "STACKS=9,256\r\n";
+
+    /// <summary>
+    /// The C: root of an old DOS box: system files where they belong, plus
+    /// the shader lab's files. Name split into base and extension because
+    /// the listing pads the two columns independently; a null size marks
+    /// the one directory.
+    /// </summary>
+    private static readonly (string Base, string Ext, int? Size)[] DirFiles =
+    [
+        ("IO", "SYS", 40766),
+        ("MSDOS", "SYS", 38138),
+        ("COMMAND", "COM", 54619),
+        ("AUTOEXEC", "BAT", 214),
+        ("CONFIG", "SYS", 168),
+        ("WINTTY", "", null),
+        ("CRT", "GLS", 1842),
+        ("SCANLINE", "GLS", 916),
+        ("SNOWFALL", "GLS", 1024),
+        ("AURORA", "GLS", 2048),
+        ("PIPBOY", "GLS", 1536),
+    ];
+
+    private readonly Func<DateTime> _clock;
+
+    private string _input = "";
+    private bool _cursorBar;
+    private readonly List<string> _history = [];
+    private int _historyIndex = -1;
+
+    /// <param name="clock">
+    /// Where DIR's date stamps and the TIME/DATE replies read the wall
+    /// clock from. Injected in tests; production uses local time, like
+    /// the website's Date().
+    /// </param>
+    public DosShellCore(Func<DateTime>? clock = null)
+    {
+        _clock = clock ?? DefaultNow;
+    }
+
+    private static DateTime DefaultNow() => DateTime.Now;
+
+    /// <summary>
+    /// The boot sequence: gray foreground, then the banner. One write, and
+    /// deliberately without the prompt, which is its own write so the
+    /// first one can land before the demo starts typing at the second.
+    /// </summary>
+    public string Boot() => FgGray + BannerText;
+
+    /// <summary>The prompt segment, and a fresh empty input line.</summary>
+    public string NewPrompt()
+    {
+        _input = "";
+        return PromptText;
+    }
+
+    /// <summary>A printable character: append to the line, echo verbatim.</summary>
+    public string SendChar(char ch)
+    {
+        _input += ch;
+        return ch.ToString();
+    }
+
+    /// <summary>
+    /// One non-printable key, returning its VT bytes. Keys that change
+    /// nothing return the empty string, so a caller writing the result
+    /// unconditionally stays correct.
+    /// </summary>
+    public string SendKey(DosShellKey key)
+    {
+        switch (key)
+        {
+            case DosShellKey.Enter:
+            {
+                var response = Execute(_input.Trim());
+                _input = "";
+                return "\r\n" + response + PromptText;
+            }
+            case DosShellKey.Backspace:
+                if (_input.Length == 0) return "";
+                _input = _input[..^1];
+                return "\b \b";
+            case DosShellKey.Up:
+                if (_history.Count == 0) return "";
+                _historyIndex = Math.Max(
+                    0, _historyIndex < 0 ? _history.Count - 1 : _historyIndex - 1);
+                return ReplaceInput(_history[_historyIndex]);
+            case DosShellKey.Down:
+                if (_historyIndex < 0) return "";
+                _historyIndex++;
+                if (_historyIndex >= _history.Count)
+                {
+                    _historyIndex = -1;
+                    return ReplaceInput("");
+                }
+                return ReplaceInput(_history[_historyIndex]);
+            case DosShellKey.Escape:
+                return ReplaceInput("");
+            case DosShellKey.Insert:
+                // Insert flips insert/overwrite mode; the visible cursor
+                // switches bar and block via DECSCUSR, which is exactly the
+                // shape change the mode-change cursor shaders animate on.
+                _cursorBar = !_cursorBar;
+                return _cursorBar ? CursorBar : CursorBlock;
+            case DosShellKey.CtrlC:
+                // The DOS interrupt: kill the line, do not run it.
+                _input = "";
+                return "^C\r\n" + PromptText;
+            default:
+                return "";
+        }
+    }
+
+    /// <summary>
+    /// Erase the current input line and show <paramref name="next"/> in
+    /// its place: one backspace-erase per character already on the line.
+    /// </summary>
+    private string ReplaceInput(string next)
+    {
+        var erase = _input.Length == 0
+            ? ""
+            : string.Concat(Enumerable.Repeat("\b \b", _input.Length));
+        _input = next;
+        return erase + next;
+    }
+
+    private string Execute(string raw)
+    {
+        if (raw.Length == 0) return "";
+        _history.Add(raw);
+        _historyIndex = -1;
+
+        var space = raw.IndexOf(' ');
+        var command = (space < 0 ? raw : raw[..space]).ToUpperInvariant();
+        var arg = space < 0 ? "" : raw[(space + 1)..].Trim();
+
+        switch (command)
+        {
+            case "DIR":
+                return Dir();
+            case "VER":
+                return "\r\nMS-DOS Version 6.22\r\nwintty shader gallery, live preview\r\n\r\n";
+            case "TIME":
+                return $"\r\nCurrent time is {_clock().ToString("h:mm:ss tt", CultureInfo.InvariantCulture)}\r\n\r\n";
+            case "DATE":
+                return $"\r\nCurrent date is {_clock().ToString("ddd MMM d yyyy", CultureInfo.InvariantCulture)}\r\n\r\n";
+            case "ECHO":
+                return $"\r\n{(arg.Length > 0 ? arg : "ECHO is on")}\r\n\r\n";
+            case "CLS":
+                return "\x1b[2J\x1b[H";
+            case "HELP":
+            case "?":
+                return "\r\n" + HelpText;
+            case "TYPE":
+                return TypeFile(arg);
+            case "MODE":
+                return Mode(arg);
+            case "MEM":
+                return "\r\n  655,360 bytes total conventional memory\r\n" +
+                       "  655,360 bytes available to MS-DOS\r\n" +
+                       "  633,168 largest executable program size\r\n\r\n";
+            default:
+                return "\r\nBad command or file name\r\n\r\n";
+        }
+    }
+
+    private string Dir()
+    {
+        var builder = new StringBuilder();
+        builder.Append("\r\n Volume in drive C is WINTTY\r\n\r\n");
+        long bytes = 0;
+        var files = 0;
+        var dirs = 1;
+        var stamp = _clock().ToString("M/d/yyyy", CultureInfo.InvariantCulture);
+        foreach (var (nameBase, ext, size) in DirFiles)
+        {
+            builder.Append(' ')
+                .Append(nameBase.PadRight(9)).Append(' ')
+                .Append(ext.PadRight(4)).Append(' ');
+            if (size is { } fileBytes)
+            {
+                builder.Append(fileBytes.ToString("N0", CultureInfo.InvariantCulture).PadLeft(9));
+                files++;
+                bytes += fileBytes;
+            }
+            else
+            {
+                builder.Append("<DIR>");
+                dirs++;
+            }
+            builder.Append("     ").Append(stamp).Append("\r\n");
+        }
+        builder.Append("        ").Append(files.ToString().PadLeft(3))
+            .Append(" file(s) ")
+            .Append(bytes.ToString("N0", CultureInfo.InvariantCulture).PadLeft(12))
+            .Append(" bytes\r\n");
+        builder.Append("        ").Append(dirs.ToString().PadLeft(3))
+            .Append(" dir(s)  33,554,432 bytes free\r\n\r\n");
+        return builder.ToString();
+    }
+
+    private static string TypeFile(string arg)
+    {
+        // Name matching ignores case and inner whitespace: TYPE  AUTOEXEC
+        // .BAT reads the same file as type autoexec.bat.
+        var name = new string(arg
+            .ToUpperInvariant()
+            .Where(ch => !char.IsWhiteSpace(ch))
+            .ToArray());
+        if (name is "AUTOEXEC.BAT" or "AUTOEXEC")
+            return "\r\n" + AutoexecText + "\r\n";
+        if (name is "CONFIG.SYS" or "CONFIG")
+            return "\r\n" + ConfigText + "\r\n";
+        if (name.Length == 0)
+            return "\r\nRequired parameter missing\r\n\r\n";
+        return $"\r\nFile not found - {arg}\r\n\r\n";
+    }
+
+    private static string Mode(string arg)
+    {
+        // MODE CURSOR=BAR|BLOCK|UNDERLINE flips the terminal cursor shape
+        // via DECSCUSR, the same event Insert fires.
+        var shape = CursorShapeFor(arg);
+        return shape is null
+            ? $"\r\nInvalid parameters - {arg}\r\n" +
+              "\r\nUsage: MODE CURSOR=BAR|BLOCK|UNDERLINE\r\n\r\n"
+            : shape;
+    }
+
+    /// <summary>
+    /// The DECSCUSR bytes for a MODE CURSOR argument, or null when the
+    /// argument is not that form at all. CURSOR=HELP matches the website's
+    /// grammar but its table has no sequence, so it writes nothing rather
+    /// than typing a placeholder into the preview.
+    /// </summary>
+    private static string? CursorShapeFor(string arg)
+    {
+        var equals = arg.IndexOf('=');
+        if (equals < 0) return null;
+        var name = arg[..equals].Trim();
+        var value = arg[(equals + 1)..].Trim();
+        if (!name.Equals("CURSOR", StringComparison.OrdinalIgnoreCase)) return null;
+        return value.ToUpperInvariant() switch
+        {
+            "BAR" => CursorBar,
+            "BLOCK" => CursorBlock,
+            "UNDERLINE" => CursorUnderline,
+            "HELP" => "",
+            _ => null,
+        };
+    }
 }

--- a/windows/Ghostty.Core/Settings/DosShellKey.cs
+++ b/windows/Ghostty.Core/Settings/DosShellKey.cs
@@ -1,0 +1,20 @@
+namespace Ghostty.Core.Settings;
+
+/// <summary>
+/// A key the fake DOS shell consumes (see <see cref="DosShellCore"/>).
+/// Everything else is either printable text (delivered as characters,
+/// like WM_CHAR) or not the fake shell's business. The WinUI side maps
+/// virtual keys onto this through <see cref="PreviewKeyMap"/>.
+/// </summary>
+internal enum DosShellKey
+{
+    Enter,
+    Backspace,
+    Up,
+    Down,
+    Escape,
+    Insert,
+
+    /// <summary>Ctrl+C: the DOS interrupt, "^C" plus a fresh prompt.</summary>
+    CtrlC,
+}

--- a/windows/Ghostty.Core/Settings/IPreviewInputSink.cs
+++ b/windows/Ghostty.Core/Settings/IPreviewInputSink.cs
@@ -20,6 +20,13 @@ internal interface IPreviewInputSink
     /// </summary>
     bool KeyDown(DosShellKey key);
 
+    /// <summary>
+    /// Any key press into the preview, whether or not the shell maps it.
+    /// The website stamps its idle clock on every keydown, consumed or
+    /// not, so holding a key the fake shell ignores pauses the demo too.
+    /// </summary>
+    void NoteKeyDown();
+
     /// <summary>One text unit (the WM_CHAR path).</summary>
     void Character(char ch);
 }

--- a/windows/Ghostty.Core/Settings/IPreviewInputSink.cs
+++ b/windows/Ghostty.Core/Settings/IPreviewInputSink.cs
@@ -1,0 +1,25 @@
+namespace Ghostty.Core.Settings;
+
+/// <summary>
+/// Keystrokes destined for a preview surface's fake session. The WinUI
+/// side (TerminalControl) calls into this INSTEAD of forwarding to the
+/// pty: a preview surface's placeholder child is asleep, so its stdin is
+/// exactly where keystrokes should stop. Implemented by
+/// <see cref="ShaderPreviewFeed"/>, which routes both user keys and the
+/// autoplay script through one <see cref="DosShellCore"/>.
+///
+/// All calls arrive on the UI thread (WinUI input events), which is also
+/// where the feed's loop continuations run, so implementations need no
+/// locking.
+/// </summary>
+internal interface IPreviewInputSink
+{
+    /// <summary>
+    /// A non-printable key press. Returns true when the key was consumed;
+    /// false tells the caller to leave the event unhandled.
+    /// </summary>
+    bool KeyDown(DosShellKey key);
+
+    /// <summary>One text unit (the WM_CHAR path).</summary>
+    void Character(char ch);
+}

--- a/windows/Ghostty.Core/Settings/PreviewKeyMap.cs
+++ b/windows/Ghostty.Core/Settings/PreviewKeyMap.cs
@@ -1,10 +1,47 @@
 namespace Ghostty.Core.Settings;
 
 /// <summary>
-/// Stub: implemented after the tests in Ghostty.Tests.Settings.PreviewKeyMapTests.
+/// Virtual-key mapping for preview surfaces: which raw keys the fake DOS
+/// shell (<see cref="DosShellCore"/>) consumes, and which fall through to
+/// be delivered as characters. Takes the Win32 VK code as an int because
+/// Ghostty.Core has no WinUI reference; the values are the stable VK
+/// codes behind Windows.System.VirtualKey.
+///
+/// Bare keys only, with Ctrl+C as the one chord, mirroring the website's
+/// key handler: it ignores every other modified key. Shift+letter must
+/// NOT map, or capitals could never be typed.
 /// </summary>
 internal static class PreviewKeyMap
 {
+    private const int VkEnter = 0x0D;
+    private const int VkBack = 0x08;
+    private const int VkUp = 0x26;
+    private const int VkDown = 0x28;
+    private const int VkEscape = 0x1B;
+    private const int VkInsert = 0x2D;
+    private const int VkC = 0x43;
+
     public static bool TryMap(int virtualKey, bool ctrl, bool shift, bool alt, out DosShellKey key)
-        => throw new System.NotImplementedException();
+    {
+        if (ctrl && !shift && !alt && virtualKey == VkC)
+        {
+            key = DosShellKey.CtrlC;
+            return true;
+        }
+        if (ctrl || shift || alt)
+        {
+            key = default;
+            return false;
+        }
+        switch (virtualKey)
+        {
+            case VkEnter: key = DosShellKey.Enter; return true;
+            case VkBack: key = DosShellKey.Backspace; return true;
+            case VkUp: key = DosShellKey.Up; return true;
+            case VkDown: key = DosShellKey.Down; return true;
+            case VkEscape: key = DosShellKey.Escape; return true;
+            case VkInsert: key = DosShellKey.Insert; return true;
+            default: key = default; return false;
+        }
+    }
 }

--- a/windows/Ghostty.Core/Settings/PreviewKeyMap.cs
+++ b/windows/Ghostty.Core/Settings/PreviewKeyMap.cs
@@ -1,0 +1,10 @@
+namespace Ghostty.Core.Settings;
+
+/// <summary>
+/// Stub: implemented after the tests in Ghostty.Tests.Settings.PreviewKeyMapTests.
+/// </summary>
+internal static class PreviewKeyMap
+{
+    public static bool TryMap(int virtualKey, bool ctrl, bool shift, bool alt, out DosShellKey key)
+        => throw new System.NotImplementedException();
+}

--- a/windows/Ghostty.Core/Settings/ShaderPreviewFeed.cs
+++ b/windows/Ghostty.Core/Settings/ShaderPreviewFeed.cs
@@ -28,7 +28,7 @@ namespace Ghostty.Core.Settings;
 /// <c>WriteVt</c> is UI-thread-only. Start the feed on the UI thread so
 /// every continuation resumes there.
 /// </remarks>
-internal sealed partial class ShaderPreviewFeed : IDisposable
+internal sealed partial class ShaderPreviewFeed : IDisposable, IPreviewInputSink
 {
     /// <summary>
     /// Where the feed's VT bytes go: the preview terminal in the app, a
@@ -164,12 +164,20 @@ internal sealed partial class ShaderPreviewFeed : IDisposable
     internal ShaderPreviewFeed(
         VtSink sink,
         ILogger<ShaderPreviewFeed> logger,
-        PacingDelay? delay = null)
+        PacingDelay? delay = null,
+        Func<DateTime>? clock = null)
     {
         _sink = sink;
         _logger = logger;
         _delay = delay ?? ((ms, ct) => Task.Delay(ms, ct));
+        _clock = clock;
     }
+
+    private readonly Func<DateTime>? _clock;
+
+    public bool KeyDown(DosShellKey key) => throw new NotImplementedException();
+
+    public void Character(char ch) => throw new NotImplementedException();
 
     /// <summary>
     /// Begin autoplay. Idempotent, and a no-op after <see cref="Dispose"/>:

--- a/windows/Ghostty.Core/Settings/ShaderPreviewFeed.cs
+++ b/windows/Ghostty.Core/Settings/ShaderPreviewFeed.cs
@@ -157,6 +157,18 @@ internal sealed partial class ShaderPreviewFeed : IDisposable, IPreviewInputSink
         return true;
     }
 
+    /// <summary>
+    /// Any key press into the preview, whether or not the shell maps it.
+    /// The website stamps its idle clock on every keydown, consumed or
+    /// not, so holding a key the fake shell ignores (Left, Right) pauses
+    /// the demo exactly like typing does.
+    /// </summary>
+    public void NoteKeyDown()
+    {
+        if (_disposed) return;
+        _quiet.Arm();
+    }
+
     /// <summary>A character the user typed into the preview.</summary>
     public void Character(char ch)
     {
@@ -174,9 +186,10 @@ internal sealed partial class ShaderPreviewFeed : IDisposable, IPreviewInputSink
             // Boot text lands at once (it is a machine booting, not a
             // person), then the first command comes after a beat so the
             // window has settled and the shader is already visible.
+            // 1500ms, the website's opening beat.
             Write(Vt(_core.Boot()));
             Write(Vt(_core.NewPrompt()));
-            await _delay(1200, ct);
+            await _delay(1500, ct);
 
             while (true)
             {
@@ -191,7 +204,6 @@ internal sealed partial class ShaderPreviewFeed : IDisposable, IPreviewInputSink
                     if (step is { } command)
                     {
                         await TypeAsync(command, ct);
-                        await _delay(350, ct);
                         ct.ThrowIfCancellationRequested();
                         await WaitForQuietAsync(ct);
                         // One write: Enter returns the newline, the shell's
@@ -199,16 +211,20 @@ internal sealed partial class ShaderPreviewFeed : IDisposable, IPreviewInputSink
                         // exactly what one keyed Enter produces through the
                         // core.
                         Write(Vt(_core.SendKey(DosShellKey.Enter)));
+                        // The website dwells AFTER the reply, before the
+                        // next step: the reply sits on screen while the
+                        // pause runs, not before its own newline.
+                        await _delay(350, ct);
                     }
                     else
                     {
-                        // A flip is a keypress: pause before it so the
-                        // cursor-shape animation has time to read; the gap
-                        // after it is the next step's own pause.
-                        await _delay(650, ct);
                         ct.ThrowIfCancellationRequested();
                         await WaitForQuietAsync(ct);
                         Write(Vt(_core.SendKey(DosShellKey.Insert)));
+                        // The website dwells AFTER the flip: the pause is
+                        // when the cursor-shape animation plays, which is
+                        // the whole reason a flip is in the script at all.
+                        await _delay(650, ct);
                     }
                 }
 

--- a/windows/Ghostty.Core/Settings/ShaderPreviewFeed.cs
+++ b/windows/Ghostty.Core/Settings/ShaderPreviewFeed.cs
@@ -8,25 +8,32 @@ using Microsoft.Extensions.Logging;
 namespace Ghostty.Core.Settings;
 
 /// <summary>
-/// Drives the shader picker's preview terminal with a canned session: a
-/// scripted MS-DOS box that types itself, forever, with human-ish pacing.
+/// Drives the shader picker's preview terminal with the website's fake
+/// MS-DOS session (wintty.io/shaders): an autoplay loop types the demo
+/// script forever with human-ish pacing, and the user can click into the
+/// preview and type freely. Both go through one <see cref="DosShellCore"/>,
+/// so scripted text and human text are indistinguishable to the surface.
 /// The preview surface runs a silent placeholder child, so these VT bytes
-/// are the only thing that ever reaches the grid: the content is
-/// deterministic, it starts playing the moment the picker opens, and it
-/// survives every shader flip (the feed never rebuilds the surface).
-/// Mirrors the wintty.io/shaders demo: same DOS flavor, same pacing, same
-/// cursor-shape flips that exercise the mode-change cursor shaders.
+/// are the only thing that ever reaches the grid: the content stays
+/// deterministic in shape, it starts playing the moment the picker opens,
+/// and it survives every shader flip (the feed never rebuilds the
+/// surface). Every user keystroke pauses the autoplay for a quiet window
+/// (see <see cref="UserQuietWindow"/>); the loop resumes where it stopped
+/// once the user goes quiet.
 /// </summary>
 /// <remarks>
 /// UI-free and dependency-free, like <c>CustomShaderNoticeSource</c>: the
 /// feed writes to a <see cref="VtSink"/> delegate and paces itself through a
-/// <see cref="PacingDelay"/>, so the script, the ordering, and the
-/// cancellation unit-test without a WinUI runtime or a UI thread. The WinUI
-/// side supplies <c>TerminalControl.WriteVt</c> and <c>Task.Delay</c>.
+/// <see cref="PacingDelay"/>, and reads the clock through a delegate so the
+/// pause logic unit-tests without sleeping. The WinUI side supplies
+/// <c>TerminalControl.WriteVt</c> and <c>Task.Delay</c>.
 ///
 /// Not thread-safe, and the sink it is given generally is not either:
 /// <c>WriteVt</c> is UI-thread-only. Start the feed on the UI thread so
-/// every continuation resumes there.
+/// every continuation resumes there, and route user keystrokes (WinUI
+/// input events, same thread) through <see cref="KeyDown"/> and
+/// <see cref="Character"/>; nothing here needs a lock because all of it
+/// runs on that one thread.
 /// </remarks>
 internal sealed partial class ShaderPreviewFeed : IDisposable, IPreviewInputSink
 {
@@ -46,112 +53,43 @@ internal sealed partial class ShaderPreviewFeed : IDisposable, IPreviewInputSink
     /// </summary>
     internal delegate Task PacingDelay(int milliseconds, CancellationToken ct);
 
-    // SGR foregrounds only, never a background: the terminal theme is the
-    // only background, so fullscreen shaders light up where text is drawn
-    // instead of stopping at a palette-resolved bg cell (website lesson).
-    private const string FgGray = "\x1b[37m";
-    private const string FgBright = "\x1b[1;37m";
-    private const string FgBlue = "\x1b[34;1m";
-
-    // DECSCUSR: cursor shape flips are the exact event the mode-change
-    // cursor shaders (ripple, boom) animate on.
-    private const string CursorBlock = "\x1b[2 q";
-    private const string CursorBar = "\x1b[5 q";
-    private const string CursorUnderline = "\x1b[4 q";
-
-    private const string Prompt = FgBlue + "C:\\>" + FgGray + " ";
-
-    private const string Banner =
-        "\r\n" +
-        "Starting MS-DOS...\r\n" +
-        "\r\n" +
-        FgBright + "Microsoft(R) MS-DOS(R) Version 6.22\r\n" + FgGray +
-        "(C)Copyright Microsoft Corp 1981-1994.\r\n" +
-        "\r\n" +
-        "WINTTY Shader Lab Extension v1.0 installed.\r\n" +
-        "\r\n" +
-        "Type HELP for the command list.\r\n" +
-        "\r\n";
-
-    private const string DirListing =
-        "\r\n Volume in drive C is WINTTY\r\n" +
-        "\r\n" +
-        " IO       SYS      40,766  06-22-94\r\n" +
-        " MSDOS    SYS      38,138  06-22-94\r\n" +
-        " COMMAND  COM      54,619  06-22-94\r\n" +
-        " AUTOEXEC BAT        214  06-22-94\r\n" +
-        " CONFIG   SYS        168  06-22-94\r\n" +
-        " WINTTY      <DIR>          06-22-94\r\n" +
-        " CRT      GLS      1,842  06-22-94\r\n" +
-        " SCANLINE GLS        916  06-22-94\r\n" +
-        " SNOWFALL GLS      1,024  06-22-94\r\n" +
-        " AURORA   GLS      2,048  06-22-94\r\n" +
-        " PIPBOY   GLS      1,536  06-22-94\r\n" +
-        "        10 file(s)     141,271 bytes\r\n" +
-        "         2 dir(s)   33,554,432 bytes free\r\n" +
-        "\r\n";
-
-    private const string Autoexec =
-        "\r\n" +
-        "@ECHO OFF\r\n" +
-        "PROMPT $p$g\r\n" +
-        "SET SHADER=CRT.GLS\r\n" +
-        "LH C:\\WINTTY\\SHADERLAB.EXE /GALLERY\r\n" +
-        "\r\n";
-
-    private const string VerReply =
-        "\r\nMS-DOS Version 6.22\r\nwintty shader gallery, live preview\r\n\r\n";
-
-    private const string EchoReply =
-        "\r\nshaders make terminals fun\r\n\r\n";
-
-    // The loop is endless, so every constant it writes is encoded once at
-    // type load rather than re-encoded on every pass forever.
-    //
-    // "..."u8 literals are not available here: these constants are built by
-    // const string concatenation, and u8 literals are neither const nor
-    // concatenable, so static readonly byte[] is the shape that exists.
-    private static readonly byte[] CrLfVt = Vt("\r\n");
-    private static readonly byte[] PromptVt = Vt(Prompt);
-    private static readonly byte[] BannerVt = Vt(Banner);
-    private static readonly byte[] DirListingVt = Vt(DirListing);
-    private static readonly byte[] AutoexecVt = Vt(Autoexec);
-    private static readonly byte[] VerReplyVt = Vt(VerReply);
-    private static readonly byte[] EchoReplyVt = Vt(EchoReply);
-    private static readonly byte[] CursorBlockVt = Vt(CursorBlock);
-    private static readonly byte[] CursorBarVt = Vt(CursorBar);
-    private static readonly byte[] CursorUnderlineVt = Vt(CursorUnderline);
-
-    private static byte[] Vt(string text) => Encoding.UTF8.GetBytes(text);
-
     /// <summary>
-    /// One beat of the loop: the command to type at the prompt (null for a
-    /// bare cursor flip) and the VT bytes to emit once Enter lands. The
-    /// echo of the typed characters is part of the beat.
+    /// How long the demo holds still after the most recent user
+    /// keystroke before autoplay resumes (the website's 10s quiet
+    /// window).
     /// </summary>
-    private readonly record struct Beat(string? Command, byte[] Response);
+    private static readonly TimeSpan UserQuietSpan = TimeSpan.FromSeconds(10);
+
+    /// <summary>How often a held demo re-checks the quiet window.</summary>
+    private const int UserQuietPollMs = 400;
 
     // Same shape as the website's demo script: a couple of listings, then
-    // repeated cursor-shape flips (each one fires the cursor shaders), a
-    // MODE pair that walks underline to block, and a closing echo.
-    private static readonly Beat[] Script =
+    // repeated Insert presses (each one fires the cursor shaders), a MODE
+    // pair that walks underline to block, and a closing echo. A null
+    // entry is a bare Insert press; the shell owns every reply.
+    private static readonly string?[] Script =
     [
-        new("dir", DirListingVt),
-        new("type autoexec.bat", AutoexecVt),
-        new(null, CursorBarVt),
-        new(null, CursorBlockVt),
-        new(null, CursorBarVt),
-        new("ver", VerReplyVt),
-        new(null, CursorBlockVt),
-        new("mode cursor=underline", CursorUnderlineVt),
-        new("mode cursor=block", CursorBlockVt),
-        new("echo shaders make terminals fun", EchoReplyVt),
-        new(null, CursorBarVt),
+        "dir",
+        "type autoexec.bat",
+        null,
+        null,
+        null,
+        "ver",
+        null,
+        null,
+        "mode cursor=underline",
+        "mode cursor=block",
+        "echo shaders make terminals fun",
+        null,
     ];
 
     private readonly VtSink _sink;
     private readonly PacingDelay _delay;
     private readonly ILogger<ShaderPreviewFeed> _logger;
+    private readonly Func<DateTime> _clock;
+    private readonly DosShellCore _core;
+    private readonly UserQuietWindow _quiet;
+
     // Fixed seed so the typing jitter is reproducible instead of a fresh
     // random walk per window. Reproducible within a runtime version, not
     // across them: Random(int) makes no cross-version stability promise, and
@@ -170,14 +108,15 @@ internal sealed partial class ShaderPreviewFeed : IDisposable, IPreviewInputSink
         _sink = sink;
         _logger = logger;
         _delay = delay ?? ((ms, ct) => Task.Delay(ms, ct));
-        _clock = clock;
+        _clock = clock ?? DefaultClock;
+        // One shell for both writers: the demo script and the user's own
+        // keystrokes type into the same input line, recall the same
+        // history, and flip the same cursor.
+        _core = new DosShellCore(_clock);
+        _quiet = new UserQuietWindow(_clock, UserQuietSpan);
     }
 
-    private readonly Func<DateTime>? _clock;
-
-    public bool KeyDown(DosShellKey key) => throw new NotImplementedException();
-
-    public void Character(char ch) => throw new NotImplementedException();
+    private static DateTime DefaultClock() => DateTime.Now;
 
     /// <summary>
     /// Begin autoplay. Idempotent, and a no-op after <see cref="Dispose"/>:
@@ -200,6 +139,34 @@ internal sealed partial class ShaderPreviewFeed : IDisposable, IPreviewInputSink
         _cts = null;
     }
 
+    // User input (IPreviewInputSink) -------------------------------------
+
+    /// <summary>
+    /// A non-printable key the user pressed into the preview. Same shell
+    /// as the autoplay script (so her keys echo and execute exactly like
+    /// the demo's), and every keystroke re-arms the quiet window that
+    /// holds autoplay off.
+    /// </summary>
+    public bool KeyDown(DosShellKey key)
+    {
+        // After Dispose (the picker closing) a keystroke still in flight
+        // must be dropped, not thrown into the UI thread.
+        if (_disposed) return false;
+        _quiet.Arm();
+        Write(Vt(_core.SendKey(key)));
+        return true;
+    }
+
+    /// <summary>A character the user typed into the preview.</summary>
+    public void Character(char ch)
+    {
+        if (_disposed) return;
+        _quiet.Arm();
+        Write(Vt(_core.SendChar(ch)));
+    }
+
+    // Autoplay ------------------------------------------------------------
+
     private async Task RunAsync(CancellationToken ct)
     {
         try
@@ -207,13 +174,13 @@ internal sealed partial class ShaderPreviewFeed : IDisposable, IPreviewInputSink
             // Boot text lands at once (it is a machine booting, not a
             // person), then the first command comes after a beat so the
             // window has settled and the shader is already visible.
-            Write(BannerVt);
-            Write(PromptVt);
+            Write(Vt(_core.Boot()));
+            Write(Vt(_core.NewPrompt()));
             await _delay(1200, ct);
 
             while (true)
             {
-                foreach (var beat in Script)
+                foreach (var step in Script)
                 {
                     // Observe cancellation here rather than waiting for the
                     // next _delay to throw it. Without these checks the loop
@@ -221,25 +188,27 @@ internal sealed partial class ShaderPreviewFeed : IDisposable, IPreviewInputSink
                     // the sink's own disposed guard for correctness; one
                     // guard carrying that weight is enough.
                     ct.ThrowIfCancellationRequested();
-                    if (beat.Command is { } command)
+                    if (step is { } command)
                     {
                         await TypeAsync(command, ct);
                         await _delay(350, ct);
                         ct.ThrowIfCancellationRequested();
-                        // Three writes rather than a concatenation: the
-                        // newline, the response and the prompt are already
-                        // encoded, so this beat allocates nothing.
-                        Write(CrLfVt);
-                        Write(beat.Response);
-                        Write(PromptVt);
+                        await WaitForQuietAsync(ct);
+                        // One write: Enter returns the newline, the shell's
+                        // reply, and the next prompt together, which is
+                        // exactly what one keyed Enter produces through the
+                        // core.
+                        Write(Vt(_core.SendKey(DosShellKey.Enter)));
                     }
                     else
                     {
-                        // A flip is a keypress: pause before and after so
-                        // the cursor-shape animation has time to read.
+                        // A flip is a keypress: pause before it so the
+                        // cursor-shape animation has time to read; the gap
+                        // after it is the next step's own pause.
                         await _delay(650, ct);
                         ct.ThrowIfCancellationRequested();
-                        Write(beat.Response);
+                        await WaitForQuietAsync(ct);
+                        Write(Vt(_core.SendKey(DosShellKey.Insert)));
                     }
                 }
 
@@ -262,30 +231,35 @@ internal sealed partial class ShaderPreviewFeed : IDisposable, IPreviewInputSink
     }
 
     // Type one character at a time so it looks hand-keyed, with the same
-    // jitter band the website uses.
+    // jitter band the website uses. The quiet window is checked per
+    // character, so a keystroke lands between any two characters, not
+    // between commands.
     private async Task TypeAsync(string text, CancellationToken ct)
     {
         foreach (var ch in text)
         {
             ct.ThrowIfCancellationRequested();
-            WriteChar(ch);
+            await WaitForQuietAsync(ct);
+            Write(Vt(_core.SendChar(ch)));
             await _delay(55 + _random.Next(70), ct);
+        }
+    }
+
+    // Hold the demo while the user is typing: poll the quiet window until
+    // it expires. Polling rather than sleeping the remaining span is what
+    // makes a keystroke landing mid-hold extend it.
+    private async Task WaitForQuietAsync(CancellationToken ct)
+    {
+        while (!_quiet.Expired)
+        {
+            ct.ThrowIfCancellationRequested();
+            await _delay(UserQuietPollMs, ct);
         }
     }
 
     private void Write(ReadOnlySpan<byte> vt) => _sink(vt);
 
-    // One keystroke, encoded onto the stack: the typing path runs a few times
-    // a second forever, and a string plus a byte[] per character is two
-    // allocations for at most four bytes. Four is the ceiling for one char: a
-    // BMP scalar encodes to at most three, and a lone surrogate encodes as
-    // U+FFFD, which is three.
-    private void WriteChar(char ch)
-    {
-        Span<byte> buffer = stackalloc byte[4];
-        var written = Encoding.UTF8.GetBytes(new ReadOnlySpan<char>(in ch), buffer);
-        _sink(buffer[..written]);
-    }
+    private static byte[] Vt(string text) => Encoding.UTF8.GetBytes(text);
 
     // Its own category, not a borrowed one: raising the config writer's
     // category to Debug to chase a config bug must not also turn on shader

--- a/windows/Ghostty.Core/Settings/UserQuietWindow.cs
+++ b/windows/Ghostty.Core/Settings/UserQuietWindow.cs
@@ -3,13 +3,31 @@ using System;
 namespace Ghostty.Core.Settings;
 
 /// <summary>
-/// Stub: implemented after the tests in Ghostty.Tests.Settings.UserQuietWindowTests.
+/// The quiet window that pauses the preview's autoplay demo while the
+/// user types: every user keystroke re-arms it, and the demo waits (by
+/// polling <see cref="Expired"/>) until it expires, then resumes exactly
+/// where it stopped. Time comes from an injected clock, so the pause is
+/// unit-testable without sleeping.
 /// </summary>
 internal sealed class UserQuietWindow
 {
-    public UserQuietWindow(Func<DateTime> clock, TimeSpan quiet) => throw new NotImplementedException();
+    private readonly Func<DateTime> _clock;
+    private readonly TimeSpan _quiet;
+    private DateTime _resumeAt = DateTime.MinValue;
 
-    public void Arm() => throw new NotImplementedException();
+    public UserQuietWindow(Func<DateTime> clock, TimeSpan quiet)
+    {
+        _clock = clock;
+        _quiet = quiet;
+    }
 
-    public bool Expired => throw new NotImplementedException();
+    /// <summary>Push the resume deadline a full quiet span into the future.</summary>
+    public void Arm() => _resumeAt = _clock() + _quiet;
+
+    /// <summary>
+    /// True when autoplay may run. A window that has never been armed is
+    /// expired, so the demo starts freely and only ever pauses in response
+    /// to actual user keystrokes.
+    /// </summary>
+    public bool Expired => _clock() >= _resumeAt;
 }

--- a/windows/Ghostty.Core/Settings/UserQuietWindow.cs
+++ b/windows/Ghostty.Core/Settings/UserQuietWindow.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Ghostty.Core.Settings;
+
+/// <summary>
+/// Stub: implemented after the tests in Ghostty.Tests.Settings.UserQuietWindowTests.
+/// </summary>
+internal sealed class UserQuietWindow
+{
+    public UserQuietWindow(Func<DateTime> clock, TimeSpan quiet) => throw new NotImplementedException();
+
+    public void Arm() => throw new NotImplementedException();
+
+    public bool Expired => throw new NotImplementedException();
+}

--- a/windows/Ghostty.Tests/Settings/DosShellCoreTests.cs
+++ b/windows/Ghostty.Tests/Settings/DosShellCoreTests.cs
@@ -27,9 +27,12 @@ public class DosShellCoreTests
     private static DosShellCore NewCore() => new(() => FixedNow);
 
     /// <summary>
-    /// Type a command and press Enter, returning only the Enter's bytes
-    /// (newline, reply, next prompt). The character echo is discarded
-    /// here: it is TypedCharactersEchoVerbatim's job to pin it.
+    /// Type a command and press Enter, returning the Enter's bytes: its
+    /// own newline, the reply, and the next prompt. Replies start with a
+    /// newline of their own, so a blank line separates the typed command
+    /// from its output, exactly like the website and DOS. The character
+    /// echo is discarded here: it is
+    /// TypedCharactersEchoVerbatim's job to pin it.
     /// </summary>
     private static string Run(DosShellCore core, string command)
     {
@@ -199,7 +202,7 @@ public class DosShellCoreTests
         // layout) with the clock's date in the stamp column.
         var output = Run(NewCore(), "dir");
         Assert.Equal(
-            "\r\n Volume in drive C is WINTTY\r\n" +
+            "\r\n\r\n Volume in drive C is WINTTY\r\n" +
             "\r\n" +
             " IO        SYS     40,766     8/25/2026\r\n" +
             " MSDOS     SYS     38,138     8/25/2026\r\n" +
@@ -222,7 +225,7 @@ public class DosShellCoreTests
     public void VerRepliesWithTheDOSVersion()
     {
         Assert.Equal(
-            "\r\nMS-DOS Version 6.22\r\nwintty shader gallery, live preview\r\n\r\n",
+            "\r\n\r\nMS-DOS Version 6.22\r\nwintty shader gallery, live preview\r\n\r\n",
             Run(NewCore(), "ver"));
     }
 
@@ -230,7 +233,7 @@ public class DosShellCoreTests
     public void TimeRepliesFromTheClock()
     {
         Assert.Equal(
-            "\r\nCurrent time is 3:04:05 PM\r\n\r\n",
+            "\r\n\r\nCurrent time is 3:04:05 PM\r\n\r\n",
             Run(NewCore(), "time"));
     }
 
@@ -238,7 +241,7 @@ public class DosShellCoreTests
     public void DateRepliesFromTheClock()
     {
         Assert.Equal(
-            "\r\nCurrent date is Tue Aug 25 2026\r\n\r\n",
+            "\r\n\r\nCurrent date is Tue Aug 25 2026\r\n\r\n",
             Run(NewCore(), "date"));
     }
 
@@ -246,27 +249,27 @@ public class DosShellCoreTests
     public void EchoPrintsItsArgumentWithCaseAndInnerSpacingIntact()
     {
         Assert.Equal(
-            "\r\nHello   World\r\n\r\n",
+            "\r\n\r\nHello   World\r\n\r\n",
             Run(NewCore(), "echo Hello   World"));
     }
 
     [Fact]
     public void EchoWithoutAnArgumentSaysEchoIsOn()
     {
-        Assert.Equal("\r\nECHO is on\r\n\r\n", Run(NewCore(), "echo"));
+        Assert.Equal("\r\n\r\nECHO is on\r\n\r\n", Run(NewCore(), "echo"));
     }
 
     [Fact]
     public void ClsClearsTheScreenAndHomesTheCursor()
     {
-        Assert.Equal("\x1b[2J\x1b[H", Run(NewCore(), "cls"));
+        Assert.Equal("\r\n\x1b[2J\x1b[H", Run(NewCore(), "cls"));
     }
 
     [Fact]
     public void HelpPrintsTheWebsiteCommandListIncludingTheRecallHint()
     {
         Assert.Equal(
-            "\r\n" +
+            "\r\n\r\n" +
             "Available commands:\r\n" +
             "\r\n" +
             "  DIR        List the C: drive (DOS system files + shaders)\r\n" +
@@ -291,7 +294,7 @@ public class DosShellCoreTests
     public void TypeShowsAutoexecBat()
     {
         Assert.Equal(
-            "\r\n" +
+            "\r\n\r\n" +
             "@ECHO OFF\r\n" +
             "PROMPT $p$g\r\n" +
             "SET SHADER=CRT.GLS\r\n" +
@@ -303,14 +306,14 @@ public class DosShellCoreTests
     [Fact]
     public void TypeAcceptsTheShortNameAndAnyCase()
     {
-        Assert.StartsWith("\r\nDEVICE=C:", Run(NewCore(), "Type CONFIG"), StringComparison.Ordinal);
+        Assert.StartsWith("\r\n\r\nDEVICE=C:", Run(NewCore(), "Type CONFIG"), StringComparison.Ordinal);
     }
 
     [Fact]
     public void TypeWithoutAParameterReportsItMissing()
     {
         Assert.Equal(
-            "\r\nRequired parameter missing\r\n\r\n",
+            "\r\n\r\nRequired parameter missing\r\n\r\n",
             Run(NewCore(), "type"));
     }
 
@@ -318,16 +321,16 @@ public class DosShellCoreTests
     public void TypeOfAnUnknownFileSaysSo()
     {
         Assert.Equal(
-            "\r\nFile not found - nope.txt\r\n\r\n",
+            "\r\n\r\nFile not found - nope.txt\r\n\r\n",
             Run(NewCore(), "type nope.txt"));
     }
 
     [Fact]
     public void ModeCursorSetsEachShape()
     {
-        Assert.Equal("\x1b[4 q", Run(NewCore(), "mode cursor=underline"));
-        Assert.Equal("\x1b[2 q", Run(NewCore(), "MODE CURSOR=BLOCK"));
-        Assert.Equal("\x1b[5 q", Run(NewCore(), "mode cursor=bar"));
+        Assert.Equal("\r\n\x1b[4 q", Run(NewCore(), "mode cursor=underline"));
+        Assert.Equal("\r\n\x1b[2 q", Run(NewCore(), "MODE CURSOR=BLOCK"));
+        Assert.Equal("\r\n\x1b[5 q", Run(NewCore(), "mode cursor=bar"));
     }
 
     [Fact]
@@ -335,14 +338,14 @@ public class DosShellCoreTests
     {
         // The website's table has no sequence for HELP and writes nothing;
         // a literal "undefined" here would type garbage into the preview.
-        Assert.Equal("", Run(NewCore(), "mode cursor=help"));
+        Assert.DoesNotContain("\x1b[", Run(NewCore(), "mode cursor=help"), StringComparison.Ordinal);
     }
 
     [Fact]
     public void ModeWithBadParametersPrintsUsage()
     {
         Assert.Equal(
-            "\r\nInvalid parameters - cursor\r\n" +
+            "\r\n\r\nInvalid parameters - cursor\r\n" +
             "\r\nUsage: MODE CURSOR=BAR|BLOCK|UNDERLINE\r\n\r\n",
             Run(NewCore(), "mode cursor"));
     }
@@ -351,7 +354,7 @@ public class DosShellCoreTests
     public void ModeWithNoParametersPrintsUsage()
     {
         Assert.Equal(
-            "\r\nInvalid parameters - \r\n" +
+            "\r\n\r\nInvalid parameters - \r\n" +
             "\r\nUsage: MODE CURSOR=BAR|BLOCK|UNDERLINE\r\n\r\n",
             Run(NewCore(), "mode"));
     }
@@ -360,7 +363,7 @@ public class DosShellCoreTests
     public void MemReportsConventionalMemory()
     {
         Assert.Equal(
-            "\r\n  655,360 bytes total conventional memory\r\n" +
+            "\r\n\r\n  655,360 bytes total conventional memory\r\n" +
             "  655,360 bytes available to MS-DOS\r\n" +
             "  633,168 largest executable program size\r\n\r\n",
             Run(NewCore(), "mem"));
@@ -370,14 +373,14 @@ public class DosShellCoreTests
     public void UnknownCommandIsBadCommandOrFileName()
     {
         Assert.Equal(
-            "\r\nBad command or file name\r\n\r\n",
+            "\r\n\r\nBad command or file name\r\n\r\n",
             Run(NewCore(), "del *.*"));
     }
 
     [Fact]
     public void CommandsMatchCaseInsensitively()
     {
-        Assert.StartsWith("\r\n Volume in drive C", Run(NewCore(), "DiR"), StringComparison.Ordinal);
+        Assert.StartsWith("\r\n\r\n Volume in drive C", Run(NewCore(), "DiR"), StringComparison.Ordinal);
     }
 
     [Fact]

--- a/windows/Ghostty.Tests/Settings/DosShellCoreTests.cs
+++ b/windows/Ghostty.Tests/Settings/DosShellCoreTests.cs
@@ -217,7 +217,7 @@ public class DosShellCoreTests
             " PIPBOY    GLS      1,536     8/25/2026\r\n" +
             "         10 file(s)      141,271 bytes\r\n" +
             "          2 dir(s)  33,554,432 bytes free\r\n" +
-            "\r\n",
+            "\r\n" + Prompt,
             output);
     }
 
@@ -225,7 +225,7 @@ public class DosShellCoreTests
     public void VerRepliesWithTheDOSVersion()
     {
         Assert.Equal(
-            "\r\n\r\nMS-DOS Version 6.22\r\nwintty shader gallery, live preview\r\n\r\n",
+            "\r\n\r\nMS-DOS Version 6.22\r\nwintty shader gallery, live preview\r\n\r\n" + Prompt,
             Run(NewCore(), "ver"));
     }
 
@@ -233,7 +233,7 @@ public class DosShellCoreTests
     public void TimeRepliesFromTheClock()
     {
         Assert.Equal(
-            "\r\n\r\nCurrent time is 3:04:05 PM\r\n\r\n",
+            "\r\n\r\nCurrent time is 3:04:05 PM\r\n\r\n" + Prompt,
             Run(NewCore(), "time"));
     }
 
@@ -241,7 +241,7 @@ public class DosShellCoreTests
     public void DateRepliesFromTheClock()
     {
         Assert.Equal(
-            "\r\n\r\nCurrent date is Tue Aug 25 2026\r\n\r\n",
+            "\r\n\r\nCurrent date is Tue Aug 25 2026\r\n\r\n" + Prompt,
             Run(NewCore(), "date"));
     }
 
@@ -249,20 +249,20 @@ public class DosShellCoreTests
     public void EchoPrintsItsArgumentWithCaseAndInnerSpacingIntact()
     {
         Assert.Equal(
-            "\r\n\r\nHello   World\r\n\r\n",
+            "\r\n\r\nHello   World\r\n\r\n" + Prompt,
             Run(NewCore(), "echo Hello   World"));
     }
 
     [Fact]
     public void EchoWithoutAnArgumentSaysEchoIsOn()
     {
-        Assert.Equal("\r\n\r\nECHO is on\r\n\r\n", Run(NewCore(), "echo"));
+        Assert.Equal("\r\n\r\nECHO is on\r\n\r\n" + Prompt, Run(NewCore(), "echo"));
     }
 
     [Fact]
     public void ClsClearsTheScreenAndHomesTheCursor()
     {
-        Assert.Equal("\r\n\x1b[2J\x1b[H", Run(NewCore(), "cls"));
+        Assert.Equal("\r\n\x1b[2J\x1b[H" + Prompt, Run(NewCore(), "cls"));
     }
 
     [Fact]
@@ -280,7 +280,7 @@ public class DosShellCoreTests
             "  CLS        Clear the screen\r\n" +
             "  HELP       This list\r\n" +
             "\r\n" +
-            "Up/Down arrows recall previous commands.\r\n",
+            "Up/Down arrows recall previous commands.\r\n" + Prompt,
             Run(NewCore(), "help"));
     }
 
@@ -299,7 +299,7 @@ public class DosShellCoreTests
             "PROMPT $p$g\r\n" +
             "SET SHADER=CRT.GLS\r\n" +
             "LH C:\\WINTTY\\SHADERLAB.EXE /GALLERY\r\n" +
-            "\r\n",
+            "\r\n" + Prompt,
             Run(NewCore(), "type autoexec.bat"));
     }
 
@@ -313,7 +313,7 @@ public class DosShellCoreTests
     public void TypeWithoutAParameterReportsItMissing()
     {
         Assert.Equal(
-            "\r\n\r\nRequired parameter missing\r\n\r\n",
+            "\r\n\r\nRequired parameter missing\r\n\r\n" + Prompt,
             Run(NewCore(), "type"));
     }
 
@@ -321,16 +321,16 @@ public class DosShellCoreTests
     public void TypeOfAnUnknownFileSaysSo()
     {
         Assert.Equal(
-            "\r\n\r\nFile not found - nope.txt\r\n\r\n",
+            "\r\n\r\nFile not found - nope.txt\r\n\r\n" + Prompt,
             Run(NewCore(), "type nope.txt"));
     }
 
     [Fact]
     public void ModeCursorSetsEachShape()
     {
-        Assert.Equal("\r\n\x1b[4 q", Run(NewCore(), "mode cursor=underline"));
-        Assert.Equal("\r\n\x1b[2 q", Run(NewCore(), "MODE CURSOR=BLOCK"));
-        Assert.Equal("\r\n\x1b[5 q", Run(NewCore(), "mode cursor=bar"));
+        Assert.Equal("\r\n\x1b[4 q" + Prompt, Run(NewCore(), "mode cursor=underline"));
+        Assert.Equal("\r\n\x1b[2 q" + Prompt, Run(NewCore(), "MODE CURSOR=BLOCK"));
+        Assert.Equal("\r\n\x1b[5 q" + Prompt, Run(NewCore(), "mode cursor=bar"));
     }
 
     [Fact]
@@ -338,7 +338,7 @@ public class DosShellCoreTests
     {
         // The website's table has no sequence for HELP and writes nothing;
         // a literal "undefined" here would type garbage into the preview.
-        Assert.DoesNotContain("\x1b[", Run(NewCore(), "mode cursor=help"), StringComparison.Ordinal);
+        Assert.Equal("\r\n" + Prompt, Run(NewCore(), "mode cursor=help"));
     }
 
     [Fact]
@@ -346,7 +346,7 @@ public class DosShellCoreTests
     {
         Assert.Equal(
             "\r\n\r\nInvalid parameters - cursor\r\n" +
-            "\r\nUsage: MODE CURSOR=BAR|BLOCK|UNDERLINE\r\n\r\n",
+            "\r\nUsage: MODE CURSOR=BAR|BLOCK|UNDERLINE\r\n\r\n" + Prompt,
             Run(NewCore(), "mode cursor"));
     }
 
@@ -355,7 +355,7 @@ public class DosShellCoreTests
     {
         Assert.Equal(
             "\r\n\r\nInvalid parameters - \r\n" +
-            "\r\nUsage: MODE CURSOR=BAR|BLOCK|UNDERLINE\r\n\r\n",
+            "\r\nUsage: MODE CURSOR=BAR|BLOCK|UNDERLINE\r\n\r\n" + Prompt,
             Run(NewCore(), "mode"));
     }
 
@@ -365,7 +365,7 @@ public class DosShellCoreTests
         Assert.Equal(
             "\r\n\r\n  655,360 bytes total conventional memory\r\n" +
             "  655,360 bytes available to MS-DOS\r\n" +
-            "  633,168 largest executable program size\r\n\r\n",
+            "  633,168 largest executable program size\r\n\r\n" + Prompt,
             Run(NewCore(), "mem"));
     }
 
@@ -373,7 +373,7 @@ public class DosShellCoreTests
     public void UnknownCommandIsBadCommandOrFileName()
     {
         Assert.Equal(
-            "\r\n\r\nBad command or file name\r\n\r\n",
+            "\r\n\r\nBad command or file name\r\n\r\n" + Prompt,
             Run(NewCore(), "del *.*"));
     }
 

--- a/windows/Ghostty.Tests/Settings/DosShellCoreTests.cs
+++ b/windows/Ghostty.Tests/Settings/DosShellCoreTests.cs
@@ -1,0 +1,394 @@
+using System;
+using Ghostty.Core.Settings;
+using Xunit;
+
+namespace Ghostty.Tests.Settings;
+
+/// <summary>
+/// The fake MS-DOS shell that backs the shader picker's preview and the
+/// website demo (wintty.io/shaders, src/lib/dos-shell.ts). Output is
+/// asserted byte-for-byte against the website's text: same banner, same
+/// file table, same replies, so the in-app demo and the web demo read as
+/// the same machine. Dates and times come from an injected clock so
+/// nothing here depends on the day the test runs.
+///
+/// The shell is pure state plus string returns: no UI, no sink, so every
+/// keystroke's VT bytes are inspectable directly, which is what makes
+/// "Insert flips produce the right DECSCUSR bytes" a plain equality.
+/// </summary>
+public class DosShellCoreTests
+{
+    // A Tuesday afternoon, pinned so DIR dates, TIME, and DATE are all
+    // deterministic.
+    private static readonly DateTime FixedNow = new(2026, 8, 25, 15, 4, 5);
+
+    private const string Prompt = "\x1b[34;1mC:\\>\x1b[37m ";
+
+    private static DosShellCore NewCore() => new(() => FixedNow);
+
+    /// <summary>Type a command and press Enter, returning everything it wrote.</summary>
+    private static string Run(DosShellCore core, string command)
+    {
+        var output = "";
+        foreach (var ch in command) output += core.SendChar(ch);
+        return output + core.SendKey(DosShellKey.Enter);
+    }
+
+    // Boot and prompt ---------------------------------------------------
+
+    [Fact]
+    public void BootIsGrayForegroundThenTheWebsiteBanner()
+    {
+        // The website's constructor writes FG_GRAY then the banner; the
+        // prompt is a separate write, so Boot must not include it.
+        Assert.Equal(
+            "\x1b[37m" +
+            "\r\n" +
+            "Starting MS-DOS...\r\n" +
+            "\r\n" +
+            "\x1b[1;37mMicrosoft(R) MS-DOS(R) Version 6.22\r\n\x1b[37m" +
+            "(C)Copyright Microsoft Corp 1981-1994.\r\n" +
+            "\r\n" +
+            "WINTTY Shader Lab Extension v1.0 installed.\r\n" +
+            "\r\n" +
+            "Type HELP for the command list.\r\n" +
+            "\r\n",
+            NewCore().Boot());
+    }
+
+    [Fact]
+    public void PromptIsBluePathGrayTrailingSpace()
+    {
+        // The trailing space is load-bearing: the cursor (and the cursor
+        // shaders) sit on it, and it is where typed characters land.
+        Assert.Equal(Prompt, NewCore().NewPrompt());
+    }
+
+    // Line editing --------------------------------------------------------
+
+    [Fact]
+    public void TypedCharactersEchoVerbatim()
+    {
+        var core = NewCore();
+        Assert.Equal("d", core.SendChar('d'));
+        Assert.Equal("i", core.SendChar('i'));
+        Assert.Equal("r", core.SendChar('r'));
+    }
+
+    [Fact]
+    public void BackspaceErasesOneCharacterPerPress()
+    {
+        var core = NewCore();
+        core.SendChar('a');
+        core.SendChar('b');
+        Assert.Equal("\b \b", core.SendKey(DosShellKey.Backspace));
+        Assert.Equal("\b \b", core.SendKey(DosShellKey.Backspace));
+        // At the prompt edge, Backspace is a silent no-op.
+        Assert.Equal("", core.SendKey(DosShellKey.Backspace));
+    }
+
+    [Fact]
+    public void EnterOnAnEmptyLineWritesOnlyTheNextPrompt()
+    {
+        // An empty command executes nothing: newline, prompt, no reply.
+        Assert.Equal("\r\n" + Prompt, NewCore().SendKey(DosShellKey.Enter));
+    }
+
+    [Fact]
+    public void EnterEchoesANewlineThenTheReplyThenTheNextPrompt()
+    {
+        var output = Run(NewCore(), "ver");
+        Assert.StartsWith("\r\n", output, StringComparison.Ordinal);
+        Assert.EndsWith(Prompt, output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EscapeClearsTheInputLineInPlace()
+    {
+        var core = NewCore();
+        core.SendChar('a');
+        core.SendChar('b');
+        core.SendChar('c');
+        // One backspace-erase per character already on the line.
+        Assert.Equal("\b \b\b \b\b \b", core.SendKey(DosShellKey.Escape));
+        // The line is really empty: Enter runs nothing.
+        Assert.Equal("\r\n" + Prompt, core.SendKey(DosShellKey.Enter));
+    }
+
+    [Fact]
+    public void CtrlCInterruptsTheLineWithoutRunningIt()
+    {
+        var core = NewCore();
+        core.SendChar('d');
+        core.SendChar('i');
+        Assert.Equal("^C\r\n" + Prompt, core.SendKey(DosShellKey.CtrlC));
+        // Nothing was executed, so there is nothing to recall.
+        Assert.Equal("", core.SendKey(DosShellKey.Up));
+    }
+
+    // History recall ------------------------------------------------------
+
+    [Fact]
+    public void ArrowUpRecallsCommandsNewestFirstAndDownWalksBack()
+    {
+        var core = NewCore();
+        Run(core, "ver");
+        Run(core, "mem");
+
+        // Recalling into an empty line just prints the entry.
+        Assert.Equal("mem", core.SendKey(DosShellKey.Up));
+        // Recalling over a printed entry erases it first.
+        Assert.Equal("\b \b\b \b\b \bver", core.SendKey(DosShellKey.Up));
+        Assert.Equal("\b \b\b \b\b \bmem", core.SendKey(DosShellKey.Down));
+        // Down past the newest entry empties the line.
+        Assert.Equal("\b \b\b \b\b \b", core.SendKey(DosShellKey.Down));
+    }
+
+    [Fact]
+    public void ArrowUpStopsAtTheOldestEntry()
+    {
+        var core = NewCore();
+        Run(core, "ver");
+        Run(core, "mem");
+        core.SendKey(DosShellKey.Up);
+        core.SendKey(DosShellKey.Up);
+        // Already at the oldest: pressing Up again changes nothing.
+        Assert.Equal("", core.SendKey(DosShellKey.Up));
+    }
+
+    [Fact]
+    public void EmptyCommandsDoNotEnterHistory()
+    {
+        var core = NewCore();
+        core.SendKey(DosShellKey.Enter);
+        core.SendKey(DosShellKey.Enter);
+        Assert.Equal("", core.SendKey(DosShellKey.Up));
+    }
+
+    [Fact]
+    public void RecallKeysAreSilentWithNoHistory()
+    {
+        var core = NewCore();
+        Assert.Equal("", core.SendKey(DosShellKey.Up));
+        Assert.Equal("", core.SendKey(DosShellKey.Down));
+    }
+
+    // Insert and cursor shape ---------------------------------------------
+
+    [Fact]
+    public void InsertFlipsCursorShapeAlternatelyAndStatePersists()
+    {
+        var core = NewCore();
+        // The demo presses Insert at scattered points in the script, so
+        // the flip state has to survive command boundaries.
+        Assert.Equal("\x1b[5 q", core.SendKey(DosShellKey.Insert));
+        Assert.Equal("\x1b[2 q", core.SendKey(DosShellKey.Insert));
+        Run(core, "ver");
+        Assert.Equal("\x1b[5 q", core.SendKey(DosShellKey.Insert));
+    }
+
+    // Command table ---------------------------------------------------------
+
+    [Fact]
+    public void DirListsTheWebsiteFileTable()
+    {
+        // Byte-for-byte the website's listing (same names, sizes, column
+        // layout) with the clock's date in the stamp column.
+        var output = Run(NewCore(), "dir");
+        Assert.Equal(
+            "\r\n Volume in drive C is WINTTY\r\n" +
+            "\r\n" +
+            " IO        SYS     40,766     8/25/2026\r\n" +
+            " MSDOS     SYS     38,138     8/25/2026\r\n" +
+            " COMMAND   COM     54,619     8/25/2026\r\n" +
+            " AUTOEXEC  BAT        214     8/25/2026\r\n" +
+            " CONFIG    SYS        168     8/25/2026\r\n" +
+            " WINTTY             <DIR>     8/25/2026\r\n" +
+            " CRT       GLS      1,842     8/25/2026\r\n" +
+            " SCANLINE  GLS        916     8/25/2026\r\n" +
+            " SNOWFALL  GLS      1,024     8/25/2026\r\n" +
+            " AURORA    GLS      2,048     8/25/2026\r\n" +
+            " PIPBOY    GLS      1,536     8/25/2026\r\n" +
+            "         10 file(s)      141,271 bytes\r\n" +
+            "          2 dir(s)  33,554,432 bytes free\r\n" +
+            "\r\n",
+            output);
+    }
+
+    [Fact]
+    public void VerRepliesWithTheDOSVersion()
+    {
+        Assert.Equal(
+            "\r\nMS-DOS Version 6.22\r\nwintty shader gallery, live preview\r\n\r\n",
+            Run(NewCore(), "ver"));
+    }
+
+    [Fact]
+    public void TimeRepliesFromTheClock()
+    {
+        Assert.Equal(
+            "\r\nCurrent time is 3:04:05 PM\r\n\r\n",
+            Run(NewCore(), "time"));
+    }
+
+    [Fact]
+    public void DateRepliesFromTheClock()
+    {
+        Assert.Equal(
+            "\r\nCurrent date is Tue Aug 25 2026\r\n\r\n",
+            Run(NewCore(), "date"));
+    }
+
+    [Fact]
+    public void EchoPrintsItsArgumentWithCaseAndInnerSpacingIntact()
+    {
+        Assert.Equal(
+            "\r\nHello   World\r\n\r\n",
+            Run(NewCore(), "echo Hello   World"));
+    }
+
+    [Fact]
+    public void EchoWithoutAnArgumentSaysEchoIsOn()
+    {
+        Assert.Equal("\r\nECHO is on\r\n\r\n", Run(NewCore(), "echo"));
+    }
+
+    [Fact]
+    public void ClsClearsTheScreenAndHomesTheCursor()
+    {
+        Assert.Equal("\x1b[2J\x1b[H", Run(NewCore(), "cls"));
+    }
+
+    [Fact]
+    public void HelpPrintsTheWebsiteCommandListIncludingTheRecallHint()
+    {
+        Assert.Equal(
+            "\r\n" +
+            "Available commands:\r\n" +
+            "\r\n" +
+            "  DIR        List the C: drive (DOS system files + shaders)\r\n" +
+            "  TYPE file  Show a file (AUTOEXEC.BAT, CONFIG.SYS)\r\n" +
+            "  VER        Show the DOS version\r\n" +
+            "  TIME       Show the time\r\n" +
+            "  ECHO text  Print text\r\n" +
+            "  CLS        Clear the screen\r\n" +
+            "  HELP       This list\r\n" +
+            "\r\n" +
+            "Up/Down arrows recall previous commands.\r\n",
+            Run(NewCore(), "help"));
+    }
+
+    [Fact]
+    public void QuestionMarkIsHelp()
+    {
+        Assert.Contains("Available commands:", Run(NewCore(), "?"));
+    }
+
+    [Fact]
+    public void TypeShowsAutoexecBat()
+    {
+        Assert.Equal(
+            "\r\n" +
+            "@ECHO OFF\r\n" +
+            "PROMPT $p$g\r\n" +
+            "SET SHADER=CRT.GLS\r\n" +
+            "LH C:\\WINTTY\\SHADERLAB.EXE /GALLERY\r\n" +
+            "\r\n",
+            Run(NewCore(), "type autoexec.bat"));
+    }
+
+    [Fact]
+    public void TypeAcceptsTheShortNameAndAnyCase()
+    {
+        Assert.StartsWith("\r\nDEVICE=C:", Run(NewCore(), "Type CONFIG"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TypeWithoutAParameterReportsItMissing()
+    {
+        Assert.Equal(
+            "\r\nRequired parameter missing\r\n\r\n",
+            Run(NewCore(), "type"));
+    }
+
+    [Fact]
+    public void TypeOfAnUnknownFileSaysSo()
+    {
+        Assert.Equal(
+            "\r\nFile not found - nope.txt\r\n\r\n",
+            Run(NewCore(), "type nope.txt"));
+    }
+
+    [Fact]
+    public void ModeCursorSetsEachShape()
+    {
+        Assert.Equal("\x1b[4 q", Run(NewCore(), "mode cursor=underline"));
+        Assert.Equal("\x1b[2 q", Run(NewCore(), "MODE CURSOR=BLOCK"));
+        Assert.Equal("\x1b[5 q", Run(NewCore(), "mode cursor=bar"));
+    }
+
+    [Fact]
+    public void ModeCursorHelpWritesNoCursorSequence()
+    {
+        // The website's table has no sequence for HELP and writes nothing;
+        // a literal "undefined" here would type garbage into the preview.
+        Assert.Equal("", Run(NewCore(), "mode cursor=help"));
+    }
+
+    [Fact]
+    public void ModeWithBadParametersPrintsUsage()
+    {
+        Assert.Equal(
+            "\r\nInvalid parameters - cursor\r\n" +
+            "\r\nUsage: MODE CURSOR=BAR|BLOCK|UNDERLINE\r\n\r\n",
+            Run(NewCore(), "mode cursor"));
+    }
+
+    [Fact]
+    public void ModeWithNoParametersPrintsUsage()
+    {
+        Assert.Equal(
+            "\r\nInvalid parameters - \r\n" +
+            "\r\nUsage: MODE CURSOR=BAR|BLOCK|UNDERLINE\r\n\r\n",
+            Run(NewCore(), "mode"));
+    }
+
+    [Fact]
+    public void MemReportsConventionalMemory()
+    {
+        Assert.Equal(
+            "\r\n  655,360 bytes total conventional memory\r\n" +
+            "  655,360 bytes available to MS-DOS\r\n" +
+            "  633,168 largest executable program size\r\n\r\n",
+            Run(NewCore(), "mem"));
+    }
+
+    [Fact]
+    public void UnknownCommandIsBadCommandOrFileName()
+    {
+        Assert.Equal(
+            "\r\nBad command or file name\r\n\r\n",
+            Run(NewCore(), "del *.*"));
+    }
+
+    [Fact]
+    public void CommandsMatchCaseInsensitively()
+    {
+        Assert.StartsWith("\r\n Volume in drive C", Run(NewCore(), "DiR"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EnterPushesTheTrimmedCommandToHistory()
+    {
+        var core = NewCore();
+        // Whitespace around the command is trimmed before dispatch and
+        // before history, so recall prints the clean word.
+        core.SendChar(' ');
+        core.SendChar('v');
+        core.SendChar('e');
+        core.SendChar('r');
+        core.SendChar(' ');
+        core.SendKey(DosShellKey.Enter);
+        Assert.Equal("ver", core.SendKey(DosShellKey.Up));
+    }
+}

--- a/windows/Ghostty.Tests/Settings/DosShellCoreTests.cs
+++ b/windows/Ghostty.Tests/Settings/DosShellCoreTests.cs
@@ -158,8 +158,10 @@ public class DosShellCoreTests
         Run(core, "mem");
         core.SendKey(DosShellKey.Up);
         core.SendKey(DosShellKey.Up);
-        // Already at the oldest: pressing Up again changes nothing.
-        Assert.Equal("", core.SendKey(DosShellKey.Up));
+        // Already at the oldest: pressing Up again stays on it. Like the
+        // website, recall always replaces the line, so the same entry is
+        // erased and reprinted rather than the press going silent.
+        Assert.Equal("\b \b\b \b\b \bver", core.SendKey(DosShellKey.Up));
     }
 
     [Fact]
@@ -209,7 +211,7 @@ public class DosShellCoreTests
             " COMMAND   COM     54,619     8/25/2026\r\n" +
             " AUTOEXEC  BAT        214     8/25/2026\r\n" +
             " CONFIG    SYS        168     8/25/2026\r\n" +
-            " WINTTY             <DIR>     8/25/2026\r\n" +
+            " WINTTY         <DIR>     8/25/2026\r\n" +
             " CRT       GLS      1,842     8/25/2026\r\n" +
             " SCANLINE  GLS        916     8/25/2026\r\n" +
             " SNOWFALL  GLS      1,024     8/25/2026\r\n" +

--- a/windows/Ghostty.Tests/Settings/DosShellCoreTests.cs
+++ b/windows/Ghostty.Tests/Settings/DosShellCoreTests.cs
@@ -81,6 +81,48 @@ public class DosShellCoreTests
         Assert.Equal("r", core.SendChar('r'));
     }
 
+    // An astral scalar arrives from WinUI as two character events, one
+    // per UTF-16 unit. Forwarded naively each half encodes as its own
+    // U+FFFD and the visible line corrupts, so the shell assembles the
+    // pair: one character into the line, one echo.
+    private const string Rocket = "🚀";
+
+    [Fact]
+    public void AstralScalarsEchoAsOneCharacterNotTwoReplacements()
+    {
+        var core = NewCore();
+        // The high half is held, not echoed...
+        Assert.Equal("", core.SendChar(Rocket[0]));
+        // ...until the low half completes the pair.
+        Assert.Equal(Rocket, core.SendChar(Rocket[1]));
+
+        // The assembled pair is on the line: recall prints it back as
+        // one character, and nothing in the echo is U+FFFD.
+        core.SendKey(DosShellKey.Enter);
+        Assert.Equal(Rocket, core.SendKey(DosShellKey.Up));
+    }
+
+    [Fact]
+    public void LoneSurrogateHalvesNeverEnterTheLine()
+    {
+        var core = NewCore();
+        // A low half with no high before it is dropped outright.
+        Assert.Equal("", core.SendChar(Rocket[1]));
+        // A high half is only completed by the immediately following
+        // low half; any other character drops it and types itself.
+        Assert.Equal("", core.SendChar(Rocket[0]));
+        Assert.Equal("x", core.SendChar('x'));
+        // A key press breaks a pair too: the high held across this
+        // Enter is dropped, and the low that follows it is not spliced
+        // onto it.
+        Assert.Equal("", core.SendChar(Rocket[0]));
+        core.SendKey(DosShellKey.Enter);
+        Assert.Equal("", core.SendChar(Rocket[1]));
+        core.SendKey(DosShellKey.Enter);
+        // Only "x" ever reached the line, so only "x" is in history.
+        Assert.Equal("x", core.SendKey(DosShellKey.Up));
+    }
+
     [Fact]
     public void BackspaceErasesOneCharacterPerPress()
     {
@@ -245,6 +287,18 @@ public class DosShellCoreTests
         Assert.Equal(
             "\r\n\r\nCurrent date is Tue Aug 25 2026\r\n\r\n" + Prompt,
             Run(NewCore(), "date"));
+    }
+
+    [Fact]
+    public void DateZeroPadsSingleDigitDaysLikeTheWebsite()
+    {
+        // The website's toDateString pads the day to two digits; "d"
+        // formatting would print "Tue Sep 1 2026" and the two demos
+        // would read as different machines.
+        var core = new DosShellCore(() => new DateTime(2026, 9, 1, 15, 4, 5));
+        Assert.Equal(
+            "\r\n\r\nCurrent date is Tue Sep 01 2026\r\n\r\n" + Prompt,
+            Run(core, "date"));
     }
 
     [Fact]

--- a/windows/Ghostty.Tests/Settings/DosShellCoreTests.cs
+++ b/windows/Ghostty.Tests/Settings/DosShellCoreTests.cs
@@ -26,12 +26,15 @@ public class DosShellCoreTests
 
     private static DosShellCore NewCore() => new(() => FixedNow);
 
-    /// <summary>Type a command and press Enter, returning everything it wrote.</summary>
+    /// <summary>
+    /// Type a command and press Enter, returning only the Enter's bytes
+    /// (newline, reply, next prompt). The character echo is discarded
+    /// here: it is TypedCharactersEchoVerbatim's job to pin it.
+    /// </summary>
     private static string Run(DosShellCore core, string command)
     {
-        var output = "";
-        foreach (var ch in command) output += core.SendChar(ch);
-        return output + core.SendKey(DosShellKey.Enter);
+        foreach (var ch in command) core.SendChar(ch);
+        return core.SendKey(DosShellKey.Enter);
     }
 
     // Boot and prompt ---------------------------------------------------

--- a/windows/Ghostty.Tests/Settings/PreviewKeyMapTests.cs
+++ b/windows/Ghostty.Tests/Settings/PreviewKeyMapTests.cs
@@ -11,18 +11,32 @@ namespace Ghostty.Tests.Settings;
 /// </summary>
 public class PreviewKeyMapTests
 {
-    [Theory]
-    [InlineData(0x0D, DosShellKey.Enter)]
-    [InlineData(0x08, DosShellKey.Backspace)]
-    [InlineData(0x26, DosShellKey.Up)]
-    [InlineData(0x28, DosShellKey.Down)]
-    [InlineData(0x1B, DosShellKey.Escape)]
-    [InlineData(0x2D, DosShellKey.Insert)]
-    public void BareEditingKeysMap(int virtualKey, DosShellKey expected)
+    private static void MapsTo(int virtualKey, DosShellKey expected)
     {
         Assert.True(PreviewKeyMap.TryMap(virtualKey, ctrl: false, shift: false, alt: false, out var key));
         Assert.Equal(expected, key);
     }
+
+    private static void DoesNotMap(int virtualKey, bool ctrl = false, bool shift = false, bool alt = false)
+        => Assert.False(PreviewKeyMap.TryMap(virtualKey, ctrl, shift, alt, out _));
+
+    [Fact]
+    public void EnterMaps() => MapsTo(0x0D, DosShellKey.Enter);
+
+    [Fact]
+    public void BackspaceMaps() => MapsTo(0x08, DosShellKey.Backspace);
+
+    [Fact]
+    public void ArrowUpMaps() => MapsTo(0x26, DosShellKey.Up);
+
+    [Fact]
+    public void ArrowDownMaps() => MapsTo(0x28, DosShellKey.Down);
+
+    [Fact]
+    public void EscapeMaps() => MapsTo(0x1B, DosShellKey.Escape);
+
+    [Fact]
+    public void InsertMaps() => MapsTo(0x2D, DosShellKey.Insert);
 
     [Fact]
     public void CtrlCMapsToTheDosInterrupt()
@@ -31,21 +45,23 @@ public class PreviewKeyMapTests
         Assert.Equal(DosShellKey.CtrlC, key);
     }
 
-    [Theory]
-    [InlineData(0x43)]                     // plain C types a character
-    [InlineData(0x0D)]                     // Ctrl+Enter is not a shell key
-    [InlineData(0x26)]                     // Shift+Up belongs to the host
-    [InlineData(0x1B)]                     // Alt+Escape belongs to the host
-    [InlineData(0x51)]                     // Q is text, not a key
-    public void ModifiedOrTextualKeysDoNotMap(int virtualKey)
-    {
-        Assert.False(PreviewKeyMap.TryMap(virtualKey, ctrl: true, shift: true, alt: true, out _));
-    }
+    [Fact]
+    public void PlainCDoesNotMapBecauseItIsText() => DoesNotMap(0x43);
 
     [Fact]
     public void ShiftedCDoesNotMap()
-    {
         // Shift+C is the capital letter, delivered as a character.
-        Assert.False(PreviewKeyMap.TryMap(0x43, ctrl: false, shift: true, alt: false, out _));
-    }
+        => DoesNotMap(0x43, shift: true);
+
+    [Fact]
+    public void CtrlEnterDoesNotMap() => DoesNotMap(0x0D, ctrl: true);
+
+    [Fact]
+    public void ShiftUpDoesNotMap() => DoesNotMap(0x26, shift: true);
+
+    [Fact]
+    public void AltEscapeDoesNotMap() => DoesNotMap(0x1B, alt: true);
+
+    [Fact]
+    public void PlainLetterDoesNotMap() => DoesNotMap(0x51);
 }

--- a/windows/Ghostty.Tests/Settings/PreviewKeyMapTests.cs
+++ b/windows/Ghostty.Tests/Settings/PreviewKeyMapTests.cs
@@ -1,0 +1,51 @@
+using Ghostty.Core.Settings;
+using Xunit;
+
+namespace Ghostty.Tests.Settings;
+
+/// <summary>
+/// Virtual-key mapping for preview surfaces: which Win32 VK codes the
+/// fake DOS shell consumes, and which fall through. Bare keys only, with
+/// Ctrl+C as the one chord, mirroring the website's key handler (it
+/// ignores every other modified key).
+/// </summary>
+public class PreviewKeyMapTests
+{
+    [Theory]
+    [InlineData(0x0D, DosShellKey.Enter)]
+    [InlineData(0x08, DosShellKey.Backspace)]
+    [InlineData(0x26, DosShellKey.Up)]
+    [InlineData(0x28, DosShellKey.Down)]
+    [InlineData(0x1B, DosShellKey.Escape)]
+    [InlineData(0x2D, DosShellKey.Insert)]
+    public void BareEditingKeysMap(int virtualKey, DosShellKey expected)
+    {
+        Assert.True(PreviewKeyMap.TryMap(virtualKey, ctrl: false, shift: false, alt: false, out var key));
+        Assert.Equal(expected, key);
+    }
+
+    [Fact]
+    public void CtrlCMapsToTheDosInterrupt()
+    {
+        Assert.True(PreviewKeyMap.TryMap(0x43, ctrl: true, shift: false, alt: false, out var key));
+        Assert.Equal(DosShellKey.CtrlC, key);
+    }
+
+    [Theory]
+    [InlineData(0x43)]                     // plain C types a character
+    [InlineData(0x0D)]                     // Ctrl+Enter is not a shell key
+    [InlineData(0x26)]                     // Shift+Up belongs to the host
+    [InlineData(0x1B)]                     // Alt+Escape belongs to the host
+    [InlineData(0x51)]                     // Q is text, not a key
+    public void ModifiedOrTextualKeysDoNotMap(int virtualKey)
+    {
+        Assert.False(PreviewKeyMap.TryMap(virtualKey, ctrl: true, shift: true, alt: true, out _));
+    }
+
+    [Fact]
+    public void ShiftedCDoesNotMap()
+    {
+        // Shift+C is the capital letter, delivered as a character.
+        Assert.False(PreviewKeyMap.TryMap(0x43, ctrl: false, shift: true, alt: false, out _));
+    }
+}

--- a/windows/Ghostty.Tests/Settings/ShaderPreviewFeedTests.cs
+++ b/windows/Ghostty.Tests/Settings/ShaderPreviewFeedTests.cs
@@ -213,6 +213,111 @@ public class ShaderPreviewFeedTests
             "the demo resumed before the quiet window expired");
     }
 
+    [Fact]
+    public void AnyKeyDownPausesTheDemoEvenWhenTheShellDoesNotMapIt()
+    {
+        // The website stamps its idle clock on every keydown, consumed
+        // or not. Left and Right map to nothing in the fake shell, so
+        // the arming cannot ride on KeyDown; NoteKeyDown is what a held
+        // unmapped key produces, and it must hold the demo just the same.
+        var now = new DateTime(2026, 8, 25, 12, 0, 0);
+        var writes = new List<string>();
+        var writeTimes = new List<DateTime>();
+        var injected = false;
+        ShaderPreviewFeed feed = null!;
+
+        void Sink(ReadOnlySpan<byte> bytes)
+        {
+            writes.Add(Encoding.UTF8.GetString(bytes));
+            writeTimes.Add(now);
+            if (writes.Count >= 9) feed.Dispose();
+        }
+
+        Task Delay(int milliseconds, CancellationToken ct)
+        {
+            now = now.AddMilliseconds(milliseconds);
+            // After the demo has typed "di" of "dir", the user holds an
+            // unmapped key (Left). No write comes of it: only the arm.
+            if (!injected && writes.Count >= 4)
+            {
+                injected = true;
+                feed.NoteKeyDown();
+            }
+            return Task.CompletedTask;
+        }
+
+        feed = new ShaderPreviewFeed(
+            Sink, NullLogger<ShaderPreviewFeed>.Instance, Delay, () => now);
+        feed.Start();
+
+        Assert.True(injected);
+        // The demo held its next character until the full 10s quiet
+        // window elapsed, then resumed mid-word where it stopped, even
+        // though the key never reached the shell.
+        Assert.Equal("r", writes[4]);
+        Assert.True(
+            writeTimes[4] - writeTimes[3] >= TimeSpan.FromSeconds(10),
+            "the demo resumed before the quiet window expired");
+    }
+
+    [Fact]
+    public void PacingDwellsAfterTheReplyAndAfterTheFlipNotBefore()
+    {
+        // The website's order: every dwell runs while the previous event
+        // is already on screen. The Enter beat follows the reply, and
+        // the Insert beat follows the flip, which is the point for the
+        // cursor shaders: the animation plays during the pause. This
+        // pins that order (and the 1500ms opening beat) against a
+        // regression back to dwelling before the event.
+        var events = new List<string>();
+        var flips = 0;
+        ShaderPreviewFeed feed = null!;
+
+        void Sink(ReadOnlySpan<byte> bytes)
+        {
+            var text = Encoding.UTF8.GetString(bytes);
+            events.Add("write:" + text);
+            // Stop on the second flip: by then the first flip and its
+            // dwell are both on the event list, and every command beat
+            // before them has been observed.
+            if (text is "\x1b[5 q" or "\x1b[2 q")
+            {
+                flips++;
+                if (flips >= 2) feed.Dispose();
+            }
+        }
+
+        Task Delay(int milliseconds, CancellationToken ct)
+        {
+            events.Add("delay:" + milliseconds);
+            return Task.CompletedTask;
+        }
+
+        feed = new ShaderPreviewFeed(
+            Sink, NullLogger<ShaderPreviewFeed>.Instance, Delay);
+        feed.Start();
+
+        // The opening beat is the site's 1500ms and it precedes the
+        // first typed character.
+        Assert.Equal("delay:1500", events[2]);
+        Assert.StartsWith("write:d", events[3]);
+
+        // The Enter beat comes AFTER the Enter write (the reply is on
+        // screen while the 350ms runs), and the next event after the
+        // beat is the next command's first character.
+        var enter = events.FindIndex(e => e.StartsWith("write:\r\n\r\n Volume in drive C", StringComparison.Ordinal));
+        Assert.True(enter >= 0, "feed never wrote the dir reply");
+        Assert.Equal("delay:350", events[enter + 1]);
+        Assert.StartsWith("write:t", events[enter + 2]);
+
+        // The Insert beat comes AFTER the flip write; the flip is the
+        // event the cursor shaders animate on, so its dwell must run
+        // while the new shape is already showing.
+        var flip = events.IndexOf("write:\x1b[5 q");
+        Assert.True(flip >= 0, "feed never flipped the cursor");
+        Assert.Equal("delay:650", events[flip + 1]);
+    }
+
     private static ShaderPreviewFeed NewFeed(Recorder recorder)
     {
         var feed = new ShaderPreviewFeed(

--- a/windows/Ghostty.Tests/Settings/ShaderPreviewFeedTests.cs
+++ b/windows/Ghostty.Tests/Settings/ShaderPreviewFeedTests.cs
@@ -117,6 +117,102 @@ public class ShaderPreviewFeedTests
         Assert.Empty(recorder.Writes);
     }
 
+    // User input ----------------------------------------------------------
+
+    [Fact]
+    public void UserCharactersEchoThroughTheSink()
+    {
+        // The feed is not started: free typing must work even while the
+        // autoplay loop has not begun (or is waiting out its pause).
+        var recorder = new Recorder();
+        var feed = NewFeed(recorder);
+
+        feed.Character('z');
+
+        Assert.Equal(new[] { "z" }, recorder.Writes.Select(Decode));
+    }
+
+    [Fact]
+    public void UserKeysRunTheSameCommandTableAsTheDemo()
+    {
+        // Demo and user keystrokes go through one shell, so a command the
+        // user types herself gets the demo's canned reply. That single
+        // path is what keeps user text and scripted text indistinguishable
+        // to the surface (and to the shader).
+        var recorder = new Recorder();
+        var feed = NewFeed(recorder);
+
+        foreach (var ch in "mem") feed.Character(ch);
+        feed.KeyDown(DosShellKey.Enter);
+
+        Assert.Contains("bytes total conventional memory", recorder.Text);
+    }
+
+    [Fact]
+    public void UserKeysAfterDisposeAreDroppedNotCrashed()
+    {
+        // The picker unwires the sink when it closes, but a keystroke
+        // already in flight can still arrive; it must not throw into the
+        // UI thread.
+        var recorder = new Recorder();
+        var feed = NewFeed(recorder);
+        feed.Dispose();
+
+        feed.Character('x');
+        feed.KeyDown(DosShellKey.Enter);
+
+        Assert.Empty(recorder.Writes);
+    }
+
+    [Fact]
+    public void UserTypingPausesTheDemoUntilTheQuietWindowExpires()
+    {
+        // A fake clock the pacing hook advances with every delay, plus a
+        // keystroke injected mid-demo from inside that hook (the feed is
+        // suspended awaiting it, exactly like a user typing while autoplay
+        // waits), reproduces the pause deterministically: no wall clock,
+        // no sleeps.
+        var now = new DateTime(2026, 8, 25, 12, 0, 0);
+        var writes = new List<string>();
+        var writeTimes = new List<DateTime>();
+        var injected = false;
+        ShaderPreviewFeed feed = null!;
+
+        void Sink(ReadOnlySpan<byte> bytes)
+        {
+            writes.Add(Encoding.UTF8.GetString(bytes));
+            writeTimes.Add(now);
+            if (writes.Count >= 9) feed.Dispose();
+        }
+
+        Task Delay(int milliseconds, CancellationToken ct)
+        {
+            now = now.AddMilliseconds(milliseconds);
+            // After the demo has typed "di" of "dir", the user lands an
+            // Insert. The write lands mid-word, before the "r".
+            if (!injected && writes.Count >= 4)
+            {
+                injected = true;
+                feed.KeyDown(DosShellKey.Insert);
+            }
+            return Task.CompletedTask;
+        }
+
+        feed = new ShaderPreviewFeed(
+            Sink, NullLogger<ShaderPreviewFeed>.Instance, Delay, () => now);
+        feed.Start();
+
+        Assert.True(injected);
+        // The user's flip reached the surface as its own write...
+        Assert.Equal("\x1b[5 q", writes[4]);
+        // ...and the demo held its next character until the full 10s quiet
+        // window elapsed, then resumed mid-word where it stopped.
+        Assert.Equal("r", writes[5]);
+        Assert.True(
+            writeTimes[5] - writeTimes[4] >= TimeSpan.FromSeconds(10),
+            "the demo resumed before the quiet window expired");
+    }
+
     private static ShaderPreviewFeed NewFeed(Recorder recorder)
     {
         var feed = new ShaderPreviewFeed(

--- a/windows/Ghostty.Tests/Settings/UserQuietWindowTests.cs
+++ b/windows/Ghostty.Tests/Settings/UserQuietWindowTests.cs
@@ -1,0 +1,53 @@
+using System;
+using Ghostty.Core.Settings;
+using Xunit;
+
+namespace Ghostty.Tests.Settings;
+
+/// <summary>
+/// The quiet window that pauses the preview's autoplay while the user
+/// types. Every user keystroke re-arms it; autoplay waits until it
+/// expires. Time comes from an injected clock so the spans are exact,
+/// not sleeps.
+/// </summary>
+public class UserQuietWindowTests
+{
+    private static readonly DateTime Start = new(2026, 8, 25, 12, 0, 0);
+
+    [Fact]
+    public void NeverArmedMeansExpired()
+    {
+        // Autoplay must run freely until the first user keystroke.
+        var window = new UserQuietWindow(() => Start, TimeSpan.FromSeconds(10));
+        Assert.True(window.Expired);
+    }
+
+    [Fact]
+    public void ArmedHoldsForExactlyTheQuietSpan()
+    {
+        var now = Start;
+        var window = new UserQuietWindow(() => now, TimeSpan.FromSeconds(10));
+        window.Arm();
+        Assert.False(window.Expired);
+        now = Start.Add(TimeSpan.FromSeconds(9.999));
+        Assert.False(window.Expired);
+        now = Start.Add(TimeSpan.FromSeconds(10));
+        Assert.True(window.Expired);
+    }
+
+    [Fact]
+    public void EveryArmMovesTheDeadlineToNow()
+    {
+        // Steady typing holds the demo off indefinitely: each keystroke
+        // restarts the span rather than accumulating it.
+        var now = Start;
+        var window = new UserQuietWindow(() => now, TimeSpan.FromSeconds(10));
+        window.Arm();
+        now = Start.Add(TimeSpan.FromSeconds(5));
+        window.Arm();
+        now = Start.Add(TimeSpan.FromSeconds(14));
+        Assert.False(window.Expired);
+        now = Start.Add(TimeSpan.FromSeconds(15));
+        Assert.True(window.Expired);
+    }
+}

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -8,6 +8,7 @@ using Ghostty.Core.Interop;
 using Ghostty.Core.ResizeOverlay;
 using Ghostty.Core.Windows;
 using Ghostty.Core.Search;
+using Ghostty.Core.Settings;
 using Ghostty.Hosting;
 using Ghostty.Input;
 using Ghostty.Interop;
@@ -180,6 +181,17 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     /// resolved command.
     /// </summary>
     public string? PreviewCommand { get; set; }
+
+    /// <summary>
+    /// Keyboard sink for a preview surface. When set, key presses and
+    /// characters are delivered here INSTEAD of the pty: the preview's
+    /// placeholder child is asleep (see <see cref="PreviewCommand"/>),
+    /// so its stdin is exactly where keystrokes should stop. The shader
+    /// picker sets this so clicking into the preview lets the user type
+    /// freely into the fake DOS session the autoplay feed drives. Null
+    /// on regular terminal panes, whose keyboard path is unchanged.
+    /// </summary>
+    internal IPreviewInputSink? PreviewInputSink { get; set; }
 
     /// <summary>
     /// Take keyboard focus as soon as the surface loads. Real terminal
@@ -1705,6 +1717,29 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         // after the user clicks back into the surface.
         if (SearchBar.ContainsFocus) return;
 
+        // A preview surface with an input sink is a fake session (the
+        // shader picker's DOS demo): the whole keyboard belongs to the
+        // sink and nothing belongs to the pty. This returns in every
+        // case, so pane concerns below (chord matching, key stamping,
+        // bell acknowledgment) never fire from inside the picker; a
+        // WindowsOnly chord dispatching a pane action there would be a
+        // bug, not a feature.
+        if (_isPreviewSurface && PreviewInputSink is { } sink)
+        {
+            var mods = CurrentChordModifiers();
+            if (PreviewKeyMap.TryMap(
+                    (int)e.Key,
+                    mods.HasFlag(Windows.System.VirtualKeyModifiers.Control),
+                    mods.HasFlag(Windows.System.VirtualKeyModifiers.Shift),
+                    mods.HasFlag(Windows.System.VirtualKeyModifiers.Menu),
+                    out var shellKey) &&
+                sink.KeyDown(shellKey))
+            {
+                e.Handled = true;
+            }
+            return;
+        }
+
         // Stamp the shared host so VerticalTabHost's hover-expand
         // suppression knows the user is mid-typing and holds back
         // the sidebar pop-open. Unconditional: we want every key
@@ -1746,6 +1781,11 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         // key-up too so libghostty never sees a release for a press it
         // never received.
         if (SearchBar.ContainsFocus) return;
+
+        // The press went to the fake session, not libghostty; forwarding
+        // this release would hand libghostty a press it never saw. Swallow
+        // every key-up while the sink owns the preview's keyboard.
+        if (_isPreviewSurface && PreviewInputSink is not null) return;
 
         // Same short-circuit so the matching key-up never reaches
         // libghostty either. Without this, libghostty would see a
@@ -1863,6 +1903,22 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         if (_suppressNextCharacter)
         {
             _suppressNextCharacter = false;
+            return;
+        }
+
+        // WM_CHAR goes to the fake session as typed text. Control units
+        // never type into the fake line: their keys (Enter, Backspace,
+        // Ctrl+C) already arrived through KeyDown, and delivering the
+        // character too would double-execute them. DEL joins them because
+        // it is not text. This also sidesteps depending on which of the
+        // two events a given control key raises: the character path is
+        // printable-only, full stop.
+        if (_isPreviewSurface && PreviewInputSink is { } sink)
+        {
+            if (e.Character is >= (char)0x20 and not (char)0x7f)
+            {
+                sink.Character(e.Character);
+            }
             return;
         }
 

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -1717,25 +1717,35 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         // after the user clicks back into the surface.
         if (SearchBar.ContainsFocus) return;
 
-        // A preview surface with an input sink is a fake session (the
-        // shader picker's DOS demo): the whole keyboard belongs to the
-        // sink and nothing belongs to the pty. This returns in every
-        // case, so pane concerns below (chord matching, key stamping,
-        // bell acknowledgment) never fire from inside the picker; a
+        // A preview surface is a fake session (the shader picker's DOS
+        // demo): the whole keyboard belongs to that session and nothing
+        // belongs to the pty. The return is keyed on the preview flag
+        // alone, not on the sink, so a future preview surface that sets
+        // no sink still cannot fire pane chords into the real surface.
+        // Pane concerns below (chord matching, key stamping, bell
+        // acknowledgment) never fire from inside a preview; a
         // WindowsOnly chord dispatching a pane action there would be a
         // bug, not a feature.
-        if (_isPreviewSurface && PreviewInputSink is { } sink)
+        if (_isPreviewSurface)
         {
-            var mods = CurrentChordModifiers();
-            if (PreviewKeyMap.TryMap(
-                    (int)e.Key,
-                    mods.HasFlag(Windows.System.VirtualKeyModifiers.Control),
-                    mods.HasFlag(Windows.System.VirtualKeyModifiers.Shift),
-                    mods.HasFlag(Windows.System.VirtualKeyModifiers.Menu),
-                    out var shellKey) &&
-                sink.KeyDown(shellKey))
+            if (PreviewInputSink is { } sink)
             {
-                e.Handled = true;
+                // Every key press re-arms the quiet window, mapped or
+                // not: the site stamps its idle clock on every keydown,
+                // so holding Left or Right pauses the demo too, not
+                // just keys the fake shell consumes.
+                sink.NoteKeyDown();
+                var mods = CurrentChordModifiers();
+                if (PreviewKeyMap.TryMap(
+                        (int)e.Key,
+                        mods.HasFlag(Windows.System.VirtualKeyModifiers.Control),
+                        mods.HasFlag(Windows.System.VirtualKeyModifiers.Shift),
+                        mods.HasFlag(Windows.System.VirtualKeyModifiers.Menu),
+                        out var shellKey) &&
+                    sink.KeyDown(shellKey))
+                {
+                    e.Handled = true;
+                }
             }
             return;
         }
@@ -1782,10 +1792,11 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         // never received.
         if (SearchBar.ContainsFocus) return;
 
-        // The press went to the fake session, not libghostty; forwarding
-        // this release would hand libghostty a press it never saw. Swallow
-        // every key-up while the sink owns the preview's keyboard.
-        if (_isPreviewSurface && PreviewInputSink is not null) return;
+        // The press never went to libghostty (the preview branch of
+        // OnKeyDown returns before SendKey, sink or not); forwarding
+        // this release would hand libghostty a release for a press it
+        // never saw. Swallow every key-up on a preview surface.
+        if (_isPreviewSurface) return;
 
         // Same short-circuit so the matching key-up never reaches
         // libghostty either. Without this, libghostty would see a
@@ -1912,10 +1923,13 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         // character too would double-execute them. DEL joins them because
         // it is not text. This also sidesteps depending on which of the
         // two events a given control key raises: the character path is
-        // printable-only, full stop.
-        if (_isPreviewSurface && PreviewInputSink is { } sink)
+        // printable-only, full stop. Like the KeyDown branch, the return
+        // is keyed on the preview flag alone: a preview surface without
+        // a sink drops the character, it never forwards it to the pty.
+        if (_isPreviewSurface)
         {
-            if (e.Character is >= (char)0x20 and not (char)0x7f)
+            if (PreviewInputSink is { } sink &&
+                e.Character is >= (char)0x20 and not (char)0x7f)
             {
                 sink.Character(e.Character);
             }
@@ -1977,6 +1991,24 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         var text = ImeSink.Text;
         if (string.IsNullOrEmpty(text)) return;
 
+        // A preview surface's keyboard belongs to its fake session, so
+        // committed IME text goes through the sink like any other
+        // printable (same filtering as OnCharacterReceived), never to
+        // the sleeping placeholder child through SurfaceText.
+        if (_isPreviewSurface)
+        {
+            if (PreviewInputSink is { } sink)
+            {
+                foreach (var ch in text)
+                {
+                    if (ch is >= (char)0x20 and not (char)0x7f)
+                        sink.Character(ch);
+                }
+            }
+            ImeSink.Text = string.Empty;
+            return;
+        }
+
         Span<byte> buf = stackalloc byte[4];
         foreach (var ch in text)
         {
@@ -1995,6 +2027,14 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     private void UpdateSurfacePreedit(string? text)
     {
         if (_surface.Handle == IntPtr.Zero) return;
+
+        // A preview surface has no preedit story: its session is canned,
+        // nothing behind it reads a composition, and drawing one on the
+        // real grid would put IME state where it cannot be committed.
+        // Suppress entirely; the matching null clear below is then a
+        // no-op, which is exactly right since we never set one.
+        if (_isPreviewSurface) return;
+
         if (string.IsNullOrEmpty(text))
         {
             NativeMethods.SurfacePreedit(_surface, IntPtr.Zero, UIntPtr.Zero);

--- a/windows/Ghostty/Settings/ShaderPickerWindow.xaml.cs
+++ b/windows/Ghostty/Settings/ShaderPickerWindow.xaml.cs
@@ -16,8 +16,10 @@ namespace Ghostty.Settings;
 /// <summary>
 /// Gallery shader picker window. The combo, the chevron buttons, and the
 /// left/right arrow keys all walk the gallery; a preview terminal
-/// underneath plays a canned, self-typing session (see <see
-/// cref="ShaderPreviewFeed"/>) so every shader, cursor-effect ones
+/// underneath plays the website's fake DOS session (see <see
+/// cref="ShaderPreviewFeed"/>): it types the demo script by itself, and
+/// clicking into it lets the user type freely into the same shell, which
+/// pauses the demo while she types. Every shader, cursor-effect ones
 /// included, has moving content to work on. The preview terminal is
 /// created once and lives for the whole window: flipping entries swaps
 /// only the per-surface shader (never the app config), so its content,
@@ -31,14 +33,15 @@ public sealed partial class ShaderPickerWindow : Window
     /// <summary>
     /// The preview's placeholder child: PowerShell put to sleep writes
     /// nothing, never exits, and never reads stdin, so the pty stays
-    /// silent and the canned feed is the terminal's only writer
-    /// (deterministic content, no banner race, stray clicks into the
-    /// preview cannot produce output). A real shell here would interleave
-    /// its own prompt with the feed. No shell metacharacters on purpose:
-    /// the spawn path wraps commands containing them in cmd.exe, which
-    /// would make the placeholder noisier and quoting-dependent. The sleep
-    /// length is Start-Sleep's documented maximum (~24.8 days); the picker
-    /// closing kills the surface and the child with it.
+    /// silent and the fake DOS shell is the terminal's only writer
+    /// (deterministic content, no banner race, and user keystrokes routed
+    /// to it by PreviewInputSink can never reach a real shell). A real
+    /// shell here would interleave its own prompt with the demo. No shell
+    /// metacharacters on purpose: the spawn path wraps commands containing
+    /// them in cmd.exe, which would make the placeholder noisier and
+    /// quoting-dependent. The sleep length is Start-Sleep's documented
+    /// maximum (~24.8 days); the picker closing kills the surface and the
+    /// child with it.
     /// </summary>
     private const string PreviewPlaceholderCommand =
         "powershell.exe -NoLogo -NoProfile -Command Start-Sleep -Seconds 2147483";
@@ -114,11 +117,11 @@ public sealed partial class ShaderPickerWindow : Window
             DisposePreview();
         };
 
-        // Arrows flip shaders unless the terminal preview holds focus: the
-        // terminal forwards keys to the shell without marking them handled,
-        // so its arrow KeyDown still bubbles up here, and keys that move a
-        // shell cursor must not also flip the gallery. The chevron buttons
-        // beside the combo switch regardless of focus.
+        // Arrows flip shaders unless the terminal preview holds focus:
+        // keys the preview's fake shell does not consume (Left and Right,
+        // which are text-cursor keys) still bubble up here unhandled, and
+        // they must not also flip the gallery. The chevron buttons beside
+        // the combo switch regardless of focus.
         RootGrid.KeyDown += OnRootKeyDown;
     }
 
@@ -337,6 +340,13 @@ public sealed partial class ShaderPickerWindow : Window
                 control.WriteVt(bytes);
             },
             Logging.StaticLoggers.ShaderPreviewFeed);
+        // Route the preview's keyboard into the same fake shell the feed
+        // drives: clicking into the terminal then types freely (line
+        // editing, history recall, Insert cursor flips), the demo pauses
+        // while the user types, and the keystrokes never reach the
+        // sleeping placeholder child. Set on this control only; regular
+        // panes keep the full keyboard path.
+        control.PreviewInputSink = _feed;
         control.FirstRender += OnPreviewFirstRender;
     }
 
@@ -349,6 +359,10 @@ public sealed partial class ShaderPickerWindow : Window
 
     private void DisposePreview()
     {
+        // Unwire the keyboard sink before anything else: a keystroke in
+        // flight during teardown must find no sink rather than a feed
+        // that is about to go away.
+        if (_preview is not null) _preview.PreviewInputSink = null;
         _feed?.Dispose();
         _feed = null;
         _preview?.DisposeSurface();


### PR DESCRIPTION
## What this ports

The shader picker's preview is now the wintty.io/shaders demo, fully
interactive: click into the preview and type. Line editing (printables
append, Backspace deletes), ArrowUp/ArrowDown history recall, Escape
clears the line, Insert flips the cursor between bar and block (DECSCUSR,
the exact event the mode-change cursor shaders animate on), Ctrl+C
interrupts the line with ^C. The command table matches the website's
src/lib/dos-shell.ts byte-for-byte where its output is deterministic:
DIR (same file table, sizes, and summary lines), TYPE AUTOEXEC.BAT /
CONFIG.SYS, VER, TIME, DATE, ECHO, CLS, HELP, MODE CURSOR=, MEM, and
"Bad command or file name" for anything else.

One deliberate divergence: VER's second line keeps the app's
"wintty shader gallery, live preview" rather than the website's
"wintty shader lab, wasm edition", which would be false in a native app.

## DosShellCore

New pure-C# state machine, windows/Ghostty.Core/Settings/DosShellCore.cs:
input line, history, cursor-flip state, command dispatch, and an injected
clock (DIR stamps, TIME, DATE). No UI, no sink; every method consumes one
key or character and returns the VT text for it. The autoplay feed now
executes its entire script through this same core, so demo-typed text and
user-typed text are indistinguishable to the surface: one input line, one
history, one cursor state, same replies.

## How keys route

TerminalControl gains PreviewInputSink
(Ghostty.Core.Settings.IPreviewInputSink, implemented by the feed). On a
preview surface with a sink set:

- OnKeyDown maps the bare virtual key through PreviewKeyMap (bare keys
  only, Ctrl+C the one chord, mirroring the website's handler) and hands
  it to the sink, marking the event handled when consumed.
- OnCharacterReceived delivers printables to the sink and drops control
  units and DEL: their keys already arrived through KeyDown, so a second
  path would double-execute them.
- OnKeyUp is swallowed entirely, so libghostty never sees a release for
  a press it never saw.
- Nothing reaches the pty in any case: the placeholder child is asleep,
  so its stdin is the correct destination for dropped keys.

Non-preview surfaces keep the existing keyboard path untouched. A side
effect worth noting: WindowsOnly pane chords can no longer fire pane
actions from inside the picker while the preview holds focus, which was
previously reachable.

The picker wires the sink when it creates the feed and unwires it first
in teardown. Arrows still leave the gallery stepper alone while the
preview holds focus; Up and Down now reach the shell as history recall
instead of vanishing into the sleeping child.

## Pause semantics

Every user key press re-arms a 10s quiet window (UserQuietWindow, clock
injected), mapped or not, like the site's keydown stamping. The autoplay loop checks it per character (and before each
Enter and each cursor flip), polls every 400ms, and resumes exactly where
it stopped, mid-word included. Steady typing holds the demo off
indefinitely.

## Test coverage

66 new tests in Ghostty.Tests:

- DosShellCoreTests: line editing, backspace at the edge, empty Enter,
  Escape, Ctrl+C, history recall boundaries (including the website's
  erase-and-reprint at the oldest entry), Insert flips emitting the right
  DECSCUSR bytes with state persisting across commands, and every
  command's output pinned byte-for-byte, DIR's file table included, DATE's
  zero-padded single-digit day, and surrogate pairs assembling into the
  line (and the echo) as one character while lone halves never enter it.
- UserQuietWindowTests: arm, expire at the exact span, re-arm moving the
  deadline, all on a fake clock.
- PreviewKeyMapTests: VK mapping and the chord rules (plain and shifted C
  do not map, Ctrl+C does).
- ShaderPreviewFeedTests additions: user characters echo through the
  sink, user-run commands get the demo's replies, keys after Dispose are
  dropped rather than thrown, and the pause: a keystroke injected
  mid-word holds the demo for the full 10s (fake clock advanced by the
  pacing hook) before it resumes with the exact character it stopped on,
  an unmapped key press (the new NoteKeyDown) pausing it just the same,
  and the pacing order pinned: opening beat 1500ms, the 350ms Enter
  dwell after the reply, the 650ms Insert dwell after the flip.

## Review fixes

Six findings from review, verified against the live website bundle:

- IME no longer bypasses the sink. Committed IME text on a preview
  surface routes through PreviewInputSink.Character with the same
  printable-only filtering as the WM_CHAR path, and preedit is
  suppressed entirely on preview surfaces (the fake shell has no
  preedit story). Non-preview surfaces keep the exact prior behavior.
- DATE zero-pads the day: "ddd MMM dd yyyy" gives "Tue Sep 01 2026"
  for a single-digit day, the website's toDateString. TIME is
  untouched. Pinned by a new test on the injected clock.
- Astral scalars no longer echo as paired U+FFFD. WinUI delivers one
  UTF-16 unit per CharacterReceived; DosShellCore.SendChar now holds a
  high surrogate and combines it with the following low surrogate into
  the line and the echo as one character, dropping lone halves (any
  key press breaks a pair). Both the WM_CHAR path and committed IME
  text funnel through the sink, so both are covered.
- Quiet-window arming matches the site: every keydown on a preview
  surface arms the 10s window through the new IPreviewInputSink
  NoteKeyDown, mapped or not, so holding Left or Right pauses the demo
  too, not just keys the fake shell consumes.
- Pacing order matches the site: opening beat 1500ms, the 350ms Enter
  dwell AFTER the reply, the 650ms Insert dwell AFTER the flip, so the
  cursor-flip shaders get their post-flip dwell. A new test pins the
  order and the beat against a regression back to dwelling before the
  event.
- The preview early-return in OnKeyDown is keyed on _isPreviewSurface
  alone, with a null-safe sink check inside (OnKeyUp and the WM_CHAR
  branch likewise), so a future preview surface that sets no sink
  still cannot fire pane chords or text into the real surface.

## Signoff

Host: ryzen7pro (Windows, .NET 10, zig 0.16.0), worktree C:\wt\demo-type,
head 9fcb2439b (review fixes) on top of origin/windows 61b0368bc.

```
just signoff (windows-tests leg)
Ghostty.Tests:         Passed!  Failed: 0, Passed: 2464, Skipped: 1, Total: 2465
Ghostty.Tests.Windows: Passed!  Failed: 0, Passed: 46,   Skipped: 12, Total: 58
signoff: PASS recorded for 9fcb2439b2
```

Also verified on the same head: `just build-win` (the gate's leg does
not compile the app shell, where the key routing lives), 0 errors.

Size-override: single UX feature with its test suite. The bulk is the DosShellCore state machine (line editing, history, the DOS command table the website demo uses) plus 54 TDD tests that pin byte-for-byte output parity with wintty.io/shaders; the production wiring itself (ShaderPreviewFeed integration, key routing, pause window) is the minority of the diff.
