### PR TITLE
tabs: single source of truth for strip order

### DIFF
--- a/windows/Ghostty.Core/Tabs/TabStripProjection.cs
+++ b/windows/Ghostty.Core/Tabs/TabStripProjection.cs
@@ -13,13 +13,11 @@ namespace Ghostty.Core.Tabs;
 /// <see cref="TabManager.TabMoved"/> carries the raw operation's indices,
 /// and <c>Normalize</c> may relocate tabs afterwards (a move that pulls a
 /// member out mid-run re-gathers its group). A listener replaying event
-/// indices against a live collection strands desynced; the projector
-/// reads the manager's FINAL state and describes what brings any strip
-/// back to it.
-///
-/// Group headers and collapsed chips arrive with the groups slice; until
-/// then the projection is the flat list both strips already rendered,
-/// which is what makes this seam behavior-neutral.
+/// indices strands desynced; the projector reads the manager's FINAL
+/// state and describes what brings any strip back to it. Until the
+/// groups slice lands (headers, collapsed chips) the projection is the
+/// flat list both strips already rendered, which is what makes this
+/// seam behavior-neutral.
 /// </summary>
 internal static class TabStripProjection
 {

--- a/windows/Ghostty.Core/Tabs/TabStripProjection.cs
+++ b/windows/Ghostty.Core/Tabs/TabStripProjection.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+
+namespace Ghostty.Core.Tabs;
+
+/// <summary>
+/// The single translation point between <see cref="TabManager"/> state
+/// and the row sequence a strip renders. Both hosts take their order
+/// from here, so the horizontal TabView and the vertical NavigationView
+/// agree on it structurally rather than coincidentally.
+///
+/// Why hosts read state instead of event indices:
+/// <see cref="TabManager.TabMoved"/> carries the raw operation's indices,
+/// and <c>Normalize</c> may relocate tabs afterwards (a move that pulls a
+/// member out mid-run re-gathers its group). A listener replaying event
+/// indices against a live collection strands desynced; the projector
+/// reads the manager's FINAL state and describes what brings any strip
+/// back to it.
+///
+/// Group headers and collapsed chips arrive with the groups slice; until
+/// then the projection is the flat list both strips already rendered,
+/// which is what makes this seam behavior-neutral.
+/// </summary>
+internal static class TabStripProjection
+{
+    /// <summary>
+    /// The row order a strip renders for the manager's current state.
+    /// A fresh list every call: callers may rebuild their containers
+    /// while walking it, and the projection must not move under them.
+    /// </summary>
+    public static IReadOnlyList<TabModel> Rows(TabManager manager)
+    {
+        var rows = new List<TabModel>(manager.Tabs.Count);
+        foreach (var tab in manager.Tabs) rows.Add(tab);
+        return rows;
+    }
+
+    /// <summary>
+    /// One repair instruction: take <see cref="Tab"/> out of wherever it
+    /// currently sits and insert it at <see cref="To"/>. The index counts
+    /// the collection's state AFTER the previous ops applied, so ops are
+    /// applied in order against the live container.
+    /// </summary>
+    public readonly record struct RowMove(TabModel Tab, int To);
+
+    /// <summary>
+    /// The moves that bring <paramref name="current"/> into
+    /// <paramref name="desired"/> order. Both lists must hold the same
+    /// tabs; only the order may differ. Rows already in place emit no op:
+    /// re-inserting an item at the index it already occupies is a
+    /// collection mutation with no effect, and once order is semantic it
+    /// is a second writer fighting the control's own reorder (the churn
+    /// the TabView sync audit flagged).
+    /// </summary>
+    public static IReadOnlyList<RowMove> Diff(
+        IReadOnlyList<TabModel> desired, IReadOnlyList<TabModel> current)
+    {
+        if (desired.Count != current.Count)
+            throw new InvalidOperationException(
+                "TabStripProjection.Diff: the strip and the manager hold " +
+                "different tab counts. Order is repairable; membership skew " +
+                "is a wiring bug, not a projection.");
+        // Left-to-right placement: every row the two lists already agree
+        // on at the front stays untouched, so an ordinary single move
+        // repairs with exactly one op and nothing else is disturbed.
+        var working = new List<TabModel>(current);
+        var ops = new List<RowMove>();
+        for (int i = 0; i < desired.Count; i++)
+        {
+            var want = desired[i];
+            int at = working.IndexOf(want);
+            if (at < 0)
+                throw new InvalidOperationException(
+                    "TabStripProjection.Diff: the strip is missing a tab the " +
+                    "manager holds. Membership skew is a wiring bug, not a " +
+                    "projection.");
+            if (at == i) continue;
+            working.RemoveAt(at);
+            working.Insert(i, want);
+            ops.Add(new RowMove(want, i));
+        }
+        return ops;
+    }
+}

--- a/windows/Ghostty.Tests/Ghostty.Tests.csproj
+++ b/windows/Ghostty.Tests/Ghostty.Tests.csproj
@@ -167,6 +167,15 @@
     <EmbeddedResource Include="..\Ghostty\Tabs\TabColorPalettePicker.xaml"
                       Link="Tabs\TabColorPalettePicker.xaml"
                       LogicalName="Ghostty.Tests.Tabs.TabColorPalettePicker.xaml" />
+    <!--
+      TabHost.xaml, for the drop-outside census in TabStripSyncWiringTests:
+      detach-by-drag stays unwired, and a XAML event attribute is invisible
+      to the .cs source sweep. A dotted LogicalName, so the test's suffix
+      match does not depend on the host's directory separator.
+    -->
+    <EmbeddedResource Include="..\Ghostty\Tabs\TabHost.xaml"
+                      Link="Tabs\TabHost.xaml"
+                      LogicalName="Ghostty.Tests.Tabs.TabHost.xaml" />
     <EmbeddedResource Include="..\Ghostty\Tabs\VerticalTabStrip.xaml"
                       Link="Tabs\VerticalTabStrip.xaml"
                       LogicalName="Ghostty.Tests.Tabs.VerticalTabStrip.xaml" />

--- a/windows/Ghostty.Tests/Ghostty.Tests.csproj
+++ b/windows/Ghostty.Tests/Ghostty.Tests.csproj
@@ -168,10 +168,9 @@
                       Link="Tabs\TabColorPalettePicker.xaml"
                       LogicalName="Ghostty.Tests.Tabs.TabColorPalettePicker.xaml" />
     <!--
-      TabHost.xaml, for the drop-outside census in TabStripSyncWiringTests:
-      detach-by-drag stays unwired, and a XAML event attribute is invisible
-      to the .cs source sweep. A dotted LogicalName, so the test's suffix
-      match does not depend on the host's directory separator.
+      TabHost.xaml, for the unwired-event censuses in TabStripSyncWiringTests:
+      a XAML event attribute is invisible to the .cs source sweep. Dotted
+      LogicalName, so suffix matching does not depend on the path separator.
     -->
     <EmbeddedResource Include="..\Ghostty\Tabs\TabHost.xaml"
                       Link="Tabs\TabHost.xaml"

--- a/windows/Ghostty.Tests/Tabs/TabStripProjectionTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabStripProjectionTests.cs
@@ -10,14 +10,13 @@ namespace Ghostty.Tests.Tabs;
 /// The projector is the single translation point between the manager's
 /// order and what a strip renders, so these tests drive it the way the
 /// hosts do: manager mutations on one side, a live collection replaying
-/// the shell's Remove-then-Insert discipline on the other.
+/// the shell's remove-then-insert discipline on the other.
 ///
-/// The three seams here are the ones PR 2 owns (spec 10, PR 2 row):
-/// raw TabMoved indices that Normalize has since repaired, a Move the
-/// invariants clamp down to a silent no-op, and the batched TabMoved
-/// pairs of a run move. The shell cannot load into this host, so the
-/// mirror stands in for TabItems; TabStripSyncWiringTests pins the real
-/// handlers to the same replay-then-reconcile shape.
+/// The seams here are the ones PR 2 owns (spec 10): raw TabMoved
+/// indices that Normalize has since repaired, a Move the invariants
+/// clamp to a silent no-op, and the batched TabMoved pairs of a run
+/// move. The shell cannot load into this host, so the mirror stands in
+/// for TabItems; TabStripSyncWiringTests pins the real handlers.
 /// </summary>
 public class TabStripProjectionTests
 {
@@ -28,11 +27,7 @@ public class TabStripProjectionTests
         return mgr;
     }
 
-    /// <summary>
-    /// A live strip: the manager's tabs in some order, mutated only by
-    /// the shell's remove-then-insert discipline. Stands in for TabItems
-    /// / MenuItems, which this test host cannot construct.
-    /// </summary>
+    /// <summary>A live strip, mutated only by the hosts' discipline.</summary>
     private sealed class Strip
     {
         public readonly List<TabModel> Items = new();
@@ -59,10 +54,8 @@ public class TabStripProjectionTests
     }
 
     /// <summary>
-    /// OnTabDragCompleted's shape, driven against a live mirror. The
-    /// wiring test pins the real handler to the same three steps: read
-    /// the strip index, Move in manager space, reconcile the strip to
-    /// the manager's final order.
+    /// OnTabDragCompleted's shape, driven against a live mirror: read the
+    /// strip index, Move in manager space, reconcile via the projector.
     /// </summary>
     private static void CompleteDrag(TabManager mgr, Strip strip, TabModel dragged)
     {
@@ -70,9 +63,12 @@ public class TabStripProjectionTests
         int oldIndex = mgr.IndexOf(dragged);
         if (oldIndex != newIndex && oldIndex >= 0)
             mgr.Move(oldIndex, newIndex);
-        strip.Apply(TabStripProjection.Diff(
-            TabStripProjection.Rows(mgr), strip.Items));
+        Reconcile(mgr, strip);
     }
+
+    // The repair step both hosts run after any strip-side change.
+    private static void Reconcile(TabManager mgr, Strip strip)
+        => strip.Apply(TabStripProjection.Diff(TabStripProjection.Rows(mgr), strip.Items));
 
     private static int ManagerMutations(TabManager mgr, Action action)
     {
@@ -169,17 +165,15 @@ public class TabStripProjectionTests
 
         mgr.Move(1, 3); // pull B out past the run end
 
-        // The manager re-gathered the run; the event reported only the raw op.
+        // The manager re-gathered the run; the event reported only the op.
         Assert.Equal(new[] { a, c, b, x }, mgr.Tabs.ToArray());
         var move = Assert.Single(moves);
         Assert.Equal((b, 1, 3), move);
 
-        // The replay followed the event's indices and stranded desynced --
-        // the seam, observed before the repair.
+        // The replay followed the event's raw indices and stranded -- the seam.
         Assert.Equal(new[] { a, c, x, b }, strip.Items);
 
-        strip.Apply(TabStripProjection.Diff(
-            TabStripProjection.Rows(mgr), strip.Items));
+        Reconcile(mgr, strip);
 
         Assert.Equal(mgr.Tabs.ToArray(), strip.Items.ToArray());
     }
@@ -198,19 +192,18 @@ public class TabStripProjectionTests
         int moved = 0;
         mgr.TabMoved += (_, _) => moved++;
 
-        // TabView's own reorder has already put B in front of the pin; the
-        // manager is asked to ratify a move into the pinned prefix.
+        // TabView's reorder already put B in front of the pin; the manager
+        // is asked to ratify a move into the pinned prefix.
         strip.Items.Remove(b);
         strip.Items.Insert(0, b);
 
         int mutations = ManagerMutations(mgr, () => CompleteDrag(mgr, strip, b));
 
-        // The clamp reduced the move to a no-op: no list change, no event.
+        // The clamp reduced the move to a no-op: no list change, no event,
+        // and the drop's reconcile pulled the strip back to the manager.
         Assert.Equal(0, mutations);
         Assert.Equal(0, moved);
         Assert.Equal(new[] { a, b, c }, mgr.Tabs.ToArray());
-
-        // The drop's reconcile pulled the strip back to the manager's order.
         Assert.Equal(mgr.Tabs.ToArray(), strip.Items.ToArray());
     }
 
