### PR TITLE
vtabs: the vertical strip's pinned zone

### DIFF
--- a/windows/Ghostty.Core/Input/PaneAction.cs
+++ b/windows/Ghostty.Core/Input/PaneAction.cs
@@ -137,4 +137,11 @@ public enum PaneAction
     MruCycleNext = 63,
     MruCyclePrev = 64,
     ShowTabOverview = 65,
+
+    // Pin the active tab into / out of the pinned prefix. Palette and
+    // context menu only: no default chord ships (owner decided: no
+    // defaults in v1), so these are not matched in KeyBindings and have
+    // no keybind-catalog verb -- the palette entry is the keyboard path.
+    PinTab = 66,
+    UnpinTab = 67,
 }

--- a/windows/Ghostty.Core/Tabs/TabAccessibleText.cs
+++ b/windows/Ghostty.Core/Tabs/TabAccessibleText.cs
@@ -35,7 +35,8 @@ internal static class TabAccessibleText
             : effectiveTitle;
 
     /// <summary>Transient state for <paramref name="tab"/>.</summary>
-    internal static string Status(TabModel tab) => Status(tab.BellRinging);
+    internal static string Status(TabModel tab)
+        => Status(tab.IsPinned, tab.BellRinging);
 
     /// <summary>
     /// Transient state for the tab, for AutomationProperties.ItemStatus.
@@ -49,9 +50,27 @@ internal static class TabAccessibleText
     /// the state. ItemStatus is the property UIA defines for exactly this
     /// -- state that rides along with an item and changes under it -- and
     /// it leaves the name alone.
+    ///
+    /// "Pinned" is the same kind of state: the row still has its title,
+    /// and what changed is where the strip keeps it. A pin that renamed
+    /// the tab would hide the one string every other surface (overview,
+    /// switcher, pane title) still agrees on.
     /// </summary>
-    internal static string Status(bool bellRinging)
-        => bellRinging ? "Bell" : string.Empty;
+    internal static string Status(bool isPinned, bool bellRinging)
+    {
+        if (!isPinned) return bellRinging ? "Bell" : string.Empty;
+        return bellRinging ? "Pinned, Bell" : "Pinned";
+    }
+
+    /// <summary>
+    /// Spoken when a keyboard or menu pin/unpin lands. The reorder a pin
+    /// performs is visible, but the zone change behind it is not: the row
+    /// keeps its title, and without an announcement the listener hears an
+    /// unexplained jump. Pointer drags announce nothing -- the user is
+    /// watching it happen (5.6).
+    /// </summary>
+    internal static string PinAnnouncement(TabModel tab, bool pinned)
+        => pinned ? $"Tab pinned, {Name(tab)}" : $"Tab unpinned, {Name(tab)}";
 
     /// <summary>
     /// Spoken when a tab starts ringing. ItemStatus is the correct

--- a/windows/Ghostty.Core/Tabs/TabPinBoundary.cs
+++ b/windows/Ghostty.Core/Tabs/TabPinBoundary.cs
@@ -1,0 +1,68 @@
+using System;
+
+namespace Ghostty.Core.Tabs;
+
+/// <summary>What one drag crossing means at the pin boundary.</summary>
+public enum TabPinZoneOp
+{
+    /// <summary>Both slots are in the same zone; a plain Move commits it.</summary>
+    None,
+
+    /// <summary>An unpinned row crossed up into the prefix and must pin.</summary>
+    Pin,
+
+    /// <summary>A pinned row crossed down out of the prefix and must unpin.</summary>
+    Unpin,
+}
+
+/// <summary>One crossing's zone meaning and its target slot.</summary>
+public readonly record struct TabPinZoneCrossing(TabPinZoneOp Op, int To);
+
+/// <summary>
+/// Classifies a drag crossing against the pinned prefix: does this
+/// crossing stay inside one zone, or does it carry the dragged row
+/// across the boundary, and if so in which direction.
+///
+/// The pinned zone is a PREFIX of the one list (spec 4.1), so a crossing
+/// is zone-crossing purely by index arithmetic: a crossing whose target
+/// slot sits on the other side of <see cref="TabManager.PinCount"/> from
+/// the dragged row cannot be committed by <see cref="TabManager.Move"/>
+/// alone -- Move clamps to the row's own zone and would silently no-op.
+/// The drag layer calls this first and turns a zone crossing into the
+/// manager's Move + <see cref="TabManager.SetPinned"/> pair, one commit
+/// at the call site.
+///
+/// Pure so the boundary grammar is unit-testable without a WinUI host;
+/// the strip applies the answer through the manager and reads the truth
+/// back, exactly as it does for a plain move.
+/// </summary>
+public static class TabPinBoundary
+{
+    /// <summary>
+    /// Classify one machine crossing. <paramref name="to"/> is the
+    /// machine's crossing slot (the same space <see cref="TabManager.Move"/>
+    /// takes). An out-of-range slot classifies as <see cref="TabPinZoneOp.None"/>
+    /// rather than a zone change: the machine never emits one, and a
+    /// malformed slot must not be promoted into a pin toggle -- the move
+    /// it rides with will refuse and the read-back catches it.
+    /// </summary>
+    public static TabPinZoneCrossing Classify(
+        bool draggedIsPinned, int pinCount, int rowCount, int to)
+    {
+        if (pinCount < 0 || pinCount > rowCount)
+            throw new ArgumentOutOfRangeException(
+                nameof(pinCount), pinCount,
+                "PinCount outside [0, rowCount] is corrupt state, not a zone.");
+        if (to < 0 || to >= rowCount)
+            return new TabPinZoneCrossing(TabPinZoneOp.None, to);
+
+        if (draggedIsPinned)
+            return to >= pinCount
+                ? new TabPinZoneCrossing(TabPinZoneOp.Unpin, to)
+                : new TabPinZoneCrossing(TabPinZoneOp.None, to);
+
+        return to < pinCount
+            ? new TabPinZoneCrossing(TabPinZoneOp.Pin, to)
+            : new TabPinZoneCrossing(TabPinZoneOp.None, to);
+    }
+}

