### PR TITLE
tabs: Duplicate Tab duplicates the tab

### DIFF
--- a/windows/Ghostty.Core/Interop/GhosttyActions.cs
+++ b/windows/Ghostty.Core/Interop/GhosttyActions.cs
@@ -56,6 +56,9 @@ internal enum GhosttyActionTag
     // ordinal it displaced is visible rather than an unexplained gap.
     SetWindowTitle = 35,
     PromptTitle = 36,
+    // The shell reported its directory (OSC 7). Recorded on the pane so
+    // duplicate tab and restore respawn the shell where it actually was.
+    Pwd = 37,
     MouseShape = 38,
     MouseVisibility = 39,
     MouseOverLink = 40,

--- a/windows/Ghostty.Core/Panes/PaneNode.cs
+++ b/windows/Ghostty.Core/Panes/PaneNode.cs
@@ -22,6 +22,17 @@ internal sealed class LeafPane : PaneNode
     /// in a no-profiles-configured cold start.
     /// </summary>
     internal Ghostty.Core.Profiles.ProfileSnapshot? Snapshot { get; set; }
+
+    /// <summary>
+    /// The last directory this pane's shell reported (OSC 7, delivered
+    /// as the pwd action). Null until the shell reports one; a profile
+    /// with no shell integration never will. Session capture persists
+    /// it, and the resolver that rebuilds a pane spawns the replacement
+    /// shell here rather than at the profile's static working-directory
+    /// -- that substitution is what "same folder" means for duplicate
+    /// and restore. Nothing else reads it.
+    /// </summary>
+    public string? LastCwd { get; set; }
 }
 
 internal sealed class SplitPane : PaneNode

--- a/windows/Ghostty.Core/Session/SessionModel.cs
+++ b/windows/Ghostty.Core/Session/SessionModel.cs
@@ -96,6 +96,13 @@ internal sealed class LeafDto : PaneNodeDto
 
     /// <summary>Replayed verbatim if <see cref="ProfileId"/> no longer resolves.</summary>
     public LeafCommand? Fallback { get; set; }
+
+    /// <summary>
+    /// The pane's last-reported directory (OSC 7), or null when the shell
+    /// never reported one. The resolver spawns the rebuilt pane here in
+    /// preference to the profile's static working-directory.
+    /// </summary>
+    public string? Cwd { get; set; }
 }
 
 internal sealed class SplitDto : PaneNodeDto

--- a/windows/Ghostty.Core/Session/SessionProfileResolver.cs
+++ b/windows/Ghostty.Core/Session/SessionProfileResolver.cs
@@ -35,21 +35,33 @@ internal static class SessionProfileResolver
     /// <summary>
     /// Per-leaf resolution: the leaf's profile if it still exists, else the
     /// saved fallback command, else null (legacy no-profile leaf -- the host
-    /// spawns the default shell).
+    /// spawns the default shell). A leaf that reported its directory (OSC 7)
+    /// is spawned there in preference to any static working-directory: that
+    /// substitution is what "same folder" means for duplicate tab and for
+    /// restore.
     /// </summary>
     public static ProfileSnapshot? ResolveLeaf(IProfileRegistry? registry, LeafDto leaf)
     {
         var byId = ResolveById(registry, leaf.ProfileId);
-        if (byId is not null) return byId;
+        if (byId is not null) return SpawnAtReportedCwd(byId, leaf.Cwd);
         if (leaf.Fallback is { } fb)
-            return new ProfileSnapshot(
+            return SpawnAtReportedCwd(new ProfileSnapshot(
                 ProfileId: leaf.ProfileId ?? "",
                 Version: 0,
                 ResolvedCommand: fb.ResolvedCommand,
                 WorkingDirectory: fb.WorkingDirectory,
                 DisplayName: fb.DisplayName,
                 Icon: new IconSpec.BundledKey("default"),
-                Visuals: EffectiveVisualOverrides.Empty);
+                Visuals: EffectiveVisualOverrides.Empty), leaf.Cwd);
         return null;
     }
+
+    /// <summary>
+    /// The pane's last-reported directory outranks the profile's static
+    /// one. Null and empty both mean "never reported"; the surface config
+    /// treats an empty working-directory as unset, so an empty string must
+    /// not replace the profile's value either.
+    /// </summary>
+    private static ProfileSnapshot SpawnAtReportedCwd(ProfileSnapshot snap, string? cwd)
+        => string.IsNullOrEmpty(cwd) ? snap : snap with { WorkingDirectory = cwd };
 }

