### PR TITLE
bench: give the fake transport pipes buffers so writes survive a late reader

### DIFF
--- a/justfile
+++ b/justfile
@@ -172,10 +172,14 @@ run-win-release: build-dll-release build-win-release
 # Ghostty.Core's CsWin32 bindings include pointer-size-dependent structs
 # (SHFILEINFOW) that cannot generate for AnyCPU, so an unqualified build
 # fails before any test runs.
+# --blame-hang: a hung testhost self-recovers with a dump after 5m instead of
+# stalling a signoff. Added after a proven FakeTransport pipe deadlock hung
+# the whole Ghostty.Tests host at zero CPU; the pipe-buffer fix removed that
+# hang, and blame-hang turns any future one into evidence.
 [windows]
 test-win:
-    dotnet test windows/Ghostty.Tests/Ghostty.Tests.csproj /p:Platform=x64
-    dotnet test windows/Ghostty.Tests.Windows/Ghostty.Tests.Windows.csproj /p:Platform=x64
+    dotnet test windows/Ghostty.Tests/Ghostty.Tests.csproj /p:Platform=x64 --blame-hang --blame-hang-timeout 5m
+    dotnet test windows/Ghostty.Tests.Windows/Ghostty.Tests.Windows.csproj /p:Platform=x64 --blame-hang --blame-hang-timeout 5m
 
 # Launch two instances a few hundred ms apart and watch for a launch splash
 # owned by the one that should be forwarding itself to the other. Opens real

--- a/windows/Ghostty.Tests/Bench/FakeTransport.cs
+++ b/windows/Ghostty.Tests/Bench/FakeTransport.cs
@@ -43,10 +43,24 @@ public sealed class FakeTransport : ITransport
         string inputPipe  = $"fake-transport-in-{Guid.NewGuid():N}";
         string outputPipe = $"fake-transport-out-{Guid.NewGuid():N}";
 
-        _inputServer = new NamedPipeServerStream(inputPipe,  PipeDirection.In,  maxNumberOfServerInstances: 1, PipeTransmissionMode.Byte);
+        // Explicit nonzero kernel buffer sizes. The default constructors pass
+        // 0, which on Windows named pipes means no store-and-forward: a
+        // WriteFile only completes against an outstanding reader. That
+        // deadlocked the bench tests whenever the harness reader cancelled
+        // before its first read: the IO thread blocked forever in its first
+        // scripted response write and the test thread blocked forever
+        // writing payload. 64 KB comfortably holds every response and payload
+        // these tests use (max 4 KB), so writes complete immediately.
+        // The client constructors have no buffer-size parameters: the kernel
+        // buffer is fixed by the server's CreateNamedPipe call, and the
+        // clients deliberately stay synchronous because Runner's sync
+        // Input.Write path already works against them and the deadline tests
+        // prove ReadAsync cancellation needs no FILE_FLAG_OVERLAPPED here.
+        const int PipeBufferSize = 64 * 1024;
+        _inputServer = new NamedPipeServerStream(inputPipe,  PipeDirection.In,  maxNumberOfServerInstances: 1, PipeTransmissionMode.Byte, PipeOptions.None, PipeBufferSize, PipeBufferSize);
         _inputClient = new NamedPipeClientStream(".", inputPipe,  PipeDirection.Out);
 
-        _outputServer = new NamedPipeServerStream(outputPipe, PipeDirection.Out, maxNumberOfServerInstances: 1, PipeTransmissionMode.Byte);
+        _outputServer = new NamedPipeServerStream(outputPipe, PipeDirection.Out, maxNumberOfServerInstances: 1, PipeTransmissionMode.Byte, PipeOptions.None, PipeBufferSize, PipeBufferSize);
         _outputClient = new NamedPipeClientStream(".", outputPipe, PipeDirection.In);
 
         // Connect both pairs synchronously before starting the IO thread.