@@ -261,10 +254,8 @@ public class TabStripProjectionTests
 
                 AssertRunContiguous(mgr, group);
                 // The rotation's paired events, replayed one by one, land
-                // wherever they land; the reconcile is what guarantees the
-                // strip ends on the manager's order.
-                strip.Apply(TabStripProjection.Diff(
-                    TabStripProjection.Rows(mgr), strip.Items));
+                // wherever they land; the reconcile guarantees the ending.
+                Reconcile(mgr, strip);
                 Assert.Equal(mgr.Tabs.ToArray(), strip.Items.ToArray());
             }
         }
@@ -288,12 +279,10 @@ public class TabStripProjectionTests
 
         Assert.Equal(new[] { p, q, a, b, c }, mgr.Tabs.ToArray());
 
-        // The per-member pairs replayed one by one cannot express the
-        // block move -- the seam, observed before the repair.
+        // Per-member pairs replayed one by one cannot express the block move.
         Assert.NotEqual(mgr.Tabs.ToArray(), strip.Items.ToArray());
 
-        strip.Apply(TabStripProjection.Diff(
-            TabStripProjection.Rows(mgr), strip.Items));
+        Reconcile(mgr, strip);
 
         Assert.Equal(mgr.Tabs.ToArray(), strip.Items.ToArray());
     }