--- a/windows/Ghostty.Core/Session/SessionTree.cs
+++ b/windows/Ghostty.Core/Session/SessionTree.cs
@@ -33,6 +33,7 @@ internal static class SessionTree
                 return new LeafDto
                 {
                     ProfileId = snap?.ProfileId,
+                    Cwd = leaf.LastCwd,
                     Fallback = snap is null
                         ? null
                         : new LeafCommand

--- a/windows/Ghostty.Tests/Session/SessionProfileResolverTests.cs
+++ b/windows/Ghostty.Tests/Session/SessionProfileResolverTests.cs
@@ -122,4 +122,63 @@ public class SessionProfileResolverTests
     {
         Assert.Null(SessionProfileResolver.ResolveLeaf(new FakeProfileRegistry(), Leaf(null, null)));
     }
+
+    private static LeafDto LeafWithCwd(string? profileId, string? cwd) => new()
+    {
+        ProfileId = profileId,
+        Cwd = cwd,
+    };
+
+    private static ResolvedProfile ProfileWithDirectory(string id) =>
+        new(id, id, $"{id}.exe", WorkingDirectory: "C:\\profile-wd",
+            Icon: new IconSpec.BundledKey("default"), TabTitle: id,
+            Visuals: EffectiveVisualOverrides.Empty, ProbeId: null,
+            OrderIndex: 0, IsDefault: false);
+
+    [Fact]
+    public void ResolveLeaf_ReportedCwd_OverridesTheProfileSDirectory()
+    {
+        var reg = new FakeProfileRegistry();
+        reg.Add(ProfileWithDirectory("pwsh"));
+
+        var snap = SessionProfileResolver.ResolveLeaf(reg, LeafWithCwd("pwsh", "C:\\src"));
+
+        Assert.NotNull(snap);
+        // "Same folder" is where the shell actually was, not where the
+        // profile's config points.
+        Assert.Equal("C:\\src", snap!.WorkingDirectory);
+        Assert.Equal("pwsh.exe", snap.ResolvedCommand);
+    }
+
+    [Fact]
+    public void ResolveLeaf_NeverReportedCwd_KeepsTheProfileSDirectory()
+    {
+        var reg = new FakeProfileRegistry();
+        reg.Add(ProfileWithDirectory("pwsh"));
+
+        Assert.Equal(
+            "C:\\profile-wd",
+            SessionProfileResolver.ResolveLeaf(reg, LeafWithCwd("pwsh", null))!.WorkingDirectory);
+        // Empty is "never reported" too: the surface config treats an
+        // empty working-directory as unset, so it must not shadow the
+        // profile's value with a string that spawns nowhere.
+        Assert.Equal(
+            "C:\\profile-wd",
+            SessionProfileResolver.ResolveLeaf(reg, LeafWithCwd("pwsh", ""))!.WorkingDirectory);
+    }
+
+    [Fact]
+    public void ResolveLeaf_ReportedCwd_OverridesTheFallbackCommandSDirectory()
+    {
+        var reg = new FakeProfileRegistry();
+        var leaf = Leaf("deleted", "cmd.exe /k echo hi");
+        leaf.Fallback!.WorkingDirectory = "C:\\saved-wd";
+        leaf.Cwd = "C:\\moved-on";
+
+        var snap = SessionProfileResolver.ResolveLeaf(reg, leaf);
+
+        Assert.NotNull(snap);
+        Assert.Equal("C:\\moved-on", snap!.WorkingDirectory);
+        Assert.Equal("cmd.exe /k echo hi", snap.ResolvedCommand);
+    }
 }

--- a/windows/Ghostty.Tests/Session/SessionTreeTests.cs
+++ b/windows/Ghostty.Tests/Session/SessionTreeTests.cs
@@ -55,6 +55,25 @@ public class SessionTreeTests
     }
 
     [Fact]
