### PR TITLE
splash: adopt the High Contrast background when an override is active

### DIFF
--- a/windows/Ghostty.Core/Accessibility/HighContrastConfigWriter.cs
+++ b/windows/Ghostty.Core/Accessibility/HighContrastConfigWriter.cs
@@ -18,6 +18,15 @@ public static class HighContrastConfigWriter
     public const int DefaultMinimumContrast = 7;
 
     /// <summary>
+    /// Convert a Win32 COLORREF (0x00BBGGRR) to the 0x00RRGGBB packing the
+    /// C# colour caches use, so a value sampled beside <see cref="Render"/>
+    /// can be compared with <c>BackgroundColor</c> without a string round
+    /// trip through the config form.
+    /// </summary>
+    public static uint ColorRefToRgb(uint colorRef) =>
+        ((colorRef & 0xFFu) << 16) | (colorRef & 0xFF00u) | ((colorRef >> 16) & 0xFFu);
+
+    /// <summary>
     /// Convert a Win32 COLORREF (0x00BBGGRR) to Ghostty's lowercase
     /// zero-padded #rrggbb config form.
     /// </summary>

--- a/windows/Ghostty.Core/Config/IConfigService.cs
+++ b/windows/Ghostty.Core/Config/IConfigService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Ghostty.Core.Accessibility;
 
 namespace Ghostty.Core.Config;
 
@@ -71,12 +72,24 @@ public interface IConfigService : IDisposable
     bool WindowsHighContrast { get; }
 
     /// <summary>
-    /// Set (or clear, with null) the High Contrast color override body to
-    /// layer on top of the user's config, then reload so it takes effect.
-    /// Called by the High Contrast monitor. A no-op when the body is
-    /// unchanged.
+    /// Set (or clear, with null) the High Contrast palette to layer on top
+    /// of the user's config, then reload so it takes effect. Called by the
+    /// High Contrast monitor. A no-op when the palette is unchanged.
     /// </summary>
-    void SetHighContrastOverride(string? body);
+    void SetHighContrastOverride(HighContrastColors? colors);
+
+    /// <summary>
+    /// The High Contrast background currently layered over the palette,
+    /// packed 0x00RRGGBB, or null when no override is active.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="BackgroundColor"/> is resolved from the user's config and
+    /// theme files, which the High Contrast override never touches: it is
+    /// layered into the native config only. Consumers that need the colour
+    /// the surface will actually settle on under High Contrast (the splash)
+    /// read this and fall back to <see cref="BackgroundColor"/>.
+    /// </remarks>
+    uint? HighContrastBackground { get; }
 
     /// <summary>
     /// Windows-only: backdrop material for the command palette.

--- a/windows/Ghostty.Tests/Accessibility/HighContrastConfigWriterTests.cs
+++ b/windows/Ghostty.Tests/Accessibility/HighContrastConfigWriterTests.cs
@@ -23,6 +23,15 @@ public sealed class HighContrastConfigWriterTests
     }
 
     [Fact]
