### PR TITLE
tabs: pin and group invariants in TabManager

### DIFF
--- a/windows/Ghostty.Core/Session/SessionModel.cs
+++ b/windows/Ghostty.Core/Session/SessionModel.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using Ghostty.Core.Panes;
+using Ghostty.Core.Tabs;
 
 namespace Ghostty.Core.Session;
 
@@ -25,6 +27,14 @@ internal sealed class WindowSession
     public WindowGeometry Geometry { get; set; } = new();
     public int ActiveTabIndex { get; set; }
     public List<TabSession> Tabs { get; set; } = [];
+
+    /// <summary>
+    /// Groups referenced by this window's tabs. Members point at their
+    /// group by <see cref="TabSession.GroupId"/>; a tab whose id has no
+    /// entry here restores ungrouped, and the restore-side repair that
+    /// enforces that is the later PR that wires restore.
+    /// </summary>
+    public List<GroupSession> Groups { get; set; } = [];
 }
 
 /// <summary>Mirror of the geometry fields already saved by WindowState.</summary>
@@ -52,6 +62,25 @@ internal sealed class TabSession
 
     /// <summary>Path to the zoomed leaf, or null if no pane was zoomed.</summary>
     public bool[]? ZoomedLeafPath { get; set; }
+
+    /// <summary>True when the tab lived in the pinned prefix.</summary>
+    public bool IsPinned { get; set; }
+
+    /// <summary>Id of the tab's group, or null when ungrouped.</summary>
+    public Guid? GroupId { get; set; }
+}
+
+/// <summary>
+/// Identity and presentation state of one tab group; members reference it
+/// by id. Group identity survives restart, unlike per-tab color, which
+/// stays in-memory by prior decision.
+/// </summary>
+internal sealed class GroupSession
+{
+    public Guid Id { get; set; }
+    public string Title { get; set; } = "";
+    public TabColor Color { get; set; }
+    public bool Collapsed { get; set; }
 }
 
 /// <summary>Polymorphic split-tree node. Leaf or split.</summary>

--- a/windows/Ghostty.Core/Tabs/TabGroup.cs
+++ b/windows/Ghostty.Core/Tabs/TabGroup.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace Ghostty.Core.Tabs;
+
+/// <summary>
+/// A named, colored set of tabs. Identity is the <see cref="Id"/>;
+/// membership lives on <see cref="TabModel.Group"/> and the registry on
+/// <see cref="TabManager.Groups"/>, so a group with no members is an
+/// orphan the manager dissolves rather than state in its own right.
+///
+/// Groups are never pinned: pinning a member removes it from the group
+/// (the Chrome rule <see cref="TabManager.SetPinned"/> applies), so a
+/// run always sits in the unpinned zone.
+///
+/// Plain get/set properties on purpose: the model invariants read these
+/// directly and mutate them through the manager, and the strips that
+/// will render title, color, and collapse state arrive in later PRs
+/// with whatever change plumbing they need at that point.
+/// </summary>
+internal sealed class TabGroup
+{
+    public Guid Id { get; } = Guid.NewGuid();
+
+    /// <summary>Label shown on the vertical header row / horizontal chip.</summary>
+    public string Title { get; set; } = "New group";
+
+    /// <summary>
+    /// Swatch shared with the per-tab tint palette. Unlike a tab, a group
+    /// has no "no color" state to render (the rail and the chip are its
+    /// identity), so the default is the palette's first swatch rather
+    /// than <see cref="TabColor.None"/>.
+    /// </summary>
+    public TabColor Color { get; set; } = TabColor.Blue;
+
+    /// <summary>
+    /// One bit shared by both strip modes, so a layout switch mid-collapse
+    /// needs no repair. Purely presentational: collapsing never mutates
+    /// the tab list and never touches activation.
+    /// </summary>
+    public bool IsCollapsed { get; set; }
+}

--- a/windows/Ghostty.Core/Tabs/TabManager.cs
+++ b/windows/Ghostty.Core/Tabs/TabManager.cs
@@ -36,6 +36,7 @@ internal sealed class TabManager
     private readonly ClosedStack<TabSession>? _closedTabs;
     private readonly ObservableCollection<TabModel> _tabs = new();
     private readonly MruList<TabModel> _mru = new();
+    private readonly List<TabGroup> _groups = new();
     private TabModel _activeTab = null!;
 
     // Exposed as the concrete ObservableCollection so WinUI can bind
@@ -50,6 +51,29 @@ internal sealed class TabManager
     /// the Ctrl+Tab MRU cycle and orders the tab overview.
     /// </summary>
     public IReadOnlyList<TabModel> MruOrder => _mru.Order;
+
+    /// <summary>
+    /// Registered groups. Everything listed here has at least one member:
+    /// <see cref="Normalize"/> dissolves emptied groups, so there is no
+    /// empty-group state to render.
+    /// </summary>
+    public IReadOnlyList<TabGroup> Groups => _groups;
+
+    /// <summary>
+    /// Size of the pinned prefix of <see cref="Tabs"/>. Derived on every
+    /// read, never stored: the pinned zone is a property of the order,
+    /// not a second collection.
+    /// </summary>
+    public int PinCount
+    {
+        get
+        {
+            int count = 0;
+            foreach (var t in _tabs)
+                if (t.IsPinned) count++;
+            return count;
+        }
+    }
 
     /// <summary>
     /// Index of <paramref name="tab"/> in <see cref="Tabs"/>, or -1
@@ -150,6 +174,7 @@ internal sealed class TabManager
         if (snapshot is not null)
             tab.AttachProfileSnapshot(snapshot);
         _tabs.Add(tab);
+        Normalize();
         TabAdded?.Invoke(this, tab);
         Activate(tab);
         return tab;
@@ -196,6 +221,10 @@ internal sealed class TabManager
 
         _tabs.RemoveAt(index);
         _mru.Remove(tab);
+        // The last member of a group may just have left; Normalize
+        // dissolves it (collapse state included) before anyone sees the
+        // removal.
+        Normalize();
         TabRemoved?.Invoke(this, tab);
 
         if (_tabs.Count == 0)
@@ -252,15 +281,334 @@ internal sealed class TabManager
         Activate(_tabs[^1]);
     }
 
