### PR TITLE
windows: report an unhandled exception from any thread, not just Main's

### DIFF
--- a/windows/Ghostty.Tests/Wiring/UnhandledExceptionWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/UnhandledExceptionWiringTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// That an unhandled exception on a thread that is not the main one still
+/// gets reported, on the CLI as well as in the GUI (#442).
+///
+/// Why this needs a guard at all: nothing about the failure is loud. An
+/// unhandled exception off the main thread does not unwind to
+/// <c>Main</c>'s catch, and under NativeAOT its fail-fast bypasses
+/// <c>SetUnhandledExceptionFilter</c>, so sentry does not see it either.
+/// Measured before the fix, `wintty +crash managed-unhandled` on a published
+/// build exited 0xC0000409 having written no log and no envelope. Deleting
+/// the registration these tests guard restores that silence, and every other
+/// test in the suite still passes.
+///
+/// The pair is what matters, not either half. Program registers so the CLI
+/// is covered; App unregisters so the GUI keeps producing exactly one
+/// artifact. Registering without the handoff double-reports every GUI crash;
+/// the handoff without the registration is what we already had.
+///
+/// What this cannot see: whether the runtime actually raises the event
+/// before dying on a given runtime and configuration. That is only
+/// observable by killing a published build, which the crash matrix does.
+/// </summary>
+public class UnhandledExceptionWiringTests
+{
+    private const string Subscription = "AppDomain.CurrentDomain.UnhandledException";
+
+    /// <summary>
+    /// Every `X += ...` or `X -= ...` under a node, in source order, paired
+    /// with the spelling of what is being subscribed to.
+    /// </summary>
+    private static List<(string Target, SyntaxKind Kind, int Position)> Subscriptions(SyntaxNode node) =>
+        node.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.IsKind(SyntaxKind.AddAssignmentExpression)
+                     || a.IsKind(SyntaxKind.SubtractAssignmentExpression))
+            .Select(a => (Target: a.Left.ToString(), Kind: a.Kind(), Position: a.SpanStart))
+            .OrderBy(x => x.Position)
+            .ToList();
+
+    [Fact]
+    public void Main_subscribes_the_fatal_handler_before_it_starts_the_thread()
+    {
+        var program = ShellSource.Load("Program.cs");
+        var main = program.Method("Main");
+
+        var subscribe = Subscriptions(main)
+            .Where(s => s.Target == Subscription && s.Kind == SyntaxKind.AddAssignmentExpression)
+            .ToList();
+        Assert.True(
+            subscribe.Count == 1,
+            $"expected exactly one '{Subscription} +=' in Main, found {subscribe.Count}");
+
+        // Before the thread runs, not merely somewhere in the method. The
+        // whole point is to cover MainImpl, so a registration that happened
+        // after main.Start() would leave the run it exists for unguarded and
+        // would still satisfy a presence-only assertion.
+        var start = main.Call("main.Start");
+        Assert.True(
+            subscribe[0].Position < start.SpanStart,
+            "the handler is registered after the main thread starts, so the run it exists to cover is unguarded");
+    }
+
+    [Fact]
+    public void The_handler_reports_both_shapes_of_unhandled_throw()
+    {
+        var program = ShellSource.Load("Program.cs");
+        var handler = program.Field("FatalHandler").Variable;
+
+        // Two, not one: ExceptionObject is typed object and is not required
+        // to hold an Exception. A handler that reports only the Exception
+        // branch drops exactly the throws nothing else can describe, and
+        // reads as complete.
+        var reports = handler.Calls("ReportFatal");
+        Assert.True(
+            reports.Count == 2,
+            $"expected FatalHandler to report on both the Exception and non-Exception paths, found {reports.Count} ReportFatal call(s)");
+    }
+
+    [Fact]
+    public void The_handoff_unsubscribes_and_does_not_re_subscribe()
+    {
+        var program = ShellSource.Load("Program.cs");
+        var handoff = program.Method("HandOffUnhandledReporting");
+
+        var subs = Subscriptions(handoff).Where(s => s.Target == Subscription).ToList();
+        Assert.True(subs.Count == 1, $"expected one '{Subscription}' subscription change, found {subs.Count}");
+        Assert.Equal(SyntaxKind.SubtractAssignmentExpression, subs[0].Kind);
+    }
+
+    [Fact]
+    public void App_stands_Program_down_only_after_installing_its_own_handlers()
+    {
+        var app = ShellSource.Load("App.xaml.cs");
+
+        var handoff = app.Root.Call("Program.HandOffUnhandledReporting");
+
+        // Every handler App installs for an unhandled throw, whichever event
+        // carries it.
+        var installs = Subscriptions(app.Root)
+            .Where(s => s.Kind == SyntaxKind.AddAssignmentExpression
+                     && (s.Target.Contains("Unhandled", StringComparison.Ordinal)
+                      || s.Target.Contains("UnobservedTask", StringComparison.Ordinal)))
+            .ToList();
+        Assert.True(installs.Count >= 2, $"expected App to install its own handlers, found {installs.Count}");
+
+        // Last, and the ordering is the safety property rather than tidiness.
+        // Standing Program down first opens a window in which neither
+        // reporter is registered, and a crash in that window is reported by
+        // nobody: the exact condition #442 is about, reintroduced in the
+        // handoff meant to close it. Overlapping instead costs a duplicate
+        // log, which is the direction to err.
+        var last = installs.Max(i => i.Position);
+        Assert.True(
+            handoff.SpanStart > last,
+            "App hands Program off before installing its own handlers, leaving a window where neither reports");
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/UnhandledExceptionWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/UnhandledExceptionWiringTests.cs
@@ -33,16 +33,29 @@ namespace Ghostty.Tests.Wiring;
 public class UnhandledExceptionWiringTests
 {
     private const string Subscription = "AppDomain.CurrentDomain.UnhandledException";
+    private const string HandlerField = "FatalHandler";
 
     /// <summary>
-    /// Every `X += ...` or `X -= ...` under a node, in source order, paired
-    /// with the spelling of what is being subscribed to.
+    /// Every `X += ...` or `X -= ...` under a node, in source order, with
+    /// BOTH sides.
+    ///
+    /// The right-hand side is carried because a guard that reads only the
+    /// left accepts its own defeat: `UnhandledException += (_, __) => { };`
+    /// is one correctly placed subscription to the right event that reports
+    /// nothing. Worse, it accepts a real bug -
+    /// `+= new UnhandledExceptionEventHandler(FatalHandler)` - where the
+    /// wrapper is not Delegate-equal to the field, so the matching `-=`
+    /// removes nothing and every GUI crash double-logs forever.
     /// </summary>
-    private static List<(string Target, SyntaxKind Kind, int Position)> Subscriptions(SyntaxNode node) =>
+    private static List<(string Target, string Handler, SyntaxKind Kind, int Position)> Subscriptions(SyntaxNode node) =>
         node.DescendantNodes().OfType<AssignmentExpressionSyntax>()
             .Where(a => a.IsKind(SyntaxKind.AddAssignmentExpression)
                      || a.IsKind(SyntaxKind.SubtractAssignmentExpression))
-            .Select(a => (Target: a.Left.ToString(), Kind: a.Kind(), Position: a.SpanStart))
+            .Select(a => (
+                Target: a.Left.ToString(),
+                Handler: a.Right.ToString(),
+                Kind: a.Kind(),
+                Position: a.SpanStart))
             .OrderBy(x => x.Position)
             .ToList();
 
@@ -58,6 +71,14 @@ public class UnhandledExceptionWiringTests
         Assert.True(
             subscribe.Count == 1,
             $"expected exactly one '{Subscription} +=' in Main, found {subscribe.Count}");
+
+        // The handler, not just A handler. Reading only the left-hand side
+        // accepts `+= (_, __) => { }`, which is one correctly placed
+        // subscription to the right event that reports nothing at all, and
+        // accepts `+= new UnhandledExceptionEventHandler(FatalHandler)`,
+        // where the wrapper is not Delegate-equal to the field so the
+        // matching `-=` removes nothing and every GUI crash double-logs.
+        Assert.Equal(HandlerField, subscribe[0].Handler);
 
         // Before the thread runs, not merely somewhere in the method. The
         // whole point is to cover MainImpl, so a registration that happened
@@ -94,6 +115,13 @@ public class UnhandledExceptionWiringTests
         var subs = Subscriptions(handoff).Where(s => s.Target == Subscription).ToList();
         Assert.True(subs.Count == 1, $"expected one '{Subscription}' subscription change, found {subs.Count}");
         Assert.Equal(SyntaxKind.SubtractAssignmentExpression, subs[0].Kind);
+
+        // Same delegate instance as the `+=`, spelled the same way. Removing
+        // anything else is a silent no-op: Delegate.Remove matches on
+        // equality, so `-= new UnhandledExceptionEventHandler(FatalHandler)`
+        // or `-= SomeOtherHandler` leaves the subscription in place and the
+        // GUI double-logs every crash forever, with nothing failing.
+        Assert.Equal(HandlerField, subs[0].Handler);
     }
 
     [Fact]
@@ -101,16 +129,36 @@ public class UnhandledExceptionWiringTests
     {
         var app = ShellSource.Load("App.xaml.cs");
 
-        var handoff = app.Root.Call("Program.HandOffUnhandledReporting");
+        // Inside the constructor, not merely somewhere in the file. Located
+        // by position alone, the assertion accepts the handoff being moved
+        // into a private method nobody calls, or wrapped in `if (false)`,
+        // as long as it sits later in the text than App's own registrations.
+        var ctor = Assert.Single(
+            app.Root.DescendantNodes().OfType<ConstructorDeclarationSyntax>()
+                .Where(c => c.Identifier.ValueText == "App"));
+        var handoff = ctor.Call("Program.HandOffUnhandledReporting");
+
+        // The AppDomain handler SPECIFICALLY. Counting handlers instead
+        // admits the mutation that reintroduces #442 in the GUI: delete
+        // App's `AppDomain.CurrentDomain.UnhandledException +=` and two
+        // matching installs remain (Application.UnhandledException and
+        // UnobservedTaskException), so a count-based guard stays green while
+        // Program hands off to nothing and a throw on a ThreadPool or render
+        // thread reaches neither reporter.
+        var appDomainInstall = Assert.Single(
+            Subscriptions(ctor)
+                .Where(s => s.Target == Subscription
+                         && s.Kind == SyntaxKind.AddAssignmentExpression));
 
         // Every handler App installs for an unhandled throw, whichever event
-        // carries it.
-        var installs = Subscriptions(app.Root)
+        // carries it: the handoff has to follow all of them, not just one.
+        var installs = Subscriptions(ctor)
             .Where(s => s.Kind == SyntaxKind.AddAssignmentExpression
                      && (s.Target.Contains("Unhandled", StringComparison.Ordinal)
                       || s.Target.Contains("UnobservedTask", StringComparison.Ordinal)))
             .ToList();
-        Assert.True(installs.Count >= 2, $"expected App to install its own handlers, found {installs.Count}");
+        Assert.True(installs.Count >= 3, $"expected App to install its three handlers, found {installs.Count}");
+        Assert.Contains(appDomainInstall, installs);
 
         // Last, and the ordering is the safety property rather than tidiness.
         // Standing Program down first opens a window in which neither

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -392,6 +392,14 @@ public partial class App : Application
         {
             LogUnhandled("UNOBSERVED TASK", e.Exception.ToString());
         };
+
+        // Program registers its own AppDomain handler at the top of Main so
+        // the CLI, which never builds an App, still reports an unhandled
+        // exception off the main thread (#442). From here on this process is
+        // the GUI and the handlers above own that class, so Program's stands
+        // down. Last, deliberately: until this line both are registered, and
+        // an overlap costs a duplicate log while a gap costs the report.
+        Program.HandOffUnhandledReporting();
     }
 
     private static void LogUnhandled(string tag, string detail)

--- a/windows/Ghostty/Program.cs
+++ b/windows/Ghostty/Program.cs
@@ -61,12 +61,19 @@ public static partial class Program
         /// exit code come from <see cref="InitGhostty"/>.</summary>
         InitFailed = 2,
 
-        /// <summary>Unhandled managed exception in the GUI startup
-        /// path. <see cref="StartGui"/>'s catch block writes
-        /// <c>ghostty-crash.log</c> in <c>AppContext.BaseDirectory</c>.
+        /// <summary>Unhandled managed exception in the startup path, on the
+        /// main thread or (via <see cref="FatalHandler"/>) on any other.
+        /// <see cref="ReportFatal"/> appends <c>ghostty-crash.log</c> in
+        /// <c>AppContext.BaseDirectory</c>, falling back to
+        /// <c>%LOCALAPPDATA%\Wintty\ghostty-crash.log</c> when the install
+        /// directory does not take writes.
         /// (A future PR should converge this with the
         /// <c>%LOCALAPPDATA%\Wintty\crash.log</c> path used by the
-        /// App-level unhandled-exception handlers.)</summary>
+        /// App-level unhandled-exception handlers. The fallback above lands
+        /// in that same folder and is still a separate file on purpose:
+        /// merging them changes which artifact each row of the crash
+        /// coverage map names, and that is the change to make deliberately
+        /// rather than as a side effect of adding a fallback.)</summary>
         ManagedUnhandled = 3,
     }
 