+    public void CaptureLeaf_CarriesThePaneSLastReportedDirectory()
+    {
+        var leaf = Leaf("pwsh");
+        leaf.LastCwd = "C:\\src";
+
+        var dto = Assert.IsType<LeafDto>(SessionTree.CaptureTree(leaf));
+
+        Assert.Equal("C:\\src", dto.Cwd);
+    }
+
+    [Fact]
+    public void CaptureLeaf_NeverReportedDirectory_StaysNull()
+    {
+        var dto = Assert.IsType<LeafDto>(SessionTree.CaptureTree(Leaf("pwsh")));
+
+        Assert.Null(dto.Cwd);
+    }
+
+    [Fact]
     public void PathOf_AndResolve_RoundTrip()
     {
         var b = Leaf("b");

--- a/windows/Ghostty.Tests/Wiring/DuplicateTabWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/DuplicateTabWiringTests.cs
@@ -1,0 +1,90 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// The decided behavior ("same shell, same folder, per pane") is
+/// three seams that must all still point at each other: the menu asks
+/// for a duplicate of THIS tab (it used to call manager.NewTab(), which
+/// copied nothing), the host consumes the shell's pwd report instead of
+/// dropping it, and the clone is placed with the pin flag set before the
+/// move (the flag defines the zone Move clamps into). Behaviour facts
+/// live in SessionTreeTests and SessionProfileResolverTests; these are
+/// the wiring guards for the hops a unit test cannot see.
+/// </summary>
+public class DuplicateTabWiringTests
+{
+    [Fact]
+    public void TheDuplicateItem_ClonesThisTab_NotANewEmptyOne()
+    {
+        var build = ShellSource.Load("Tabs.TabContextMenuBuilder.cs").Method("Build");
+
+        // The old shape: a menu item that opened an empty tab and called
+        // it a duplicate. Its return to Build must stay a failure.
+        Assert.Empty(build.Calls("manager.NewTab"));
+
+        Assert.Equal(
+            "tab",
+            build.Call("requestDuplicate").Arg(0));
+    }
+
+    [Fact]
+    public void ThePwdAction_IsConsumed_AndReachesTheControl()
+    {
+        var section = ShellSource.Load("Hosting.GhosttyHost.cs")
+            .Case("OnAction", "Pwd");
+
+        // The marshaled report goes to the surface's own control; a null
+        // or a different expression would record nothing or record the
+        // wrong pane's directory.
+        Assert.Equal(
+            "pwd",
+            section.Call("c.RaisePwdChanged").Arg(0));
+
+        // Handled: returning 0 tells libghostty the apprt did not act.
+        Assert.Contains("return 1;", section.Statements.ToString());
+    }
+
+    [Fact]
+    public void TheControlSPwd_LandsOnThePane()
+    {
+        var handler = ShellSource.Load("Panes.PaneHost.cs")
+            .Method("OnTerminalPwdChanged");
+
+        var writes = handler.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.Left.ToString() == "leaf.LastCwd")
+            .ToList();
+        Assert.True(
+            writes.Count == 1 && writes[0].Right.ToString() == "pwd",
+            "the pane's last-reported directory must be set from the report");
+    }
+
+    [Fact]
+    public void Duplicate_CapturesRebuildsAndPlaces_PinBeforeMove()
+    {
+        var dup = ShellSource.Load("MainWindow.xaml.cs").Method("DuplicateTab");
+
+        // The clone is the capture/restore pair, in that order.
+        var capture = dup.Call("Ghostty.Core.Session.SessionCapture.CaptureTab");
+        var adopt = dup.Call("_tabManager.AdoptTab");
+        Assert.True(
+            capture.SpanStart < adopt.SpanStart,
+            "the live tab must be captured before the clone is adopted");
+
+        // And the duplicate must never degenerate into a plain new tab.
+        Assert.Empty(dup.Calls("_tabManager.NewTab"));
+
+        // Pin comes home before the move: the flag defines the zone Move
+        // clamps into, so moving first lands a pinned source's clone in
+        // the wrong zone and the pin then relocates it away from its
+        // source.
+        var pinned = dup.Call("_tabManager.SetPinned");
+        var moved = dup.Call("_tabManager.Move");
+        Assert.True(
+            pinned.SpanStart < moved.SpanStart,
+            "the clone's pin flag must be set before the placement move");
+    }
+}

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -437,6 +437,15 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     internal void RaiseFirstRender() => FirstRender?.Invoke(this, EventArgs.Empty);
 
     /// <summary>
+    /// The shell reported its directory (OSC 7 via the pwd action).
+    /// PaneHost records it on the pane so a duplicate or restore spawns
+    /// the replacement shell there; the control itself does nothing
+    /// else with it.
+    /// </summary>
+    internal event EventHandler<string?>? PwdChanged;
+    internal void RaisePwdChanged(string? pwd) => PwdChanged?.Invoke(this, pwd);
+
+    /// <summary>
     /// Notify the UIA automation peer that the terminal selection changed so
     /// assistive tech re-queries it. No-op when no automation peer has been
     /// created (i.e. no AT client is attached), so non-AT users pay nothing.

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -626,6 +626,23 @@ internal sealed partial class GhosttyHost : IDisposable
                     return 1;
                 }
 