+    /// <summary>
+    /// Reorder one tab. The target is clamped against the pin boundary:
+    /// a pinned tab cannot land outside the prefix and an unpinned tab
+    /// cannot land inside it. Crossing the boundary on purpose is the
+    /// caller's Move + <see cref="SetPinned"/> pair, one commit at the
+    /// call site (the drag and keyboard layers), not something a plain
+    /// reorder implies.
+    /// </summary>
     public void Move(int from, int to)
     {
         if (from < 0 || from >= _tabs.Count) return;
         if (to < 0 || to >= _tabs.Count) return;
         if (from == to) return;
         var tab = _tabs[from];
+        if (tab.IsPinned)
+            to = Math.Clamp(to, 0, PinCount - 1);
+        else
+            to = Math.Clamp(to, PinCount, _tabs.Count - 1);
+        if (from == to) return;
         _tabs.RemoveAt(from);
         _tabs.Insert(to, tab);
+        // The clamp keeps the op itself inside the invariants except for
+        // group contiguity, which a pull-out mid-run breaks; Normalize
+        // re-gathers the run. TabMoved still reports THIS op's indices:
+        // repair relocations are state fixes the projector reconciles,
+        // not moves to announce one by one.
+        Normalize();
         TabMoved?.Invoke(this, (tab, from, to));
+    }
+
+    /// <summary>
+    /// Pin or unpin, relocating the tab to the zone boundary: the end of
+    /// the pinned prefix when pinning (so pinning keeps your neighbours),
+    /// the first unpinned slot when unpinning. Pinning a grouped tab
+    /// removes it from its group; activation and MRU are untouched.
+    /// </summary>
+    public void SetPinned(TabModel tab, bool pinned)
+    {
+        if (!_tabs.Contains(tab)) return;
+        if (tab.IsPinned == pinned) return;
+        if (pinned && tab.Group is not null)
+            Ungroup(tab);
+        tab.IsPinned = pinned;
+        int from = _tabs.IndexOf(tab);
+        _tabs.RemoveAt(from);
+        // After the removal, the pinned count is the same slot for both
+        // directions: end of the prefix, or first unpinned index.
+        int to = PinCount;
+        _tabs.Insert(to, tab);
+        Normalize();
+        if (from != to)
+            TabMoved?.Invoke(this, (tab, from, to));
+    }
+
+    /// <summary>
+    /// Slide the run containing <paramref name="from"/> so the grabbed
+    /// member lands at <paramref name="to"/>, the other members rotating
+    /// around it in their circular order. An intra-run operation: the
+    /// target is clamped into the run's own span, because relocating the
+    /// whole run is <see cref="MoveGroup"/> and pulling a member out of
+    /// its run is <see cref="Ungroup"/> plus <see cref="Move"/>.
+    /// </summary>
+    public void MoveRun(int from, int to)
+    {
+        if (from < 0 || from >= _tabs.Count) return;
+        var grabbed = _tabs[from];
+        var run = RunOf(grabbed);
+        if (run.Count <= 1)
+        {
+            Move(from, to);
+            return;
+        }
+
+        int start = _tabs.IndexOf(run[0]);
+        to = Math.Clamp(to, start, start + run.Count - 1);
+        if (to == from) return;
+
+        // The run keeps its circular order; only where the grabbed member
+        // sits inside it changes. Members after it lead, members before it
+        // trail, and the span re-forms around the grabbed slot.
+        var rotated = new List<TabModel>(run.Count - 1);
+        for (int i = (from - start) + 1; i < run.Count; i++) rotated.Add(run[i]);
+        for (int i = 0; i < from - start; i++) rotated.Add(run[i]);
+
+        var span = new List<TabModel>(run.Count);
+        span.AddRange(rotated.GetRange(0, to - start));
+        span.Add(grabbed);
+        span.AddRange(rotated.GetRange(to - start, run.Count - 1 - (to - start)));
+
+        var before = new List<TabModel>(_tabs);
+        ReplaceSpan(start, span);
+        Normalize();
+        RaiseRunMoved(run, before);
+    }
+
+    /// <summary>
+    /// Move a group's whole run as a unit so its first member lands at
+    /// <paramref name="targetIndex"/>, internal member order preserved.
+    /// The run is clamped to land whole and clear of the pinned prefix;
+    /// groups cannot be pinned.
+    /// </summary>
+    public void MoveGroup(TabGroup group, int targetIndex)
+    {
+        var run = MembersOf(group);
+        if (run.Count == 0) return;
+        int start = _tabs.IndexOf(run[0]);
+        // The target is the run head's slot in the final list: clamped to
+        // land whole and clear of the pinned prefix (groups cannot be
+        // pinned). State only reachable through the manager keeps that
+        // clamp window non-empty; corrupt state (a tab pinned while still
+        // grouped) can invert it, and Normalize below repairs whatever
+        // the clamp cannot express.
+        targetIndex = Math.Clamp(targetIndex, PinCount, Math.Max(PinCount, _tabs.Count - run.Count));
+        if (targetIndex == start) return;
+
+        var before = new List<TabModel>(_tabs);
+        foreach (var tab in run) _tabs.Remove(tab);
+        // Removing the block only shortens the list ahead of it; the
+        // landing slot counts kept tabs, so the clamped target inserts
+        // as-is.
+        for (int k = 0; k < run.Count; k++)
+            _tabs.Insert(targetIndex + k, run[k]);
+        Normalize();
+        RaiseRunMoved(run, before);
+    }
+
+    /// <summary>
+    /// The contiguous run containing <paramref name="tab"/> in list order:
+    /// its group's members, or the tab alone when ungrouped.
+    /// </summary>
+    public IReadOnlyList<TabModel> RunOf(TabModel tab)
+    {
+        if (tab.Group is null)
+            return new List<TabModel> { tab };
+        return MembersOf(tab.Group);
+    }
+
+    /// <summary>
+    /// Put <paramref name="members"/> into <paramref name="group"/> and
+    /// gather them into one contiguous run (in their current relative
+    /// order) at the first member's position. Pinned members are skipped:
+    /// the prefix outranks membership, the same rule <see cref="SetPinned"/>
+    /// applies in the other direction.
+    /// </summary>
+    public void GroupTabs(IReadOnlyList<TabModel> members, TabGroup group)
+    {
+        ArgumentNullException.ThrowIfNull(members);
+        ArgumentNullException.ThrowIfNull(group);
+        bool any = false;
+        foreach (var tab in members)
+        {
+            if (!_tabs.Contains(tab) || tab.IsPinned) continue;
+            tab.Group = group;
+            any = true;
+        }
+        // An empty group must never be registered: Normalize dissolves
+        // them, and a caller that grouped nothing gets nothing.
+        if (!any) return;
+        if (!_groups.Contains(group)) _groups.Add(group);
+        Normalize();
+    }
+
+    /// <summary>
+    /// Remove one tab from its group. The group dissolves if this was its
+    /// last member, collapse state included. The tab keeps its position.
+    /// </summary>
+    public void Ungroup(TabModel tab)
+    {
+        if (tab.Group is null) return;
+        tab.Group = null;
+        Normalize();
+    }
+
+    /// <summary>
+    /// Collapse or expand a group. Presentation only: no list mutation,
+    /// and the active member of a collapsed group keeps its row once the
+    /// projector lands. Collapse state lives on the group so both strip
+    /// modes share one bit.
+    /// </summary>
+    public void CollapseGroup(TabGroup group, bool collapsed)
+    {
+        group.IsCollapsed = collapsed;
+    }
+
+    /// <summary>
+    /// Sort the pinned prefix A-Z by <see cref="TabModel.EffectiveTitle"/>,
+    /// stable: equal titles keep their current order, so a second call is
+    /// a no-op. Unpinned tabs are never touched.
+    /// </summary>
+    public void SortPinned()
+    {
+        int count = PinCount;
+        if (count <= 1) return;
+        var sorted = new List<TabModel>(count);
+        for (int i = 0; i < count; i++) sorted.Add(_tabs[i]);
+        // Insertion sort because List.Sort is unstable, and stability is
+        // what makes equal titles idempotent here.
+        for (int i = 1; i < sorted.Count; i++)
+        {
+            var key = sorted[i];
+            int j = i - 1;
+            while (j >= 0 &&
+                   string.Compare(sorted[j].EffectiveTitle, key.EffectiveTitle,
+                       StringComparison.OrdinalIgnoreCase) > 0)
+            {
+                sorted[j + 1] = sorted[j];
+                j--;
+            }
+            sorted[j + 1] = key;
+        }
+        for (int i = 0; i < sorted.Count; i++)
+        {
+            var tab = sorted[i];
+            int from = _tabs.IndexOf(tab);
+            if (from == i) continue;
+            _tabs.RemoveAt(from);
+            _tabs.Insert(i, tab);
+            // Each placement pulls from later in the prefix, so these are
+            // ordinary single moves in the list state at fire time.
+            TabMoved?.Invoke(this, (tab, from, i));
+        }
+    }
+
+    /// <summary>
+    /// Splice the contiguous span starting at <paramref name="start"/> for
+    /// <paramref name="newSpan"/>. Members are removed high-to-low and
+    /// reinserted at the same span start, which cannot shift the span
+    /// (nothing before it moves) and keeps every intermediate mutation a
+    /// plain Remove/Insert for CollectionChanged listeners.
+    /// </summary>
+    private void ReplaceSpan(int start, List<TabModel> newSpan)
+    {
+        for (int i = newSpan.Count - 1; i >= 0; i--) _tabs.RemoveAt(start + i);
+        for (int i = 0; i < newSpan.Count; i++) _tabs.Insert(start + i, newSpan[i]);
+    }
+
+    private void RaiseRunMoved(IReadOnlyList<TabModel> run, List<TabModel> before)
+    {
+        // One event per relocated member, old index from before the splice
+        // and new index from after. Unlike Move's, these pairs are not
+        // individually applicable single moves - a run rotation cannot be
+        // walked one tab at a time - so the consumer is the projector,
+        // which re-derives rows from manager state rather than replaying
+        // index math.
+        foreach (var tab in run)
+        {
+            int from = before.IndexOf(tab);
+            int to = _tabs.IndexOf(tab);
+            if (from < 0 || from == to) continue;
+            TabMoved?.Invoke(this, (tab, from, to));
+        }
+    }
+
+    /// <summary>
+    /// Repair the three list invariants after a mutation: no group without
+    /// members, all pinned tabs in a leading prefix, every group's members
+    /// in one contiguous run. Deterministic and silent - it raises no
+    /// events and touches nothing but the order it repairs - so public
+    /// mutators can run it before raising their own.
+    /// </summary>
+    private void Normalize()
+    {
+        // The prefix outranks membership (SetPinned's Chrome rule, applied
+        // in the other direction): a tab that is somehow both pinned and
+        // grouped loses the group, which also keeps every run inside the
+        // unpinned zone so no repair below can straddle the boundary.
+        // Membership is registry-backed: a group this window does not
+        // list (an adoptee's source-window group, later a stale restore
+        // id) is not a group at all here, so the member arrives
+        // ungrouped.
+        foreach (var t in _tabs)
+        {
+            if (t.Group is null) continue;
+            if (t.IsPinned || !_groups.Contains(t.Group))
+                t.Group = null;
+        }
+
+        // No empty groups: the last member leaving dissolves the group,
+        // and its collapse state dies with the object.
+        _groups.RemoveAll(g => MembersOf(g).Count == 0);
+
+        // Pin prefix, repaired in place: the first pinned tab found after
+        // unpinned tabs moves back to the prefix end. Both zones keep
+        // their relative order, so a repair never shuffles tabs the
+        // mutation did not touch.
+        int prefix = 0;
+        for (int i = 0; i < _tabs.Count; i++)
+        {
+            if (!_tabs[i].IsPinned) continue;
+            if (i != prefix)
+            {
+                var tab = _tabs[i];
+                _tabs.RemoveAt(i);
+                _tabs.Insert(prefix, tab);
+            }
+            prefix++;
+        }
+
+        // Group contiguity: a non-contiguous run re-forms at its first
+        // member, in list order. This is what puts a member back after a
+        // raw Move pulls it out mid-run; leaving the run on purpose is
+        // Ungroup plus Move at the call site.
+        foreach (var group in _groups)
+        {
+            var members = MembersOf(group);
+            if (members.Count <= 1) continue;
+            int start = _tabs.IndexOf(members[0]);
+            bool contiguous = true;
+            for (int k = 0; k < members.Count; k++)
+            {
+                if (ReferenceEquals(_tabs[start + k], members[k])) continue;
+                contiguous = false;
+                break;
+            }
+            if (contiguous) continue;
+            foreach (var tab in members)
+                _tabs.Remove(tab);
+            for (int k = 0; k < members.Count; k++)
+                _tabs.Insert(start + k, members[k]);
+        }
+    }
+
+    private List<TabModel> MembersOf(TabGroup group)
+    {
+        var members = new List<TabModel>();
+        foreach (var t in _tabs)
+            if (ReferenceEquals(t.Group, group)) members.Add(t);
+        return members;
     }
 
     private TabModel CreateTab(ProfileSnapshot? snapshot)