@@ -205,10 +212,50 @@ public static partial class Program
     }
 
     /// <summary>
+    /// Backing field for <see cref="GpuLogPath"/>. Null until the first read.
+    /// </summary>
+    private static string? _gpuLogPath;
+
+    /// <summary>
     /// Persistent GPU diagnostic log path.  Survives reboot so we can
     /// read crash details after a GPU driver crash takes down the machine.
     /// </summary>
-    private static readonly string GpuLogPath = Path.Combine(
+    /// <remarks>
+    /// Resolved on first read rather than in a static field initializer, and
+    /// that is a correctness fix rather than a micro-optimization.
+    /// <see cref="Main"/> now touches a <c>Program</c> static
+    /// (<see cref="FatalHandler"/>) on its very first statement, outside any
+    /// catch, and that touch is what runs this type's initializer.
+    /// <c>Environment.GetFolderPath</c> can fail on a broken or half-loaded
+    /// roaming profile, and a failure there does not surface as "the GPU log
+    /// path is unavailable": it surfaces as a TypeInitializationException on
+    /// the line that installs the unhandled-exception handler. Nothing is
+    /// registered, nothing catches it, and the process dies with no log and
+    /// none of the exit codes callers are told to discriminate on. That is
+    /// the bug class the registration exists to close, reintroduced by the
+    /// statement that installs it.
+    ///
+    /// Wrapping that registration in a try instead was considered and
+    /// rejected. It hides the symptom without fixing it: a failed type
+    /// initializer is permanent for the life of the process, so the very next
+    /// static call into this class (MainImpl itself) throws
+    /// TypeInitializationException again, now from a place with even less
+    /// context to report from. Moving the one initializer that can fail out of
+    /// the initializer is both the smaller and the complete change, and every
+    /// read of this property already sits inside a try that treats an
+    /// unavailable log as best effort.
+    ///
+    /// What is left in the initializer after this cannot fail the same way:
+    /// two allocations, a lambda, and <see cref="LaunchWorkingDirectory"/>,
+    /// whose <c>Environment.CurrentDirectory</c> read is a per-process value
+    /// Win32 hands back without touching the profile or the disk.
+    ///
+    /// Unsynchronized, and deliberately not cached against failure. Two
+    /// threads racing here compute two equal strings and one is discarded; a
+    /// read that threw simply tries again next time, which costs one path
+    /// combine and can only turn a failure into a success.
+    /// </remarks>
+    private static string GpuLogPath => _gpuLogPath ??= Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
         AppIdentity.StateDirName, "gpu.log");
 