--- a/windows/Ghostty.Tests/Tabs/TabStripProjectionTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabStripProjectionTests.cs
@@ -1,0 +1,310 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using Ghostty.Core.Tabs;
+using Xunit;
+
+namespace Ghostty.Tests.Tabs;
+
+/// <summary>
+/// The projector is the single translation point between the manager's
+/// order and what a strip renders, so these tests drive it the way the
+/// hosts do: manager mutations on one side, a live collection replaying
+/// the shell's Remove-then-Insert discipline on the other.
+///
+/// The three seams here are the ones PR 2 owns (spec 10, PR 2 row):
+/// raw TabMoved indices that Normalize has since repaired, a Move the
+/// invariants clamp down to a silent no-op, and the batched TabMoved
+/// pairs of a run move. The shell cannot load into this host, so the
+/// mirror stands in for TabItems; TabStripSyncWiringTests pins the real
+/// handlers to the same replay-then-reconcile shape.
+/// </summary>
+public class TabStripProjectionTests
+{
+    private static TabManager NewManager(int extraTabs)
+    {
+        var mgr = new TabManager((_) => new FakePaneHost());
+        for (int i = 0; i < extraTabs; i++) mgr.NewTab();
+        return mgr;
+    }
+
+    /// <summary>
+    /// A live strip: the manager's tabs in some order, mutated only by
+    /// the shell's remove-then-insert discipline. Stands in for TabItems
+    /// / MenuItems, which this test host cannot construct.
+    /// </summary>
+    private sealed class Strip
+    {
+        public readonly List<TabModel> Items = new();
+
+        public Strip(IEnumerable<TabModel> seed) => Items.AddRange(seed);
+
+        // TabHost-style replay of one TabMoved payload: take the item
+        // out, insert it at the event's raw index.
+        public void Replay(TabModel tab, int to)
+        {
+            Items.Remove(tab);
+            Items.Insert(to, tab);
+        }
+
+        // The projector's ops, applied the way both hosts apply them.
+        public void Apply(IReadOnlyList<TabStripProjection.RowMove> ops)
+        {
+            foreach (var op in ops)
+            {
+                Items.Remove(op.Tab);
+                Items.Insert(op.To, op.Tab);
+            }
+        }
+    }
+
+    /// <summary>
+    /// OnTabDragCompleted's shape, driven against a live mirror. The
+    /// wiring test pins the real handler to the same three steps: read
+    /// the strip index, Move in manager space, reconcile the strip to
+    /// the manager's final order.
+    /// </summary>
+    private static void CompleteDrag(TabManager mgr, Strip strip, TabModel dragged)
+    {
+        int newIndex = strip.Items.IndexOf(dragged);
+        int oldIndex = mgr.IndexOf(dragged);
+        if (oldIndex != newIndex && oldIndex >= 0)
+            mgr.Move(oldIndex, newIndex);
+        strip.Apply(TabStripProjection.Diff(
+            TabStripProjection.Rows(mgr), strip.Items));
+    }
+
+    private static int ManagerMutations(TabManager mgr, Action action)
+    {
+        int count = 0;
+        NotifyCollectionChangedEventHandler handler = (_, _) => count++;
+        mgr.Tabs.CollectionChanged += handler;
+        try { action(); } finally { mgr.Tabs.CollectionChanged -= handler; }
+        return count;
+    }
+
+    // --- Rows ---
+
+    [Fact]
+    public void Rows_are_the_manager_order_while_headers_are_off()
+    {
+        var mgr = NewManager(2); // [A, B, C]
+        var expected = mgr.Tabs.ToArray();
+
+        Assert.Equal(expected, TabStripProjection.Rows(mgr));
+    }
+
+    [Fact]
+    public void Rows_is_a_snapshot_that_survives_a_later_reorder()
+    {
+        var mgr = NewManager(1); // [A, B, C]
+        var rows = TabStripProjection.Rows(mgr);
+        var expected = rows.ToArray();
+
+        mgr.Move(0, 2);
+
+        Assert.Equal(expected, rows); // the projection did not move under its reader
+    }
+
+    // --- Diff ---
+
+    [Fact]
+    public void Diff_of_matching_orders_is_empty()
+    {
+        var mgr = NewManager(2);
+        var rows = TabStripProjection.Rows(mgr);
+
+        Assert.Empty(TabStripProjection.Diff(rows, new List<TabModel>(rows)));
+    }
+
+    [Fact]
+    public void Diff_of_an_order_shifted_behind_its_target_is_one_op()
+    {
+        var mgr = NewManager(3); // [A, B, C, D]
+        var desired = new[] { mgr.Tabs[0], mgr.Tabs[2], mgr.Tabs[1], mgr.Tabs[3] };
+
+        var ops = TabStripProjection.Diff(desired, new List<TabModel>(mgr.Tabs));
+
+        var op = Assert.Single(ops);
+        Assert.Equal(mgr.Tabs[2], op.Tab); // C moves forward; nothing else is disturbed
+        Assert.Equal(1, op.To);
+    }
+
+    [Fact]
+    public void Diff_of_a_full_reversal_takes_one_op_per_row_but_the_last()
+    {
+        var mgr = NewManager(2); // [A, B, C]
+        var desired = new[] { mgr.Tabs[2], mgr.Tabs[1], mgr.Tabs[0] };
+
+        Assert.Equal(2, TabStripProjection.Diff(desired, new List<TabModel>(mgr.Tabs)).Count);
+    }
+
+    [Fact]
+    public void Diff_refuses_membership_skew_instead_of_repairing_past_it()
+    {
+        var mgr = NewManager(2);
+        var other = NewManager(0);
+
+        Assert.Throws<InvalidOperationException>(
+            () => TabStripProjection.Diff(mgr.Tabs, new List<TabModel> { mgr.Tabs[0] }));
+        Assert.Throws<InvalidOperationException>(
+            () => TabStripProjection.Diff(mgr.Tabs, new List<TabModel>(other.Tabs)));
+    }
+
+    // --- Seam a: TabMoved reports raw op indices; Normalize repairs after ---
+
+    [Fact]
+    public void A_move_normalize_repairs_strands_a_raw_replay_and_the_projector_converges_it()
+    {
+        var mgr = NewManager(3); // [A, B, C, X]
+        var group = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[0], mgr.Tabs[1], mgr.Tabs[2] }, group);
+        var a = mgr.Tabs[0];
+        var b = mgr.Tabs[1];
+        var c = mgr.Tabs[2];
+        var x = mgr.Tabs[3];
+        var strip = new Strip(mgr.Tabs);
+        var moves = new List<(TabModel tab, int from, int to)>();
+        mgr.TabMoved += (_, e) => { moves.Add(e); strip.Replay(e.tab, e.to); };
+
+        mgr.Move(1, 3); // pull B out past the run end
+
+        // The manager re-gathered the run; the event reported only the raw op.
+        Assert.Equal(new[] { a, c, b, x }, mgr.Tabs.ToArray());
+        var move = Assert.Single(moves);
+        Assert.Equal((b, 1, 3), move);
+
+        // The replay followed the event's indices and stranded desynced --
+        // the seam, observed before the repair.
+        Assert.Equal(new[] { a, c, x, b }, strip.Items);
+
+        strip.Apply(TabStripProjection.Diff(
+            TabStripProjection.Rows(mgr), strip.Items));
+
+        Assert.Equal(mgr.Tabs.ToArray(), strip.Items.ToArray());
+    }
+
+    // --- Seam b: a Move the invariants clamp to a no-op ---
+
+    [Fact]
+    public void A_clamped_move_mutates_nothing_raises_nothing_and_the_drop_reconciles_the_strip()
+    {
+        var mgr = NewManager(2); // [A, B, C]
+        mgr.SetPinned(mgr.Tabs[0], true); // prefix = [A]
+        var a = mgr.Tabs[0];
+        var b = mgr.Tabs[1];
+        var c = mgr.Tabs[2];
+        var strip = new Strip(mgr.Tabs);
+        int moved = 0;
+        mgr.TabMoved += (_, _) => moved++;
+
+        // TabView's own reorder has already put B in front of the pin; the
+        // manager is asked to ratify a move into the pinned prefix.
+        strip.Items.Remove(b);
+        strip.Items.Insert(0, b);
+
+        int mutations = ManagerMutations(mgr, () => CompleteDrag(mgr, strip, b));
+
+        // The clamp reduced the move to a no-op: no list change, no event.
+        Assert.Equal(0, mutations);
+        Assert.Equal(0, moved);
+        Assert.Equal(new[] { a, b, c }, mgr.Tabs.ToArray());
+
+        // The drop's reconcile pulled the strip back to the manager's order.
+        Assert.Equal(mgr.Tabs.ToArray(), strip.Items.ToArray());
+    }
+
+    // --- The drop path: the audit invariant ---
+
+    [Fact]
+    public void A_drag_completion_leaves_manager_and_strip_in_agreement_and_moves_once()
+    {
+        var mgr = NewManager(2); // [A, B, C]
+        var a = mgr.Tabs[0];
+        var b = mgr.Tabs[1];
+        var c = mgr.Tabs[2];
+        var strip = new Strip(mgr.Tabs);
+        // TabView applied the reorder its own way: C dragged one slot left.
+        strip.Items.Remove(c);
+        strip.Items.Insert(1, c);
+        int moved = 0;
+        mgr.TabMoved += (_, _) => moved++;
+
+        CompleteDrag(mgr, strip, c);
+
+        Assert.Equal(1, moved);
+        Assert.Equal(new[] { a, c, b }, mgr.Tabs.ToArray());
+        Assert.Equal(mgr.Tabs.ToArray(), strip.Items.ToArray());
+    }
+
+    // --- Seam c: batched TabMoved pairs from run moves ---
+
+    [Theory]
+    [InlineData(3)]
+    [InlineData(4)]
+    [InlineData(5)]
+    public void MoveRun_rotations_replayed_raw_converge_through_the_projector(int runSize)
+    {
+        for (int from = 0; from < runSize; from++)
+        {
+            for (int to = 0; to < runSize; to++)
+            {
+                if (from == to) continue;
+
+                var mgr = NewManager(runSize - 1);
+                var group = new TabGroup();
+                mgr.GroupTabs(mgr.Tabs.ToArray(), group);
+                var strip = new Strip(mgr.Tabs);
+                mgr.TabMoved += (_, e) => strip.Replay(e.tab, e.to);
+
+                mgr.MoveRun(from, to);
+
+                AssertRunContiguous(mgr, group);
+                // The rotation's paired events, replayed one by one, land
+                // wherever they land; the reconcile is what guarantees the
+                // strip ends on the manager's order.
+                strip.Apply(TabStripProjection.Diff(
+                    TabStripProjection.Rows(mgr), strip.Items));
+                Assert.Equal(mgr.Tabs.ToArray(), strip.Items.ToArray());
+            }
+        }
+    }
+
+    [Fact]
+    public void MoveGroup_across_a_nonmember_strands_a_raw_replay_and_the_projector_converges_it()
+    {
+        var mgr = NewManager(4); // [P, A, B, C, Q]
+        var group = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[1], mgr.Tabs[2], mgr.Tabs[3] }, group);
+        var p = mgr.Tabs[0];
+        var a = mgr.Tabs[1];
+        var b = mgr.Tabs[2];
+        var c = mgr.Tabs[3];
+        var q = mgr.Tabs[4];
+        var strip = new Strip(mgr.Tabs);
+        mgr.TabMoved += (_, e) => strip.Replay(e.tab, e.to);
+
+        mgr.MoveGroup(group, 4); // the run lands after Q
+
+        Assert.Equal(new[] { p, q, a, b, c }, mgr.Tabs.ToArray());
+
+        // The per-member pairs replayed one by one cannot express the
+        // block move -- the seam, observed before the repair.
+        Assert.NotEqual(mgr.Tabs.ToArray(), strip.Items.ToArray());
+
+        strip.Apply(TabStripProjection.Diff(
+            TabStripProjection.Rows(mgr), strip.Items));
+
+        Assert.Equal(mgr.Tabs.ToArray(), strip.Items.ToArray());
+    }
+
+    private static void AssertRunContiguous(TabManager mgr, TabGroup group)
+    {
+        var positions = new List<int>();
+        for (int i = 0; i < mgr.Tabs.Count; i++)
+            if (ReferenceEquals(mgr.Tabs[i].Group, group))
+                positions.Add(i);
+        Assert.NotEmpty(positions);
+        Assert.Equal(positions[^1] - positions[0] + 1, positions.Count);
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/ShellSource.cs
+++ b/windows/Ghostty.Tests/Wiring/ShellSource.cs
@@ -267,6 +267,17 @@ internal static class SyntaxQueries
         return found[0];
     }
 