+                case GhosttyActionTag.Pwd:
+                {
+                    // The shell reported its directory (OSC 7): char* at +8,
+                    // same shape as SetTitle. Recorded on the pane, nowhere
+                    // else; a duplicate or restore spawns the replacement
+                    // shell there instead of at the profile's static
+                    // working-directory.
+                    var pwdPtr = Marshal.ReadIntPtr(actionPtr, 8);
+                    var pwd = Marshal.PtrToStringUTF8(pwdPtr);
+                    _dispatcher.TryEnqueue(() =>
+                    {
+                        if (TryResolveControl(surfaceHandle, out var c) && c is not null)
+                            c.RaisePwdChanged(pwd);
+                    });
+                    return 1;
+                }
+
                 case GhosttyActionTag.PromptTitle:
                 {
                     // Switched rather than compared against Tab. Reading this

--- a/windows/Ghostty/Input/PaneActionRouter.cs
+++ b/windows/Ghostty/Input/PaneActionRouter.cs
@@ -368,6 +368,22 @@ internal sealed class PaneActionRouter
     }
 
     /// <summary>
+    /// Raised when the per-tab context menu asks for a duplicate of one
+    /// specific tab. MainWindow performs the clone: it owns the
+    /// capture/restore pair and the pane-host factory, none of which the
+    /// router (or the menu builder) should reach into.
+    /// </summary>
+    public event EventHandler<TabModel>? DuplicateTabRequested;
+
+    /// <summary>
+    /// Public dispatch entry for the menu's Duplicate Tab item, the same
+    /// one-hop shape as <see cref="RequestToggleTabLayout"/>: no chord
+    /// stands behind it (no defaults in v1), so there is no PaneAction.
+    /// </summary>
+    public void RequestDuplicateTab(TabModel tab)
+        => DuplicateTabRequested?.Invoke(this, tab);
+
+    /// <summary>
     /// Public dispatch entry for the sidebar collapse toggle. Reuses
     /// the existing ToggleVerticalTabsPinnedRequested event so
     /// MainWindow has one handler for every source (Ctrl+Shift+Space

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1962,6 +1962,7 @@ public sealed partial class MainWindow : Window
         };
 
         _router.ReopenClosedTabRequested += (_, _) => ReopenClosedTab();
+        _router.DuplicateTabRequested += (_, tab) => DuplicateTab(tab);
         _router.ReopenClosedWindowRequested += (_, _) =>
             ((App)Application.Current).ReopenClosedWindow();
 
@@ -1983,6 +1984,38 @@ public sealed partial class MainWindow : Window
         // AdoptTab raises TabAdded -> AddPaneHost + activation, so the rebuilt
         // tab renders and focuses just like the session-restore path.
         _tabManager.AdoptTab(tab);
+    }
+
+    /// <summary>
+    /// Duplicate Tab: the source tab's pane arrangement with fresh shells,
+    /// each pane spawned at its source pane's last-reported directory
+    /// (the resolver's substitution; a pane whose shell never reported
+    /// falls back to the profile's static working-directory). A duplicate
+    /// is a capture of the live tab plus the rebuild reopen-closed-tab
+    /// already performs -- never a NewTab(), which copies nothing.
+    /// </summary>
+    private void DuplicateTab(TabModel tab)
+    {
+        var index = _tabManager.Tabs.IndexOf(tab);
+        if (index < 0) return;
+        var session = Ghostty.Core.Session.SessionCapture.CaptureTab(
+            tab.PaneHost.RootNode,
+            tab.PaneHost.ActiveLeaf,
+            tab.PaneHost.ZoomedLeaf,
+            tab.ProfileId,
+            tab.UserOverrideTitle);
+        if (new Ghostty.Session.SessionRestorer(_factory, App.ProfileRegistry)
+                .BuildTab(session) is not { } clone) return;
+
+        // Adopt appends and activates. Pin comes before the move: the flag
+        // defines the zone Move clamps into, so a pinned source's clone is
+        // relocated into the prefix first and only then placed next to its
+        // source. An unpinned source skips straight to the move.
+        _tabManager.AdoptTab(clone);
+        if (tab.IsPinned) _tabManager.SetPinned(clone, pinned: true);
+        var appended = _tabManager.Tabs.IndexOf(clone);
+        if (appended >= 0) _tabManager.Move(appended, index + 1);
+        FocusActiveLeaf();
     }
 
     // Auto-dismiss timer for the Ctrl+Tab preview popup. Restarted on every

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -899,6 +899,7 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         t.GotFocus -= OnTerminalGotFocus;
         t.CloseRequested -= OnTerminalCloseRequested;
         t.ContextMenuRequested -= OnTerminalContextMenuRequested;