--- a/windows/Ghostty.Tests/Tabs/TabAccessibleTextTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabAccessibleTextTests.cs
@@ -92,9 +92,58 @@ public class TabAccessibleTextTests
     [Fact]
     public void Bell_IsStatus_AndLeavesTheNameAlone()
     {
-        Assert.Equal("Bell", TabAccessibleText.Status(bellRinging: true));
-        Assert.Equal(string.Empty, TabAccessibleText.Status(bellRinging: false));
+        Assert.Equal("Bell", TabAccessibleText.Status(isPinned: false, bellRinging: true));
+        Assert.Equal(string.Empty, TabAccessibleText.Status(isPinned: false, bellRinging: false));
         Assert.Equal("pwsh", TabAccessibleText.Name("pwsh"));
+    }
+
+    /// <summary>
+    /// A pin is the same kind of state: the row keeps its title and its
+    /// place in the name, and what changed rides ItemStatus. Without the
+    /// segment, a screen-reader user hears an unexplained reorder when
+    /// the tab jumps zones; the status is what says why.
+    /// </summary>
+    [Fact]
+    public void Pin_IsStatus_AndComposesWithTheBell()
+    {
+        Assert.Equal("Pinned", TabAccessibleText.Status(isPinned: true, bellRinging: false));
+        Assert.Equal("Pinned, Bell", TabAccessibleText.Status(isPinned: true, bellRinging: true));
+        Assert.Equal("Bell", TabAccessibleText.Status(isPinned: false, bellRinging: true));
+        Assert.Equal(string.Empty, TabAccessibleText.Status(isPinned: false, bellRinging: false));
+    }
+
+    /// <summary>
+    /// The tab overload is what the strips render, so a pinned tab with a
+    /// bell reads both segments and an unpinned quiet tab reads nothing.
+    /// </summary>
+    [Fact]
+    public void TabOverload_ReportsPinAndBellTogether()
+    {
+        var tab = new TabModel(new FakePaneHost());
+        tab.ShellReportedTitle = "build.log";
+
+        Assert.Equal(string.Empty, TabAccessibleText.Status(tab));
+
+        tab.IsPinned = true;
+        Assert.Equal("Pinned", TabAccessibleText.Status(tab));
+
+        tab.BellRinging = true;
+        Assert.Equal("Pinned, Bell", TabAccessibleText.Status(tab));
+    }
+
+    /// <summary>
+    /// The pin announcement says what happened and to which tab, the same
+    /// contract the bell announcement has: the user is not looking at the
+    /// strip, and "Tab pinned" alone leaves them counting.
+    /// </summary>
+    [Fact]
+    public void PinAnnouncement_NamesTheTabAndTheDirection()
+    {
+        var tab = new TabModel(new FakePaneHost());
+        tab.ShellReportedTitle = "build.log";
+
+        Assert.Equal("Tab pinned, build.log", TabAccessibleText.PinAnnouncement(tab, pinned: true));
+        Assert.Equal("Tab unpinned, build.log", TabAccessibleText.PinAnnouncement(tab, pinned: false));
     }
 
     /// <summary>
@@ -105,7 +154,7 @@ public class TabAccessibleTextTests
     [Fact]
     public void AcknowledgedBell_ClearsTheStatus()
     {
-        var status = TabAccessibleText.Status(bellRinging: false);
+        var status = TabAccessibleText.Status(isPinned: false, bellRinging: false);
         Assert.NotNull(status);
         Assert.Equal(string.Empty, status);
     }

--- a/windows/Ghostty.Tests/Tabs/TabManagerPinGroupTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabManagerPinGroupTests.cs
@@ -165,6 +165,90 @@ public class TabManagerPinGroupTests
         Assert.Equal(1, mgr.PinCount);
     }
 
+    // --- The drag layer's zone-crossing commit: SetPinned + Move, one call site ---
+    //
+    // A drag that carries a row across the pin boundary cannot commit with
+    // Move alone (the clamps above are exactly why), so the caller pairs
+    // SetPinned with Move. These pin the pairing's observable contract:
+    // the drop lands at the crossing's slot, never at the zone boundary
+    // SetPinned relocates to.
+
+    [Fact]
+    public void Crossing_up_pins_and_lands_at_the_crossing_slot()
+    {
+        var mgr = NewManager(3); // [A, B, C, D]
+        NameTabs(mgr);
+        mgr.SetPinned(mgr.Tabs[0], true);
+        mgr.SetPinned(mgr.Tabs[1], true); // prefix = A, B
+        var c = mgr.Tabs[2];
+
+        // C dragged up to slot 1: pin first (relocates to the prefix end,
+        // slot 2), then move into the slot the crossing asked for.
+        mgr.SetPinned(c, true);
+        mgr.Move(mgr.IndexOf(c), 1);
+
+        Assert.True(c.IsPinned);
+        Assert.Equal(3, mgr.PinCount);
+        Assert.Equal(new[] { "A", "C", "B", "D" }, Titles(mgr));
+    }
+
+    [Fact]
+    public void Crossing_down_unpins_and_lands_at_the_crossing_slot()
+    {
+        var mgr = NewManager(2); // [A, B, C]
+        NameTabs(mgr);
+        mgr.SetPinned(mgr.Tabs[0], true); // prefix = A
+        var a = mgr.Tabs[0];
+
+        // A dragged down to slot 2: unpin first (relocates to the first
+        // unpinned slot, which is slot 1 here), then move to the slot.
+        mgr.SetPinned(a, false);
+        mgr.Move(mgr.IndexOf(a), 2);
+
+        Assert.False(a.IsPinned);
+        Assert.Equal(0, mgr.PinCount);
+        Assert.Equal(new[] { "B", "C", "A" }, Titles(mgr));
+    }
+
+    [Fact]
+    public void Unpinning_to_the_boundary_crossing_relocates_then_lands()
+    {
+        var mgr = NewManager(3); // [A, B, C, D]
+        NameTabs(mgr);
+        mgr.SetPinned(mgr.Tabs[0], true);
+        mgr.SetPinned(mgr.Tabs[1], true); // prefix = A, B
+        var a = mgr.Tabs[0];
+        int moved = 0;
+        mgr.TabMoved += (_, _) => moved++;
+
+        // Crossing slot == PinCount is the first unpinned slot in the
+        // pre-commit frame. The unpin relocates A to the boundary (slot 1
+        // in the new frame), and the paired Move carries it the rest of
+        // the way to the crossing's slot.
+        mgr.SetPinned(a, false);
+        mgr.Move(mgr.IndexOf(a), 2);
+
+        Assert.False(a.IsPinned);
+        Assert.Equal(1, mgr.PinCount);
+        Assert.Equal(new[] { "B", "C", "A", "D" }, Titles(mgr));
+        Assert.Equal(2, moved); // the relocation, then the placement
+    }
+
+    private static void NameTabs(TabManager mgr)
+    {
+        string[] names = ["A", "B", "C", "D", "E", "F", "G", "H"];
+        for (int i = 0; i < mgr.Tabs.Count && i < names.Length; i++)
+            Title(mgr.Tabs[i], names[i]);
+    }
+
+    private static string[] Titles(TabManager mgr)
+    {
+        var titles = new string[mgr.Tabs.Count];
+        for (int i = 0; i < mgr.Tabs.Count; i++)
+            titles[i] = mgr.Tabs[i].EffectiveTitle;
+        return titles;
+    }
+
     // --- Group contiguity ---
 
     [Fact]

