### PR TITLE
gates: read the fuzz suite exit codes the way it writes them

### DIFF
--- a/.agents/scripts/nightly_fuzz.ps1
+++ b/.agents/scripts/nightly_fuzz.ps1
@@ -122,6 +122,24 @@ function Write-Status([string]$phase) {
     } catch {}
 }
 
+# The fuzz suite's exit codes carry the suite's whole point (the table in
+# windows/scripts/README.md, decided in fuzz-suite.ps1's Get-Verdict): 2 is a
+# product finding, 1 is a harness that never exercised the product. Reading
+# them the wrong way round files a product bug against a broken harness and
+# buries a real finding under an infra title, and the inverted switch that did
+# it here read plausibly for months. Kept as a function so the self-test can
+# assert against THIS mapping rather than a copy of the rules, which is what
+# lets a self-test pass while the shipped roll-up is inverted.
+function Get-FuzzOutcome {
+    param($Code)
+    switch ([int]$Code) {
+        0       { 'clean' }
+        2       { 'findings' }
+        1       { 'harness' }
+        default { 'unknown' }
+    }
+}
+
 if ($SelfTest) {
     $failed = $false
     $idle = [NightlyIdleProbe]::MinutesIdle()
@@ -134,6 +152,27 @@ if ($SelfTest) {
     if ($cfg.hibernateAfter) { Write-Host 'SELF-TEST FAILED: config roundtrip'; $failed = $true }
     if (-not (Wait-ForIdle -IdleMinutes 0 -TimeoutMinutes 0)) { Write-Host 'SELF-TEST FAILED: zero-threshold idle wait'; $failed = $true }
     if (Wait-ForIdle -IdleMinutes 99999 -TimeoutMinutes 0) { Write-Host 'SELF-TEST FAILED: timeout path returned true'; $failed = $true }
+    # The fuzz exit-code mapping, asserted one code at a time rather than as a
+    # table lookup that would restate Get-FuzzOutcome's switch and agree with
+    # it however it is written. This shipped inverted - 1 filed as a product
+    # finding, 2 falling through to "harness failure" - and no self-test
+    # noticed, because nothing here read the mapping at all.
+    foreach ($c in @(
+        @{ code = 0; want = 'clean';    why = '0 is a clean run' }
+        @{ code = 1; want = 'harness';  why = '1 means the harness could not run, so no product bug is filed' }
+        @{ code = 2; want = 'findings'; why = '2 means real product findings' }
+        @{ code = 7; want = 'unknown';  why = 'a code outside the contract is not silently a pass' }
+    )) {
+        $got = Get-FuzzOutcome $c.code
+        if ($got -ne $c.want) {
+            Write-Host "SELF-TEST FAILED: fuzz exit $($c.code) mapped to '$got', expected '$($c.want)' ($($c.why))"
+            $failed = $true
+        }
+    }
+    # An unset exit code is 'nothing was measured', never a finding: the run
+    # site defaults it with `?? 1`, and this pins the value that default feeds.
+    if ((Get-FuzzOutcome ($null ?? 1)) -ne 'harness') { Write-Host 'SELF-TEST FAILED: missing exit code must degrade to a harness failure, not a product finding'; $failed = $true }
+
     # The self-test dir must be disjoint from the real logs, or a run of the
     # self-test would wipe the user's saved options.
     if ($logDir -eq (Join-Path $repoRoot '.agents\nightly-logs')) { Write-Host 'SELF-TEST FAILED: not sandboxed'; $failed = $true }
@@ -291,13 +330,17 @@ if ($NoFuzz -or (-not $config.runFuzz)) {
     Write-Status 'fuzz'
     $global:LASTEXITCODE = $null
     just --justfile (Join-Path $wt 'justfile') --working-directory $wt fuzz
-    $fuzzRc = $LASTEXITCODE ?? 2
+    # `?? 1`, matching every recipe in the justfile: a `just` that never ran
+    # leaves $LASTEXITCODE unset, and nothing was measured. Defaulting that to
+    # 2 would invent a product finding out of a recipe that never started.
+    $fuzzRc = $LASTEXITCODE ?? 1
     $script:status.results['fuzz'] = $fuzzRc
     Write-Host "nightly: fuzz rc=$fuzzRc"
-    switch ($fuzzRc) {
-        0 { Get-Date -Format 'yyyy-MM-dd' | Set-Content $fuzzStateFile }
-        1 { File-Issue '[nightly] fuzz suite found product failures' "``just fuzz`` exited 1 (product findings)." }
-        default { File-Issue '[nightly] fuzz suite could not run' "``just fuzz`` exited $fuzzRc (harness failure, coverage is not running)." }
+    switch (Get-FuzzOutcome $fuzzRc) {
+        'clean'    { Get-Date -Format 'yyyy-MM-dd' | Set-Content $fuzzStateFile }
+        'findings' { File-Issue '[nightly] fuzz suite found product failures' "``just fuzz`` exited 2 (product findings)." }
+        'harness'  { File-Issue '[nightly] fuzz suite could not run' "``just fuzz`` exited 1 (harness failure, coverage is not running)." }
+        'unknown'  { File-Issue '[nightly] fuzz suite could not run' "``just fuzz`` exited $fuzzRc, outside the suite's 0/1/2 contract, so the product was never judged." }
     }
 }
 

--- a/.agents/scripts/nightly_fuzz.ps1
+++ b/.agents/scripts/nightly_fuzz.ps1
@@ -132,6 +132,12 @@ function Write-Status([string]$phase) {
 # lets a self-test pass while the shipped roll-up is inverted.
 function Get-FuzzOutcome {
     param($Code)
+    # $null explicitly, not left to [int] coercion, which turns "no exit code
+    # was ever collected" into 0, into a clean night - one that stamps
+    # last-fuzz-success and so resets the very starvation check that exists to
+    # notice the leg never ran. The run site's `?? 1` makes that unreachable
+    # today, and a guard two hundred lines away is not a guard.
+    if ($null -eq $Code) { return 'harness' }
     switch ([int]$Code) {
         0       { 'clean' }
         2       { 'findings' }
@@ -169,9 +175,11 @@ if ($SelfTest) {
             $failed = $true
         }
     }
-    # An unset exit code is 'nothing was measured', never a finding: the run
-    # site defaults it with `?? 1`, and this pins the value that default feeds.
-    if ((Get-FuzzOutcome ($null ?? 1)) -ne 'harness') { Write-Host 'SELF-TEST FAILED: missing exit code must degrade to a harness failure, not a product finding'; $failed = $true }
+    # $null is the input that matters, not `$null ?? 1`: `??` is evaluated
+    # before the call, so asserting on it would only re-test code 1 above while
+    # reading like coverage of the missing-exit-code path. An exit code that was
+    # never collected must not coerce to 0 and pass as a clean night.
+    if ((Get-FuzzOutcome $null) -ne 'harness') { Write-Host 'SELF-TEST FAILED: an uncollected exit code must not read as a clean run'; $failed = $true }
 
     # The self-test dir must be disjoint from the real logs, or a run of the
     # self-test would wipe the user's saved options.
@@ -338,8 +346,8 @@ if ($NoFuzz -or (-not $config.runFuzz)) {
     Write-Host "nightly: fuzz rc=$fuzzRc"
     switch (Get-FuzzOutcome $fuzzRc) {
         'clean'    { Get-Date -Format 'yyyy-MM-dd' | Set-Content $fuzzStateFile }
-        'findings' { File-Issue '[nightly] fuzz suite found product failures' "``just fuzz`` exited 2 (product findings)." }
-        'harness'  { File-Issue '[nightly] fuzz suite could not run' "``just fuzz`` exited 1 (harness failure, coverage is not running)." }
+        'findings' { File-Issue '[nightly] fuzz suite found product failures' "``just fuzz`` exited $fuzzRc (product findings)." }
+        'harness'  { File-Issue '[nightly] fuzz suite could not run' "``just fuzz`` exited $fuzzRc (harness failure, coverage is not running)." }
         'unknown'  { File-Issue '[nightly] fuzz suite could not run' "``just fuzz`` exited $fuzzRc, outside the suite's 0/1/2 contract, so the product was never judged." }
     }
 }


### PR DESCRIPTION
The nightly run mapped fuzz exit `1` to "found product failures" and let `2`
fall through `default` as "could not run". That is the suite's contract
backwards. Per `windows/scripts/README.md` and `fuzz-suite.ps1`'s `Get-Verdict`,
`2` is a product finding and `1` is a harness that never exercised the product.

So a real finding was filed under an infra title, and a harness that measured
nothing was filed as a product bug against a build it never touched. That is
exactly the confusion the 0/1/2 split exists to prevent, and `nightly_fuzz.ps1`
was the only place in the repo that got it wrong.

A missing exit code defaulted to `2` as well, inventing a product finding out of
a `just` that never started. It now degrades to `1`, matching the `?? 1` every
recipe in the justfile already uses. Note the `fuzz` recipe itself ends with
`exit ($LASTEXITCODE ?? 1)`, so the only way that default fires at all is a
recipe that never ran.

The mapping moved into `Get-FuzzOutcome` so `-SelfTest` asserts the shipped rule
rather than a copy of it, the same discipline `Get-SuiteOutcome` already uses.
Nothing in the self-test read the mapping before, which is why an inverted
switch survived.

## Second commit: the trap the first one walked into

Review caught the new function repeating, verbatim, what `Get-Verdict` guards
against: with no explicit `$null` check, `[int]$null` coerces to `0`, so "no
exit code was ever collected" maps to `clean`. That arm stamps
`last-fuzz-success.txt`, which resets the seven-day starvation check. A fuzz leg
that never ran would report a green night and silence its own alarm.

The self-test assertion meant to cover this was tautological: `$null ?? 1` is
evaluated before the call, so it asserted `Get-FuzzOutcome 1`, already covered
by the table above, while reading like coverage of the missing path. It now
passes `$null` itself.

The findings and harness arms also hardcoded "exited 1" and "exited 2" rather
than the code observed, so a mapping that drifted would print a confident wrong
number into the issue body. All three arms now report `$fuzzRc`.

## Verification

`just gates-selftest` green; `signoff` PASS recorded for the head commit.

Both guards were checked by mutation rather than by passing on green. Reverting
`Get-FuzzOutcome` to the inverted mapping:

```
SELF-TEST FAILED: fuzz exit 1 mapped to 'findings', expected 'harness'
SELF-TEST FAILED: fuzz exit 2 mapped to 'harness', expected 'findings'
```

Deleting the null guard:

```
SELF-TEST FAILED: an uncollected exit code must not read as a clean run
```