+    /// <summary>
+    /// Every assignment to a bare field name, wherever it sits. A
+    /// suppression flag is as much about position as about existing, so
+    /// callers filter on span rather than this collapsing to a bool.
+    /// </summary>
+    public static IEnumerable<AssignmentExpressionSyntax> AssignsTo(
+        this SyntaxNode node, string field)
+        => node.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.Left is IdentifierNameSyntax id
+                        && id.Identifier.ValueText == field);
+
     /// <summary>The literal source of one argument of a call.</summary>
     public static string Arg(this InvocationExpressionSyntax call, int index)
     {

--- a/windows/Ghostty.Tests/Wiring/TabStripSyncWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabStripSyncWiringTests.cs
@@ -1,0 +1,270 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// The strip-order bridge between <c>TabManager</c> and the two strip
+/// hosts: the drag lifecycle, the reconcile, and the vertical strip's
+/// rebuild path.
+///
+/// The shell assembly cannot be loaded into this test host, so what
+/// these tests can drive is the hosts' parsed source. The behaviour the
+/// bridge exists for is tested outright in TabStripProjectionTests
+/// (manager in, live-mirror replay out); what a parse adds here is the
+/// assurance the hosts still route through it -- with the polarity each
+/// route needs, which is the part a "the call exists" guard skips.
+/// </summary>
+public sealed class TabStripSyncWiringTests
+{
+    private const string TabHostSource = "Tabs.TabHost.xaml.cs";
+    private const string VerticalSource = "Tabs.VerticalTabStrip.xaml.cs";
+
+    // --- MoveItem: the no-op guard ---
+
+    [Fact]
+    public void MoveItem_declines_an_item_already_at_its_target_before_touching_the_strip()
+    {
+        var moveItem = ShellSource.Load(TabHostSource).Method("MoveItem");
+
+        // The live index comes off the strip, not out of the event: the
+        // event's indices are the raw op's, and TabView's own reorder has
+        // usually applied them already by the time this handler runs.
+        var liveIndex = moveItem.DescendantNodes()
+            .OfType<EqualsValueClauseSyntax>()
+            .Select(v => v.Value)
+            .OfType<InvocationExpressionSyntax>()
+            .Where(c => c.CalleeText().EndsWith("TabItems.IndexOf", StringComparison.Ordinal))
+            .ToList();
+        Assert.True(
+            liveIndex.Count == 1,
+            "MoveItem should read the item's current index from TabItems once; " +
+            $"found {liveIndex.Count} such reads.");
+
+        var firstMutation = moveItem.DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .First(c => c.CalleeText().EndsWith("TabItems.Remove", StringComparison.Ordinal));
+
+        var guard = moveItem.DescendantNodes().OfType<IfStatementSyntax>()
+            .Where(IsAlreadyInPlaceGuard)
+            .ToList();
+        Assert.True(
+            guard.Count == 1 && guard[0].SpanStart < firstMutation.SpanStart,
+            "MoveItem must decline an item that is already at the target index " +
+            "before its first TabItems.Remove. The guard is an equality test on " +
+            "purpose: the inverted form skips exactly the move it exists to skip.");
+
+        // An unbraced if body IS the return statement rather than a block
+        // containing one, so accept either shape.
+        var body = guard.Count == 1 ? guard[0].Statement : null;
+        var bailed = body is ReturnStatementSyntax { Expression: null }
+            || body?.DescendantNodes()
+                .OfType<ReturnStatementSyntax>()
+                .Any(r => r.Expression is null) == true;
+        Assert.True(
+            bailed,
+            "The already-in-place guard must return, not fall through to the move.");
+    }
+
+    [Fact]
+    public void MoveItem_lets_the_projector_own_the_final_word()
+    {
+        var moveItem = ShellSource.Load(TabHostSource).Method("MoveItem");
+
+        // TabMoved carries the raw op's indices and Normalize may have
+        // relocated tabs after it, so the single-row fast path is never
+        // the last writer: the reconcile after it re-derives the strip
+        // from the manager's final state.
+        var firstMutation = moveItem.DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .First(c => c.CalleeText().EndsWith("TabItems.Remove", StringComparison.Ordinal));
+        var reconcile = moveItem.Calls("ReconcileStripOrder").ToList();
+
+        Assert.True(
+            reconcile.Count == 1 && reconcile[0].SpanStart > firstMutation.SpanStart,
+            "MoveItem must hand the result to ReconcileStripOrder after its own " +
+            "mutations: the event's indices predate Normalize's repair.");
+    }
+
+    // --- Drag lifecycle: seam cover and the drop reconcile ---
+
+    [Fact]
+    public void Drag_start_hides_the_seam_cover_and_the_drop_replaces_it()
+    {
+        var src = ShellSource.Load(TabHostSource);
+        var starting = src.Method("OnTabDragStarting");
+        var completed = src.Method("OnTabDragCompleted");
+
+        Assert.True(
+            SetsFlag(starting, "_stripDragActive", SyntaxKind.TrueLiteralExpression),
+            "OnTabDragStarting must raise _stripDragActive: mid-drag the cover " +
+            "would ride the stale slot for the whole drag (audit 3.2, item 1).");
+        Assert.True(
+            SetsFlag(completed, "_stripDragActive", SyntaxKind.FalseLiteralExpression),
+            "OnTabDragCompleted must lower _stripDragActive so the cover is placed again.");
+
+        // Wired even though TabHost.xaml predates it: the drag start is
+        // where the stale-slot window opens.
+        var ctor = src.Root.DescendantNodes()
+            .OfType<ConstructorDeclarationSyntax>()
+            .Single(c => c.Identifier.ValueText == "TabHost");
+        var hooked = ctor.DescendantNodes()
+            .OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.OperatorToken.IsKind(SyntaxKind.PlusEqualsToken)
+                        && a.Left.ToString().EndsWith("TabDragStarting", StringComparison.Ordinal))
+            .ToList();
+        Assert.True(
+            hooked.Count == 1,
+            "The constructor must subscribe OnTabDragStarting on TabViewControl.TabDragStarting.");
+    }
+
+    [Fact]
+    public void The_seam_cover_stays_down_while_a_drag_holds_the_strip()
+    {
+        var bridge = ShellSource.Load(TabHostSource).Method("UpdateSelectedTabBridge");
+
+        // The gate reads the flag and hides the cover, and it sits ahead
+        // of the placement math -- after TransformToVisual the stale slot
+        // has already been measured.
+        var gate = bridge.DescendantNodes().OfType<IfStatementSyntax>()
+            .Where(i => i.Condition.ToString().Contains("_stripDragActive", StringComparison.Ordinal))
+            .ToList();
+        Assert.True(
+            gate.Count == 1,
+            "UpdateSelectedTabBridge needs one _stripDragActive gate.");
+
+        var placement = bridge.DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .First(c => c.CalleeText().Contains("TransformToVisual", StringComparison.Ordinal));
+        var hides = gate.Count == 1
+            && gate[0].SpanStart < placement.SpanStart
+            && gate[0].Statement.DescendantNodes()
+                .OfType<InvocationExpressionSyntax>()
+                .Any(c => c.CalleeText() == "SelectedTabSeamChanged?.Invoke");
+        Assert.True(
+            hides,
+            "The drag gate must hide the cover itself, ahead of the placement math.");
+    }
+
+    [Fact]
+    public void The_drop_reconciles_even_when_the_manager_refused_the_move()
+    {
+        var completed = ShellSource.Load(TabHostSource).Method("OnTabDragCompleted");
+
+        var reconcile = completed.Calls("ReconcileStripOrder").ToList();
+        Assert.True(
+            reconcile.Count == 1,
+            "OnTabDragCompleted must reconcile the strip to the manager's order.");
+        Assert.Empty(reconcile[0].Ancestors().OfType<IfStatementSyntax>());
+
+        // The refused drop raises no TabMoved, so nothing else would run
+        // the reconcile: a clamp against the pin boundary (PR 4's grammar)
+        // leaves TabView's own reorder standing unless the reconcile is
+        // unconditional.
+    }
+
+    // --- Vertical strip reads its order from the projector ---
+
+    [Fact]
+    public void Vertical_rebuild_takes_its_order_from_the_projector()
+    {
+        var rebuild = ShellSource.Load(VerticalSource).Method("RebuildAllItems");
+
+        Assert.Single(rebuild.Calls("TabStripProjection.Rows"));
+    }
+
+    // --- The drop-outside invariant: no detach-by-drag bypass ---
+
+    [Fact]
+    public void TabDroppedOutside_stays_unwired()
+    {
+        // Detach-by-drag is non-goal N1: a drop outside the strip cancels,
+        // and everything stays consistent because nothing consumes the
+        // event. A handler here is the bypass path, so it is refused in
+        // both places one could appear -- code-behind, which this sweep
+        // reads, and the XAML attribute, which compiles into a .g.cs this
+        // census cannot see and is pinned by the embedded markup below.
+        var wired = new List<string>();
+        foreach (var (resource, root) in ShellSource.AllShellSources())
+        {
+            bool any = root.DescendantNodes()
+                .OfType<AssignmentExpressionSyntax>()
+                .Any(a => a.OperatorToken.IsKind(SyntaxKind.PlusEqualsToken)
+                          && a.Left.ToString().EndsWith("TabDroppedOutside", StringComparison.Ordinal));
+            if (any) wired.Add(resource);
+        }
+
+        Assert.True(
+            wired.Count == 0,
+            "TabDroppedOutside subscriptions appeared in: " + string.Join(", ", wired)
+            + ". Detach-by-drag is a non-goal; a drop outside the strip cancels.");
+
+        Assert.False(
+            ReadEmbedded("Tabs.TabHost.xaml").Contains("TabDroppedOutside", StringComparison.Ordinal),
+            "TabHost.xaml wires TabDroppedOutside; the drag bridge must stay a "
+            + "reorder bridge, not grow a detach path.");
+    }
+
+    private static string ReadEmbedded(string suffix)
+    {
+        var asm = System.Reflection.Assembly.GetExecutingAssembly();
+        var name = asm.GetManifestResourceNames()
+            .Single(n => n.EndsWith(suffix, StringComparison.OrdinalIgnoreCase));
+        using var stream = asm.GetManifestResourceStream(name);
+        Assert.NotNull(stream);
+        using var reader = new StreamReader(stream!);
+        return reader.ReadToEnd();
+    }
+
+    // --- TabItemsChanged stays unwired, with the reason at the wiring site ---
+
+    [Fact]
+    public void TabItemsChanged_stays_unwired_and_the_reason_lives_at_the_wiring_site()
+    {
+        // It fires for the hosts' own writes as much as for TabView's, so
+        // a validation handler on it re-enters the reconcile that mutates
+        // TabItems. If one ever lands it needs a re-entrancy fence and a
+        // reason the two existing validation points do not cover.
+        var subscribed = new List<string>();
+        foreach (var (resource, root) in ShellSource.AllShellSources())
+        {
+            bool any = root.DescendantNodes()
+                .OfType<AssignmentExpressionSyntax>()
+                .Any(a => a.OperatorToken.IsKind(SyntaxKind.PlusEqualsToken)
+                          && a.Left.ToString().EndsWith("TabItemsChanged", StringComparison.Ordinal));
+            if (any) subscribed.Add(resource);
+        }
+
+        Assert.True(
+            subscribed.Count == 0,
+            "TabItemsChanged subscriptions appeared in: " + string.Join(", ", subscribed)
+            + ". A validation handler there re-enters the reconcile that mutates TabItems.");
+
+        var ctor = ShellSource.Load(TabHostSource).Root.DescendantNodes()
+            .OfType<ConstructorDeclarationSyntax>()
+            .Single(c => c.Identifier.ValueText == "TabHost");
+        Assert.True(
+            ctor.ToString().Contains("TabItemsChanged", StringComparison.Ordinal),
+            "The decision to leave TabItemsChanged unwired must be recorded in the "
+            + "constructor it concerns, where the next reader of the event list looks.");
+    }
+
+    // An equality check between the item's current index and the target.
+    private static bool IsAlreadyInPlaceGuard(IfStatementSyntax ifStatement)
+        => ifStatement.Condition is BinaryExpressionSyntax binary
+            && binary.IsKind(SyntaxKind.EqualsExpression)
+            && binary.ToString().Contains("current", StringComparison.Ordinal)
+            && binary.ToString().Contains("to", StringComparison.Ordinal);
+
+    private static bool SetsFlag(MethodDeclarationSyntax method, string field, SyntaxKind literal)
+        => method.DescendantNodes()
+            .OfType<AssignmentExpressionSyntax>()
+            .Any(a => a.Left is IdentifierNameSyntax id
+                      && id.Identifier.ValueText == field
+                      && a.Right.IsKind(literal));
+}