--- a/windows/Ghostty.Tests/Tabs/TabPinBoundaryTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabPinBoundaryTests.cs
@@ -1,0 +1,101 @@
+using System;
+using Ghostty.Core.Tabs;
+using Xunit;
+
+namespace Ghostty.Tests.Tabs;
+
+/// <summary>
+/// The pinned prefix is a slot range to the drag machine, so the only new
+/// decision a pinned-zone drag makes is what one crossing MEANS: stay in
+/// the zone, or carry the row across the boundary. That decision is pure
+/// arithmetic over (pinned, PinCount, rowCount, slot), so it lives in Core
+/// next to the machine and the whole boundary grammar is pinned here.
+/// The strip's job afterwards is mechanical: SetPinned then Move, read
+/// the truth back.
+/// </summary>
+public class TabPinBoundaryTests
+{
+    [Fact]
+    public void A_crossing_inside_one_zone_is_not_a_zone_change()
+    {
+        // [P, P, U, U]: pinned moves within the prefix...
+        Assert.Equal(TabPinZoneOp.None,
+            TabPinBoundary.Classify(draggedIsPinned: true, pinCount: 2, rowCount: 4, to: 1).Op);
+        // ...and unpinned moves within the rest.
+        Assert.Equal(TabPinZoneOp.None,
+            TabPinBoundary.Classify(draggedIsPinned: false, pinCount: 2, rowCount: 4, to: 3).Op);
+    }
+
+    [Fact]
+    public void An_unpinned_row_crossing_up_pins()
+    {
+        var crossing = TabPinBoundary.Classify(
+            draggedIsPinned: false, pinCount: 2, rowCount: 4, to: 1);
+        Assert.Equal(TabPinZoneOp.Pin, crossing.Op);
+        Assert.Equal(1, crossing.To);
+    }
+
+    [Fact]
+    public void A_pinned_row_crossing_down_unpins()
+    {
+        var crossing = TabPinBoundary.Classify(
+            draggedIsPinned: true, pinCount: 2, rowCount: 4, to: 2);
+        Assert.Equal(TabPinZoneOp.Unpin, crossing.Op);
+        Assert.Equal(2, crossing.To);
+    }
+
+    [Fact]
+    public void The_first_unpinned_slot_is_outside_the_zone()
+    {
+        // to == PinCount is the first unpinned slot: not a pin. This is
+        // the off-by-one that would pin on a harmless nudge if flipped.
+        Assert.Equal(TabPinZoneOp.None,
+            TabPinBoundary.Classify(draggedIsPinned: false, pinCount: 2, rowCount: 4, to: 2).Op);
+    }
+
+    [Fact]
+    public void The_last_pinned_slot_is_inside_the_zone()
+    {
+        Assert.Equal(TabPinZoneOp.Pin,
+            TabPinBoundary.Classify(draggedIsPinned: false, pinCount: 2, rowCount: 4, to: 1).Op);
+    }
+
+    [Fact]
+    public void With_no_pins_nothing_can_cross()
+    {
+        Assert.Equal(TabPinZoneOp.None,
+            TabPinBoundary.Classify(draggedIsPinned: false, pinCount: 0, rowCount: 3, to: 0).Op);
+    }
+
+    [Fact]
+    public void With_all_rows_pinned_there_is_no_way_out()
+    {
+        // Every slot is inside the prefix, so no crossing an all-pinned
+        // window can produce reads as an unpin -- the row has nowhere to
+        // go, which is the manager's own clamp expressed as a class.
+        for (int to = 0; to < 3; to++)
+            Assert.Equal(TabPinZoneOp.None,
+                TabPinBoundary.Classify(draggedIsPinned: true, pinCount: 3, rowCount: 3, to).Op);
+    }
+
+    [Fact]
+    public void An_out_of_range_slot_is_never_promoted_to_a_zone_change()
+    {
+        // The machine never emits one, and a malformed slot must not
+        // become a pin toggle: None sends it to Move, which refuses, and
+        // the strip's read-back catches the refusal.
+        Assert.Equal(TabPinZoneOp.None,
+            TabPinBoundary.Classify(draggedIsPinned: false, pinCount: 2, rowCount: 4, to: -1).Op);
+        Assert.Equal(TabPinZoneOp.None,
+            TabPinBoundary.Classify(draggedIsPinned: true, pinCount: 2, rowCount: 4, to: 4).Op);
+    }
+
+    [Fact]
+    public void PinCount_outside_the_row_span_is_corrupt_state()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            TabPinBoundary.Classify(draggedIsPinned: false, pinCount: -1, rowCount: 4, to: 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            TabPinBoundary.Classify(draggedIsPinned: false, pinCount: 5, rowCount: 4, to: 0));
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/TabPinZoneWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabPinZoneWiringTests.cs
@@ -1,0 +1,265 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// The pinned zone rides the PR 3 drag machine unchanged: the boundary is
+/// index arithmetic in front of the commit, and everything the machine
+/// already guarantees (arranged centers, velocity before the terminal
+/// transition, the refused-crossing read-back) carries over. What is new
+/// here is the one thing a wiring guard can actually see: a zone crossing
+/// commits as SetPinned plus Move, in that order, with the truth read
+/// back afterwards -- and a cancel puts the FLAGS back before it puts the
+/// ORDER back, because the order is only expressible with the flags set.
+///
+/// Wiring guards, not behaviour tests: the boundary grammar's decisions
+/// are pinned in TabPinBoundaryTests and the pairing in
+/// TabManagerPinGroupTests. Whether the strip lands the row on the right
+/// pixel is only observable on a live drag.
+/// </summary>
+public class TabPinZoneWiringTests
+{
+    private static ShellSource Strip() => ShellSource.Load("Tabs.VerticalTabStrip.xaml.cs");
+
+    /// <summary>
+    /// The commit classifies the crossing first, pins (or unpins) before
+    /// it moves, and re-reads the row's index in between: SetPinned
+    /// relocates the row, so a Move fired with the pre-pin index would
+    /// land the row a slot off -- or get clamped into the zone it just
+    /// left, which the refused-crossing break then turns into a dropped
+    /// crossing for the rest of the gesture.
+    /// </summary>
+    [Fact]
+    public void ZoneCrossing_CommitsAsSetPinnedThenMove_WithTheIndexReRead()
+    {
+        var commit = Strip().Method("EvaluateDrag");
+
+        var setPinned = commit.Calls("_manager.SetPinned").Single();
+        var move = commit.Calls("_manager.Move").Single();
+        Assert.True(
+            setPinned.Span.Start < move.Span.Start,
+            "the zone crossing must SetPinned before Move: Move clamps into the "
+            + "row's CURRENT zone, so moving first commits nothing");
+
+        // The relocation changed where the row sits; the placement has to
+        // start from where it actually ended up.
+        Assert.True(
+            commit.Calls("_manager.IndexOf").Any(
+                call => call.Span.Start > setPinned.Span.Start
+                        && call.Span.End < move.Span.Start),
+            "the row's index must be re-read between SetPinned and Move");
+
+        // The flag's polarity is the crossing's direction. The argument
+        // alone is only a variable name, so the initializer is what
+        // actually goes red when the comparison inverts -- SetPinned(false)
+        // on a crossing up would unpin the row mid-gesture.
+        Assert.Equal("pin", setPinned.Arg(1));
+        var flag = commit.DescendantNodes().OfType<LocalDeclarationStatementSyntax>()
+            .Single(l => l.Declaration.Variables.Any(v => v.Identifier.ValueText == "pin"));
+        Assert.Equal(
+            "zone.Op == TabPinZoneOp.Pin",
+            flag.Declaration.Variables.Single().Initializer!.Value.ToString());
+
+        // The zone commit repaints the boundary in the same tick: the
+        // stroke is the gesture's aiming feedback and it just moved.
+        // Painting it through UpdateSelectionRow or UpdateRowSeparators
+        // alike, the pass has to follow the Move.
+        var repaint = commit.Calls("UpdateRowSeparators").Single();
+        Assert.True(
+            repaint.Span.Start > move.Span.Start,
+            "the boundary must be repainted after the zone commit lands");
+    }
+
+    /// <summary>
+    /// The refused-crossing contract 3b landed applies to zone crossings
+    /// too: a clamp that swallowed the placement updates the machine and
+    /// BREAKS. A `continue` here would re-fire the identical refused
+    /// crossing forever, because Evaluate is pure per tick.
+    /// </summary>
+    [Fact]
+    public void ARefusedCrossing_BreaksTheCommitLoop()
+    {
+        var refuse = Strip().Method("EvaluateDrag").DescendantNodes()
+            .OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "actual != crossing.To");
+
+        Assert.True(
+            refuse.Statement.DescendantNodesAndSelf().OfType<BreakStatementSyntax>().Any(),
+            "the refused crossing must break out of the commit loop");
+        Assert.True(
+            !refuse.Statement.DescendantNodesAndSelf().OfType<ContinueStatementSyntax>().Any(),
+            "a refused crossing that continues re-fires itself forever: Evaluate "
+            + "is pure per tick, so nothing will have changed by the next pass");
+    }
+
+    /// <summary>
+    /// A cancel that survived a mid-drag pin must restore the pin FLAGS
+    /// before replaying the pre-drag order: Move clamps against the
+    /// boundary the flags define, so order-first leaves the row stranded
+    /// on the wrong side and the replay diverges from the state it is
+    /// restoring.
+    /// </summary>
+    [Fact]
+    public void Cancel_RestoresPinFlags_BeforeReplayingTheOrder()
+    {
+        var cancel = Strip().Method("CancelDrag");
+
+        var restore = cancel.Calls("_manager.SetPinned").Single();
+        var diff = cancel.Calls("TabStripProjection.Diff").Single();
+        Assert.True(
+            restore.Span.Start < diff.Span.Start,
+            "flags must come home before the order diff is computed: SetPinned "
+            + "relocates, so the diff has to run against the state the flags leave");
+
+        // And they come home as they left: restoring the complement hands
+        // every row the opposite flag and the replay diverges from the
+        // state it is restoring.
+        Assert.Equal("wasPinned", restore.Arg(1));
+    }
+
+    /// <summary>
+    /// The zone edge is the manager's PinCount, read at paint time, not a
+    /// count the strip caches: the boundary has to move the moment the
+    /// prefix does, and a cached count is the one thing that would not.
+    /// The stroke itself comes from the boundary brush, which is what
+    /// brightens while a drag is live.
+    /// </summary>
+    [Fact]
+    public void TheBoundaryStroke_IsPlacedFromTheManagersPinCount()
+    {
+        var separators = Strip().Method("UpdateRowSeparators");
+
+        Assert.True(
+            separators.DescendantNodes().OfType<MemberAccessExpressionSyntax>().Any(
+                m => m.Expression.ToString() == "_manager"
+                     && m.Name.Identifier.ValueText == "PinCount"),
+            "the boundary index must come from the manager's PinCount");
+        Assert.Single(separators.Calls("BoundaryStrokeBrush"));
+
+        // The zone edge takes the accent and the ordinary gaps take the
+        // row brush; swapping them paints the boundary grey and every
+        // divider in accent.
+        var fill = separators.DescendantNodes().OfType<EqualsValueClauseSyntax>()
+            .Single(v => v.Value.ToString().Contains("BoundaryStrokeBrush"));
+        Assert.Equal(
+            "boundary ? BoundaryStrokeBrush() : _rowSeparatorBrush",
+            fill.Value.ToString());
+
+        // The boundary gap never skips: the zone edge stays visible even
+        // when the active row sits on it.
+        var boundaryIf = separators.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "boundary");
+        Assert.True(
+            !boundaryIf.Statement.DescendantNodesAndSelf()
+                .OfType<ContinueStatementSyntax>().Any(),
+            "the boundary gap must not skip");
+
+        // The brightening is the gesture's aiming feedback, so its
+        // polarity is load-bearing: dim while idle, bright while a drag
+        // is live. Inverting it darkens the boundary exactly when the
+        // gesture needs it.
+        var brush = Strip().Method("BoundaryStrokeBrush");
+        var alpha = brush.DescendantNodes().OfType<LocalDeclarationStatementSyntax>()
+            .Single(l => l.Declaration.Variables.Any(v => v.Identifier.ValueText == "alpha"));
+        Assert.Equal(
+            "_drag is null ? (byte)0x59 : (byte)0xE6",
+            alpha.Declaration.Variables.Single().Initializer!.Value.ToString());
+    }
+
+    /// <summary>
+    /// Pointer drags announce nothing (5.6): the user is watching the row
+    /// cross. The strip watches SetPinned happen all day and never speaks;
+    /// the announcement hangs off the router, which is what makes a pin a
+    /// commanded one (palette, chord, or context menu).
+    /// </summary>
+    [Fact]
+    public void TheStrip_NeverAnnounces_AndTheWindowAnnouncesCommandedPins()
+    {
+        Assert.Empty(Strip().Root.Calls("UiaAnnouncer.Announce"));
+
+        var window = ShellSource.Load("MainWindow.xaml.cs");
+        var subscription = window.Root.DescendantNodes()
+            .OfType<AssignmentExpressionSyntax>()
+            .Single(a => a.Left.ToString() == "_router.TabPinChangedFromCommand");
+
+        Assert.NotEmpty(subscription.Right.Calls("UiaAnnouncer.Announce"));
+    }
+
+    /// <summary>
+    /// The menu item toggles, and its label is re-evaluated on every open:
+    /// a flyout built while the tab was unpinned can be opened after a
+    /// drag pinned it, and a stale "Pin Tab" that pins a pinned tab is a
+    /// command that lies. The click's polarity is the toggle itself.
+    /// </summary>
+    [Fact]
+    public void ThePinMenuItem_Toggles_AndRelabelsOnOpen()
+    {
+        var build = ShellSource.Load("Tabs.TabContextMenuBuilder.cs").Method("Build");
+
+        var click = build.Calls("requestPin").Single();
+        Assert.Equal("!tab.IsPinned", click.Arg(1));
+
+        // The build-time label sits in the item's initializer as a bare
+        // `Text = ...`; the re-evaluation is the one that names the item.
+        var relabels = build.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.Left.ToString() == "pin.Text")
+            .ToList();
+        Assert.True(
+            relabels.Count == 1,
+            $"expected exactly one relabel of the built item, found {relabels.Count}");
+        Assert.True(
+            relabels[0].Ancestors().OfType<AssignmentExpressionSyntax>()
+                .Any(a => a.Left.ToString() == "flyout.Opening"),
+            "the relabel must live in the Opening handler, not only at build time");
+    }
+
+    /// <summary>
+    /// Sort Pinned joins the strip menu only while two pins exist to
+    /// order; the manager no-ops below that, and an item that offers a
+    /// no-op is chrome pretending to be a command.
+    /// </summary>
+    [Fact]
+    public void SortPinned_IsOfferedOnlyWhileTwoPinsExist()
+    {
+        var build = ShellSource.Load("Tabs.StripContextMenuBuilder.cs").Method("Build");
+
+        var gate = build.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "manager.PinCount > 1");
+        Assert.Single(gate.Calls("manager.SortPinned"));
+    }
+
+    /// <summary>
+    /// The case's job is the polarity; RequestPin's is the op and the
+    /// event. The manager op is shared with the drag, the announcement is
+    /// not, and the event is what carries that distinction to the window.
+    /// </summary>
+    [Fact]
+    public void TheRouter_CommandsThePin_ThenRaisesTheCommandSourceEvent()
+    {
+        var source = ShellSource.Load("Input.PaneActionRouter.cs");
+
+        // PinTab asks for pinned and UnpinTab for unpinned. Inverting the
+        // comparison turns the palette's "Pin Tab" into an unpin while the
+        // label still promises a pin.
+        var section = source.Case("Invoke", "PaneAction.PinTab");
+        Assert.Equal(
+            "action == PaneAction.PinTab",
+            section.Calls("RequestPin").Single().Arg(1));
+
+        var pin = source.Method("RequestPin");
+        var setPinned = pin.Calls("_tabs.SetPinned").Single();
+        var raised = pin.Calls("TabPinChangedFromCommand?.Invoke").Single();
+        Assert.True(
+            setPinned.Span.Start < raised.Span.Start,
+            "the event reports the state the tab was left in, so it must fire "
+            + "after the manager op");
+
+        // A command naming the state the tab already has did nothing, and
+        // announcing it would narrate a change that never happened.
+        Assert.Single(pin.DescendantNodes().OfType<IfStatementSyntax>()
+            .Where(i => i.Condition.ToString() == "tab.IsPinned == pin"));
+    }
+}

