### PR TITLE
windows: give the whole lane one High Contrast surface

### DIFF
--- a/windows/Ghostty.Tests/Wiring/FrameStyleWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/FrameStyleWiringTests.cs
@@ -504,6 +504,75 @@ public sealed class FrameStyleWiringTests
     }
 
     /// <summary>
+    /// High Contrast without the palette is the one bare lane that is a
+    /// colour at all, and the window cannot name it: the surface is an
+    /// HC-overridable theme resource, which is why ApplyStripChromeFill
+    /// pushes null there and the strip resolves it for the middle row. The
+    /// host's own two rows -- the icon lane and the new-tab band -- took the
+    /// null literally and stayed transparent, splitting the lane into two
+    /// surfaces in the one mode whose entire point is a surface Windows
+    /// controls.
+    ///
+    /// They paint from the strip's resolved brush now. Asserted on the
+    /// shapes that reproduce the split: a bare arm that goes straight to
+    /// transparent, a second resolution of the resource instead of the
+    /// shared read, and the host painting before the strip has resolved,
+    /// which is the previous frame's answer on a High Contrast toggle.
+    /// </summary>
+    [Fact]
+    public void The_bare_HighContrast_lane_is_one_surface()
+    {
+        var host = ShellSource.Load("Tabs.VerticalTabHost.xaml.cs").Method("SetChromeFill");
+
+        // The strip resolves first; both of the host's lane-surface writes
+        // paint from that answer.
+        var stripPush = host.Call("_strip.SetChromeFill");
+        var writes = host.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.Left.ToString() is "Background" or "StripRoot.Background")
+            .ToList();
+        Assert.Equal(2, writes.Count);
+
+        var brush = Assert.Single(
+            host.DescendantNodes().OfType<VariableDeclaratorSyntax>(),
+            v => v.Identifier.ValueText == "brush");
+        foreach (var write in writes)
+        {
+            Assert.True(
+                write.SpanStart > stripPush.SpanStart,
+                $"`{write}` paints before `_strip.SetChromeFill`, so a bare lane "
+                    + "reads the brush the previous frame resolved.");
+            Assert.Equal("brush", write.Right.ToString());
+        }
+
+        // The bare arm falls back to the strip's own High Contrast surface
+        // and only then to transparent. Straight to transparent is the split;
+        // a resource resolved here is the same split one hop away, because
+        // two resolutions can disagree.
+        var fill = Assert.IsType<ConditionalExpressionSyntax>(brush.Initializer?.Value);
+        Assert.Contains("TabColorBrush.FromPackedRgb", fill.WhenTrue.ToString());
+        var bare = Assert.IsType<BinaryExpressionSyntax>(fill.WhenFalse);
+        Assert.True(
+            bare.IsKind(SyntaxKind.CoalesceExpression),
+            $"the bare lane reads `{bare}`; it has to be the strip's surface or "
+                + "transparent, nothing painted in between.");
+        Assert.Equal("_strip.HighContrastLaneSurface", bare.Left.ToString());
+        Assert.Equal("TransparentBrush", bare.Right.ToString());
+
+        // And that property answers with the surface the strip already
+        // resolved, and only under High Contrast. Every other bare lane is
+        // the backdrop's, which is the non-HC behaviour this must not move.
+        var surface = Property(
+            ShellSource.Load("Tabs.VerticalTabStrip.xaml.cs"), "HighContrastLaneSurface");
+        var gate = Assert.IsType<ConditionalExpressionSyntax>(
+            surface.ExpressionBody?.Expression);
+        Assert.Equal("_highContrast", gate.Condition.ToString());
+        Assert.Equal("Background", gate.WhenTrue.ToString());
+        Assert.True(
+            gate.WhenFalse.IsKind(SyntaxKind.NullLiteralExpression),
+            $"without High Contrast the lane is the backdrop's, not `{gate.WhenFalse}`.");
+    }
+
+    /// <summary>
     /// The key the strip's surface is filed under, as an argument or as an
     /// indexer. Matched on the literal so a comment mentioning it is not a
     /// write and a variable holding it is not missed for being one.

--- a/windows/Ghostty/Tabs/VerticalTabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabHost.xaml.cs
@@ -295,26 +295,26 @@ internal sealed partial class VerticalTabHost : UserControl, ITabHost
     /// while the title row an inch above it went opaque. window-theme names
     /// the shade and frame-style decides whether it is painted; neither of
     /// those questions is asked again here.