+    public void ColorRefToRgb_ByteSwapsIntoTheCachePacking()
+    {
+        // COLORREF is 0x00BBGGRR; the C# colour caches pack 0x00RRGGBB.
+        // 0x00123456 => B=0x12 G=0x34 R=0x56 => 0x00563412.
+        Assert.Equal(0x00563412u, HighContrastConfigWriter.ColorRefToRgb(0x00123456u));
+        Assert.Equal(0x00FFFFFFu, HighContrastConfigWriter.ColorRefToRgb(0x00FFFFFFu));
+    }
+
+    [Fact]
     public void Render_EmitsAllFiveLinesInOrder()
     {
         var colors = new HighContrastColors(

--- a/windows/Ghostty.Tests/Config/SettingsConfigWriterTests.cs
+++ b/windows/Ghostty.Tests/Config/SettingsConfigWriterTests.cs
@@ -134,7 +134,8 @@ public class SettingsConfigWriterTests
         public bool VerticalTabsHoverExpand => false;
         public bool CommandPaletteGroupCommands => false;
         public bool WindowsHighContrast => false;
-        public void SetHighContrastOverride(string? body) { }
+        public void SetHighContrastOverride(Ghostty.Core.Accessibility.HighContrastColors? colors) { }
+        public uint? HighContrastBackground => null;
         public string CommandPaletteBackground => "acrylic";
         public string NoColorOverride => "notify";
         public string LogLevel => "info";

--- a/windows/Ghostty.Tests/Logging/SettingsConfigWriterLoggingTests.cs
+++ b/windows/Ghostty.Tests/Logging/SettingsConfigWriterLoggingTests.cs
@@ -63,7 +63,8 @@ public class SettingsConfigWriterLoggingTests
         public bool VerticalTabsHoverExpand => false;
         public bool CommandPaletteGroupCommands => false;
         public bool WindowsHighContrast => false;
-        public void SetHighContrastOverride(string? body) { }
+        public void SetHighContrastOverride(Ghostty.Core.Accessibility.HighContrastColors? colors) { }
+        public uint? HighContrastBackground => null;
         public string CommandPaletteBackground => "acrylic";
         public string NoColorOverride => "notify";
         public string LogLevel => "info";

--- a/windows/Ghostty.Tests/Wiring/SplashThemeCorrectionWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/SplashThemeCorrectionWiringTests.cs
@@ -1,4 +1,6 @@
 using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Xunit;
 
@@ -35,8 +37,19 @@ public class SplashThemeCorrectionWiringTests
         var launched = ShellSource.Load("App.xaml.cs").Method("OnLaunched");
         var adopt = launched.Call("Ghostty.Shell.SplashWindow.AdoptBackground");
 
-        // The terminal's colour, not the desktop's and not a constant.
-        Assert.Equal("_configService.BackgroundColor", adopt.Arg(0));
+        // The terminal's colour, not the desktop's and not a constant. Under
+        // HC that is the override's colour: BackgroundColor resolves from the
+        // config and theme files, which the High Contrast override is not
+        // layered into, so the theme colour here is exactly the mismatch the
+        // reveal used to uncover (#793). Pinned as a parsed coalesce rather
+        // than as text so the operands cannot trade places, which would put
+        // the theme colour back in charge under HC.
+        var colour = Assert.IsType<BinaryExpressionSyntax>(adopt.ArgExpression(0));
+        Assert.True(
+            colour.IsKind(SyntaxKind.CoalesceExpression),
+            "the splash's colour is not chosen between High Contrast and the theme");
+        Assert.Equal("_configService.HighContrastBackground", colour.Left.ToString());
+        Assert.Equal("_configService.BackgroundColor", colour.Right.ToString());
 
         // Statement order inside the method body, so the ordering is checked
         // rather than merely "somewhere in here".
@@ -65,6 +78,38 @@ public class SplashThemeCorrectionWiringTests
             handedOver < firstWindow,
             "the correction is published after the first window is built, which is too "
                 + "late for it to finish before a frame is revealed");
+    }
+
+    /// <summary>
+    /// What the window records for the next launch's splash must be the
+    /// colour that launch will settle on. Under High Contrast that is the
+    /// override's colour: BackgroundColor is resolved from the config and
+    /// theme files, which the override is not layered into, so recording it
+    /// under HC leaves the next HC launch starting one step from the right
+    /// colour and crossfading on every start (#793).
+    /// </summary>
+    [Fact]
+    public void TheRecordedBackground_PrefersTheHighContrastColour_WhenAnOverrideIsLayered()
+    {
+        var record = ShellSource.Load("MainWindow.xaml.cs").Method("RecordSplashBackground");
+
+        var background = record.Body!.Statements
+            .OfType<LocalDeclarationStatementSyntax>()
+            .Single(s => s.Declaration.Variables.Any(v => v.Identifier.ValueText == "background"));
+
+        // The mask survives from before; what it is applied to is the fix.
+        var mask = Assert.IsType<BinaryExpressionSyntax>(
+            background.Declaration.Variables.Single().Initializer!.Value);
+        Assert.True(mask.IsKind(SyntaxKind.BitwiseAndExpression));
+        Assert.Equal("0x00FFFFFFu", mask.Right.ToString());
+
+        var colour = Assert.IsType<BinaryExpressionSyntax>(
+            Assert.IsType<ParenthesizedExpressionSyntax>(mask.Left).Expression);
+        Assert.True(
+            colour.IsKind(SyntaxKind.CoalesceExpression),
+            "the recorded colour is not chosen between High Contrast and the theme");
+        Assert.Equal("_configService.HighContrastBackground", colour.Left.ToString());
+        Assert.Equal("_configService.BackgroundColor", colour.Right.ToString());
     }
 
     /// <summary>