--- a/windows/Ghostty.Tests/Wiring/TabStripSyncWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabStripSyncWiringTests.cs
@@ -10,19 +10,15 @@ namespace Ghostty.Tests.Wiring;
 
 /// <summary>
 /// The strip-order bridge between <c>TabManager</c> and the two strip
-/// hosts: the drag lifecycle, the reconcile, and the vertical strip's
-/// rebuild path.
-///
-/// The shell assembly cannot be loaded into this test host, so what
-/// these tests can drive is the hosts' parsed source. The behaviour the
-/// bridge exists for is tested outright in TabStripProjectionTests
-/// (manager in, live-mirror replay out); what a parse adds here is the
-/// assurance the hosts still route through it -- with the polarity each
-/// route needs, which is the part a "the call exists" guard skips.
+/// hosts: the drag lifecycle, the reconcile, the vertical rebuild. The
+/// shell cannot load into this test host, so these guards parse it; the
+/// behaviour itself is tested outright in TabStripProjectionTests. What
+/// a parse adds is the polarity each route needs.
 /// </summary>
 public sealed class TabStripSyncWiringTests
 {
     private const string TabHostSource = "Tabs.TabHost.xaml.cs";
+    private const string TabHostXaml = "Tabs.TabHost.xaml";
     private const string VerticalSource = "Tabs.VerticalTabStrip.xaml.cs";
 
     // --- MoveItem: the no-op guard ---
@@ -33,8 +29,8 @@ public sealed class TabStripSyncWiringTests
         var moveItem = ShellSource.Load(TabHostSource).Method("MoveItem");
 
         // The live index comes off the strip, not out of the event: the
-        // event's indices are the raw op's, and TabView's own reorder has
-        // usually applied them already by the time this handler runs.
+        // event's indices are the raw op's, which TabView has usually
+        // applied already by the time this handler runs.
         var liveIndex = moveItem.DescendantNodes()
             .OfType<EqualsValueClauseSyntax>()
             .Select(v => v.Value)
@@ -43,8 +39,7 @@ public sealed class TabStripSyncWiringTests
             .ToList();
         Assert.True(
             liveIndex.Count == 1,
-            "MoveItem should read the item's current index from TabItems once; " +
-            $"found {liveIndex.Count} such reads.");
+            $"MoveItem should read the item's index from TabItems once; found {liveIndex.Count}.");
 
         var firstMutation = moveItem.DescendantNodes()
             .OfType<InvocationExpressionSyntax>()
@@ -55,20 +50,16 @@ public sealed class TabStripSyncWiringTests
             .ToList();
         Assert.True(
             guard.Count == 1 && guard[0].SpanStart < firstMutation.SpanStart,
-            "MoveItem must decline an item that is already at the target index " +
-            "before its first TabItems.Remove. The guard is an equality test on " +
-            "purpose: the inverted form skips exactly the move it exists to skip.");
+            "MoveItem must decline an in-place item before its first TabItems.Remove; "
+            + "equality on purpose, since the inverted form skips the move it exists to skip.");
 
         // An unbraced if body IS the return statement rather than a block
         // containing one, so accept either shape.
         var body = guard.Count == 1 ? guard[0].Statement : null;
         var bailed = body is ReturnStatementSyntax { Expression: null }
-            || body?.DescendantNodes()
-                .OfType<ReturnStatementSyntax>()
+            || body?.DescendantNodes().OfType<ReturnStatementSyntax>()
                 .Any(r => r.Expression is null) == true;
-        Assert.True(
-            bailed,
-            "The already-in-place guard must return, not fall through to the move.");
+        Assert.True(bailed, "The in-place guard must return, not fall through to the move.");
     }
 
     [Fact]
@@ -77,18 +68,28 @@ public sealed class TabStripSyncWiringTests
         var moveItem = ShellSource.Load(TabHostSource).Method("MoveItem");
 
         // TabMoved carries the raw op's indices and Normalize may have
-        // relocated tabs after it, so the single-row fast path is never
-        // the last writer: the reconcile after it re-derives the strip
-        // from the manager's final state.
+        // relocated tabs after it, so no path through MoveItem is ever
+        // the last writer.
         var firstMutation = moveItem.DescendantNodes()
             .OfType<InvocationExpressionSyntax>()
             .First(c => c.CalleeText().EndsWith("TabItems.Remove", StringComparison.Ordinal));
+        var guard = moveItem.DescendantNodes().OfType<IfStatementSyntax>()
+            .Where(IsAlreadyInPlaceGuard)
+            .ToList();
         var reconcile = moveItem.Calls("ReconcileStripOrder").ToList();
 
         Assert.True(
-            reconcile.Count == 1 && reconcile[0].SpanStart > firstMutation.SpanStart,
-            "MoveItem must hand the result to ReconcileStripOrder after its own " +
-            "mutations: the event's indices predate Normalize's repair.");
+            reconcile.Count == 2,
+            "MoveItem must reconcile on BOTH paths: an in-place index for the moved "
+            + "item does not mean Normalize did not repair the rest of the strip "
+            + $"(group re-gather). Found {reconcile.Count}; one call means a path returns early.");
+        Assert.True(
+            guard.Count == 1 && reconcile.Any(r =>
+                r.SpanStart > guard[0].SpanStart && r.Span.End < guard[0].Span.End),
+            "The in-place early return must run ReconcileStripOrder before returning.");
+        Assert.True(
+            reconcile.Any(r => r.SpanStart > firstMutation.SpanStart),
+            "The moved path must reconcile after its own mutations.");
     }
 
     // --- Drag lifecycle: seam cover and the drop reconcile ---
@@ -102,11 +103,19 @@ public sealed class TabStripSyncWiringTests
 
         Assert.True(
             SetsFlag(starting, "_stripDragActive", SyntaxKind.TrueLiteralExpression),
-            "OnTabDragStarting must raise _stripDragActive: mid-drag the cover " +
-            "would ride the stale slot for the whole drag (audit 3.2, item 1).");
+            "OnTabDragStarting must raise _stripDragActive (audit 3.2, item 1).");
         Assert.True(
             SetsFlag(completed, "_stripDragActive", SyntaxKind.FalseLiteralExpression),
             "OnTabDragCompleted must lower _stripDragActive so the cover is placed again.");
+
+        // Synchronous, not queued: a dispatcher hop paints one frame
+        // against the stale slot. Nothing else runs between the flag
+        // going up and the drag, so deleting the hide must fail here.
+        var hide = starting.Calls("SelectedTabSeamChanged?.Invoke").ToList();
+        Assert.True(
+            hide.Count == 1
+                && hide[0].Arg(0) == "0" && hide[0].Arg(1) == "0" && hide[0].Arg(2) == "null",
+            "OnTabDragStarting must hide the cover synchronously with (0, 0, null).");
 
         // Wired even though TabHost.xaml predates it: the drag start is
         // where the stale-slot window opens.