@@ -488,43 +535,265 @@ public static partial class Program
         AppDomain.CurrentDomain.UnhandledException -= FatalHandler;
 
     /// <summary>
-    /// Last-resort reporter for an exception that escaped <see cref="MainImpl"/>.
+    /// Name of the startup crash log. Written next to the binary when that
+    /// directory takes writes, and under <c>%LOCALAPPDATA%</c> when it does
+    /// not; see <see cref="ReportFatal"/>.
+    /// </summary>
+    private const string CrashLogFileName = "ghostty-crash.log";
+
+    /// <summary>
+    /// Serializes the whole of <see cref="ReportFatal"/>.
+    /// </summary>
+    /// <remarks>
+    /// Until <see cref="FatalHandler"/> existed, every caller of
+    /// <see cref="ReportFatal"/> was on the thread <see cref="Main"/> creates:
+    /// its own catch, and <see cref="StartGui"/>'s. Registering an AppDomain
+    /// handler removed that invariant without changing a line of the reporter.
+    /// The runtime raises UnhandledException on whichever thread is dying, and
+    /// a cascading failure (a pool thread and a render thread going down
+    /// together) raises it on several within microseconds of each other.
+    ///
+    /// Two unsynchronized reporters produce one of two outcomes, and both are
+    /// worse than a lost microsecond. The file open collides and one thread
+    /// takes an IOException that the bare catch below swallows, so one crash
+    /// is recorded nowhere at all; or the process fail-fasts while a writer is
+    /// partway through the file, leaving a truncated or empty
+    /// <see cref="CrashLogFileName"/>. The empty file is the one outcome this
+    /// reporter must never produce: it reads as "the crash reporter is
+    /// broken", which sends whoever is debugging away from the exception
+    /// instead of at it. <c>App.LogUnhandled</c> takes a lock for exactly this
+    /// reason and says so.
+    ///
+    /// Held for the whole body rather than only around the file write. The two
+    /// stderr writers are shared mutable state as well, and two interleaved
+    /// multi-line exception dumps in one console are close to unreadable.
+    ///
+    /// Held without a timeout, deliberately. A thread that fail-fasts while
+    /// holding this leaves any waiter blocked, but that waiter is inside a
+    /// process the runtime is tearing down anyway, and losing the second
+    /// report is far cheaper than tearing the first one in half. A timeout
+    /// would buy nothing: the holder is not coming back to release it.
+    /// </remarks>
+    private static readonly Lock ReportFatalLock = new();
+
+    /// <summary>
+    /// Last-resort reporter for an exception that escaped <see cref="MainImpl"/>,
+    /// or that reached <see cref="FatalHandler"/> from any other thread.
     /// Writes to stderr, tees to the terminal when stderr has been redirected,