--- a/windows/Ghostty/Accessibility/HighContrastMonitor.cs
+++ b/windows/Ghostty/Accessibility/HighContrastMonitor.cs
@@ -79,6 +79,8 @@ internal sealed partial class HighContrastMonitor : IDisposable
             SelectionBackground: GetSysColor(COLOR_HIGHLIGHT),
             SelectionForeground: GetSysColor(COLOR_HIGHLIGHTTEXT));
 
-        _configService.SetHighContrastOverride(HighContrastConfigWriter.Render(colors));
+        // The palette, not the rendered body: ConfigService owns the layering
+        // and needs the colours beside it to answer HighContrastBackground.
+        _configService.SetHighContrastOverride(colors);
     }
 }

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -808,7 +808,14 @@ public partial class App : Application
         // does nothing at all when the colour it already painted turns out
         // to have been right, and the first window is still below, so there
         // is room to land before anything is revealed.
-        Ghostty.Shell.SplashWindow.AdoptBackground(_configService.BackgroundColor);
+        //
+        // The HC colour is asked for explicitly because BackgroundColor
+        // never sees the override: it resolves from the config and theme
+        // files, which the override is not layered into, and the splash
+        // would settle on the theme colour while the reveal uncovers
+        // COLOR_WINDOW (issue #793).
+        Ghostty.Shell.SplashWindow.AdoptBackground(
+            _configService.HighContrastBackground ?? _configService.BackgroundColor);
 
         // Session manager: owns restore decision + debounced persistence.
         // Constructed before window creation so we can decide whether to

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -2778,7 +2778,14 @@ public sealed partial class MainWindow : Window
     /// </remarks>
     private bool RecordSplashBackground()
     {
-        var background = _configService.BackgroundColor & 0x00FFFFFFu;
+        // The HC colour when the override is layered, not BackgroundColor:
+        // that one resolves from the config and theme files, which the
+        // override is not layered into, so persisting it under HC would
+        // start the next HC launch's splash on the theme colour -- one step
+        // further from the colour the terminal is about to settle on
+        // (issue #793).
+        var background = (_configService.HighContrastBackground
+            ?? _configService.BackgroundColor) & 0x00FFFFFFu;
 
         // Neither a configured background nor a configured theme means the
         // colour is the built-in theme's, which tracks the desktop and so is

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
+using Ghostty.Core.Accessibility;
 using Ghostty.Core.Config;
 using Ghostty.Core.Env;
 using Ghostty.Core.Shell;
@@ -70,11 +71,12 @@ internal sealed partial class ConfigService : IConfigService, Ghostty.Core.Profi
     public string CommandPaletteBackground { get; private set; } = "acrylic";
     public string NoColorOverride { get; private set; } = NoColorPolicy.Default;
 
-    // The High Contrast override config body to layer on top of the user's
-    // config, or null when HC is inactive/opted-out. Set by
-    // HighContrastMonitor; consumed in Reload. Only touched on the UI thread
-    // (the monitor marshals its events, and Reload runs on the UI thread).
-    private string? _highContrastOverrideBody;
+    // The High Contrast palette to layer on top of the user's config, or
+    // null when HC is inactive/opted-out. Set by HighContrastMonitor;
+    // consumed in Reload and by HighContrastBackground. Only touched on the
+    // UI thread (the monitor marshals its events, and Reload runs on the UI
+    // thread).
+    private HighContrastColors? _highContrastOverrideColors;
     public string LogLevel { get; private set; } = "info";
     public string LogFilter { get; private set; } = string.Empty;
 
@@ -546,15 +548,16 @@ internal sealed partial class ConfigService : IConfigService, Ghostty.Core.Profi
             NativeMethods.ConfigLoadCliArgs(newConfig);
             NativeMethods.ConfigLoadRecursiveFiles(newConfig);
             // Layer the High Contrast override last so it wins over the
-            // user's colors while HC is active. Skipped (body == null) when
-            // HC is off or opted-out, restoring the user's config.
+            // user's colors while HC is active. Skipped when HC is off or
+            // opted-out, restoring the user's config.
             //
             // Still last now that the CLI and its config-file includes load
             // above it: High Contrast is an accessibility override and has to
             // outrank anything the user asked for, a file named on the command
             // line included.
-            if (_highContrastOverrideBody is { } hcBody)
+            if (_highContrastOverrideColors is { } hcColors)
             {
+                var hcBody = Ghostty.Core.Accessibility.HighContrastConfigWriter.Render(hcColors);
                 var hcPath = Ghostty.Accessibility.HighContrastOverrideFile.Write(hcBody);
                 if (hcPath is not null)
                     NativeMethods.ConfigLoadFile(newConfig, hcPath);
@@ -768,19 +771,36 @@ internal sealed partial class ConfigService : IConfigService, Ghostty.Core.Profi
     public void SuppressWatcher(bool suppress) => _suppressWatcher = suppress;
 
     /// <summary>
-    /// Set (or clear, with null) the High Contrast override config body and
+    /// Set (or clear, with null) the High Contrast override palette and
     /// reload so the layered colors take effect. Called by
     /// <c>HighContrastMonitor</c> on the UI thread. Skips the reload when the
-    /// body is unchanged, so spurious palette-change events don't churn the
+    /// palette is unchanged, so spurious palette-change events don't churn the
     /// config.
     /// </summary>
-    public void SetHighContrastOverride(string? body)
+    public void SetHighContrastOverride(HighContrastColors? colors)
     {
-        if (string.Equals(_highContrastOverrideBody, body, StringComparison.Ordinal))
-            return;
-        _highContrastOverrideBody = body;
+        if (_highContrastOverrideColors == colors) return;
+        _highContrastOverrideColors = colors;
         Reload();
     }
+
+    /// <summary>
+    /// The High Contrast background the override layers over the palette,
+    /// packed 0x00RRGGBB, or null when HC is off or opted out.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="BackgroundColor"/> keeps resolving from the config and
+    /// theme files: the override is layered into the native config only, and
+    /// making the C# cache HC-aware would move every chrome consumer that
+    /// reads it under HC (VerticalTitleInk, the drag region, the title bar)
+    /// onto colours #790 verified as they are. This is the one place the
+    /// colour the terminal will actually settle on is answerable, which is
+    /// what the splash needs.
+    /// </remarks>
+    public uint? HighContrastBackground =>
+        _highContrastOverrideColors is { } hc
+            ? Ghostty.Core.Accessibility.HighContrastConfigWriter.ColorRefToRgb(hc.Background)
+            : null;
 
     private void CacheDiagnostics()
     {


### PR DESCRIPTION
Fixes #793.

## Problem

Under High Contrast the splash correction settled on the theme-resolved background (0x1E1E2E) while the reveal uncovered COLOR_WINDOW (0x202020), so the splash ended mis-tinted by (2,2,14). RecordSplashBackground also persisted the theme colour under HC, so the next HC launch started one step from the right colour.

## Root cause

The High Contrast override body is layered only into the native config; BackgroundColor is resolved by ResolveThemedColor from the config and theme files and never sees it. Both splash colour consumers (the AdoptBackground publish in App.OnLaunched and MainWindow.RecordSplashBackground) read BackgroundColor, so both answered the pre-HC colour even after the #788 ordering fix.

## Fix

Narrow, splash-side only: ConfigService now keeps the High Contrast palette (not just its rendered body) and exposes HighContrastBackground (0x00RRGGBB, null when no override). The splash adoption and RecordSplashBackground coalesce it in front of BackgroundColor. BackgroundColor itself is unchanged: the #790 matrix verified the HC chrome that reads it (VerticalTitleInk, drag region, title bar), and making it HC-aware would move those paths onto unverified colours.

SetHighContrastOverride now takes HighContrastColors instead of the rendered body string; ConfigService renders the body itself when layering, which is where the colours now live.

## Guards

- SplashThemeCorrectionWiringTests.TheResolvedBackground_IsHandedOver_AfterHighContrastLands_AndBeforeTheFirstWindow now pins the adoption argument as a parsed coalesce with HighContrastBackground on the left, so the operands cannot trade places.
- SplashThemeCorrectionWiringTests.TheRecordedBackground_PrefersTheHighContrastColour_WhenAnOverrideIsLayered (new) pins the same coalesce inside RecordSplashBackground under the 0x00FFFFFF mask.
- HighContrastConfigWriterTests.ColorRefToRgb_ByteSwapsIntoTheCachePacking covers the new COLORREF to RGB conversion.

Mutation-checked: dropping the HC leg at either call site turns its guard red; swapping the coalesce operands turns the adoption guard red (and cannot compile in the shell: uint ?? uint? is CS0019). Restored, all green.

## Verified

- Ghostty.Tests full run: 2758 passed, 1 pre-existing skip.
- Shell project builds clean (x64).
- Non-HC behaviour unchanged: HighContrastBackground is null without an override, so both call sites read BackgroundColor exactly as before.