@@ -128,27 +137,31 @@ public sealed class TabStripSyncWiringTests
     {
         var bridge = ShellSource.Load(TabHostSource).Method("UpdateSelectedTabBridge");
 
-        // The gate reads the flag and hides the cover, and it sits ahead
-        // of the placement math -- after TransformToVisual the stale slot
-        // has already been measured.
+        // The gate reads the flag bare and hides the cover itself, ahead
+        // of the placement math. The condition is matched as a parsed bare
+        // identifier, not a substring: the inverted gate mentions the same
+        // flag but parses as a prefix unary expression.
         var gate = bridge.DescendantNodes().OfType<IfStatementSyntax>()
-            .Where(i => i.Condition.ToString().Contains("_stripDragActive", StringComparison.Ordinal))
+            .Where(i => i.Condition is IdentifierNameSyntax id
+                        && id.Identifier.ValueText == "_stripDragActive")
             .ToList();
         Assert.True(
             gate.Count == 1,
-            "UpdateSelectedTabBridge needs one _stripDragActive gate.");
+            "UpdateSelectedTabBridge needs one bare `if (_stripDragActive)` gate.");
 
         var placement = bridge.DescendantNodes()
             .OfType<InvocationExpressionSyntax>()
             .First(c => c.CalleeText().Contains("TransformToVisual", StringComparison.Ordinal));
-        var hides = gate.Count == 1
-            && gate[0].SpanStart < placement.SpanStart
-            && gate[0].Statement.DescendantNodes()
+        var hide = gate.Count == 1
+            ? gate[0].Statement.DescendantNodes()
                 .OfType<InvocationExpressionSyntax>()
-                .Any(c => c.CalleeText() == "SelectedTabSeamChanged?.Invoke");
+                .FirstOrDefault(c => c.CalleeText() == "SelectedTabSeamChanged?.Invoke")
+            : null;
         Assert.True(
-            hides,
-            "The drag gate must hide the cover itself, ahead of the placement math.");
+            hide is not null
+                && hide.Arg(0) == "0" && hide.Arg(1) == "0" && hide.Arg(2) == "null"
+                && gate[0].SpanStart < placement.SpanStart,
+            "The drag gate must hide the cover with (0, 0, null), ahead of the placement math.");
     }
 
     [Fact]
@@ -168,6 +181,66 @@ public sealed class TabStripSyncWiringTests
         // unconditional.
     }
 
+    // --- The reconcile is defensive at the UI boundary ---
+
+    [Fact]
+    public void A_reconcile_failure_logs_and_rebuilds_instead_of_dying()
+    {
+        var reconcile = ShellSource.Load(TabHostSource).Method("ReconcileStripOrder");
+
+        var rebuild = reconcile.Calls("RebuildStripFromManager").ToList();
+        Assert.True(
+            rebuild.Count == 1,
+            "ReconcileStripOrder must fall back to RebuildStripFromManager: skew is "
+            + "currently impossible, but a terminal's strip must not die.");
+        var catchClause = rebuild.Count == 1
+            ? rebuild[0].Ancestors().OfType<CatchClauseSyntax>().FirstOrDefault()
+            : null;
+        Assert.True(
+            catchClause is not null,
+            "The rebuild fallback must be reached from a catch, not called inline.");
+        var filter = catchClause?.Filter?.ToString() ?? "";
+        Assert.True(
+            filter.Contains("InvalidOperationException", StringComparison.Ordinal)
+                && filter.Contains("KeyNotFoundException", StringComparison.Ordinal),
+            "The catch must be filtered to the skew family (Diff's throws and the "
+            + "item-map lookup's miss); a bare catch swallows unrelated UI failures.");
+
+        var rebuildMethod = ShellSource.Load(TabHostSource).Method("RebuildStripFromManager");
+        Assert.True(
+            rebuildMethod.Calls("TabStripProjection.Rows").Count == 1,
+            "The rebuild must take its order from the projector, like the reconcile does.");
+    }
+
+    [Fact]
+    public void The_reconcile_never_leaks_a_dropped_selection_as_an_activation()
+    {
+        var reconcile = ShellSource.Load(TabHostSource).Method("ReconcileStripOrder");
+
+        var firstMutation = reconcile.DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .First(c => c.CalleeText().EndsWith("TabItems.Remove", StringComparison.Ordinal));
+
+        // ListView drops the selection when the selected item is removed
+        // and does not restore it on re-insert; live, that drop arrives as
+        // an activation of whatever TabView picked instead.
+        var assigns = reconcile.AssignsTo("_suppressSelectionEvent").ToList();
+        var arms = assigns.Where(a => a.Right.IsKind(SyntaxKind.TrueLiteralExpression)).ToList();
+        var disarms = assigns.Where(a => a.Right.IsKind(SyntaxKind.FalseLiteralExpression)).ToList();
+        Assert.True(
+            arms.Count == 1 && arms[0].SpanStart < firstMutation.SpanStart,
+            "ReconcileStripOrder must arm _suppressSelectionEvent before its first removal.");
+        Assert.True(
+            disarms.Count == 1 && disarms[0].SpanStart > firstMutation.SpanStart,
+            "ReconcileStripOrder must disarm _suppressSelectionEvent after the loop.");
+
+        var activate = reconcile.Calls("SelectActive").ToList();
+        Assert.True(
+            activate.Count == 1 && activate[0].SpanStart > firstMutation.SpanStart,
+            "ReconcileStripOrder must call SelectActive after the loop to re-assert "
+            + "the manager's active tab.");
+    }
+
     // --- Vertical strip reads its order from the projector ---
 
     [Fact]
@@ -178,36 +251,58 @@ public sealed class TabStripSyncWiringTests
         Assert.Single(rebuild.Calls("TabStripProjection.Rows"));
     }
 
-    // --- The drop-outside invariant: no detach-by-drag bypass ---
+    // --- Unwired events: no detach path, no re-entrant validation ---
 
     [Fact]
     public void TabDroppedOutside_stays_unwired()
     {
-        // Detach-by-drag is non-goal N1: a drop outside the strip cancels,
-        // and everything stays consistent because nothing consumes the
-        // event. A handler here is the bypass path, so it is refused in
-        // both places one could appear -- code-behind, which this sweep
-        // reads, and the XAML attribute, which compiles into a .g.cs this
-        // census cannot see and is pinned by the embedded markup below.
-        var wired = new List<string>();
-        foreach (var (resource, root) in ShellSource.AllShellSources())
-        {
-            bool any = root.DescendantNodes()
-                .OfType<AssignmentExpressionSyntax>()
-                .Any(a => a.OperatorToken.IsKind(SyntaxKind.PlusEqualsToken)
-                          && a.Left.ToString().EndsWith("TabDroppedOutside", StringComparison.Ordinal));
-            if (any) wired.Add(resource);
-        }
-
-        Assert.True(
-            wired.Count == 0,
-            "TabDroppedOutside subscriptions appeared in: " + string.Join(", ", wired)
-            + ". Detach-by-drag is a non-goal; a drop outside the strip cancels.");
+        // Detach-by-drag is non-goal N1: a drop outside the strip cancels
+        // and nothing consumes the event, so any handler is the bypass
+        // path. Refused in both places one could appear -- code-behind,
+        // which Subscribers sweeps, and the XAML attribute, which compiles
+        // into a .g.cs that sweep cannot see (pinned below).
+        Assert.Empty(Subscribers("TabDroppedOutside"));
 
         Assert.False(
-            ReadEmbedded("Tabs.TabHost.xaml").Contains("TabDroppedOutside", StringComparison.Ordinal),
+            ReadEmbedded(TabHostXaml).Contains("TabDroppedOutside", StringComparison.Ordinal),
             "TabHost.xaml wires TabDroppedOutside; the drag bridge must stay a "
             + "reorder bridge, not grow a detach path.");
+    }
+
+    [Fact]
+    public void TabItemsChanged_stays_unwired_and_the_reason_lives_at_the_wiring_site()
+    {
+        // It fires for the hosts' own writes as much as for TabView's, so
+        // a validation handler on it re-enters the reconcile that mutates
+        // TabItems. If one ever lands it needs a re-entrancy fence and a
+        // reason the existing validation points do not cover.
+        Assert.Empty(Subscribers("TabItemsChanged"));
+
+        var ctor = ShellSource.Load(TabHostSource).Root.DescendantNodes()
+            .OfType<ConstructorDeclarationSyntax>()
+            .Single(c => c.Identifier.ValueText == "TabHost");
+        Assert.True(
+            ctor.ToString().Contains("TabItemsChanged", StringComparison.Ordinal),
+            "The decision to leave TabItemsChanged unwired must be recorded in the "
+            + "constructor it concerns, where the next reader of the event list looks.");
+
+        // The sweep above reads code-behind only; a XAML attribute compiles
+        // into a .g.cs it can never see, so the markup is pinned directly.
+        Assert.False(
+            ReadEmbedded(TabHostXaml).Contains("TabItemsChanged", StringComparison.Ordinal),
+            "TabHost.xaml wires TabItemsChanged; the census above cannot see a XAML attribute.");
+    }
+
+    // Every shell file subscribing the event via +=, by resource name.
+    private static List<string> Subscribers(string eventName)
+    {
+        var found = new List<string>();
+        foreach (var (resource, root) in ShellSource.AllShellSources())
+            if (root.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+                    .Any(a => a.OperatorToken.IsKind(SyntaxKind.PlusEqualsToken)
+                              && a.Left.ToString().EndsWith(eventName, StringComparison.Ordinal)))
+                found.Add(resource);
+        return found;
     }
 
     private static string ReadEmbedded(string suffix)
