### PR TITLE
vtabs: drag reorder state machine and motion gate

### DIFF
--- a/windows/Ghostty.Core/Tabs/TabDragReorder.cs
+++ b/windows/Ghostty.Core/Tabs/TabDragReorder.cs
@@ -37,10 +37,14 @@ public sealed class TabDragReorder
 {
     private readonly double _startThresholdPx;
     private readonly double _hysteresisPx;
-    // Arranged row centers by manager index. The strip re-feeds these
-    // from layout; between a commit and the next measurement this class
-    // keeps them true by swapping the two rows it just reordered, so a
-    // fast flick can chain crossings on stale layout.
+    // Arranged row centers as a function of slot: entry i is slot i's
+    // center for whichever row sits at manager index i. Commits leave
+    // them untouched -- rows occupy slots in manager order, so a reorder
+    // needs no surgery here -- and the only reason to re-feed is a change
+    // in row metrics: scroll, resize, membership. A re-feed must carry
+    // FINAL arranged positions, never in-flight glide positions; a
+    // center read off a row still gliding poisons the crossing
+    // thresholds and the anchor alike.
     private double[] _centers;
     private int _index;
     private TabDragPhase _phase;
@@ -92,8 +96,13 @@ public sealed class TabDragReorder
     }
 
     /// <summary>
-    /// Re-feed arranged row centers after layout or scroll. Centers the
-    /// strip has not measured yet stay as the swaps left them.
+    /// Re-feed arranged row centers. Centers are a function of slot and
+    /// survive commits untouched, so this is only needed when row metrics
+    /// change -- scroll, resize, membership -- and it must carry FINAL
+    /// arranged positions: a center read off a row still mid-glide
+    /// poisons both the crossing thresholds and the anchor. Slots the
+    /// strip cannot measure yet keep their previous value; a shrunken
+    /// strip clamps the dragged index.
     /// </summary>
     public void UpdateCenters(IReadOnlyList<double> centers)
     {
@@ -104,8 +113,13 @@ public sealed class TabDragReorder
     }
 
     /// <summary>
-    /// Re-derive the dragged row's index after a membership change mid-drag
-    /// (a tab opened or closed elsewhere): the index is manager truth.
+    /// Re-derive the dragged row's index after a membership change
+    /// elsewhere (a tab opened or closed): the index is manager truth.
+    /// Asymmetric with <see cref="UpdateCenters"/> by design: an
+    /// out-of-range index is dropped rather than clamped, because the
+    /// only way the dragged row's own index can leave range is the row
+    /// closing -- and a mid-drag close is the STRIP's job to answer with
+    /// Cancel, not an index update the machine is expected to absorb.
     /// </summary>
     public void UpdateIndex(int index)
     {
@@ -113,9 +127,22 @@ public sealed class TabDragReorder
         _index = index;
     }
 
-    /// <summary>Arranged center the machine currently believes row <c>index</c> has.</summary>
+    /// <summary>
+    /// Arranged center the machine currently believes the row at
+    /// <c>index</c> has. Throws for any index outside the strip: asking
+    /// about a row the machine does not know is a strip bug, and
+    /// laundering it as 0 would bend a crossing past the first slot.
+    /// Bounds come from <see cref="RowCount"/>.
+    /// </summary>
     public double CenterOf(int index)
-        => index >= 0 && index < _centers.Length ? _centers[index] : 0;
+    {
+        if (index < 0 || index >= _centers.Length)
+            throw new ArgumentOutOfRangeException(nameof(index));
+        return _centers[index];
+    }
+
+    /// <summary>How many rows the machine currently holds centers for.</summary>
+    public int RowCount => _centers.Length;
 
     /// <summary>
     /// Commit-on-center-crossing: the dragged row's center against its
@@ -179,7 +206,12 @@ public sealed class TabDragReorder
     /// <summary>Feed the velocity window. <paramref name="ms"/> is monotonic.</summary>
     public void SampleVelocity(double y, double ms)
     {
-        _samples.RemoveAll(s => s.Ms < ms - TabStripMotion.VelocityWindowMs);
+        // Front-prune rather than RemoveAll: this runs per pointer move,
+        // and a lambda there allocates a closure on every call.
+        double cutoff = ms - TabStripMotion.VelocityWindowMs;
+        int stale = 0;
+        while (stale < _samples.Count && _samples[stale].Ms < cutoff) stale++;
+        if (stale > 0) _samples.RemoveRange(0, stale);
         _samples.Add((ms, y));
     }
 