@@ -364,6 +712,8 @@ internal sealed class TabManager
 
         _tabs.RemoveAt(index);
         _mru.Remove(tab);
+        // Same dissolve-on-last-member rule as the close path.
+        Normalize();
         TabRemoved?.Invoke(this, tab);
 
         if (_tabs.Count == 0)
@@ -389,7 +739,11 @@ internal sealed class TabManager
     /// manager. Rewires <see cref="TabModel.OnClose"/>,
     /// <see cref="IPaneHost.LeafFocused"/>, progress forwarding, and
     /// property-change forwarding to the adopter's event graph.
-    /// Raises <see cref="TabAdded"/> and activates the tab.
+    /// Raises <see cref="TabAdded"/> and activates the tab. Pin state
+    /// travels with the tab: a pinned adoptee is folded into this
+    /// window's prefix. Group membership does not: the tab's group, if
+    /// any, belongs to the source window's registry, and Normalize drops
+    /// unregistered membership, so the tab arrives ungrouped.
     /// </summary>
     public void AdoptTab(TabModel tab)
     {
@@ -398,6 +752,7 @@ internal sealed class TabManager
 
         WireAdoptedTab(tab);
         _tabs.Add(tab);
+        Normalize();
         TabAdded?.Invoke(this, tab);
         Activate(tab);
     }