@@ -219,39 +314,6 @@ public sealed class TabStripSyncWiringTests
         Assert.NotNull(stream);
         using var reader = new StreamReader(stream!);
         return reader.ReadToEnd();
-    }
-
-    // --- TabItemsChanged stays unwired, with the reason at the wiring site ---
-
-    [Fact]
-    public void TabItemsChanged_stays_unwired_and_the_reason_lives_at_the_wiring_site()
-    {
-        // It fires for the hosts' own writes as much as for TabView's, so
-        // a validation handler on it re-enters the reconcile that mutates
-        // TabItems. If one ever lands it needs a re-entrancy fence and a
-        // reason the two existing validation points do not cover.
-        var subscribed = new List<string>();
-        foreach (var (resource, root) in ShellSource.AllShellSources())
-        {
-            bool any = root.DescendantNodes()
-                .OfType<AssignmentExpressionSyntax>()
-                .Any(a => a.OperatorToken.IsKind(SyntaxKind.PlusEqualsToken)
-                          && a.Left.ToString().EndsWith("TabItemsChanged", StringComparison.Ordinal));
-            if (any) subscribed.Add(resource);
-        }
-
-        Assert.True(
-            subscribed.Count == 0,
-            "TabItemsChanged subscriptions appeared in: " + string.Join(", ", subscribed)
-            + ". A validation handler there re-enters the reconcile that mutates TabItems.");
-
-        var ctor = ShellSource.Load(TabHostSource).Root.DescendantNodes()
-            .OfType<ConstructorDeclarationSyntax>()
-            .Single(c => c.Identifier.ValueText == "TabHost");
-        Assert.True(
-            ctor.ToString().Contains("TabItemsChanged", StringComparison.Ordinal),
-            "The decision to leave TabItemsChanged unwired must be recorded in the "
-            + "constructor it concerns, where the next reader of the event list looks.");
     }
 
     // An equality check between the item's current index and the target.

--- a/windows/Ghostty/Logging/LogEvents.cs
+++ b/windows/Ghostty/Logging/LogEvents.cs
@@ -113,4 +113,10 @@ internal static class LogEvents
     {
         public const int SwapChainInitFailed = 3000;
     }
+
+    // 3100-3199: Tab strip
+    internal static class TabStrip
+    {
+        public const int ReconcileFailed = 3100; // TabHost
+    }
 }

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -79,6 +79,21 @@ internal sealed partial class TabHost : UserControl, ITabHost
         // under Equal sizing, so the strip resizing moves it too.
         Loaded += (_, _) => QueueBridgeUpdate();
         TabViewControl.SizeChanged += (_, _) => UpdateSelectedTabBridge();
+
+        // The drag lifecycle gates the seam cover (OnTabDragStarting /
+        // OnTabDragCompleted). Mid-drag the strip's slots are TabView's
+        // reorder preview rather than the manager's order, and the cover
+        // is placed from the active item's slot, so it is suppressed for
+        // the length of the drag and re-placed at the drop.
+        TabViewControl.TabDragStarting += OnTabDragStarting;
+
+        // TabView.TabItemsChanged stays unwired on purpose. It fires for
+        // this control's own writes (AddItem, MoveItem, the reconcile) as
+        // much as for TabView's, so a validation handler on it would
+        // re-enter the reconcile that mutates TabItems. The validation
+        // points are the reconcile in MoveItem and the one in
+        // OnTabDragCompleted; both read the manager rather than the
+        // control.
     }
 
     private void AddItem(TabModel tab)
@@ -235,10 +250,57 @@ internal sealed partial class TabHost : UserControl, ITabHost
     private void MoveItem(TabModel tab, int to)
     {
         if (!_itemByModel.TryGetValue(tab, out var item)) return;
+        var current = TabViewControl.TabItems.IndexOf(item);
+        // A TabView drag drop raises this event after the control has
+        // already applied the move itself, so the common case is
+        // in-place. Re-inserting an item at the index it already
+        // occupies churns the strip (container regeneration) for no
+        // effect.
+        if (current == to) return;
         TabViewControl.TabItems.Remove(item);
         TabViewControl.TabItems.Insert(to, item);
         // _paneHostContainer order does not matter — Visibility picks
         // the active one. No reorder needed there.
+
+        // The event's indices are the raw op's, and Normalize may have
+        // repaired further than the op asked (a move that breaks group
+        // contiguity re-gathers the run). The reconcile re-derives the
+        // strip from the manager's final state and owns the last word;
+        // the fast path above just settles the ordinary case in one op.
+        ReconcileStripOrder();
+    }
+
+    /// <summary>
+    /// Bring TabItems back into the order the manager holds, via
+    /// <see cref="TabStripProjection"/>. The repair for every seam where
+    /// the two can disagree: Normalize's silent relocations after a raw
+    /// move, and TabView's own reorder that the manager refused or
+    /// clamped. Zero ops when they already agree, so the calls on the
+    /// happy paths cost one comparison per tab.
+    /// </summary>
+    private void ReconcileStripOrder()
+    {
+        foreach (var op in TabStripProjection.Diff(
+            TabStripProjection.Rows(_manager), StripOrder()))
+        {
+            var item = _itemByModel[op.Tab];
+            TabViewControl.TabItems.Remove(item);
+            TabViewControl.TabItems.Insert(op.To, item);
+        }
+    }
+
+    /// <summary>
+    /// The strip's current order, as models. AddItem put the TabModel in
+    /// each item's DataContext, so the order reads back without a second
+    /// map to keep in step.
+    /// </summary>
+    private List<TabModel> StripOrder()
+    {
+        var order = new List<TabModel>(TabViewControl.TabItems.Count);
+        foreach (var item in TabViewControl.TabItems)
+            if (item is TabViewItem { DataContext: TabModel tab })
+                order.Add(tab);
+        return order;
     }
 
     private void SelectActive()
@@ -331,6 +393,16 @@ internal sealed partial class TabHost : UserControl, ITabHost
 
     private void UpdateSelectedTabBridge()
     {
+        if (_stripDragActive)
+        {
+            // Mid-drag the strip's slots are TabView's reorder preview,
+            // not the manager's order; placing from them paints the cover
+            // onto a stale slot for the length of the drag. The drop
+            // re-places it.
+            SelectedTabSeamChanged?.Invoke(0, 0, null);
+            return;
+        }
+
         var active = _manager.ActiveTab;
         if (active is null
             || !_itemByModel.TryGetValue(active, out var item)
@@ -786,8 +858,25 @@ internal sealed partial class TabHost : UserControl, ITabHost
         e.Handled = true;
     }
 
+    /// <summary>
+    /// True while a TabView drag has the strip. The seam cover derives
+    /// from the active item's arranged slot, and during a drag that slot
+    /// is TabView's reorder preview rather than the manager's order.
+    /// </summary>
+    private bool _stripDragActive;
+
+    private void OnTabDragStarting(TabView sender, TabViewTabDragStartingEventArgs args)
+    {
+        _stripDragActive = true;
+        // Hidden synchronously: the drag is live from this call onward,
+        // and anything the strip does from here moves slots the manager
+        // has not agreed to yet.
+        SelectedTabSeamChanged?.Invoke(0, 0, null);
+    }
+
     private void OnTabDragCompleted(TabView sender, TabViewTabDragCompletedEventArgs args)
     {
+        _stripDragActive = false;
         if (args.Item is TabViewItem item)
         {
             var newIndex = TabViewControl.TabItems.IndexOf(item);
@@ -798,10 +887,19 @@ internal sealed partial class TabHost : UserControl, ITabHost
                     var oldIndex = _manager.IndexOf(model);
                     if (oldIndex != newIndex && oldIndex >= 0)
                         _manager.Move(oldIndex, newIndex);
-                    return;
+                    break;
                 }
             }
         }
+        // The drop is where the two orders can end up disagreeing with
+        // nobody left to fix it: TabView has already applied whatever
+        // reorder it wanted, and the manager may have refused the move
+        // outright (an invariant clamp mutates nothing and raises
+        // nothing) or repaired further than the op asked. The strip
+        // yields to the manager; on an accepted drag this is a no-op
+        // scan.
+        ReconcileStripOrder();
+        QueueBridgeUpdate();
     }
 
     /// <summary>

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -5,6 +5,8 @@ using Ghostty.Dialogs;
 using Ghostty.Input;
 using Ghostty.Panes;
 using Ghostty.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