--- a/windows/Ghostty/Commands/BuiltInCommandSource.cs
+++ b/windows/Ghostty/Commands/BuiltInCommandSource.cs
@@ -65,6 +65,8 @@ internal sealed class BuiltInCommandSource : ICommandSource
         AddPaneCommand(commands, PaneAction.ResizeSplitRight, "Resize Split Right", "Move the nearest vertical split divider right", CommandCategory.Pane);
         AddPaneCommand(commands, PaneAction.MoveTabRight, "Move Tab Right", "Move the active tab one position right", CommandCategory.Tab);
         AddPaneCommand(commands, PaneAction.MoveTabLeft, "Move Tab Left", "Move the active tab one position left", CommandCategory.Tab);
+        AddPaneCommand(commands, PaneAction.PinTab, "Pin Tab", "Pin the active tab into the pinned zone", CommandCategory.Tab, "\uE718");
+        AddPaneCommand(commands, PaneAction.UnpinTab, "Unpin Tab", "Unpin the active tab from the pinned zone", CommandCategory.Tab, "\uE77A");
         AddPaneCommand(commands, PaneAction.ToggleVerticalTabsPinned, "Toggle Vertical Tabs Pinned", "Pin or unpin the vertical tab sidebar", CommandCategory.Tab);
         AddTabLayoutSwitchCommand(commands);
         AddPaneCommand(commands, PaneAction.ToggleQuickTerminal, "Toggle Quake Terminal", "Show or hide the singleton drop-down terminal", CommandCategory.Terminal, icon: null, pathKey: "quake");