--- a/windows/Ghostty.Core/Tabs/TabManager.cs
+++ b/windows/Ghostty.Core/Tabs/TabManager.cs
@@ -37,6 +37,10 @@ internal sealed class TabManager
     private readonly ObservableCollection<TabModel> _tabs = new();
     private readonly MruList<TabModel> _mru = new();
     private readonly List<TabGroup> _groups = new();
+    // The wrapper is created once and handed out on every read of Groups:
+    // free per read, and a caller that casts it back to IList throws
+    // instead of mutating the registry behind Normalize's back.
+    private readonly ReadOnlyCollection<TabGroup> _groupsView;
     private TabModel _activeTab = null!;
 
     // Exposed as the concrete ObservableCollection so WinUI can bind
@@ -57,7 +61,7 @@ internal sealed class TabManager
     /// <see cref="Normalize"/> dissolves emptied groups, so there is no
     /// empty-group state to render.
     /// </summary>
-    public IReadOnlyList<TabGroup> Groups => _groups;
+    public IReadOnlyList<TabGroup> Groups => _groupsView;
 
     /// <summary>
     /// Size of the pinned prefix of <see cref="Tabs"/>. Derived on every
@@ -133,6 +137,7 @@ internal sealed class TabManager
     {
         _paneHostFactory = paneHostFactory;
         _closedTabs = closedTabs;
+        _groupsView = new(_groups);
         if (seed is null)
         {
             var first = CreateTab(initialSnapshot);
@@ -384,6 +389,7 @@ internal sealed class TabManager
     /// </summary>
     public void MoveGroup(TabGroup group, int targetIndex)
     {
+        ArgumentNullException.ThrowIfNull(group);
         var run = MembersOf(group);
         if (run.Count == 0) return;
         int start = _tabs.IndexOf(run[0]);
@@ -413,6 +419,7 @@ internal sealed class TabManager
     /// </summary>
     public IReadOnlyList<TabModel> RunOf(TabModel tab)
     {
+        ArgumentNullException.ThrowIfNull(tab);
         if (tab.Group is null)
             return new List<TabModel> { tab };
         return MembersOf(tab.Group);
@@ -462,6 +469,7 @@ internal sealed class TabManager
     /// </summary>
     public void CollapseGroup(TabGroup group, bool collapsed)
     {
+        ArgumentNullException.ThrowIfNull(group);
         group.IsCollapsed = collapsed;
     }
 
@@ -472,6 +480,10 @@ internal sealed class TabManager
     /// </summary>
     public void SortPinned()
     {
+        // The one mutator that skips Normalize: only the prefix is
+        // reordered, and a pinned tab can never be grouped (pinning a
+        // grouped tab ungroups it; groups cannot be pinned), so a sort
+        // cannot leave anything for Normalize to repair.
         int count = PinCount;
         if (count <= 1) return;
         var sorted = new List<TabModel>(count);

--- a/windows/Ghostty.Core/Tabs/TabModel.cs
+++ b/windows/Ghostty.Core/Tabs/TabModel.cs
@@ -140,6 +140,36 @@ internal sealed class TabModel : INotifyPropertyChanged
         set { if (field != value) { field = value; Raise(); } }
     }
 
+    /// <summary>
+    /// True while the tab sits in the pinned prefix. Set through
+    /// <see cref="TabManager.SetPinned"/>, which relocates the tab to the
+    /// zone boundary; writing it directly leaves the order to be repaired
+    /// by the manager's next mutation.
+    /// </summary>
+    public bool IsPinned
+    {
+        get;
+        set { if (field != value) { field = value; Raise(); } }
+    }
+
+    /// <summary>
+    /// The tab's group, or null when ungrouped. Owned by
+    /// <see cref="TabManager"/>: its mutators keep members contiguous and
+    /// keep groups out of the pinned prefix, so a direct write is a state
+    /// change the manager repairs on its next mutation, not an order
+    /// change in itself.
+    /// </summary>
+    public TabGroup? Group
+    {
+        get;
+        set
+        {
+            if (ReferenceEquals(field, value)) return;
+            field = value;
+            Raise();
+        }
+    }
+
     // Title precedence: explicit user override beats anything; then
     // the shell's OSC 0/2 reported title (which knows what the user
     // is actually running, e.g. "vim file.txt"); then the profile's

--- a/windows/Ghostty.Tests/Tabs/TabManagerPinGroupTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabManagerPinGroupTests.cs
@@ -490,17 +490,41 @@ public class TabManagerPinGroupTests
         Assert.Equal(0, changes);
     }
 
+    [Fact]
+    public void AdoptTab_folds_a_pinned_adoptee_into_the_prefix()
+    {
+        var src = NewManager(1); // [s0, s1]
+        var dest = NewManager(2); // [a, b, c]
+        dest.SetPinned(dest.Tabs[1], true); // [b*, a, c]
+        src.SetPinned(src.Tabs[1], true); // [s1*, s0]
+
+        // A detached tab keeps its pin; the adopter honors it instead of
+        // letting the tab sink into the unpinned zone.
+        var adoptee = src.DetachTab(src.Tabs[0]);
+
+        dest.AdoptTab(adoptee);
+
+        Assert.Equal(2, dest.PinCount);
+        // Adoption appends, so Normalize lifts the adoptee to the END of
+        // the existing prefix rather than the front of it.
+        Assert.Same(adoptee, dest.Tabs[1]);
+        Assert.True(adoptee.IsPinned);
+        Assert.Null(adoptee.Group);
+        Assert.False(dest.Tabs[2].IsPinned);
+    }
+
     // --- The invariants hold across arbitrary op sequences ---
 
     [Fact]
     public void Random_op_sequences_keep_the_invariants()
     {
         var mgr = NewManager(2);
+        var orphans = new List<TabModel>();
         var random = new Random(20260828);
 
         for (int step = 0; step < 300; step++)
         {
-            switch (random.Next(8))
+            switch (random.Next(11))
             {
                 case 0:
                     mgr.SetPinned(mgr.Tabs[random.Next(mgr.Tabs.Count)], random.Next(2) == 0);
@@ -531,6 +555,23 @@ public class TabManagerPinGroupTests
                     break;
                 case 7:
                     mgr.MoveRun(random.Next(mgr.Tabs.Count), random.Next(mgr.Tabs.Count + 1));
+                    break;
+                case 8:
+                    mgr.SortPinned();
+                    break;
+                case 9:
+                    // The tab leaves this window and may come back later.
+                    if (mgr.Tabs.Count > 1)
+                        orphans.Add(mgr.DetachTab(mgr.Tabs[random.Next(mgr.Tabs.Count)]));
+                    break;
+                case 10:
+                    if (orphans.Count > 0)
+                    {
+                        int pick = random.Next(orphans.Count);
+                        var adoptee = orphans[pick];
+                        orphans.RemoveAt(pick);
+                        mgr.AdoptTab(adoptee);
+                    }
                     break;
             }
 

--- a/windows/Ghostty.Tests/Tabs/TabManagerPinGroupTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabManagerPinGroupTests.cs
@@ -1,0 +1,574 @@
+using System;
+using System.Collections.Generic;
+using Ghostty.Core.Tabs;
+using Xunit;
+
+namespace Ghostty.Tests.Tabs;
+
+public class TabManagerPinGroupTests
+{
+    private static TabManager NewManager()
+        => new TabManager((_) => new FakePaneHost());
+
+    private static TabManager NewManager(int extraTabs)
+    {
+        var mgr = NewManager();
+        for (int i = 0; i < extraTabs; i++) mgr.NewTab();
+        return mgr;
+    }
+
+    private static void Title(TabModel tab, string title) => tab.UserOverrideTitle = title;
+
+    // --- PinCount / SetPinned ---
+
+    [Fact]
+    public void PinCount_is_derived_from_the_order()
+    {
+        var mgr = NewManager(2);
+        Assert.Equal(0, mgr.PinCount);
+        mgr.SetPinned(mgr.Tabs[2], true);
+        Assert.Equal(1, mgr.PinCount);
+        mgr.SetPinned(mgr.Tabs[1], true); // relocation moved the first pin to the front
+        Assert.Equal(2, mgr.PinCount);
+        mgr.SetPinned(mgr.Tabs[0], false);
+        Assert.Equal(1, mgr.PinCount);
+    }
+
+    [Fact]
+    public void SetPinned_true_relocates_to_end_of_prefix()
+    {
+        var mgr = NewManager(2); // [A, B, C]
+        var c = mgr.Tabs[2];
+        mgr.SetPinned(c, true);
+        Assert.Same(c, mgr.Tabs[0]);
+        Assert.Equal(1, mgr.PinCount);
+    }
+
+    [Fact]
+    public void SetPinned_false_relocates_to_first_unpinned_slot()
+    {
+        var mgr = NewManager(2); // [A, B, C]
+        mgr.SetPinned(mgr.Tabs[0], true);
+        mgr.SetPinned(mgr.Tabs[1], true); // [A, B, C] all pinned
+        var a = mgr.Tabs[0];
+        (TabModel tab, int from, int to)? evt = null;
+        mgr.TabMoved += (_, e) => evt = e;
+
+        mgr.SetPinned(a, false);
+
+        Assert.Same(a, mgr.Tabs[1]); // first slot after the remaining pin
+        Assert.Equal((a, 0, 1), evt);
+    }
+
+    [Fact]
+    public void SetPinned_lands_after_the_existing_prefix()
+    {
+        var mgr = NewManager(2); // [A, B, C]
+        mgr.SetPinned(mgr.Tabs[0], true); // prefix = [A]
+        var c = mgr.Tabs[2];
+        (TabModel tab, int from, int to)? evt = null;
+        mgr.TabMoved += (_, e) => evt = e;
+
+        mgr.SetPinned(c, true);
+
+        Assert.Same(c, mgr.Tabs[1]); // right after A, not the front
+        Assert.Equal((c, 2, 1), evt);
+    }
+
+    [Fact]
+    public void SetPinned_to_the_current_state_is_a_noop_without_events()
+    {
+        var mgr = NewManager(1);
+        mgr.SetPinned(mgr.Tabs[0], true);
+        int moved = 0;
+        mgr.TabMoved += (_, _) => moved++;
+        mgr.SetPinned(mgr.Tabs[0], true);
+        mgr.SetPinned(mgr.Tabs[1], false);
+        Assert.Equal(0, moved);
+    }
+
+    [Fact]
+    public void SetPinned_in_a_one_tab_window_pins_without_moving()
+    {
+        var mgr = NewManager(0);
+        var only = mgr.ActiveTab;
+        mgr.SetPinned(only, true);
+        Assert.True(only.IsPinned);
+        Assert.Equal(1, mgr.PinCount);
+        Assert.Same(only, mgr.Tabs[0]);
+        mgr.SetPinned(only, false);
+        Assert.False(only.IsPinned);
+        Assert.Equal(0, mgr.PinCount);
+    }
+
+    [Fact]
+    public void Pinning_a_grouped_tab_removes_it_from_its_group()
+    {
+        var mgr = NewManager(2); // [A, B, C]
+        var group = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[1], mgr.Tabs[2] }, group);
+        var b = mgr.Tabs[1];
+
+        mgr.SetPinned(b, true);
+
+        Assert.Null(b.Group);
+        Assert.Same(group, mgr.Tabs[2].Group);
+        Assert.Contains(group, mgr.Groups);
+        Assert.Same(b, mgr.Tabs[0]);
+    }
+
+    [Fact]
+    public void NewTab_appends_after_the_pinned_prefix()
+    {
+        var mgr = NewManager(0);
+        mgr.SetPinned(mgr.Tabs[0], true);
+        var fresh = mgr.NewTab();
+        Assert.Same(fresh, mgr.Tabs[1]);
+        Assert.False(fresh.IsPinned);
+        Assert.Equal(1, mgr.PinCount);
+    }
+
+    // --- Move clamping at the pin boundary ---
+
+    [Fact]
+    public void Move_clamps_a_pinned_tab_inside_the_prefix()
+    {
+        var mgr = NewManager(2); // [A, B, C]
+        mgr.SetPinned(mgr.Tabs[0], true);
+        mgr.SetPinned(mgr.Tabs[1], true); // [A, B, C], prefix = A, B
+        var a = mgr.Tabs[0];
+        (TabModel tab, int from, int to)? evt = null;
+        mgr.TabMoved += (_, e) => evt = e;
+
+        mgr.Move(0, 2); // intent: into the unpinned zone
+
+        Assert.True(a.IsPinned);
+        Assert.Same(a, mgr.Tabs[1]); // clamped to the last prefix slot
+        Assert.Equal((a, 0, 1), evt);
+        Assert.Equal(2, mgr.PinCount);
+    }
+
+    [Fact]
+    public void Move_clamps_an_unpinned_tab_out_of_the_prefix()
+    {
+        var mgr = NewManager(2); // [A, B, C]
+        mgr.SetPinned(mgr.Tabs[0], true);
+        var b = mgr.Tabs[1];
+        int moved = 0;
+        mgr.TabMoved += (_, _) => moved++;
+
+        mgr.Move(1, 0); // intent: into the pinned zone
+
+        Assert.False(b.IsPinned);
+        Assert.Equal(0, moved);
+        Assert.Same(b, mgr.Tabs[1]);
+        Assert.Equal(1, mgr.PinCount);
+    }
+
+    // --- Group contiguity ---
+
+    [Fact]
+    public void Move_pulling_a_member_out_midrun_repairs_contiguity()
+    {
+        var mgr = NewManager(3); // [A, B, C, D]
+        var group = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[0], mgr.Tabs[1], mgr.Tabs[2] }, group);
+        var b = mgr.Tabs[1];
+        (TabModel tab, int from, int to)? evt = null;
+        mgr.TabMoved += (_, e) => evt = e;
+
+        mgr.Move(1, 3); // pull B out past the run end
+
+        // The op's own indices are what TabMoved reports; Normalize then
+        // re-gathers the run around its first member.
+        Assert.Equal((b, 1, 3), evt);
+        AssertRunContiguous(mgr, group);
+        Assert.Equal(4, mgr.Tabs.Count);
+    }
+
+    [Fact]
+    public void GroupTabs_gathers_scattered_members_into_one_run()
+    {
+        var mgr = NewManager(3); // [A, B, C, D]
+        var group = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[0], mgr.Tabs[2] }, group);
+
+        AssertRunContiguous(mgr, group);
+        Assert.Contains(group, mgr.Groups);
+    }
+
+    [Fact]
+    public void GroupTabs_skips_pinned_members()
+    {
+        var mgr = NewManager(2); // [A, B, C]
+        mgr.SetPinned(mgr.Tabs[0], true);
+        var group = new TabGroup();
+        var a = mgr.Tabs[0];
+
+        mgr.GroupTabs(new[] { a, mgr.Tabs[1] }, group);
+
+        Assert.Null(a.Group);
+        Assert.Same(group, mgr.Tabs[1].Group);
+        Assert.True(a.IsPinned);
+    }
+
+    [Fact]
+    public void RunOf_returns_the_group_run_or_a_singleton()
+    {
+        var mgr = NewManager(3); // [A, B, C, D]
+        var group = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[0], mgr.Tabs[2] }, group);
+        var gathered = mgr.RunOf(mgr.Tabs[0]);
+
+        Assert.Equal(2, gathered.Count);
+        Assert.Contains(mgr.Tabs[0], gathered);
+        Assert.Contains(mgr.Tabs[1], gathered);
+
+        var lone = mgr.RunOf(mgr.Tabs[3]);
+        Assert.Single(lone);
+        Assert.Same(mgr.Tabs[3], lone[0]);
+    }
+
+    // --- Empty groups dissolve ---
+
+    [Fact]
+    public void Ungrouping_the_last_member_dissolves_the_group()
+    {
+        var mgr = NewManager(1);
+        var group = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[0] }, group);
+        mgr.CollapseGroup(group, true);
+
+        mgr.Ungroup(mgr.Tabs[0]);
+
+        Assert.Null(mgr.Tabs[0].Group);
+        Assert.DoesNotContain(group, mgr.Groups);
+        Assert.Empty(mgr.Groups);
+    }
+
+    [Fact]
+    public void Closing_group_members_dissolves_the_group()
+    {
+        var mgr = NewManager(2); // [A, B, C]
+        var group = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[0], mgr.Tabs[1] }, group);
+        mgr.CollapseGroup(group, true);
+
+        mgr.CloseTab(mgr.Tabs[1]);
+        Assert.Contains(group, mgr.Groups); // still one member left
+        mgr.CloseTab(mgr.Tabs[0]);
+
+        Assert.DoesNotContain(group, mgr.Groups); // collapse state died with it
+    }
+
+    [Fact]
+    public void GroupTabs_with_no_eligible_member_registers_nothing()
+    {
+        var mgr = NewManager(0);
+        var group = new TabGroup();
+        mgr.SetPinned(mgr.Tabs[0], true);
+
+        mgr.GroupTabs(new[] { mgr.Tabs[0] }, group);
+
+        Assert.Empty(mgr.Groups);
+        Assert.Null(mgr.Tabs[0].Group);
+    }
+
+    // --- Collapse ---
+
+    [Fact]
+    public void CollapseGroup_sets_the_bit_without_touching_the_list()
+    {
+        var mgr = NewManager(2);
+        var group = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[0], mgr.Tabs[1] }, group);
+        var order = new List<TabModel>(mgr.Tabs);
+        int moved = 0;
+        mgr.TabMoved += (_, _) => moved++;
+
+        mgr.CollapseGroup(group, true);
+
+        Assert.True(group.IsCollapsed);
+        Assert.Equal(0, moved);
+        Assert.Equal(order, mgr.Tabs);
+        mgr.CollapseGroup(group, false);
+        Assert.False(group.IsCollapsed);
+    }
+
+    // --- MoveGroup / MoveRun rotations ---
+
+    [Fact]
+    public void MoveGroup_moves_the_run_as_a_unit_preserving_member_order()
+    {
+        var mgr = NewManager(4); // [A, B, C, D, E]
+        mgr.SetPinned(mgr.Tabs[0], true); // prefix = [A]
+        var group = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[1], mgr.Tabs[2], mgr.Tabs[3] }, group);
+        var a = mgr.Tabs[0];
+        var e = mgr.Tabs[4];
+        var b = mgr.Tabs[1];
+        var c = mgr.Tabs[2];
+        var d = mgr.Tabs[3];
+
+        mgr.MoveGroup(group, 2); // one past the run start
+
+        Assert.Equal(new[] { a, e, b, c, d }, mgr.Tabs.ToArray());
+        AssertRunContiguous(mgr, group);
+        Assert.Equal(2, mgr.IndexOf(b));
+    }
+
+    [Fact]
+    public void MoveGroup_clamps_out_of_the_pinned_prefix()
+    {
+        var mgr = NewManager(3); // [A, B, C, D]
+        mgr.SetPinned(mgr.Tabs[0], true);
+        mgr.SetPinned(mgr.Tabs[1], true);
+        var group = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[2], mgr.Tabs[3] }, group);
+        var order = new List<TabModel>(mgr.Tabs);
+
+        mgr.MoveGroup(group, 0); // intent: the run at the very front
+
+        Assert.Equal(order, mgr.Tabs); // already flush against the prefix
+    }
+
+    [Fact]
+    public void MoveRun_rotates_the_run_around_the_grabbed_member()
+    {
+        var mgr = NewManager(4); // [A, B, C, D, E]
+        var group = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[0], mgr.Tabs[1], mgr.Tabs[2], mgr.Tabs[3], mgr.Tabs[4] }, group);
+        var a = mgr.Tabs[0];
+        var b = mgr.Tabs[1];
+        var c = mgr.Tabs[2];
+        var d = mgr.Tabs[3];
+        var e = mgr.Tabs[4];
+
+        mgr.MoveRun(2, 4); // grab C, drag it to the run's end
+
+        Assert.Equal(new[] { d, e, a, b, c }, mgr.Tabs.ToArray());
+        AssertRunContiguous(mgr, group);
+    }
+
+    [Fact]
+    public void MoveRun_clamps_into_the_run_span()
+    {
+        var mgr = NewManager(3); // [A, B, C, D]
+        var group = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[1], mgr.Tabs[2] }, group); // run [B, C]
+        var a = mgr.Tabs[0];
+        var b = mgr.Tabs[1];
+        var c = mgr.Tabs[2];
+        var d = mgr.Tabs[3];
+
+        mgr.MoveRun(1, 3); // intent: B past the run end
+
+        Assert.Equal(new[] { a, c, b, d }, mgr.Tabs.ToArray()); // stopped at the run's last slot
+        AssertRunContiguous(mgr, group);
+    }
+
+    [Fact]
+    public void MoveRun_on_an_ungrouped_tab_is_a_plain_move()
+    {
+        var mgr = NewManager(2); // [A, B, C]
+        var b = mgr.Tabs[1];
+        (TabModel tab, int from, int to)? evt = null;
+        mgr.TabMoved += (_, e) => evt = e;
+
+        mgr.MoveRun(1, 2); // to the last slot, like Move
+
+        Assert.Same(b, mgr.Tabs[2]);
+        Assert.Equal((b, 1, 2), evt);
+    }
+
+    // --- SortPinned ---
+
+    [Fact]
+    public void SortPinned_orders_the_prefix_by_effective_title()
+    {
+        var mgr = NewManager(3); // [A, B, C, D]
+        Title(mgr.Tabs[0], "cocoa");
+        Title(mgr.Tabs[1], "alpha");
+        Title(mgr.Tabs[2], "bravo");
+        Title(mgr.Tabs[3], "zulu");
+        mgr.SetPinned(mgr.Tabs[0], true);
+        mgr.SetPinned(mgr.Tabs[1], true);
+        mgr.SetPinned(mgr.Tabs[2], true);
+        var alpha = mgr.Tabs[1];
+        var bravo = mgr.Tabs[2];
+        var cocoa = mgr.Tabs[0];
+        var zulu = mgr.Tabs[3];
+
+        mgr.SortPinned();
+
+        Assert.Equal(new[] { alpha, bravo, cocoa, zulu }, mgr.Tabs.ToArray());
+        Assert.Equal(3, mgr.PinCount);
+    }
+
+    [Fact]
+    public void SortPinned_is_stable_for_equal_titles()
+    {
+        var mgr = NewManager(2); // [A, B, C]
+        Title(mgr.Tabs[0], "same");
+        Title(mgr.Tabs[1], "same");
+        Title(mgr.Tabs[2], "ahead");
+        mgr.SetPinned(mgr.Tabs[0], true);
+        mgr.SetPinned(mgr.Tabs[1], true);
+        mgr.SetPinned(mgr.Tabs[2], true);
+        var ahead = mgr.Tabs[2];
+        var first = mgr.Tabs[0];
+        var second = mgr.Tabs[1];
+
+        mgr.SortPinned();
+
+        // Only "ahead" moves up; the two equal titles keep their order.
+        Assert.Equal(new[] { ahead, first, second }, mgr.Tabs.ToArray());
+    }
+
+    [Fact]
+    public void SortPinned_is_idempotent()
+    {
+        var mgr = NewManager(2);
+        Title(mgr.Tabs[0], "b");
+        Title(mgr.Tabs[1], "a");
+        mgr.SetPinned(mgr.Tabs[0], true);
+        mgr.SetPinned(mgr.Tabs[1], true);
+
+        mgr.SortPinned();
+        var order = new List<TabModel>(mgr.Tabs);
+        int moved = 0;
+        mgr.TabMoved += (_, _) => moved++;
+
+        mgr.SortPinned();
+
+        Assert.Equal(0, moved);
+        Assert.Equal(order, mgr.Tabs);
+    }
+
+    // --- MRU and activation are orthogonal to strip order ---
+
+    [Fact]
+    public void Pin_group_and_reorder_mutators_never_touch_mru_order()
+    {
+        var mgr = NewManager(3);
+        mgr.Activate(mgr.Tabs[0]); // MRU: [0, 3, 2, 1]
+        var expected = mgr.MruOrder.ToArray();
+        var group = new TabGroup();
+
+        mgr.SetPinned(mgr.Tabs[1], true);
+        mgr.Move(0, mgr.Tabs.Count - 1);
+        mgr.GroupTabs(new[] { mgr.Tabs[2], mgr.Tabs[3] }, group);
+        mgr.CollapseGroup(group, true);
+        mgr.MoveGroup(group, 0);
+        mgr.MoveRun(1, 3);
+        mgr.SortPinned();
+        mgr.SetPinned(mgr.Tabs[0], false);
+        mgr.Ungroup(mgr.Tabs[2]);
+
+        Assert.Equal(expected, mgr.MruOrder.ToArray());
+    }
+
+    [Fact]
+    public void Pin_group_and_reorder_mutators_never_change_the_active_tab()
+    {
+        var mgr = NewManager(3);
+        mgr.Activate(mgr.Tabs[2]);
+        var active = mgr.ActiveTab;
+        int changes = 0;
+        mgr.ActiveTabChanged += (_, _) => changes++;
+        var group = new TabGroup();
+
+        mgr.SetPinned(mgr.Tabs[1], true);
+        mgr.Move(0, mgr.Tabs.Count - 1);
+        mgr.GroupTabs(new[] { mgr.Tabs[0], mgr.Tabs[3] }, group);
+        mgr.MoveGroup(group, 0);
+        mgr.MoveRun(2, 3);
+        mgr.SortPinned();
+        mgr.Ungroup(mgr.Tabs[0]);
+
+        Assert.Same(active, mgr.ActiveTab);
+        Assert.Equal(0, changes);
+    }
+
+    // --- The invariants hold across arbitrary op sequences ---
+
+    [Fact]
+    public void Random_op_sequences_keep_the_invariants()
+    {
+        var mgr = NewManager(2);
+        var random = new Random(20260828);
+
+        for (int step = 0; step < 300; step++)
+        {
+            switch (random.Next(8))
+            {
+                case 0:
+                    mgr.SetPinned(mgr.Tabs[random.Next(mgr.Tabs.Count)], random.Next(2) == 0);
+                    break;
+                case 1:
+                    mgr.Move(random.Next(mgr.Tabs.Count), random.Next(mgr.Tabs.Count));
+                    break;
+                case 2:
+                    mgr.NewTab();
+                    break;
+                case 3:
+                    if (mgr.Tabs.Count > 1)
+                        mgr.CloseTab(mgr.Tabs[random.Next(mgr.Tabs.Count)]);
+                    break;
+                case 4:
+                    var members = new List<TabModel>();
+                    for (int n = random.Next(1, 4); n > 0; n--)
+                        members.Add(mgr.Tabs[random.Next(mgr.Tabs.Count)]);
+                    mgr.GroupTabs(members, new TabGroup());
+                    break;
+                case 5:
+                    if (mgr.Groups.Count > 0)
+                        mgr.Ungroup(mgr.Tabs[random.Next(mgr.Tabs.Count)]);
+                    break;
+                case 6:
+                    if (mgr.Groups.Count > 0)
+                        mgr.MoveGroup(mgr.Groups[random.Next(mgr.Groups.Count)], random.Next(mgr.Tabs.Count + 1));
+                    break;
+                case 7:
+                    mgr.MoveRun(random.Next(mgr.Tabs.Count), random.Next(mgr.Tabs.Count + 1));
+                    break;
+            }
+
+            AssertInvariantsHold(mgr);
+        }
+    }
+
+    private static void AssertInvariantsHold(TabManager mgr)
+    {
+        // Invariant 1: the pinned tabs are exactly the prefix.
+        for (int i = 0; i < mgr.Tabs.Count; i++)
+            Assert.Equal(i < mgr.PinCount, mgr.Tabs[i].IsPinned);
+
+        // Invariant 2: every registered group's members form one
+        // contiguous run. Invariant 3 falls out of the membership check:
+        // a group with no members cannot appear here, and no tab points
+        // at an unregistered group.
+        foreach (var group in mgr.Groups)
+        {
+            var positions = new List<int>();
+            for (int i = 0; i < mgr.Tabs.Count; i++)
+                if (ReferenceEquals(mgr.Tabs[i].Group, group))
+                    positions.Add(i);
+            Assert.NotEmpty(positions);
+            Assert.Equal(positions[^1] - positions[0] + 1, positions.Count);
+        }
+        foreach (var tab in mgr.Tabs)
+            if (tab.Group is not null)
+                Assert.Contains(tab.Group, mgr.Groups);
+    }
+
+    private static void AssertRunContiguous(TabManager mgr, TabGroup group)
+    {
+        var positions = new List<int>();
+        for (int i = 0; i < mgr.Tabs.Count; i++)
+            if (ReferenceEquals(mgr.Tabs[i].Group, group))
+                positions.Add(i);
+        Assert.NotEmpty(positions);
+        Assert.Equal(positions[^1] - positions[0] + 1, positions.Count);
+    }
+}