@@ -38,6 +40,10 @@ internal sealed partial class TabHost : UserControl, ITabHost
     // (which would drop the 2px progress bar and the tab-color tint).
     private readonly Dictionary<TabModel, TextBlock> _headerTextByModel = new();
     private bool _suppressSelectionEvent;
+    // From the process-wide factory rather than injected: this control is
+    // built before DI contexts exist and logs one terminal condition only.
+    private readonly ILogger _log =
+        (ILogger?)App.LoggerFactory?.CreateLogger<TabHost>() ?? NullLogger.Instance;
 
     public FrameworkElement HostElement => this;
 
@@ -80,20 +86,17 @@ internal sealed partial class TabHost : UserControl, ITabHost
         Loaded += (_, _) => QueueBridgeUpdate();
         TabViewControl.SizeChanged += (_, _) => UpdateSelectedTabBridge();
 
-        // The drag lifecycle gates the seam cover (OnTabDragStarting /
-        // OnTabDragCompleted). Mid-drag the strip's slots are TabView's
-        // reorder preview rather than the manager's order, and the cover
-        // is placed from the active item's slot, so it is suppressed for
-        // the length of the drag and re-placed at the drop.
+        // The drag lifecycle gates the seam cover below: mid-drag the
+        // strip's slots are TabView's reorder preview, not the manager's
+        // order, so the cover (placed from the active item's slot) is
+        // suppressed for the drag and re-placed at the drop.
         TabViewControl.TabDragStarting += OnTabDragStarting;
 
         // TabView.TabItemsChanged stays unwired on purpose. It fires for
-        // this control's own writes (AddItem, MoveItem, the reconcile) as
-        // much as for TabView's, so a validation handler on it would
-        // re-enter the reconcile that mutates TabItems. The validation
-        // points are the reconcile in MoveItem and the one in
-        // OnTabDragCompleted; both read the manager rather than the
-        // control.
+        // this control's own writes as much as for TabView's, so a
+        // validation handler on it would re-enter the reconcile that
+        // mutates TabItems. The validation points are the reconciles in
+        // MoveItem and OnTabDragCompleted; both read the manager.
     }
 
     private void AddItem(TabModel tab)
@@ -251,22 +254,25 @@ internal sealed partial class TabHost : UserControl, ITabHost
     {
         if (!_itemByModel.TryGetValue(tab, out var item)) return;
         var current = TabViewControl.TabItems.IndexOf(item);
-        // A TabView drag drop raises this event after the control has
-        // already applied the move itself, so the common case is
-        // in-place. Re-inserting an item at the index it already
-        // occupies churns the strip (container regeneration) for no
-        // effect.
-        if (current == to) return;
+        // A drag drop raises this event after TabView has applied the
+        // move itself, so the common case is in-place, and re-inserting
+        // at the index the item already occupies churns the strip for
+        // nothing. But "in-place" is measured against the moved item only
+        // -- Normalize can have repaired the rest of the strip around it
+        // (group re-gather), so the early return still runs the reconcile.
+        if (current == to)
+        {
+            ReconcileStripOrder();
+            return;
+        }
         TabViewControl.TabItems.Remove(item);
         TabViewControl.TabItems.Insert(to, item);
         // _paneHostContainer order does not matter — Visibility picks
         // the active one. No reorder needed there.
 
         // The event's indices are the raw op's, and Normalize may have
-        // repaired further than the op asked (a move that breaks group
-        // contiguity re-gathers the run). The reconcile re-derives the
-        // strip from the manager's final state and owns the last word;
-        // the fast path above just settles the ordinary case in one op.
+        // repaired further than the op asked; the reconcile re-derives
+        // the strip from the manager's state and owns the last word.
         ReconcileStripOrder();
     }
 
@@ -280,13 +286,51 @@ internal sealed partial class TabHost : UserControl, ITabHost
     /// </summary>
     private void ReconcileStripOrder()
     {
-        foreach (var op in TabStripProjection.Diff(
-            TabStripProjection.Rows(_manager), StripOrder()))
+        var repaired = false;
+        // ListView drops its selection when the selected item is removed
+        // and does not restore it on re-insert; live, that drop surfaces
+        // as an activation of whatever TabView picked instead. A repair
+        // must never read as a tab switch.
+        _suppressSelectionEvent = true;
+        try
         {
-            var item = _itemByModel[op.Tab];
-            TabViewControl.TabItems.Remove(item);
-            TabViewControl.TabItems.Insert(op.To, item);
+            foreach (var op in TabStripProjection.Diff(
+                TabStripProjection.Rows(_manager), StripOrder()))
+            {
+                var item = _itemByModel[op.Tab];
+                TabViewControl.TabItems.Remove(item);
+                TabViewControl.TabItems.Insert(op.To, item);
+                repaired = true;
+            }
         }
+        catch (Exception ex) when (ex is InvalidOperationException or KeyNotFoundException)
+        {
+            // Diff throws on membership skew, the lookup on a model
+            // without an item; neither is producible today. The pure
+            // layer keeps its throws as the oracle; here a terminal's
+            // strip must not die, so rebuild from the manager.
+            _log.LogReconcileFailed(ex);
+            RebuildStripFromManager();
+            repaired = true;
+        }
+        finally
+        {
+            _suppressSelectionEvent = false;
+        }
+        if (repaired) SelectActive();
+    }
+
+    /// <summary>
+    /// The reconcile's last resort: rebuild TabItems in manager order
+    /// from the items this host owns, repairing skew in both directions
+    /// (a tab the strip lost, an item the manager does not hold).
+    /// </summary>
+    private void RebuildStripFromManager()
+    {
+        TabViewControl.TabItems.Clear();
+        foreach (var tab in TabStripProjection.Rows(_manager))
+            if (_itemByModel.TryGetValue(tab, out var item))
+                TabViewControl.TabItems.Add(item);
     }
 
     /// <summary>
@@ -1210,4 +1254,13 @@ internal sealed partial class TabHost : UserControl, ITabHost
         }
     }
 
+}
+
+internal static partial class TabHostLogExtensions
+{
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.TabStrip.ReconcileFailed,
+                   Level = LogLevel.Error,
+                   Message = "[tabs] strip order reconcile failed; rebuilt the strip from the tab manager")]
+    internal static partial void LogReconcileFailed(
+        this ILogger logger, System.Exception ex);
 }

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -1078,7 +1078,13 @@ internal sealed partial class VerticalTabStrip : UserControl
         // otherwise stay in MenuItems with their subscriptions live.
         foreach (var tab in _hooks.Keys.ToArray())
             RemoveItem(tab);
-        foreach (var tab in _manager.Tabs)
+        // Row order comes from the projector, the same source the
+        // horizontal strip reconciles against, so the two strips cannot
+        // disagree by construction. Identical to Tabs while headers are
+        // off, which is what makes the swap behavior-neutral; the
+        // Add/Remove branches above stay index-honoring because with no
+        // headers the collection's indices ARE the projection's.
+        foreach (var tab in TabStripProjection.Rows(_manager))
             AddItem(tab);
     }
 

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -1081,9 +1081,9 @@ internal sealed partial class VerticalTabStrip : UserControl
         // Row order comes from the projector, the same source the
         // horizontal strip reconciles against, so the two strips cannot
         // disagree by construction. Identical to Tabs while headers are
-        // off, which is what makes the swap behavior-neutral; the
-        // Add/Remove branches above stay index-honoring because with no
-        // headers the collection's indices ARE the projection's.
+        // off (which makes the swap behavior-neutral); the Add/Remove
+        // branches above stay index-honoring because with no headers the
+        // collection's indices ARE the projection's.
         foreach (var tab in TabStripProjection.Rows(_manager))
             AddItem(tab);
     }


### PR DESCRIPTION
PR 2 of the tab reorder/groups/pins ladder (spec: docs/specs/2026-08-28-tab-reorder-groups-pins.md, sections 3/4.3/5.3/9.2/10). Behavior-neutral de-risk before the drag and pin PRs; no new user-visible features.

- New pure TabStripProjection (Rows / RowMove / Diff) becomes the one translation point between TabManager state and both strips; the strips' order now reconciles from the manager's post-Normalize final state, never from raw event indices.
- Closes the three seams PR 1's review proved real but unreachable: TabMoved-vs-Normalize replay stranding (the [A,B,C,X] re-gather converges), Move's silent clamp no longer strands TabView's built-in reorder (drop path reconciles unconditionally), and MoveRun/MoveGroup batch TabMoved replay convergence is proven by a theory sweeping every rotation at run sizes 3/4/5.
- MoveItem's in-place path still reconciles before returning; ReconcileStripOrder is defensive at the UI boundary (log + full rebuild on membership skew; Diff keeps its throws as the pure layer's oracle), never leaks a dropped selection as an activation, and suppresses selection events while repairing.
- Seam cover (active-tab drag seam) is suppressed on drag start and re-placed on completion, per spec 5.3 - the one intended visible change.
- Wiring tests are mutation-observed per spec 9.2: guards pin polarity and arguments (bare-identifier gate condition, hide invoke args), the census covers both the C# sweep and the compiled XAML surface, and a combined mutant flips exactly the five expected guards.

Size-override: single-concern de-risk slice; ~40% of the countable lines are the three test files, and splitting the projector away from the seams it closes would strand both.