--- a/windows/Ghostty/Input/PaneActionRouter.cs
+++ b/windows/Ghostty/Input/PaneActionRouter.cs
@@ -166,6 +166,18 @@ internal sealed class PaneActionRouter
     /// </summary>
     public event EventHandler? ShowTabOverviewRequested;
 
+    /// <summary>
+    /// Raised after a commanded pin/unpin has landed on the manager --
+    /// palette entry, chord, or the per-tab context menu, all of which
+    /// dispatch through <see cref="RequestPin"/>. The bool is the state
+    /// the tab was left in. MainWindow listens to raise the UIA
+    /// announcement from a window-owned element: pointer drags cross the
+    /// same boundary through <see cref="TabManager.SetPinned"/> and raise
+    /// nothing, so the source has to be the dispatch path, not the state
+    /// change.
+    /// </summary>
+    public event EventHandler<(TabModel Tab, bool Pinned)>? TabPinChangedFromCommand;
+
     public void Invoke(PaneAction action)
     {
         // Event-only actions that don't need pane/tab state — handle
@@ -315,6 +327,14 @@ internal sealed class PaneActionRouter
                 if (i > 0) _tabs.Move(i, i - 1);
                 break;
             }
+            case PaneAction.PinTab:
+            case PaneAction.UnpinTab:
+            {
+                var tab = _tabs.ActiveTab;
+                if (tab is not null)
+                    RequestPin(tab, action == PaneAction.PinTab);
+                break;
+            }
             default:
                 throw new ArgumentOutOfRangeException(nameof(action), action, null);
         }