+        t.PwdChanged -= OnTerminalPwdChanged;
         t.DisposeSurface();
     }
 
@@ -1326,7 +1327,16 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         // multi-pane closing collapses correctly.
         t.CloseRequested += OnTerminalCloseRequested;
         t.ContextMenuRequested += OnTerminalContextMenuRequested;
+        t.PwdChanged += OnTerminalPwdChanged;
         return t;
+    }
+
+    private void OnTerminalPwdChanged(object? sender, string? pwd)
+    {
+        if (sender is not TerminalControl tc) return;
+        var leaf = PaneTree.Leaves(_root).FirstOrDefault(l => ReferenceEquals(l.Terminal(), tc));
+        if (leaf is null) return;
+        leaf.LastCwd = pwd;
     }
 
     private void OnTerminalContextMenuRequested(object? sender, Windows.Foundation.Point? position)

--- a/windows/Ghostty/Tabs/TabContextMenuBuilder.cs
+++ b/windows/Ghostty/Tabs/TabContextMenuBuilder.cs
@@ -33,6 +33,7 @@ internal static class TabContextMenuBuilder
         DialogTracker dialogs,
         Action toggleTabLayout,
         Action<TabModel, bool> requestPin,
+        Action<TabModel> requestDuplicate,
         bool isVertical = false,
         Func<SnapZoneSource>? getSnapSource = null,
         Action<TabModel, SnapZone>? detachWithZone = null)
@@ -86,8 +87,14 @@ internal static class TabContextMenuBuilder
         pin.Click += (_, _) => requestPin(tab, !tab.IsPinned);
         flyout.Items.Add(pin);
 
+        // Duplicate is a clone of THIS tab -- same shells, same split
+        // arrangement, each pane respawned at its source pane's
+        // last-reported directory -- so it routes through the caller's
+        // hook the way pin does. It used to be manager.NewTab() here,
+        // which copied nothing; the clone itself lives at the window
+        // layer, which owns the capture/restore pair.
         var dup = new MenuFlyoutItem { Text = "Duplicate Tab" };
-        dup.Click += (_, _) => manager.NewTab();
+        dup.Click += (_, _) => requestDuplicate(tab);
         flyout.Items.Add(dup);
 
         flyout.Items.Add(new MenuFlyoutSeparator());

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -188,6 +188,7 @@ internal sealed partial class TabHost : UserControl, ITabHost
                 _dialogs,
                 toggleTabLayout: () => _router.RequestToggleTabLayout(),
                 requestPin: _router.RequestPin,
+                requestDuplicate: _router.RequestDuplicateTab,
                 getSnapSource: GetSnapSource,
                 detachWithZone: DetachWithZone),
             DataContext = tab,

--- a/windows/Ghostty/Tabs/VerticalTabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabHost.xaml.cs
@@ -206,6 +206,7 @@ internal sealed partial class VerticalTabHost : UserControl, ITabHost
                 _dialogs,
                 toggleTabLayout: () => _router.RequestToggleTabLayout(),
                 requestPin: _router.RequestPin,
+                requestDuplicate: _router.RequestDuplicateTab,
                 isVertical: true,
                 getSnapSource: () => TabWindowActions.GetSnapSource(XamlRoot),
                 detachWithZone: (t, z) => TabWindowActions.DetachWithZone(XamlRoot, t, z));


### PR DESCRIPTION
Duplicate Tab called manager.NewTab() and duplicated nothing. Per the owner decision it now duplicates same shell, same folder, per pane: a split tab clones its pane arrangement via the SessionCapture/SessionRestorer pair (new surfaces, fresh shells), and each cloned pane respawns at its source pane's last-reported cwd.

To make that possible, per-pane cwd now exists at all: libghostty already parsed OSC 7 and delivered it as GHOSTTY_ACTION_PWD (37), but the C# tag table skipped it. The tag is dispatched now and the leaf records LastCwd.

Announced behavior widening, owner-approved: the cwd preference lives in the shared SessionProfileResolver, so session restore and reopen-closed-tab also respawn panes at the pane's last-reported directory when shell integration reported one. Shells without OSC 7 (pwsh on Windows never reports; WSL/MSYS/Cygwin report through the zig-side file:// translation) fall back to the profile's working-directory as before. Bad or vanished directories are already gated in zig (openDirAbsolute + stat + Exec access pre-check) and degrade to the profile default.

Clone of a pinned source lands adjacent inside the pin prefix (pin before move - load-bearing ordering, wiring-tested); groups do not travel with the clone, consistent with the detach rule. No keybind in v1.