--- a/windows/Ghostty.Tests/Bench/FakeTransportTests.cs
+++ b/windows/Ghostty.Tests/Bench/FakeTransportTests.cs
@@ -1,0 +1,66 @@
+using System.Diagnostics;
+using Xunit;
+
+namespace Ghostty.Tests.Bench;
+
+public class FakeTransportTests
+{
+    private static readonly TimeSpan BoundedWait = TimeSpan.FromSeconds(5);
+
+    // Regression for a proven suite-wide deadlock. With the zero-size pipe
+    // buffers the default NamedPipeServerStream constructor passes, a write
+    // only completes against an outstanding reader. When the harness reader
+    // cancelled before its first read (threadpool delay under full-suite
+    // contention), the IO thread blocked forever in its first scripted
+    // response write. This test pins the opposite: the write must land in
+    // the kernel buffer even though NOTHING has read the output pipe yet.
+    [Fact]
+    public void ScriptedResponseWrite_CompletesWithoutAnyReader()
+    {
+        int responderCalls = 0;
+        using var t = new FakeTransport(_ =>
+        {
+            Interlocked.Increment(ref responderCalls);
+            return new byte[] { 0x01 };
+        });
+
+        // First input chunk on the test thread: the IO thread is parked in
+        // its first Read, so this always completes. Its response write is the
+        // write-before-read under test.
+        t.Input.Write(new byte[] { 0x00 }, 0, 1);
+        t.Input.Flush();
+
+        // Second input chunk from a background task: pre-fix the IO thread
+        // never comes back for it (stuck in the first response write), so
+        // this write blocks. Keeping it off the test thread lets the poll
+        // below fail the test inside the bound instead of hanging the suite.
+        var secondWrite = Task.Run(() =>
+        {
+            t.Input.Write(new byte[] { 0x00 }, 0, 1);
+            t.Input.Flush();
+        });
+
+        // The responder only runs its second call after the first response
+        // write completed with zero readers on the output pipe.
+        var sw = Stopwatch.StartNew();
+        while (Volatile.Read(ref responderCalls) < 2 && sw.Elapsed < BoundedWait)
+            Thread.Sleep(10);
+
+        Assert.True(Volatile.Read(ref responderCalls) >= 2,
+            $"scripted response write never completed without a reader within {BoundedWait.TotalSeconds:F0}s");
+
+        // Drain both responses so the read side is proven too, not just the
+        // responder count. Both bytes are already in the kernel buffer, so
+        // the synchronous reads return without blocking.
+        byte[] received = new byte[2];
+        int read = 0;
+        while (read < received.Length)
+        {
+            int n = t.Output.Read(received, read, received.Length - read);
+            Assert.True(n > 0, "output pipe reached EOF before both responses were drained");
+            read += n;
+        }
+        Assert.Equal((byte)0x01, received[0]);
+        Assert.Equal((byte)0x01, received[1]);
+    }
+}


### PR DESCRIPTION
## Problem

`Bench.HarnessTests.RunThroughputIteration_ThrowsOnDeadlineExceeded` intermittently deadlocked the whole Ghostty.Tests testhost: a permanent, zero-CPU hang right after the final "Passed!" printed, so the run never exited and stalled signoffs. Root-caused during the 790/793 landing signoffs from a hang dump of the stuck testhost plus the decompiled runtime, which showed both stuck threads.

Mechanism:

- `FakeTransport` created its four pipes with constructors that pass no buffer sizes, so `inBufferSize`/`outBufferSize` are 0: no kernel store-and-forward, a `WriteFile` only completes against an outstanding reader.
- `Runner.RunThroughputIteration` starts the output-pipe reader via `Task.Run`. If the 250 ms deadline CTS fires before the reader issues its first read (threadpool delay under full-suite contention), the reader completes cancelled without ever reading.
- The transport IO thread then blocks forever in its first scripted response `WriteFile` (no reader), and the test thread blocks forever writing payload into the input pipe. Deadlock, zero CPU.

## Fix

- `FakeTransport.cs`: both server pipes now pass an explicit 64 KB `inBufferSize`/`outBufferSize` (well above the ~4 KB these tests ever move), so a write lands in the kernel buffer and completes even with no concurrent reader. The client streams stay synchronous: `NamedPipeClientStream` has no buffer-size parameters (the kernel buffer is fixed by the server's `CreateNamedPipe`), and the existing deadline tests already prove `ReadAsync` cancellation works without `FILE_FLAG_OVERLAPPED`, so adding `PipeOptions.Asynchronous` would be change for its own sake.

## Regression test

`FakeTransportTests.ScriptedResponseWrite_CompletesWithoutAnyReader` pins the write-before-read property deterministically: a scripted transport receives two input chunks, the second from a background task, and the test polls (bounded at 5 s) for the responder's second call, which is only reachable if the first response write completed with zero readers on the output pipe.

Mutation-checked: with the buffer sizes reverted to 0 the test fails in 5 s with "scripted response write never completed without a reader within 5s" (red, no hang); with the fix it passes. The pre-fix behaviour (block forever) therefore fails the test via timeout instead of hanging the suite. `RunThroughputIteration_ThrowsOnDeadlineExceeded` still passes and still exercises its OCE-to-TimeoutException deadline path.

## Mitigation

`just test-win` now runs both `dotnet test` invocations with `--blame-hang --blame-hang-timeout 5m`, so any future hang self-recovers with a dump instead of stalling a signoff.

## Test evidence

- Bench filter: 37 passed, 1 pre-existing skip.
- Full Ghostty.Tests (`-p:Platform=x64`): 2759 passed, 1 pre-existing skip, 12 s.
- Mutation: new test red in 5 s with zero buffers, green with 64 KB.

Fixes the intermittent Ghostty.Tests testhost hang observed during the 790/793 signoffs.