@@ -327,6 +347,25 @@ internal sealed class PaneActionRouter
     /// </summary>
     public void RequestToggleTabLayout()
         => ToggleTabLayoutRequested?.Invoke(this, EventArgs.Empty);
+
+    /// <summary>
+    /// One pin, one implementation: the manager op plus the event that
+    /// tells the window to announce it. Invoke's PinTab/UnpinTab land
+    /// here, and so does the per-tab context menu, whose pin targets the
+    /// right-clicked tab rather than the active one. Pointer drags cross
+    /// the same boundary through <see cref="TabManager.SetPinned"/>
+    /// directly and announce nothing (5.6), so the source is the dispatch
+    /// path, not the state change.
+    /// </summary>
+    public void RequestPin(TabModel tab, bool pin)
+    {
+        if (_tabs.IndexOf(tab) < 0) return;
+        // A command naming the state the tab already has did nothing;
+        // announcing it would narrate a change that never happened.
+        if (tab.IsPinned == pin) return;
+        _tabs.SetPinned(tab, pin);
+        TabPinChangedFromCommand?.Invoke(this, (tab, pin));
+    }
 
     /// <summary>
     /// Public dispatch entry for the sidebar collapse toggle. Reuses

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -845,6 +845,17 @@ public sealed partial class MainWindow : Window
             _tabManager,
             (tab, text) => UiaAnnouncer.Announce(BellAnnouncementSource(tab), text, "tab-bell"));
 
+        // Commanded pins (palette, chord, context menu) announce; pointer
+        // drags do not. The router is what makes a pin commanded, so the
+        // announcement hangs off the router event rather than off the
+        // manager state -- SetPinned fires for every source and cannot
+        // tell them apart.
+        _router.TabPinChangedFromCommand += (_, e) =>
+            UiaAnnouncer.Announce(
+                BellAnnouncementSource(e.Tab),
+                TabAccessibleText.PinAnnouncement(e.Tab, e.Pinned),
+                "tab-pin");
+
         AppWindow.Changed += (_, args) =>
         {
             // Cheap insurance rather than a known crash: no case has been

--- a/windows/Ghostty/Tabs/StripContextMenuBuilder.cs
+++ b/windows/Ghostty/Tabs/StripContextMenuBuilder.cs
@@ -33,6 +33,18 @@ internal static class StripContextMenuBuilder
 
         flyout.Items.Add(new MenuFlyoutSeparator());
 
+        // Only meaningful once two pins exist to order (the manager
+        // no-ops below that), and the item is rebuilt on every open, so
+        // unpinning down to one pin takes the item with it rather than
+        // offering a dead command.
+        if (manager.PinCount > 1)
+        {
+            var sortPinned = new MenuFlyoutItem { Text = "Sort Pinned Tabs" };
+            sortPinned.Click += (_, _) => manager.SortPinned();
+            flyout.Items.Add(sortPinned);
+            flyout.Items.Add(new MenuFlyoutSeparator());
+        }
+
         // Label flips to match the destination state so users see
         // where they will end up. The per-tab menu (TabContextMenuBuilder)
         // offers the same switch because a filled tab bar has no empty

--- a/windows/Ghostty/Tabs/TabContextMenuBuilder.cs
+++ b/windows/Ghostty/Tabs/TabContextMenuBuilder.cs
@@ -32,6 +32,7 @@ internal static class TabContextMenuBuilder
         Action<TabModel> requestDetachToNewWindow,
         DialogTracker dialogs,
         Action toggleTabLayout,
+        Action<TabModel, bool> requestPin,
         bool isVertical = false,
         Func<SnapZoneSource>? getSnapSource = null,
         Action<TabModel, SnapZone>? detachWithZone = null)
@@ -71,6 +72,19 @@ internal static class TabContextMenuBuilder
             }
         };
         flyout.Items.Add(rename);
+
+        // One implementation for both hosts: the label is the only thing
+        // that flips here. The pin itself routes through the caller's hook
+        // (the router's RequestPin) so a menu pin announces exactly like a
+        // palette one; the relocation it triggers is still the manager's
+        // (SetPinned moves the tab to the zone boundary), so the strips
+        // pick it up through their normal sync paths.
+        var pin = new MenuFlyoutItem
+        {
+            Text = tab.IsPinned ? "Unpin Tab" : "Pin Tab",
+        };
+        pin.Click += (_, _) => requestPin(tab, !tab.IsPinned);
+        flyout.Items.Add(pin);
 
         var dup = new MenuFlyoutItem { Text = "Duplicate Tab" };
         dup.Click += (_, _) => manager.NewTab();
@@ -120,11 +134,15 @@ internal static class TabContextMenuBuilder
         // Re-evaluate IsEnabled on each open so tabs closed after
         // the flyout was built (but before the user right-clicked)
         // are reflected in the grey state. Matches Windows Terminal.