--- a/windows/Ghostty.Tests/Tabs/TabSessionPinGroupTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabSessionPinGroupTests.cs
@@ -1,0 +1,93 @@
+using System;
+using Ghostty.Core.Session;
+using Ghostty.Core.Tabs;
+using Xunit;
+
+namespace Ghostty.Tests.Tabs;
+
+/// <summary>
+/// Serialization surface for the pin/group fields of section 6 of the
+/// tab-reorder spec. Restore-side repair is wired by a later PR; this
+/// only proves the fields survive the source-generated round trip.
+/// </summary>
+public class TabSessionPinGroupTests
+{
+    private static TabSession Tab(bool pinned = false, Guid? groupId = null)
+        => new TabSession { Tree = new LeafDto { ProfileId = "pwsh" }, IsPinned = pinned, GroupId = groupId };
+
+    [Fact]
+    public void RoundTrip_preserves_pins_group_refs_and_collapse_state()
+    {
+        var groupId = Guid.NewGuid();
+        var state = new SessionState
+        {
+            CleanShutdown = true,
+            Windows =
+            {
+                new WindowSession
+                {
+                    ActiveTabIndex = 2,
+                    Groups =
+                    {
+                        new GroupSession
+                        {
+                            Id = groupId,
+                            Title = "work",
+                            Color = TabColor.Green,
+                            Collapsed = true,
+                        },
+                    },
+                    Tabs =
+                    {
+                        Tab(pinned: true),
+                        Tab(groupId: groupId),
+                        Tab(),
+                    },
+                },
+            },
+        };
+
+        var back = SessionSerializer.Deserialize(SessionSerializer.Serialize(state));
+
+        Assert.NotNull(back);
+        var window = Assert.Single(back!.Windows);
+        var group = Assert.Single(window.Groups);
+        Assert.Equal(groupId, group.Id);
+        Assert.Equal("work", group.Title);
+        Assert.Equal(TabColor.Green, group.Color);
+        Assert.True(group.Collapsed);
+
+        Assert.True(window.Tabs[0].IsPinned);
+        Assert.Null(window.Tabs[0].GroupId);
+        Assert.False(window.Tabs[1].IsPinned);
+        Assert.Equal(groupId, window.Tabs[1].GroupId);
+        Assert.False(window.Tabs[2].IsPinned);
+        Assert.Null(window.Tabs[2].GroupId);
+    }
+
+    [Fact]
+    public void RoundTrip_of_a_session_without_pins_or_groups_stays_clean()
+    {
+        var state = new SessionState
+        {
+            Windows =
+            {
+                new WindowSession
+                {
+                    Tabs = { Tab(), Tab() },
+                },
+            },
+        };
+
+        var back = SessionSerializer.Deserialize(SessionSerializer.Serialize(state));
+
+        Assert.NotNull(back);
+        var window = Assert.Single(back!.Windows);
+        Assert.Empty(window.Groups);
+        Assert.All(window.Tabs, t =>
+        {
+            Assert.False(t.IsPinned);
+            Assert.Null(t.GroupId);
+        });
+    }
+}