-    /// and drops a crash log next to the binary, mirroring what
+    /// and appends a crash log next to the binary (or under
+    /// <c>%LOCALAPPDATA%</c> when that fails), mirroring what
     /// <see cref="StartGui"/>'s catch does for the GUI path.
+    ///
+    /// Every sink gets its own try, and the method as a whole is written not to
+    /// throw: an escape from here escapes <see cref="FatalHandler"/> too, and
+    /// a reporter that dies reporting is indistinguishable from no reporter.
     /// </summary>
     private static int ReportFatal(Exception ex)
     {
-        var message = $"{AppIdentity.LogTag} FATAL: {ex}";
-
-        WriteStderr(message);
-
-        // Its own try, not one shared with the write above: a stderr that
-        // refuses writes is exactly when the terminal tee is the only copy
-        // anyone sees, and sharing a try would drop it along with the write
-        // that failed. Same reasoning as InitGhostty's two-sink report.
+        // Formatted once, defensively, and shared by every sink below.
+        // ToString on an exception is not guaranteed to succeed - a custom
+        // exception can throw from it, and a broken inner exception is exactly
+        // the kind of thing that gets thrown here - so formatting it three
+        // times would give the reporter three chances to die on the failure it
+        // exists to record. The degraded form still names the type, which is
+        // most of the value.
+        string detail;
         try
         {
-            _preRedirectStderr?.WriteLine(message);
-            _preRedirectStderr?.Flush();
+            detail = ex.ToString();
         }
-        catch
+        catch (Exception formatting)
         {
-            // Reporting must not throw over the top of the real failure.
+            detail = $"{ex.GetType()} (ToString threw {formatting.GetType()})";
         }
 
-        try
+        var message = $"{AppIdentity.LogTag} FATAL: {detail}";
+
+        lock (ReportFatalLock)
         {
-            File.WriteAllText(
-                Path.Combine(AppContext.BaseDirectory, "ghostty-crash.log"),
-                $"{DateTime.UtcNow:O}\n{ex}\n");
-        }
-        catch
-        {
-            // Best effort.
+            // Wrapped, where it used to be the one bare sink of the three.
+            // WriteConsole absorbs IOException and UnauthorizedAccessException,
+            // which is the right filter for ordinary logging and the wrong one
+            // here: on an arbitrary thread during teardown Console.Error's
+            // writer can already be disposed, and ObjectDisposedException is an
+            // InvalidOperationException, so it went straight through, out of
+            // this method, out of FatalHandler, and the file log that would
+            // have outlived the process was never reached. A failing first sink
+            // must not cost the last one. See TryWriteStderr.
+            TryWriteStderr(message);
+
+            // Its own try, not one shared with the write above: a stderr that
+            // refuses writes is exactly when the terminal tee is the only copy
+            // anyone sees, and sharing a try would drop it along with the write
+            // that failed. Same reasoning as InitGhostty's two-sink report.
+            try
+            {
+                _preRedirectStderr?.WriteLine(message);
+                _preRedirectStderr?.Flush();
+            }
+            catch
+            {
+                // Reporting must not throw over the top of the real failure.
+            }
+
+            // The file sink is last and matters most: it is the only copy that
+            // outlives the process, so it is the one worth trying twice.
+            //
+            // Appended rather than truncated, with a delimiter and a timestamp
+            // on every entry. A second crash used to erase the first, which on
+            // a cascade meant the surviving log described the follow-on failure
+            // and not the one that started it. crash-matrix.ps1 identifies the
+            // log by hashing its contents rather than by length, so an append
+            // still registers as "this run wrote a crash log" - more reliably
+            // than an overwrite, in fact, since two similar exceptions can
+            // produce the same bytes. Nothing prunes the file; entries are a
+            // few KB and only ever written by a process that is already dying.
+            try
+            {
+                var entry =
+                    $"=== {AppIdentity.ProductName} crash {DateTimeOffset.UtcNow:O} " +
+                    $"(pid {Environment.ProcessId}, " +
+                    $"managed thread {Environment.CurrentManagedThreadId}) ==={Environment.NewLine}" +
+                    $"{detail}{Environment.NewLine}{Environment.NewLine}";
+
+                // AppContext.BaseDirectory first, and it stays the default:
+                // it is where the crash matrix looks, where the docs send
+                // people, and where a portable unzip-and-run keeps everything
+                // else about the run.
+                //
+                // It is not always writable, though. A per-user Velopack
+                // install is fine; a machine-wide install, anything under
+                // Program Files, and a portable copy dropped somewhere
+                // protected are not, and there the log silently vanished -
+                // proved with a deny ACE on the exe directory. So fall back to
+                // the per-user state directory, which is writable by
+                // definition for the account that is crashing.
+                //
+                // Deliberately NOT the same file as App.LogUnhandled's
+                // %LOCALAPPDATA%\Wintty\crash.log, even though it lands in the
+                // same folder. Converging the startup log with the GUI's log is
+                // a separate change with its own consequences for the coverage
+                // map (one artifact per class); see the ExitCode.ManagedUnhandled
+                // doc comment, which already carries that note.
+                var primary = Path.Combine(AppContext.BaseDirectory, CrashLogFileName);
+                if (!TryAppendCrashLog(primary, entry)
+                    && TryGetFallbackCrashLogPath() is { } fallback
+                    && TryAppendCrashLog(fallback, entry))
+                {
+                    // Say where it went, and only when it went somewhere
+                    // unexpected. A log that quietly moved is a log nobody
+                    // finds: every reader of this project has been told to look
+                    // next to the binary, so the one launch where that is wrong
+                    // is the one that has to announce itself.
+                    TryWriteStderr(
+                        $"{AppIdentity.LogTag} could not write {primary}; " +
+                        $"crash log written to {fallback} instead");
+                }
+            }
+            catch
+            {
+                // Best effort. Both helpers already swallow their own
+                // failures, so this covers the little that is left: building
+                // the entry, and combining the default path.
+            }
         }
 
         return (int)ExitCode.ManagedUnhandled;
+    }
+
+    /// <summary>
+    /// Append one crash entry to <paramref name="path"/>, creating the
+    /// directory if it is not there. Returns whether the entry landed, so the
+    /// caller can decide whether to try somewhere else, rather than throwing
+    /// out of a reporter that must not throw.
+    /// </summary>
+    private static bool TryAppendCrashLog(string path, string entry)
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(dir))
+                Directory.CreateDirectory(dir);
+
+            File.AppendAllText(path, entry);
+            return true;
+        }
+        catch
+        {
+            // A read-only install directory, a full disk, a log another tool
+            // holds exclusively. Best effort: the caller has a second location
+            // to try, and the stderr sinks have already said what happened for
+            // anyone with a console to read it.
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Where the crash log goes when the install directory refuses it, or null
+    /// when even that cannot be resolved.
+    /// </summary>
+    /// <remarks>
+    /// Its own method, and its own try, because
+    /// <c>Environment.GetFolderPath</c> is the call that fails on a broken
+    /// profile - the same call the lazy <see cref="GpuLogPath"/> exists to keep
+    /// out of the type initializer. An empty result is rejected rather than
+    /// combined, because Path.Combine would turn it into a relative path and
+    /// scatter crash logs across whatever the current directory happened to be.
+    /// </remarks>
+    private static string? TryGetFallbackCrashLogPath()
+    {
+        try
+        {
+            var localAppData = Environment.GetFolderPath(
+                Environment.SpecialFolder.LocalApplicationData);
+            if (string.IsNullOrEmpty(localAppData))
+                return null;
+
+            return Path.Combine(localAppData, AppIdentity.StateDirName, CrashLogFileName);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// <see cref="WriteStderr"/> for a caller that must not let a refused write
+    /// become the failure it was in the middle of reporting.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="WriteConsole"/> catches IOException and
+    /// UnauthorizedAccessException, which is the correct filter for ordinary
+    /// logging: it absorbs what a hostile handle does and lets a real bug
+    /// through. It is the wrong filter for a reporter that now runs on
+    /// arbitrary threads while the process is being torn down, where
+    /// <see cref="Console.Error"/>'s writer may already have been disposed.
+    /// ObjectDisposedException derives from InvalidOperationException, not
+    /// IOException, so it passes straight through the filter. Hence the wider
+    /// net, at the call sites that cannot afford a narrow one, rather than
+    /// widening WriteConsole for everybody.
+    /// </remarks>
+    private static void TryWriteStderr(string message)
+    {
+        try
+        {
+            WriteStderr(message);
+        }
+        catch
+        {
+            // Not dropped on the floor, for the same reason WriteConsole does
+            // not drop the failures it does absorb: when the writer itself is
+            // gone, a debugger is the only channel left, and it is already
+            // where the DX12 debug layer reports.
+            try
+            {
+                OutputDebugStringW($"{message}{Environment.NewLine}");
+            }
+            catch
+            {
+                // There is nowhere after this one.
+            }
+        }
     }
 
     /// <summary>

--- a/windows/Ghostty/Program.cs
+++ b/windows/Ghostty/Program.cs
@@ -409,6 +409,22 @@ public static partial class Program
         // native/ghostty.dll would otherwise unwind this delegate unhandled
         // and abort with an exit code that is none of the ExitCode values
         // callers are told to discriminate on.
+        // The catch below only sees exceptions that unwind out of MainImpl on
+        // THIS thread. An unhandled exception on any other thread does not
+        // unwind anywhere: it goes straight to RaiseFailFastException, which
+        // under NativeAOT bypasses SetUnhandledExceptionFilter too, so sentry
+        // never sees it either. Measured on a published build, that left
+        // `wintty +crash managed-unhandled` exiting 0xC0000409 with no crash
+        // log and no envelope: nothing anywhere recorded it (#442).
+        //
+        // The GUI has never had this hole, because App's constructor installs
+        // the same handler. This is the CLI, which builds no App at all, plus
+        // the stretch of MainImpl that runs before one exists on either path.
+        // Handed off to App rather than left registered alongside it, so the
+        // GUI keeps producing exactly one artifact; see
+        // HandOffUnhandledReporting.
+        AppDomain.CurrentDomain.UnhandledException += FatalHandler;
+
         var exitCode = 0;
         var main = new Thread(
             () =>
@@ -428,6 +444,48 @@ public static partial class Program
         main.Join();
         return exitCode;
     }
+
+    /// <summary>
+    /// Reports an unhandled exception from any thread, then lets the runtime
+    /// tear the process down as it was going to.
+    ///
+    /// A field rather than a lambda at the registration site because it has to
+    /// be unsubscribable: <see cref="HandOffUnhandledReporting"/> needs the
+    /// same delegate instance to remove.
+    ///
+    /// <c>ExceptionObject</c> is typed <c>object</c> and is not required to be
+    /// an <see cref="Exception"/> (a non-CLS throw, or a corrupted-state
+    /// rethrow, need not be), so the non-Exception case is reported rather
+    /// than dropped: whatever it is, it is the reason the process is dying.
+    /// </summary>
+    private static readonly UnhandledExceptionEventHandler FatalHandler = (_, e) =>
+    {
+        if (e.ExceptionObject is Exception ex)
+        {
+            ReportFatal(ex);
+            return;
+        }
+
+        ReportFatal(new Exception(
+            $"non-Exception unhandled throw: {e.ExceptionObject?.ToString() ?? "(null)"}"));
+    };
+
+    /// <summary>
+    /// Stops reporting unhandled exceptions from here, because <c>App</c> has
+    /// just installed its own handlers and owns the GUI's crash artifact.
+    ///
+    /// Called by App at the END of its own registration, not by this class
+    /// before starting the GUI, so there is no window in between where an
+    /// unhandled exception would reach neither reporter. The two overlap for
+    /// the length of App's constructor instead, which is the safe direction to
+    /// err.
+    ///
+    /// Without this, a GUI crash would produce two logs saying the same thing
+    /// in two places, and the coverage map names exactly one artifact per
+    /// class.
+    /// </summary>
+    internal static void HandOffUnhandledReporting() =>
+        AppDomain.CurrentDomain.UnhandledException -= FatalHandler;
 
     /// <summary>
     /// Last-resort reporter for an exception that escaped <see cref="MainImpl"/>.

--- a/windows/scripts/crash-matrix.ps1
+++ b/windows/scripts/crash-matrix.ps1
@@ -95,18 +95,23 @@ $matrix = @(
     # so SetUnhandledExceptionFilter never runs and nothing is captured. Same
     # result as env-failfast, by the same mechanism.
     #
-    # No crash log either, and that is the CLI telling the truth rather than a
-    # gap: the handler that writes one is registered in App.xaml.cs, which is
-    # the GUI, and the CLI path runs in Program.MainImpl before any App
-    # exists. That handler is what covers this class in the shipped app, with
-    # a managed stack trace, and it is measured through the palette the way
-    # the libghostty rows are.
+    # A crash log, though, and the exit code is what says the fix is real
+    # rather than a regression: the process still dies at 0xC0000409 and
+    # still produces no envelope, and it now leaves the artifact the
+    # ownership rule assigns to a managed exception.
     #
-    # This row used to expect a log, and got one, because the throw was caught
-    # by Main's catch-all and turned into ReportFatal: the process never
-    # crashed and the row passed for the wrong reason. The trigger now throws
-    # from its own thread.
-    @{ Kind = 'managed-unhandled'; Envelope = $false; CrashLog = $false; ExitCode = -1073740791 }
+    # This row expected NO log until Program.Main started registering an
+    # AppDomain.CurrentDomain.UnhandledException handler of its own. Before
+    # that, the only such handler lived in App.xaml.cs, so the CLI - which
+    # builds no App - reported this class nowhere at all. That was the gap,
+    # not the truth, and it was the whole of issue #442.
+    #
+    # Read the pair, not the row: a log WITHOUT 0xC0000409 would mean the
+    # throw was caught somewhere and the process never crashed, which is how
+    # this row passed for the wrong reason once before, back when the trigger
+    # threw inline and Main's catch-all turned it into a clean ReportFatal.
+    # The trigger throws from its own thread precisely so that cannot recur.
+    @{ Kind = 'managed-unhandled'; Envelope = $false; CrashLog = $true;  ExitCode = -1073740791 }
     @{ Kind = 'env-failfast';      Envelope = $false; CrashLog = $false; ExitCode = -1073740791 }
     @{ Kind = 'stack-overflow';    Envelope = $false; CrashLog = $false; ExitCode = -1073741571 }
     # Zero, and it is load-bearing: this row exists to prove a thousand
@@ -219,10 +224,18 @@ function Get-EnvelopeSet {
         Select-Object -ExpandProperty Name)
 }
 
-# The managed handler uses File.WriteAllText, which OVERWRITES. Detecting a
-# crash log by growth therefore misses every row after the first: a shorter
-# exception replaces a longer one and the length goes down. Identify the file
-# by its contents instead, so "was it rewritten" is what gets measured.
+# Identify the crash log by its CONTENTS, not by its size.
+#
+# The reason has changed once already and the stamp survived both, which is
+# why it is worth writing down. The managed handler used to call
+# File.WriteAllText, which overwrites: detecting a log by growth missed every
+# row after the first, because a shorter exception replaced a longer one and
+# the length went DOWN. It now appends (each entry delimited and timestamped),
+# so growth would work again - but a hash still measures the right thing and a
+# length no longer distinguishes two crashes that happen to write the same
+# number of bytes. Appending also makes the hash strictly better than it was:
+# two identical exceptions in a row used to produce byte-identical files and
+# now cannot.
 function Get-CrashLogStamp {
     if (-not (Test-Path $CrashLog)) { return '<absent>' }
     $item = Get-Item $CrashLog


### PR DESCRIPTION
Updated after a code review that ran the harness this PR forgot about.

## What review broke, and it was the important one

`windows/scripts/crash-matrix.ps1` is this project's own crash-coverage gate,
and it asserted `CrashLog = $false` for `managed-unhandled`. Making that log
appear turned it red. This PR measured exactly the artifact that breaks the
row and never re-ran the harness asserting its absence, because the "2783
passed" it reported is the xunit suite and the matrix is not in it.

Fixed, and the whole map re-measured on a published build:

| Kind | Exit | Envelope | CrashLog |
| --- | --- | --- | --- |
| native-seh | `0xE0000001` | yes | no |
| **managed-unhandled** | `0xC0000409` | no | **yes** |
| env-failfast | `0xC0000409` | no | no |
| stack-overflow | `0xC00000FD` | no | no |
| handled-storm | `0` | no | no |

`crash matrix: all rows matched`, exit 0. Every other row unchanged.

## What it exposed

`ReportFatal` was written when every caller was on the main thread.
`FatalHandler` removed that invariant:

- **No lock**, while `App.LogUnhandled` takes one for exactly this reason.
  Now one lock around the whole body.
- **It truncated**, so a second crash erased the first. Now appends, each
  entry delimited and timestamped. Verified: two crashes, two entries.
- **It wrote only beside the binary.** Review proved with a deny ACE that the
  artifact silently vanishes where that directory is not writable. Now falls
  back to `%LOCALAPPDATA%\Wintty\ghostty-crash.log`. Verified by making the
  primary unwritable: primary untouched, fallback written, exit unchanged.
- `WriteStderr` was the one unwrapped sink, and a disposed `Console.Error`
  raises `ObjectDisposedException`, which `WriteConsole`'s filter does not
  catch, so it would have escaped before the file sink ran.
- `GpuLogPath` is now lazy: the `+=` was the first touch of a `Program` static
  outside any catch, so a throwing class initializer would have failed on the
  very line installing the handler.

## The guards were weak in the two ways that mattered

They read only the LEFT side of `+=`, so `+= (_, __) => { }` passed all four
tests with zero reporting. And the handoff test COUNTED App's handlers rather
than naming them, so deleting App's own AppDomain registration kept the count
at two and stayed green while the GUI lost background-thread coverage.

Both now assert the handler by name, and the handoff is located by its
containing constructor rather than by file position. Both mutations were
supplied by review and both now fail.

## Correction to this PR's earlier claim

It said "nothing anywhere recorded it". The NativeAOT runtime already prints
the stack to stderr before fail-fasting. The accurate claim is that nothing
recorded it **in a file**, and stderr is unavailable on exactly the windowless
launches this matters for.

`Ghostty.Tests`: 2783 passed, 1 skipped.