+        // The pin item's LABEL rides the same pass: a flyout can be
+        // built while the tab is unpinned and opened after a drag
+        // pinned it, and a stale "Pin Tab" that unpins would lie.
         flyout.Opening += (_, _) =>
         {
             detach.IsEnabled = manager.Tabs.Count > 1;
             if (moveToZone is not null)
                 moveToZone.IsEnabled = manager.Tabs.Count > 1;
+            pin.Text = tab.IsPinned ? "Unpin Tab" : "Pin Tab";
         };
 
         flyout.Items.Add(new MenuFlyoutSeparator());

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -187,6 +187,7 @@ internal sealed partial class TabHost : UserControl, ITabHost
                 requestDetachToNewWindow: RequestDetachToNewWindow,
                 _dialogs,
                 toggleTabLayout: () => _router.RequestToggleTabLayout(),
+                requestPin: _router.RequestPin,
                 getSnapSource: GetSnapSource,
                 detachWithZone: DetachWithZone),
             DataContext = tab,
@@ -220,6 +221,16 @@ internal sealed partial class TabHost : UserControl, ITabHost
                 bellGlyph.Visibility = tab.BellRinging
                     ? Visibility.Visible
                     : Visibility.Collapsed;
+                ApplyItemAccessibleText(item, tab);
+            }
+            else if (e.PropertyName == nameof(TabModel.IsPinned))
+            {
+                // "Pinned" rides ItemStatus, and the flag change is the
+                // only event that always carries it: SetPinned relocates
+                // to the zone boundary and skips TabMoved when from == to
+                // (the boundary tab pinning up, the last pinned tab
+                // unpinning), so a relocation-path refresh alone would
+                // leave the boundary tab's status stale for life.
                 ApplyItemAccessibleText(item, tab);
             }
         };

--- a/windows/Ghostty/Tabs/VerticalTabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabHost.xaml.cs
@@ -205,6 +205,7 @@ internal sealed partial class VerticalTabHost : UserControl, ITabHost
                 requestDetachToNewWindow: t => TabWindowActions.DetachToNewWindow(XamlRoot, t),
                 _dialogs,
                 toggleTabLayout: () => _router.RequestToggleTabLayout(),
+                requestPin: _router.RequestPin,
                 isVertical: true,
                 getSnapSource: () => TabWindowActions.GetSnapSource(XamlRoot),
                 detachWithZone: (t, z) => TabWindowActions.DetachWithZone(XamlRoot, t, z));

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -508,10 +508,39 @@ internal sealed partial class VerticalTabStrip : UserControl
     }
 
     /// <summary>
+    /// Height of the pin-boundary stroke. The zone edge is a statement
+    /// about the list, not a divider between equals, so it is twice an
+    /// ordinary row line and never skippers.
+    /// </summary>
+    private const double BoundaryStrokeHeight = 2;
+
+    /// <summary>
+    /// The pin boundary's stroke. Dimmed while idle; brightened while a
+    /// drag is live -- the boundary is the thing a drag-to-pin is aiming
+    /// at, and the brightening is the gesture's aiming feedback. Resolved
+    /// from the strip accent (a theme resource) on every placement, so
+    /// High Contrast re-themes it the way every other accent use here
+    /// does; a fresh brush per call because AccentBrush is the shared
+    /// resource instance and mutating its alpha would retint the panel.
+    /// </summary>
+    private Brush BoundaryStrokeBrush()
+    {
+        var accent = AccentBrush.Color;
+        byte alpha = _drag is null ? (byte)0x59 : (byte)0xE6;
+        return new SolidColorBrush(Color.FromArgb(alpha, accent.R, accent.G, accent.B));
+    }
+
+    /// <summary>
     /// One line in each gap between rows, skipping both gaps that touch the
     /// selected row: those two edges are already drawn, in the accent, by the
     /// selected row's own top and bottom stroke. Drawing them again puts two
     /// lines a pixel apart.
+    ///
+    /// The gap after the last pinned row never skips and never takes the
+    /// row-separator brush: it is the pin zone's edge, drawn in the accent
+    /// at double height, and it is the only boundary the strip shows for
+    /// the zone (spec 5.1's section header and fixed panel are not built
+    /// here). It exists only while both zones do.
     ///
     /// Rebuilt rather than kept in sync per item, because the thing being
     /// mirrored is MUXC's arranged layout, and the only honest read of that
@@ -526,20 +555,32 @@ internal sealed partial class VerticalTabStrip : UserControl
         // back by another door.
         var used = 0;
 
-        if (_rowSeparatorBrush is null || ActualWidth <= 0)
+        if (ActualWidth <= 0)
         {
             HideSeparatorsFrom(0);
             return;
         }
 
+        // The boundary lives in the gap after the last pinned row, which
+        // is only a real gap while an unpinned tab exists below it.
+        var boundaryIndex = _manager.PinCount - 1;
+        var hasBoundary = boundaryIndex >= 0 && boundaryIndex + 1 < _manager.Tabs.Count;
+
         var tabs = _manager.Tabs;
         for (var i = 0; i + 1 < tabs.Count; i++)
         {
+            var boundary = hasBoundary && i == boundaryIndex;
+            if (boundary)
+            {
+                // The boundary marks the zone, not the row under it: it
+                // never skips, so the edge stays visible when the active
+                // row sits on it.
+            }
             // Only skip the gaps the selected row is actually covering. The
             // row is collapsed during a layout morph and on MUXC's first
             // frame, and skipping on those passes left two gaps with nothing
             // drawing them and nothing hiding them either.
-            if (selectionRowVisible)
+            else if (selectionRowVisible)
             {
                 if (ReferenceEquals(tabs[i], _manager.ActiveTab)) continue;
                 if (ReferenceEquals(tabs[i + 1], _manager.ActiveTab)) continue;
@@ -561,6 +602,12 @@ internal sealed partial class VerticalTabStrip : UserControl
                 continue;
             }
 
+            // A null row-separator brush means this theme separates by
+            // shade and wants no lines; the boundary still draws, because
+            // it is the zone's edge and drag-to-pin needs it visible.
+            Brush? fill = boundary ? BoundaryStrokeBrush() : _rowSeparatorBrush;
+            if (fill is null) continue;
+
             Border line;
             if (used < _rowSeparators.Count)
             {
@@ -576,10 +623,11 @@ internal sealed partial class VerticalTabStrip : UserControl
             }
 
             line.Width = Math.Max(0, ActualWidth - RowInsetLeft);
-            line.Background = _rowSeparatorBrush;
+            line.Height = boundary ? BoundaryStrokeHeight : 1;
+            line.Background = fill;
             line.Visibility = Visibility.Visible;
             Canvas.SetLeft(line, RowInsetLeft);
-            Canvas.SetTop(line, bottom - RowInsetVertical);
+            Canvas.SetTop(line, bottom - RowInsetVertical - (boundary ? 1 : 0));
             used++;
         }
 