### PR DESCRIPTION
PR 1 of the tab reorder/groups/pins ladder (spec: docs/specs/2026-08-28-tab-reorder-groups-pins.md, sections 4/6/9.1). Ghostty.Core only, no UI.

Size-override: 667 of 1176 insertions are the two test files; the model surface is a single concern (pin/group invariants) and the spec's PR 1 scope.

- TabModel gains IsPinned and Group (INPC, change-guarded); new TabGroup (Id/Title/Color/IsCollapsed).
- TabManager gains a Groups registry (read-only wrapper), derived PinCount, RunOf, and the mutators SetPinned, MoveRun, MoveGroup, GroupTabs, Ungroup, CollapseGroup, SortPinned.
- A private Normalize() enforces the three invariants (pin prefix, group contiguity, no empty groups) after every mutation, before events. Move(from, to) now clamps against the pin boundary; its TabMoved contract is unchanged.
- SessionModel gains Groups/GroupSession and TabSession.IsPinned/GroupId. Scope truth: the save-side capture does not populate these fields yet and restore lands in PR 5 - this PR only carries the round-trip fields.
- The new mutators have no callers yet (by design): with PinCount == 0 and no groups, Normalize is provably a no-op and the strips are untouched.

Tests: 31 new (invariant coverage per spec 9.1 plus a seeded 300-step random walk over 11 ops asserting all three invariants after every step, including detach/adopt hand-off and the pinned-adoptee prefix fold-in).