+    ///
+    /// The one bare lane that is a colour at all is High Contrast without
+    /// the palette: the window cannot name that surface, so the strip
+    /// resolves it for the middle row and the host's two rows paint from
+    /// the same resolved brush. The strip goes first, because its answer is
+    /// what the bare arm reads.
     /// </summary>
     internal void SetChromeFill(uint? fillRgb)
     {
-        if (fillRgb is { } rgb)
-        {
-            var brush = TabColorBrush.FromPackedRgb(rgb);
-            Background = brush;
-            StripRoot.Background = brush;
-        }
-        else
-        {
-            // Transparent rather than cleared: StripRoot carries the lane's
-            // ContextRequested handler, and a null Background is not
-            // hit-testable, so clearing it takes the strip's context menu
-            // with it everywhere the rows do not reach.
-            Background = TransparentBrush;
-            StripRoot.Background = TransparentBrush;
-        }
-
         _strip.SetChromeFill(fillRgb);
+
+        // Transparent rather than cleared when there is no surface: StripRoot
+        // carries the lane's ContextRequested handler, and a null Background
+        // is not hit-testable, so clearing it takes the strip's context menu
+        // with it everywhere the rows do not reach.
+        var brush = fillRgb is { } rgb
+            ? TabColorBrush.FromPackedRgb(rgb)
+            : _strip.HighContrastLaneSurface ?? TransparentBrush;
+        Background = brush;
+        StripRoot.Background = brush;
     }
 
     private static readonly SolidColorBrush TransparentBrush =

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -442,6 +442,20 @@ internal sealed partial class VerticalTabStrip : UserControl
     }
 
     /// <summary>
+    /// The surface this control resolved for a bare lane under High
+    /// Contrast, or null on every other bare lane.
+    ///
+    /// High Contrast without the palette is the one bare lane that is a
+    /// colour at all: the window pushes no fill there precisely because the
+    /// surface is an HC-overridable theme resource it cannot name, and this
+    /// control resolves it. The host's own two rows read this rather than
+    /// resolving again, so all three lane rows come off the one resolution
+    /// -- two resolutions of the same resource can disagree about the
+    /// element theme they resolve against.
+    /// </summary>
+    internal Brush? HighContrastLaneSurface => _highContrast ? Background : null;
+
+    /// <summary>
     /// The lane's surface on the palette path.
     ///
     /// No High Contrast arm, unlike the default path: that mode pins the


### PR DESCRIPTION
Under High Contrast with `window-theme = system`, `ApplyStripChromeFill` pushes `null` on purpose so the vertical strip resolves its own HC-overridable surface. The host's own two lane rows (the icon lane and the new-tab band) took the `null` literally and stayed transparent, splitting the lane into two surfaces in the one mode whose point is a surface Windows controls (#791).

Per the decision on #791, rows 0 and 2 now paint from the strip's resolved surface:

- `VerticalTabStrip.HighContrastLaneSurface` exposes the brush the strip already resolved under HC, and null on every other bare lane.
- `VerticalTabHost.SetChromeFill` resolves the strip first and paints both of its surfaces from `TabColorBrush.FromPackedRgb(rgb)` or the strip's HC surface, falling back to transparent only when there is none. The non-HC bare lane is unchanged: it still reads transparent over the backdrop.

MainWindow is untouched, so the palette path (`TabBarBackground`) and the non-HC system path are as before.

Guard: `The_bare_HighContrast_lane_is_one_surface` pins the strip-first ordering, the shared read (`_strip.HighContrastLaneSurface ?? TransparentBrush`), and the HC-only gate on the property. Verified red with the fix reverted, green restored. Full suite: 2760 passed.

Live captures under `C:/temp/hc-verify/791/` (HC on and off, pre-fix and fixed builds): lane uniform on the fixed build under HC, and pre-fix vs fixed pixel-identical under HC-off with a magenta backdrop probe confirming rows 0/2 still sample the backdrop exactly as before outside HC. In this session's HC scheme the resolved HC surface coincides with the backdrop colour (#202020), so the pre-fix split is colour-invisible here; the visible split is the one captured in the #790 matrix run cited on the issue.

Closes #791.