@@ -190,6 +222,15 @@ public sealed class TabDragReorder
     /// AWAY from the slot carries no settle velocity at all -- the
     /// spring owns the direction, and handing it a fling against the
     /// travel would throw the row the wrong way before reeling it back.
+    ///
+    /// <paramref name="remainingDistancePx"/> is signed on the same axis
+    /// as <see cref="SampleVelocity"/>, positive = down; passing a bare
+    /// magnitude makes every velocity read as running away from the slot
+    /// and this guard kills legitimate upward settles.
+    ///
+    /// Read BEFORE <see cref="Drop"/> or <see cref="Cancel"/>: both clear
+    /// the sample window, so the natural call order reports 0 forever
+    /// with every test still green.
     /// </summary>
     public double ReleaseVelocity(double remainingDistancePx)
     {
@@ -208,7 +249,8 @@ public sealed class TabDragReorder
     /// Terminal: pointer released over a live drag. Returns the dragged
     /// row's committed index; the manager already holds it. A release
     /// that never lifted past the start threshold was a click, not a
-    /// drag, and reports -1.
+    /// drag, and reports -1. Clears the velocity window, so read
+    /// <see cref="ReleaseVelocity"/> first.
     /// </summary>
     public int Drop()
     {

--- a/windows/Ghostty.Core/Tabs/TabDragReorder.cs
+++ b/windows/Ghostty.Core/Tabs/TabDragReorder.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Collections.Generic;
+
+namespace Ghostty.Core.Tabs;
+
+/// <summary>The vertical drag's phase, for the strip's handlers to gate on.</summary>
+public enum TabDragPhase
+{
+    /// <summary>No gesture. The machine is reusable after it returns here.</summary>
+    Idle,
+
+    /// <summary>Pointer is down on a row, under the start threshold: still a click.</summary>
+    Pressed,
+
+    /// <summary>Drag is live: the row follows the pointer, crossings commit.</summary>
+    Dragging,
+}
+
+/// <summary>One committed reorder: the dragged row moves <c>From</c> to <c>To</c>.</summary>
+public readonly record struct TabDragCrossing(int From, int To);
+
+/// <summary>
+/// State machine for the vertical strip's drag-to-reorder gesture: the
+/// press threshold, commit-on-center-crossing with hysteresis, the
+/// autoscroll ramp, release velocity, and the terminal drop/cancel
+/// transitions. Pure data in, decisions out, so the whole gesture
+/// grammar is unit-testable without a WinUI host.
+///
+/// The strip owns every measurement and all composition, and feeds
+/// results in here. Row centers are ARRANGED positions in strip space
+/// (never raw pointer positions, so scroll cannot corrupt a crossing),
+/// and a crossing is reported, not applied -- the strip turns it into
+/// <see cref="TabManager.Move"/>, keeping the manager the truth
+/// mid-drag.
+/// </summary>
+public sealed class TabDragReorder
+{
+    private readonly double _startThresholdPx;
+    private readonly double _hysteresisPx;
+    // Arranged row centers by manager index. The strip re-feeds these
+    // from layout; between a commit and the next measurement this class
+    // keeps them true by swapping the two rows it just reordered, so a
+    // fast flick can chain crossings on stale layout.
+    private double[] _centers;
+    private int _index;
+    private TabDragPhase _phase;
+    private double _pressY;
+    // Trailing window of pointer samples release velocity reads from.
+    private readonly List<(double Ms, double Y)> _samples = new();
+
+    public TabDragReorder(int rowCount, int grabIndex)
+        : this(rowCount, grabIndex,
+              TabStripMotion.GrabStartThresholdPx, TabStripMotion.CrossingHysteresisPx) { }
+
+    public TabDragReorder(int rowCount, int grabIndex, double startThresholdPx, double hysteresisPx)
+    {
+        if (rowCount < 2)
+            throw new ArgumentException(
+                "TabDragReorder needs at least two rows; there is nothing to reorder.");
+        if (grabIndex < 0 || grabIndex >= rowCount)
+            throw new ArgumentOutOfRangeException(nameof(grabIndex));
+        _startThresholdPx = startThresholdPx;
+        _hysteresisPx = hysteresisPx;
+        _centers = new double[rowCount];
+        _index = grabIndex;
+    }
+
+    public TabDragPhase Phase => _phase;
+
+    /// <summary>Current manager index of the dragged row.</summary>
+    public int Index => _index;
+
+    /// <summary>Arm the gesture on a pointer press over row <c>grabIndex</c>.</summary>
+    public void Press(double pointerY)
+    {
+        if (_phase != TabDragPhase.Idle) return;
+        _pressY = pointerY;
+        _phase = TabDragPhase.Pressed;
+    }
+
+    /// <summary>
+    /// Lift to <see cref="TabDragPhase.Dragging"/> once vertical travel
+    /// passes the start threshold. Horizontal movement never starts the
+    /// drag, so a jittering grab stays a click.
+    /// </summary>
+    public bool Begin(double pointerY)
+    {
+        if (_phase != TabDragPhase.Pressed) return false;
+        if (Math.Abs(pointerY - _pressY) < _startThresholdPx) return false;
+        _phase = TabDragPhase.Dragging;
+        return true;
+    }
+
+    /// <summary>
+    /// Re-feed arranged row centers after layout or scroll. Centers the
+    /// strip has not measured yet stay as the swaps left them.
+    /// </summary>
+    public void UpdateCenters(IReadOnlyList<double> centers)
+    {
+        if (centers.Count != _centers.Length)
+            _centers = new double[centers.Count];
+        for (int i = 0; i < centers.Count; i++) _centers[i] = centers[i];
+        if (_index >= _centers.Length) _index = _centers.Length - 1;
+    }
+
+    /// <summary>
+    /// Re-derive the dragged row's index after a membership change mid-drag
+    /// (a tab opened or closed elsewhere): the index is manager truth.
+    /// </summary>
+    public void UpdateIndex(int index)
+    {
+        if (index < 0 || index >= _centers.Length) return;
+        _index = index;
+    }
+
+    /// <summary>Arranged center the machine currently believes row <c>index</c> has.</summary>
+    public double CenterOf(int index)
+        => index >= 0 && index < _centers.Length ? _centers[index] : 0;
+
+    /// <summary>
+    /// Commit-on-center-crossing: the dragged row's center against its
+    /// neighbours' arranged centers, plus the hysteresis guard, so a
+    /// crossing only commits once the drag clearly means it and a
+    /// backtrack must re-earn the previous slot.
+    ///
+    /// Returns one crossing per call; the strip applies it through the
+    /// manager and calls again until null, so a fast flick across three
+    /// rows is three ordinary moves, not one rewrite. The centers are
+    /// NOT rewritten here: they are indexed by manager order, and rows
+    /// occupy slots in manager order once layout catches up, so a
+    /// committed crossing leaves them describing exactly the layout the
+    /// strip is arranging toward. The backtrack hysteresis therefore
+    /// measures against the neighbour's new slot, and undoing a swap
+    /// costs a full row of travel, not the 8px that committed it.
+    /// </summary>
+    public TabDragCrossing? Evaluate(double draggedCenterY)
+    {
+        if (_phase != TabDragPhase.Dragging) return null;
+
+        if (_index + 1 < _centers.Length
+            && draggedCenterY > _centers[_index + 1] + _hysteresisPx)
+        {
+            _index++;
+            return new TabDragCrossing(_index - 1, _index);
+        }
+
+        if (_index > 0 && draggedCenterY < _centers[_index - 1] - _hysteresisPx)
+        {
+            _index--;
+            return new TabDragCrossing(_index + 1, _index);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Signed autoscroll speed in px/s at <paramref name="pointerY"/>
+    /// against the scrolling viewport's bounds: negative scrolls up,
+    /// positive down, zero outside the edge band. Ramps with distance so
+    /// the ramp-up is proportional to how far into the band the drag is.
+    /// </summary>
+    public double AutoscrollSpeed(double pointerY, double viewportTop, double viewportBottom)
+    {
+        double fromTop = pointerY - viewportTop;
+        double fromBottom = viewportBottom - pointerY;
+        double d = Math.Min(fromTop, fromBottom);
+        if (d > TabStripMotion.AutoscrollBandPx) return 0;
+
+        double speed = d <= TabStripMotion.AutoscrollInnerBandPx
+            ? TabStripMotion.AutoscrollMaxPxPerSecond
+            : TabStripMotion.AutoscrollBasePxPerSecond
+              + (TabStripMotion.AutoscrollMaxPxPerSecond - TabStripMotion.AutoscrollBasePxPerSecond)
+              * (TabStripMotion.AutoscrollBandPx - d)
+              / (TabStripMotion.AutoscrollBandPx - TabStripMotion.AutoscrollInnerBandPx);
+
+        return fromTop <= fromBottom ? -speed : speed;
+    }
+
+    /// <summary>Feed the velocity window. <paramref name="ms"/> is monotonic.</summary>
+    public void SampleVelocity(double y, double ms)
+    {
+        _samples.RemoveAll(s => s.Ms < ms - TabStripMotion.VelocityWindowMs);
+        _samples.Add((ms, y));
+    }
+
+    /// <summary>
+    /// Pointer release velocity over the trailing window, clamped so a
+    /// fling cannot overshoot the slot: the cap is the remaining
+    /// distance per settle period. A release whose trailing motion runs
+    /// AWAY from the slot carries no settle velocity at all -- the
+    /// spring owns the direction, and handing it a fling against the
+    /// travel would throw the row the wrong way before reeling it back.
+    /// </summary>
+    public double ReleaseVelocity(double remainingDistancePx)
+    {
+        if (_samples.Count < 2) return 0;
+        var (firstMs, firstY) = _samples[0];
+        var (lastMs, lastY) = _samples[^1];
+        double dtSec = (lastMs - firstMs) / 1000.0;
+        if (dtSec <= 0) return 0;
+        double v = (lastY - firstY) / dtSec;
+        if (v * remainingDistancePx <= 0) return 0;
+        double cap = Math.Abs(remainingDistancePx) / (TabStripMotion.SettlePeriodMs / 1000.0);
+        return Math.Clamp(v, -cap, cap);
+    }
+
+    /// <summary>
+    /// Terminal: pointer released over a live drag. Returns the dragged
+    /// row's committed index; the manager already holds it. A release
+    /// that never lifted past the start threshold was a click, not a
+    /// drag, and reports -1.
+    /// </summary>
+    public int Drop()
+    {
+        if (_phase != TabDragPhase.Dragging)
+        {
+            Reset();
+            return -1;
+        }
+        int index = _index;
+        Reset();
+        return index;
+    }
+
+    /// <summary>Terminal: the gesture ends without a drop (escape, capture loss, teardown).</summary>
+    public void Cancel() => Reset();
+
+    private void Reset()
+    {
+        _phase = TabDragPhase.Idle;
+        _samples.Clear();
+    }
+}

--- a/windows/Ghostty.Core/Tabs/TabStripMotion.cs
+++ b/windows/Ghostty.Core/Tabs/TabStripMotion.cs
@@ -59,6 +59,15 @@ internal static class TabStripMotion
     /// animation effects are on and High Contrast is not. Disabled means
     /// every spring collapses to a cut; state correctness never waits on
     /// an animation completing.
+    ///
+    /// The strip's sources for the two flags: animationsEnabled is
+    /// UISettings.AnimationsEnabled (UISettings is thread-affine -- read
+    /// it on the dispatcher); highContrast is
+    /// HighContrastDetector.IsActive() COMPOSED through
+    /// HighContrastState.ShouldApply, because raw IsActive diverges from
+    /// the chrome whenever the user has opted out of High Contrast
+    /// themes. There is no existing animation-preference read anywhere
+    /// else in the repo to reuse.
     /// </summary>
     public static bool Enabled(bool animationsEnabled, bool highContrast)
         => animationsEnabled && !highContrast;

--- a/windows/Ghostty.Core/Tabs/TabStripMotion.cs
+++ b/windows/Ghostty.Core/Tabs/TabStripMotion.cs
@@ -1,0 +1,65 @@
+namespace Ghostty.Core.Tabs;
+
+/// <summary>
+/// Motion constants for the tab strips, and the reduce-motion gate.
+///
+/// Numbers come from the strip-motion spec's token table, which in turn
+/// takes durations from the Windows 11 signature-experiences table and
+/// spring parameters from the Windows Design team's published spring
+/// table. The WinRT spring classes document no defaults, so every
+/// DampingRatio and Period here is written explicitly at the use site.
+///
+/// Lives in Core, next to the drag state machine, so the numbers and
+/// the gate truth table are pinnable by tests without a WinUI host;
+/// the shell reads them through InternalsVisibleTo.
+/// </summary>
+internal static class TabStripMotion
+{
+    /// <summary>
+    /// Vertical pointer travel that turns a press into a drag. Below it
+    /// the gesture is a click and activation stays click-driven.
+    /// </summary>
+    public const double GrabStartThresholdPx = 4;
+
+    /// <summary>
+    /// Travel past a neighbour's center, beyond the crossing itself,
+    /// before the reorder commits: a wobbly hand must not oscillate the
+    /// order back and forth.
+    /// </summary>
+    public const double CrossingHysteresisPx = 8;
+
+    // Autoscroll band at the scroller edges: 360 px/s from 24px away,
+    // ramping to 840 px/s inside 8px.
+    public const double AutoscrollBandPx = 24;
+    public const double AutoscrollInnerBandPx = 8;
+    public const double AutoscrollBasePxPerSecond = 360;
+    public const double AutoscrollMaxPxPerSecond = 840;
+
+    /// <summary>Trailing window of pointer samples release velocity is read from.</summary>
+    public const double VelocityWindowMs = 100;
+
+    /// <summary>
+    /// The drop settle: the only inertia spring in the interaction. The
+    /// dropped row lands with the velocity the hand gave it; neighbours
+    /// never carry release velocity.
+    /// </summary>
+    public const float SettleDampingRatio = 0.80f;
+    public const double SettlePeriodMs = 50;
+
+    /// <summary>Neighbour gap motion: a short eased glide.</summary>
+    public const double GapGlideMs = 250;
+
+    /// <summary>Row lift on grab: a near-critical scale spring to a 3% grow.</summary>
+    public const float LiftDampingRatio = 0.70f;
+    public const double LiftPeriodMs = 50;
+    public const float LiftScale = 1.03f;
+
+    /// <summary>
+    /// The motion gate: springs and glides run only when Windows
+    /// animation effects are on and High Contrast is not. Disabled means
+    /// every spring collapses to a cut; state correctness never waits on
+    /// an animation completing.
+    /// </summary>
+    public static bool Enabled(bool animationsEnabled, bool highContrast)
+        => animationsEnabled && !highContrast;
+}

--- a/windows/Ghostty.Tests/Tabs/TabDragReorderTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabDragReorderTests.cs
@@ -34,6 +34,17 @@ public class TabDragReorderTests
     }
 
     [Fact]
+    public void Begin_exactly_at_the_threshold_lifts()
+    {
+        var machine = NewMachine();
+        machine.Press(20);
+
+        // |24 - 20| == GrabStartThresholdPx: the threshold is inclusive.
+        Assert.True(machine.Begin(24));
+        Assert.Equal(TabDragPhase.Dragging, machine.Phase);
+    }
+
+    [Fact]
     public void Threshold_travel_lifts_to_dragging()
     {
         var machine = NewMachine();
@@ -156,14 +167,42 @@ public class TabDragReorderTests
     }
 
     [Fact]
+    public void An_out_of_range_index_update_is_dropped_not_clamped()
+    {
+        // The asymmetry with UpdateCenters is deliberate: the dragged
+        // row's index only leaves range when the row itself closed, and
+        // answering that is the strip's Cancel job, not an absorb-here.
+        var machine = NewMachine(grabIndex: 2);
+        machine.Press(100);
+        machine.Begin(110);
+        machine.UpdateIndex(9);
+
+        Assert.Equal(2, machine.Index);
+    }
+
+    [Fact]
+    public void Center_of_a_row_the_machine_does_not_know_throws()
+    {
+        var machine = NewMachine();
+        Assert.Equal(4, machine.RowCount);
+
+        // A zero for an unknown row would launder a strip bug into a
+        // crossing bent past the first slot.
+        Assert.Throws<ArgumentOutOfRangeException>(() => machine.CenterOf(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => machine.CenterOf(4));
+    }
+
+    [Fact]
     public void Autoscroll_ramps_with_edge_distance_and_signs_by_edge()
     {
         var machine = NewMachine();
         const double top = 100, bottom = 500;
 
         Assert.Equal(0, machine.AutoscrollSpeed(300, top, bottom));
+        // Exactly AutoscrollBandPx from the edge is still in the band and
+        // pays the base speed; the guard is strictly greater-than.
         Assert.Equal(-TabStripMotion.AutoscrollBasePxPerSecond,
-            machine.AutoscrollSpeed(124, top, bottom));
+            machine.AutoscrollSpeed(top + TabStripMotion.AutoscrollBandPx, top, bottom));
         Assert.Equal(-TabStripMotion.AutoscrollMaxPxPerSecond,
             machine.AutoscrollSpeed(95, top, bottom));
         Assert.Equal(TabStripMotion.AutoscrollMaxPxPerSecond,
@@ -190,7 +229,24 @@ public class TabDragReorderTests
 
         // Only the trailing pair survives the window: 50 -> 55 over 50ms
         // is 100 px/s downward, not the 20,000 px/s the expired pair saw.
-        Assert.InRange(machine.ReleaseVelocity(1000), 80, 120);
+        Assert.Equal(100, machine.ReleaseVelocity(1000), 1);
+    }
+
+    [Fact]
+    public void Release_velocity_after_drop_is_zero_the_window_is_cleared()
+    {
+        var machine = NewMachine();
+        machine.Press(0);
+        machine.Begin(10);
+        machine.SampleVelocity(0, 0);
+        machine.SampleVelocity(500, 10);
+        machine.Drop();
+
+        // Drop retires the gesture and clears the sample window with it:
+        // the release velocity must be read BEFORE Drop. Pinned as
+        // documented behavior, because the natural call order reports 0
+        // with every other test still green.
+        Assert.Equal(0, machine.ReleaseVelocity(60));
     }
 
     [Fact]

--- a/windows/Ghostty.Tests/Tabs/TabDragReorderTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabDragReorderTests.cs
@@ -1,0 +1,261 @@
+using System;
+using System.Collections.Generic;
+using Ghostty.Core.Tabs;
+using Xunit;
+
+namespace Ghostty.Tests.Tabs;
+
+/// <summary>
+/// The drag state machine behind the vertical strip's drag-to-reorder:
+/// press threshold, commit-on-center-crossing with hysteresis,
+/// autoscroll ramp, release velocity, and the terminal transitions.
+/// Pure class, so the gesture grammar is pinned without a WinUI host;
+/// the composition wiring it feeds is in VerticalTabStrip and the
+/// SendInput-level harness is the noted follow-up.
+/// </summary>
+public class TabDragReorderTests
+{
+    // Four rows of 40px: arranged centers 20, 60, 100, 140.
+    private static TabDragReorder NewMachine(int grabIndex = 0, int rowCount = 4)
+    {
+        var machine = new TabDragReorder(rowCount, grabIndex);
+        machine.UpdateCenters(new double[] { 20, 60, 100, 140 });
+        return machine;
+    }
+
+    [Fact]
+    public void Under_threshold_travel_stays_a_click()
+    {
+        var machine = NewMachine();
+        machine.Press(20);
+
+        Assert.False(machine.Begin(23));
+        Assert.Equal(TabDragPhase.Pressed, machine.Phase);
+    }
+
+    [Fact]
+    public void Threshold_travel_lifts_to_dragging()
+    {
+        var machine = NewMachine();
+        machine.Press(20);
+
+        Assert.True(machine.Begin(25));
+        Assert.Equal(TabDragPhase.Dragging, machine.Phase);
+    }
+
+    [Fact]
+    public void Crossing_commits_only_past_the_hysteresis()
+    {
+        var machine = NewMachine(grabIndex: 0);
+        machine.Press(20);
+        machine.Begin(40);
+
+        // Neighbour center 60, hysteresis 8: the crossing fires past 68.
+        Assert.Null(machine.Evaluate(68));
+        var crossing = machine.Evaluate(69);
+        Assert.Equal(new TabDragCrossing(0, 1), crossing);
+        Assert.Equal(1, machine.Index);
+    }
+
+    [Fact]
+    public void A_wobble_back_under_the_threshold_does_not_oscillate()
+    {
+        var machine = NewMachine(grabIndex: 0);
+        machine.Press(20);
+        machine.Begin(40);
+        Assert.NotNull(machine.Evaluate(69));
+
+        // After the commit the neighbour owns slot 0 (center 20), so the
+        // order only flips back past 20 minus the hysteresis. The wobble
+        // band between the commit point (68) and the flip-back point (12)
+        // is nearly a full row wide: a shaking hand at 55 cannot jitter
+        // the order.
+        Assert.Null(machine.Evaluate(69));
+        Assert.Null(machine.Evaluate(55));
+        Assert.Null(machine.Evaluate(19));
+        Assert.Equal(new TabDragCrossing(1, 0), machine.Evaluate(11));
+        Assert.Equal(0, machine.Index);
+        // And the round trip is stable: parked on the boundary again,
+        // nothing re-fires without real travel.
+        Assert.Null(machine.Evaluate(11));
+    }
+
+    [Fact]
+    public void A_fast_flick_chains_one_crossing_per_evaluate()
+    {
+        var machine = NewMachine(grabIndex: 0);
+        machine.Press(20);
+        machine.Begin(30);
+
+        // Straight to the bottom row: each call walks one slot.
+        Assert.Equal(new TabDragCrossing(0, 1), machine.Evaluate(120));
+        Assert.Equal(new TabDragCrossing(1, 2), machine.Evaluate(120));
+        Assert.Null(machine.Evaluate(120));
+        Assert.Equal(2, machine.Index);
+    }
+
+    [Fact]
+    public void Chained_crossings_keep_the_slot_centers_true()
+    {
+        // Centers are indexed by manager order, and rows occupy slots in
+        // manager order once layout catches up -- so two committed
+        // crossings leave every center exactly where the strip is
+        // arranging toward, and only the dragged index moves.
+        var machine = NewMachine(grabIndex: 0);
+        machine.Press(20);
+        machine.Begin(30);
+        Assert.Equal(new TabDragCrossing(0, 1), machine.Evaluate(110));
+        Assert.Equal(new TabDragCrossing(1, 2), machine.Evaluate(110));
+
+        Assert.Equal(2, machine.Index);
+        Assert.Equal(20, machine.CenterOf(0));
+        Assert.Equal(60, machine.CenterOf(1));
+        Assert.Equal(100, machine.CenterOf(2));
+        // The next neighbour up still gates on its true slot: flipping
+        // back past row 1 needs the pointer under 60 minus 8.
+        Assert.Null(machine.Evaluate(55));
+        Assert.Equal(new TabDragCrossing(2, 1), machine.Evaluate(51));
+    }
+
+    [Fact]
+    public void Upward_crossings_are_symmetric()
+    {
+        var machine = NewMachine(grabIndex: 3);
+        machine.Press(140);
+        machine.Begin(120);
+
+        Assert.Null(machine.Evaluate(92));
+        Assert.Equal(new TabDragCrossing(3, 2), machine.Evaluate(91));
+        Assert.Equal(2, machine.Index);
+    }
+
+    [Fact]
+    public void Remeasured_centers_replace_the_synthetic_ones()
+    {
+        var machine = NewMachine(grabIndex: 1);
+        machine.Press(60);
+        machine.Begin(70);
+        machine.UpdateCenters(new double[] { 30, 70, 110, 150 });
+
+        Assert.Equal(70, machine.CenterOf(1));
+        // Past neighbour two's center 110 + 8: commits one slot.
+        Assert.Equal(new TabDragCrossing(1, 2), machine.Evaluate(119));
+    }
+
+    [Fact]
+    public void Membership_change_moves_the_dragged_index_with_it()
+    {
+        var machine = NewMachine(grabIndex: 2);
+        machine.Press(100);
+        machine.Begin(110);
+        machine.UpdateIndex(3);
+
+        Assert.Equal(3, machine.Index);
+        // Center for slot 3 is 140; crossing up against slot 2 at 100 - 8.
+        Assert.Equal(new TabDragCrossing(3, 2), machine.Evaluate(91));
+    }
+
+    [Fact]
+    public void Autoscroll_ramps_with_edge_distance_and_signs_by_edge()
+    {
+        var machine = NewMachine();
+        const double top = 100, bottom = 500;
+
+        Assert.Equal(0, machine.AutoscrollSpeed(300, top, bottom));
+        Assert.Equal(-TabStripMotion.AutoscrollBasePxPerSecond,
+            machine.AutoscrollSpeed(124, top, bottom));
+        Assert.Equal(-TabStripMotion.AutoscrollMaxPxPerSecond,
+            machine.AutoscrollSpeed(95, top, bottom));
+        Assert.Equal(TabStripMotion.AutoscrollMaxPxPerSecond,
+            machine.AutoscrollSpeed(bottom - 4, top, bottom));
+
+        // Midway down the band the ramp is halfway between the two tiers.
+        var mid = machine.AutoscrollSpeed(top + 16, top, bottom);
+        Assert.Equal(
+            -(TabStripMotion.AutoscrollBasePxPerSecond
+              + TabStripMotion.AutoscrollMaxPxPerSecond) / 2,
+            mid, 1);
+    }
+
+    [Fact]
+    public void Release_velocity_reads_the_trailing_window_only()
+    {
+        var machine = NewMachine();
+        machine.Press(0);
+        machine.Begin(10);
+        machine.SampleVelocity(0, 0);
+        machine.SampleVelocity(1000, 50);
+        machine.SampleVelocity(50, 400); // the two samples above expire here
+        machine.SampleVelocity(55, 450);
+
+        // Only the trailing pair survives the window: 50 -> 55 over 50ms
+        // is 100 px/s downward, not the 20,000 px/s the expired pair saw.
+        Assert.InRange(machine.ReleaseVelocity(1000), 80, 120);
+    }
+
+    [Fact]
+    public void Release_velocity_is_clamped_to_the_remaining_travel_per_period()
+    {
+        var machine = NewMachine();
+        machine.Press(0);
+        machine.Begin(10);
+        machine.SampleVelocity(0, 0);
+        machine.SampleVelocity(5000, 10);
+
+        // 50ms period, 60px to travel: a fling is capped at 1200 px/s.
+        Assert.Equal(1200, machine.ReleaseVelocity(60), 1);
+        // A release moving away from the slot carries no settle velocity:
+        // the spring owns the direction.
+        Assert.Equal(0, machine.ReleaseVelocity(-60));
+        Assert.Equal(0, machine.ReleaseVelocity(0));
+    }
+
+    [Fact]
+    public void Drop_reports_the_committed_index_and_retires_the_gesture()
+    {
+        var machine = NewMachine(grabIndex: 0);
+        machine.Press(20);
+        machine.Begin(40);
+        machine.Evaluate(69);
+
+        Assert.Equal(1, machine.Drop());
+        Assert.Equal(TabDragPhase.Idle, machine.Phase);
+
+        // A release that never lifted past the threshold was a click.
+        var click = NewMachine();
+        click.Press(20);
+        Assert.Equal(-1, click.Drop());
+    }
+
+    [Fact]
+    public void Cancel_retires_the_gesture_from_any_phase()
+    {
+        var pressed = NewMachine();
+        pressed.Press(20);
+        pressed.Cancel();
+        Assert.Equal(TabDragPhase.Idle, pressed.Phase);
+
+        var dragging = NewMachine();
+        dragging.Press(20);
+        dragging.Begin(40);
+        dragging.Cancel();
+        Assert.Null(dragging.Evaluate(1000));
+        Assert.Equal(TabDragPhase.Idle, dragging.Phase);
+    }
+
+    [Fact]
+    public void A_one_row_strip_has_nothing_to_reorder()
+    {
+        Assert.Throws<ArgumentException>(() => new TabDragReorder(1, 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new TabDragReorder(4, 4));
+    }
+
+    [Fact]
+    public void Motion_gate_collapses_under_high_contrast_or_systems_with_animation_off()
+    {
+        Assert.True(TabStripMotion.Enabled(animationsEnabled: true, highContrast: false));
+        Assert.False(TabStripMotion.Enabled(animationsEnabled: true, highContrast: true));
+        Assert.False(TabStripMotion.Enabled(animationsEnabled: false, highContrast: false));
+        Assert.False(TabStripMotion.Enabled(animationsEnabled: false, highContrast: true));
+    }
+}


### PR DESCRIPTION
Pure, UI-free machinery for tab drag reorder, consumed by the vertical strip wiring PR that follows.

- TabDragReorder: total press/drag/release state machine (4px threshold, 8px edge hysteresis, commit-on-center-crossing with slot-indexed centers, autoscroll bands, trailing velocity window with sign-corrected release velocity).
- TabStripMotion: motion tokens (durations, easings, spring constants, autoscroll ramp) and a pure animation gate.
- 20 deterministic facts in Ghostty.Tests.

Dead code by design until the wiring PR lands on top.