@@ -1349,6 +1397,11 @@ internal sealed partial class VerticalTabStrip : UserControl
         public required TabModel Tab;
         public required TabDragReorder Machine;
         public required IReadOnlyList<TabModel> PreDragOrder;
+        // Pin flags at gesture start. A cancel restores them before the
+        // order replay: the pre-drag order is only expressible with the
+        // pre-drag flags set, because Move clamps against the boundary
+        // the flags define.
+        public required IReadOnlySet<TabModel> PreDragPinned;
         public required uint PointerId;
         public double PressY;
         public double PressBaseCenter;
@@ -1423,6 +1476,8 @@ internal sealed partial class VerticalTabStrip : UserControl
             Tab = tab,
             Machine = machine,
             PreDragOrder = TabStripProjection.Rows(_manager),
+            PreDragPinned = new HashSet<TabModel>(
+                _manager.Tabs.Where(t => t.IsPinned)),
             PointerId = e.Pointer.PointerId,
             LastPointerY = point.Position.Y,
             PressY = point.Position.Y,
@@ -1543,7 +1598,14 @@ internal sealed partial class VerticalTabStrip : UserControl
             return;
         }
 
-        if (drag.HidesSelectionRow) UpdateSelectionRow();
+        if (drag.HidesSelectionRow)
+            UpdateSelectionRow();
+        else
+            // The boundary stroke brightens for the length of the gesture
+            // regardless of which row is lifted; the active-row case got
+            // its refresh above. Placement of the selection row itself
+            // stays frozen mid-drag (UpdateSelectionRow's guard).
+            UpdateRowSeparators(selectionRowVisible: true);
         StartAutoscroll(drag);
         DragTrace($"DRAG begin index={drag.Machine.Index} " +
             $"rows={_manager.Tabs.Count} motion={(drag.MotionOn ? "on" : "off")}");
@@ -1891,9 +1953,38 @@ internal sealed partial class VerticalTabStrip : UserControl
         while (drag.Machine.Evaluate(draggedCenter) is { } crossing)
         {
             var from = _manager.IndexOf(drag.Tab);
+            // The pinned prefix is a slot range to the machine; a crossing
+            // that lands on the far side of it is a zone change Move alone
+            // would clamp away. SetPinned first relocates the row to the
+            // boundary (end of the prefix pinning down, first unpinned slot
+            // pinning up), and the Move then places it at the crossing's
+            // slot inside the new zone -- the drop position, not append-last.
+            var zone = TabPinBoundary.Classify(
+                drag.Tab.IsPinned, _manager.PinCount, _manager.Tabs.Count, crossing.To);
             _commitChurn = true;
-            try { _manager.Move(from, crossing.To); }
+            try
+            {
+                if (zone.Op != TabPinZoneOp.None)
+                {
+                    bool pin = zone.Op == TabPinZoneOp.Pin;
+                    _manager.SetPinned(drag.Tab, pin);
+                    DragTrace($"DRAG {(pin ? "pin" : "unpin")} {crossing.From}->{crossing.To}");
+                    from = _manager.IndexOf(drag.Tab);
+                    if (from < 0) { CancelDrag("closed"); return; }
+                }
+                _manager.Move(from, crossing.To);
+            }
             finally { _commitChurn = false; }
+            if (zone.Op != TabPinZoneOp.None)
+            {
+                // The boundary is the thing this gesture aims at, so the
+                // one commit that moves it repaints it now rather than
+                // leaving the stroke at its pre-crossing gap until the
+                // drag ends. Ordinary moves keep the deliberate mid-drag
+                // freeze: nothing about the boundary changed for them.
+                if (drag.HidesSelectionRow) UpdateSelectionRow();
+                else UpdateRowSeparators(selectionRowVisible: true);
+            }
             if (!_items.ContainsKey(drag.Tab)) { CancelDrag("closed"); return; }
 
             // Move clamps at the pin boundary and no-ops on collapse, so
@@ -1902,7 +1993,7 @@ internal sealed partial class VerticalTabStrip : UserControl
             // tick would re-cross it for the rest of the gesture. Tell
             // the machine where the row actually is, skip the rebind,
             // and break: re-evaluating now would re-fire the identical
-            // refused crossing. Pin-aware ordering itself is PR 4.
+            // refused crossing.
             var actual = _manager.IndexOf(drag.Tab);
             if (actual != crossing.To)
             {
@@ -2080,6 +2171,20 @@ internal sealed partial class VerticalTabStrip : UserControl
         EndDrag(drag, settle: false, velocity: 0);
         try
         {
+            // Flags come home before the order does. A mid-drag boundary
+            // crossing committed a SetPinned, and the pre-drag order is
+            // not expressible until the pre-drag flags are back: Move
+            // clamps against the boundary the flags define. Each restore
+            // is its own relocation, so the order diff below has to be
+            // computed against the state the flags leave behind.
+            foreach (var tab in TabStripProjection.Rows(_manager))
+            {
+                bool wasPinned = drag.PreDragPinned.Contains(tab);
+                if (tab.IsPinned == wasPinned) continue;
+                _commitChurn = true;
+                try { _manager.SetPinned(tab, wasPinned); }
+                finally { _commitChurn = false; }
+            }
             foreach (var op in TabStripProjection.Diff(
                 drag.PreDragOrder, TabStripProjection.Rows(_manager)))
             {


### PR DESCRIPTION
Pinned tabs become a working zone in the vertical strip, on top of the drag machinery from #806/#807.

- TabPinBoundary.Classify (pure) decides what a crossing means: pin, unpin, or move. Zone crossings commit as SetPinned -> read-back -> Move under the churn fence, with refused crossings re-indexed and traced like any other refused commit; CancelDrag restores pin flags before computing the order diff.
- Boundary stroke after the last pinned row: accent, double height, never skipped, brightens while a drag is live and repaints on zone commits so it tracks the aiming point.
- Entry points in both modes: tab context menu Pin/Unpin, strip menu Sort Pinned Tabs (PinCount > 1), palette commands - all routed through PaneActionRouter.RequestPin, the single implementation of op + announcement (no-op pins announce nothing). Pin/unpin updates AutomationProperties.ItemStatus even when SetPinned's relocation is silent (boundary tab).
- Keyboard/palette pins announce via TabPinChangedFromCommand; pointer drags stay silent.
- Vertical rendering only; horizontal pin rendering and the structural pinned panel are later ladder PRs.