### PR TITLE
vtabs: give the pinned prefix a fixed panel of its own

### DIFF
--- a/windows/Ghostty.Tests/Wiring/PinnedPanelWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/PinnedPanelWiringTests.cs
@@ -1,0 +1,311 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// The pinned panel's structure (spec 5.1): a fixed, non-scrolling section
+/// above the list, headed by a small-caps header, holding icon-only rows
+/// for the pinned prefix. The strip now has TWO row containers, and the
+/// guards here pin the seams that two containers create: where the shelf
+/// is hosted, who owns order and membership, how a row is measured, and
+/// the one trap a fixed section above the scroller sets for the drag
+/// machine's autoscroll.
+///
+/// Wiring guards, not behaviour tests: whether the panel paints on the
+/// right pixels is only observable on a live strip.
+/// </summary>
+public class PinnedPanelWiringTests
+{
+    private static ShellSource Strip() => ShellSource.Load("Tabs.VerticalTabStrip.xaml.cs");
+
+    /// <summary>
+    /// The shelf rides PaneCustomContent, and that placement is the whole
+    /// design: a root-grid row would sit outside the pane and fight MUXC's
+    /// pane/compact switching; a MenuItems entry would scroll with the
+    /// list and join MUXC selection, which a pinned section must not do.
+    /// PaneCustomContent is the slot MUXC already reserves between the
+    /// pane toggle and the scrolling list.
+    /// </summary>
+    [Fact]
+    public void TheShelf_IsHostedInPaneCustomContent_NotTheScrollingList()
+    {
+        var build = Strip().Method("BuildPinnedShelf");
+
+        var placed = build.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Single(a => a.Left.ToString() == "NavView.PaneCustomContent");
+        Assert.Equal("_pinnedShelf", placed.Right.ToString());
+
+        // Nothing about the shelf may travel through the scrolling list:
+        // the container is what makes it fixed and non-selecting.
+        Assert.DoesNotContain(
+            build.DescendantNodes().OfType<InvocationExpressionSyntax>(),
+            i => i.CalleeText().Contains("MenuItems"));
+
+        // Its chrome (header visibility, boundary alpha) is refreshed by the
+        // pass every selection-placement and drag entry/exit path already
+        // calls, so the two states the shelf tracks cannot go stale on a
+        // path that forgets to ask.
+        Assert.Single(Strip().Method("UpdateRowSeparators")
+            .Calls("UpdatePinnedShelfChrome"));
+    }
+
+    /// <summary>
+    /// "Pinned" is a section heading, not a row: it carries heading
+    /// semantics, it is named for find-by-name, and it is chrome of the
+    /// shelf rather than an item of the row panel -- a client that walks
+    /// the panel's children must find tabs, never the title.
+    /// </summary>
+    [Fact]
+    public void TheHeader_IsAHeading_AndNotARowOfThePanel()
+    {
+        var build = Strip().Method("BuildPinnedShelf");
+
+        var named = build.Calls("AutomationProperties.SetName").Single();
+        Assert.Equal("_pinnedHeader", named.Arg(0));
+        Assert.Equal("\"Pinned\"", named.Arg(1));
+
+        var heading = build.Calls("AutomationProperties.SetHeadingLevel").Single();
+        Assert.Equal("_pinnedHeader", heading.Arg(0));
+        Assert.Equal("AutomationHeadingLevel.Level2", heading.Arg(1));
+
+        // The shelf's own children: header, then the row panel, then the
+        // boundary stroke. The header must not land inside the row panel,
+        // where it would read as one of the things it titles.
+        var adds = build.Calls("_pinnedShelf.Children.Add")
+            .Select(c => c.Arg(0))
+            .ToList();
+        Assert.Equal(new[] { "_pinnedHeader", "_pinnedPanel", "_boundaryStroke" }, adds);
+        Assert.Empty(build.Calls("_pinnedPanel.Children.Add"));
+
+        // BuildPinnedShelf only parks the header collapsed as the initial
+        // state; the anyPins gate in the chrome refresh is the one thing
+        // that ever flips it. Asserted on the ternary's polarity, because a
+        // header that never becomes visible is 24px of chrome and a heading
+        // no client ever finds -- the build-time collapse alone passes a
+        // visibility-blind guard.
+        var shelf = Strip().Method("UpdatePinnedShelfChrome");
+        var headerVisible = shelf.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Single(a => a.Left.ToString() == "_pinnedHeader.Visibility");
+        Assert.Equal(
+            "anyPins ? Visibility.Visible : Visibility.Collapsed",
+            headerVisible.Right.ToString());
+    }
+
+    /// <summary>
+    /// Rows live in two containers now, and the resolver is the seam: it
+    /// is the one place that knows which container holds a tab, and every
+    /// measurement and drag read goes through it, so both containers sit
+    /// in the same coordinate space -- the strip root -- and the drag
+    /// machine's arranged-center arithmetic keeps working across a zone
+    /// crossing untouched. A resolver that lost a container would make
+    /// pinned rows unmeasurable: no selection fill, no drag, no separator
+    /// gaps.
+    /// </summary>
+    [Fact]
+    public void RowsInBothContainers_MeasureAgainstTheStripRoot()
+    {
+        var strip = Strip();
+        var resolve = strip.Method("RowElementOf");
+
+        // Both containers, pinned first: a row is where the pinned registry
+        // says it is, else where the body registry says it is.
+        Assert.Contains(resolve.DescendantNodes().OfType<MemberAccessExpressionSyntax>(),
+            m => m.Expression.ToString() == "_pinnedRows");
+        Assert.Contains(resolve.DescendantNodes().OfType<MemberAccessExpressionSyntax>(),
+            m => m.Expression.ToString() == "_items");
+
+        // And the reads that define the coordinate space route through it,
+        // rather than reaching into one container directly.
+        foreach (var method in new[]
+                 {
+                     "RowCenterY", "StartDragVisual", "RebindFollow", "GlideRow",
+                     "TabElement", "UpdateSelectionRow",
+                 })
+        {
+            var body = strip.Method(method);
+            Assert.Single(body.Calls("RowElementOf"));
+            Assert.DoesNotContain(
+                body.DescendantNodes().OfType<MemberAccessExpressionSyntax>(),
+                m => m.Expression.ToString() == "_items");
+        }
+    }
+
+    /// <summary>
+    /// Membership comes from the collection events, order from the
+    /// projection: with pinned rows outside MenuItems, a manager index
+    /// counts slots the list does not hold, so the event index can no
+    /// longer be the order authority for the body. The reconcile applies
+    /// the projection to both containers, repairs membership skew with a
+    /// rebuild, fences the MUXC list it reorders, and refreshes the shelf.
+    /// </summary>
+    [Fact]
+    public void Order_ComesFromTheProjection_AndSkewRebuilds()
+    {
+        var reconcile = Strip().Method("ReconcileRowOrder");
+
+        Assert.Single(reconcile.Calls("TabStripProjection.Rows"));
+        Assert.Single(reconcile.Calls("UpdatePinnedShelfChrome"));
+        Assert.Single(reconcile.Calls("RebuildAllItems"));
+
+        // Skew is checked against BOTH registries. A condition that names
+        // only one of them passes a body container that drifted (or a panel
+        // one) straight into an indexer miss or a silently wrong order.
+        var skew = reconcile.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.DescendantNodes().OfType<InvocationExpressionSyntax>()
+                             .Any(c => c.CalleeText() == "RebuildAllItems"));
+        var condition = skew.Condition.ToString();
+        Assert.Contains("_pinnedRows.Count != pinned.Count", condition);
+        Assert.Contains("_items.Count != body.Count", condition);
+        Assert.Contains("_pinnedPanel.Children.Count != pinned.Count", condition);
+        Assert.Contains("NavView.MenuItems.Count != body.Count", condition);
+
+        // The MUXC list is fenced while the reconcile mutates it: reordering
+        // under a live selection raises SelectionChanged for a row the user
+        // did not pick, and that reaches activation.
+        var fence = reconcile.AssignsTo("_syncing")
+            .Where(a => a.Right.ToString() == "true")
+            .ToList();
+        Assert.Single(fence);
+        var firstInsert = reconcile.Calls("items.Insert").Single();
+        Assert.True(fence[0].Span.Start < firstInsert.Span.Start,
+            "the reconcile must fence MUXC selection before its first list insert");
+    }
+
+    /// <summary>
+    /// A click on a shelf row has no MUXC SelectionChanged behind it -- the
+    /// panel is outside selection -- so the drag machine's sub-threshold
+    /// release is the only thing that can carry the activation. The
+    /// press-time row decides which container the click landed in (by
+    /// release time a zone churn may have moved it), the activation is the
+    /// same fenced one the selection handler runs, and body clicks keep
+    /// flowing through MUXC untouched.
+    /// </summary>
+    [Fact]
+    public void ClickingAShelfRow_ActivatesThroughTheSubThresholdRelease()
+    {
+        var released = Strip().Method("OnDragPointerReleased");
+
+        // The guard names the press-time container. Dropping the conjunct
+        // activates on every sub-threshold release -- body rows would then
+        // activate twice, once here and once through MUXC; inverting it
+        // never does, which is the missing-activation regression itself.
+        var click = released.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString()
+                .Contains("drag.PressRow is VerticalTabPinnedRow"));
+
+        var activate = click.Calls("_manager.Activate").Single();
+        Assert.Equal("drag.Tab", activate.Arg(0));
+
+        // Fenced like the selection handler's activation: Activate can
+        // surface a selection change synchronously, and an unfenced one
+        // re-enters as a choice the user did not make.
+        var fence = click.AssignsTo("_syncing")
+            .Where(a => a.Right.ToString() == "true")
+            .ToList();
+        Assert.Single(fence);
+        Assert.True(fence[0].Span.Start < activate.Span.Start,
+            "the activation must be fenced, not just performed");
+    }
+
+    /// <summary>
+    /// The seam cover clips to the container the active row lives in. A
+    /// pinned active row sits above the scroller, so clamping it to the
+    /// scrolling viewport produces an empty span and the cover collapses --
+    /// the pane-border join silently disappears for exactly the tabs the
+    /// panel exists to hold. Asserted on the branch shapes: the pinned arm
+    /// must take the shelf and nothing else may.
+    /// </summary>
+    [Fact]
+    public void TheSeamViewport_ClipsToTheContainerTheActiveRowLivesIn()
+    {
+        var viewport = Strip().Method("SelectionViewport");
+
+        var pick = viewport.DescendantNodes().OfType<ConditionalExpressionSyntax>()
+            .Single(c => c.Condition.ToString().Contains("VerticalTabPinnedRow"));
+        Assert.Contains("_pinnedShelf", pick.WhenTrue.ToString());
+        Assert.Contains("_menuItemsScroller", pick.WhenFalse.ToString());
+    }
+
+    /// <summary>
+    /// The panel is fixed ABOVE the scroller, so a pointer resting on it is
+    /// above the viewport: to the machine that reads as fromTop negative,
+    /// the deepest point of the scroll-up band, and the strip would
+    /// phantom-scroll up at full speed under a stationary finger. The band
+    /// is defined to start at the scroller's top edge and never above it --
+    /// the guard is before the speed computation, so the band arithmetic is
+    /// never even reached with a pointer outside the scroller.
+    /// </summary>
+    [Fact]
+    public void ThePanelPointer_DoesNotAutoscroll()
+    {
+        var tick = Strip().Method("OnAutoscrollTick");
+
+        var guard = tick.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "drag.LastPointerY < top");
+        Assert.True(
+            guard.Statement.DescendantNodesAndSelf().OfType<ReturnStatementSyntax>().Any(),
+            "a pointer above the scroller must stand down, not just slow down");
+
+        var speed = tick.Calls("drag.Machine.AutoscrollSpeed").Single();
+        Assert.True(guard.Span.Start < speed.Span.Start,
+            "the guard must precede the band computation: AutoscrollSpeed with a "
+            + "negative fromTop is the phantom scroll itself");
+        Assert.Equal("top", speed.Arg(1));
+    }
+
+    /// <summary>
+    /// The drag arms on rows in EITHER container: a press on a pinned row
+    /// must resolve the tab through the pinned row's ancestry, and the
+    /// element-ownership guard must ask the resolver, not the body
+    /// registry -- a body-only check would refuse to lift pinned rows, or
+    /// worse, lift a stale element the strip no longer owns.
+    /// </summary>
+    [Fact]
+    public void TheDrag_ArmsOnARowInEitherContainer()
+    {
+        var pressed = Strip().Method("OnDragPointerPressed");
+
+        // The pinned row ancestry is in the resolution chain.
+        Assert.Contains(pressed.DescendantNodes().OfType<InvocationExpressionSyntax>(),
+            i => i.CalleeText().Contains("FindAncestor<VerticalTabPinnedRow>"));
+
+        // And ownership is the resolver's answer compared by identity.
+        var guard = pressed.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString().Contains("ReferenceEquals(owned, item)"));
+        Assert.Contains("RowElementOf(tab) is not { } owned", guard.Condition.ToString());
+
+        // The same rule downstream: the churn path re-resolves through the
+        // resolver too, so a zone crossing that moves the dragged row into
+        // the panel rebinds the follow on the row's new element.
+        Assert.Equal(2, Strip().Method("EvaluateDrag").Calls("RowElementOf").Count);
+    }
+
+    /// <summary>
+    /// An icon-only row has no title text, so the accessible name and the
+    /// "Pinned"/"Bell" status are the whole contract with an assistive
+    /// client -- and they have to be re-derived when the title or the bell
+    /// changes, not stamped once at build. The strip's title binding lands
+    /// on Refresh, which is where that chrome is re-applied; naming the
+    /// full argument text is what makes a Name/Status swap go red.
+    /// </summary>
+    [Fact]
+    public void PinnedRows_KeepTheirNameAndStatus_ThroughRetitle()
+    {
+        var refresh = ShellSource.Load("Tabs.VerticalTabPinnedRow.cs").Method("Refresh");
+
+        var name = refresh.Call("AutomationProperties.SetName");
+        Assert.Equal("this", name.Arg(0));
+        Assert.Equal("TabAccessibleText.Name(tab)", name.Arg(1));
+
+        var status = refresh.Call("AutomationProperties.SetItemStatus");
+        Assert.Equal("this", status.Arg(0));
+        Assert.Equal("TabAccessibleText.Status(tab)", status.Arg(1));
+
+        var tooltip = refresh.Call("ToolTipService.SetToolTip");
+        Assert.Equal("this", tooltip.Arg(0));
+        Assert.Equal("tab.EffectiveTitle", tooltip.Arg(1));
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/TabPinZoneWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabPinZoneWiringTests.cs
@@ -121,47 +121,69 @@ public class TabPinZoneWiringTests
     }
 
     /// <summary>
-    /// The zone edge is the manager's PinCount, read at paint time, not a
-    /// count the strip caches: the boundary has to move the moment the
-    /// prefix does, and a cached count is the one thing that would not.
-    /// The stroke itself comes from the boundary brush, which is what
-    /// brightens while a drag is live.
+    /// The structural panel moved the pinned rows out of the scrolling
+    /// list, so the zone edge is no longer a gap in the separator pool:
+    /// it is the stroke along the shelf's bottom edge. The #808 semantics
+    /// travel with it unchanged -- the manager's PinCount is the edge's
+    /// truth at paint time, the stroke exists only while both zones do,
+    /// it never depends on which row is active, and the drag gate is what
+    /// brightens it.
     /// </summary>
     [Fact]
-    public void TheBoundaryStroke_IsPlacedFromTheManagersPinCount()
+    public void TheBoundaryStroke_RidesTheShelf_NotTheRowPool()
     {
-        var separators = Strip().Method("UpdateRowSeparators");
+        var strip = Strip();
 
-        Assert.True(
-            separators.DescendantNodes().OfType<MemberAccessExpressionSyntax>().Any(
-                m => m.Expression.ToString() == "_manager"
-                     && m.Name.Identifier.ValueText == "PinCount"),
-            "the boundary index must come from the manager's PinCount");
-        Assert.Single(separators.Calls("BoundaryStrokeBrush"));
+        // The pool draws only the ordinary row lines now. An accent stroke
+        // left in it would paint a second boundary across a body-row gap,
+        // at a slot where the zone does not end.
+        var separators = strip.Method("UpdateRowSeparators");
+        Assert.Empty(separators.Calls("BoundaryStrokeBrush"));
 
-        // The zone edge takes the accent and the ordinary gaps take the
-        // row brush; swapping them paints the boundary grey and every
-        // divider in accent.
-        var fill = separators.DescendantNodes().OfType<EqualsValueClauseSyntax>()
-            .Single(v => v.Value.ToString().Contains("BoundaryStrokeBrush"));
+        // And it only walks the body rows: the pinned prefix renders above
+        // the scroller and has no gaps in this pool to draw.
+        var loop = separators.DescendantNodes().OfType<ForStatementSyntax>().Single();
+        var start = loop.Declaration!.Variables.Single(v => v.Identifier.ValueText == "i");
+        Assert.Equal("_manager.PinCount", start.Initializer!.Value.ToString());
+
+        // The shelf refresh rides the separator pass: it is the one call
+        // every selection-placement and drag entry/exit path already makes,
+        // so the stroke's brighten/dim cannot be forgotten on an exit path.
+        Assert.Single(separators.Calls("UpdatePinnedShelfChrome"));
+
+        var shelf = strip.Method("UpdatePinnedShelfChrome");
+        Assert.Single(shelf.Calls("BoundaryStrokeBrush"));
+
+        // The shelf and the header exist only while pins do.
+        var anyPins = shelf.DescendantNodes().OfType<LocalDeclarationStatementSyntax>()
+            .Single(l => l.Declaration.Variables.Any(v => v.Identifier.ValueText == "anyPins"));
         Assert.Equal(
-            "boundary ? BoundaryStrokeBrush() : _rowSeparatorBrush",
-            fill.Value.ToString());
+            "_manager.PinCount > 0",
+            anyPins.Declaration.Variables.Single().Initializer!.Value.ToString());
+        var shelfVisible = shelf.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Single(a => a.Left.ToString() == "_pinnedShelf.Visibility");
+        Assert.Equal(
+            "anyPins ? Visibility.Visible : Visibility.Collapsed",
+            shelfVisible.Right.ToString());
 
-        // The boundary gap never skips: the zone edge stays visible even
-        // when the active row sits on it.
-        var boundaryIf = separators.DescendantNodes().OfType<IfStatementSyntax>()
-            .Single(i => i.Condition.ToString() == "boundary");
-        Assert.True(
-            !boundaryIf.Statement.DescendantNodesAndSelf()
-                .OfType<ContinueStatementSyntax>().Any(),
-            "the boundary gap must not skip");
+        // The stroke itself only while both zones do -- the same gate the
+        // in-list boundary always had, all tabs pinned draws no edge.
+        var bothZones = shelf.DescendantNodes().OfType<LocalDeclarationStatementSyntax>()
+            .Single(l => l.Declaration.Variables.Any(v => v.Identifier.ValueText == "bothZones"));
+        Assert.Equal(
+            "anyPins && _manager.PinCount < _manager.Tabs.Count",
+            bothZones.Declaration.Variables.Single().Initializer!.Value.ToString());
+        var strokeVisible = shelf.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Single(a => a.Left.ToString() == "_boundaryStroke.Visibility");
+        Assert.Equal(
+            "bothZones ? Visibility.Visible : Visibility.Collapsed",
+            strokeVisible.Right.ToString());
 
         // The brightening is the gesture's aiming feedback, so its
         // polarity is load-bearing: dim while idle, bright while a drag
         // is live. Inverting it darkens the boundary exactly when the
         // gesture needs it.
-        var brush = Strip().Method("BoundaryStrokeBrush");
+        var brush = strip.Method("BoundaryStrokeBrush");
         var alpha = brush.DescendantNodes().OfType<LocalDeclarationStatementSyntax>()
             .Single(l => l.Declaration.Variables.Any(v => v.Identifier.ValueText == "alpha"));
         Assert.Equal(

--- a/windows/Ghostty/Tabs/VerticalTabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabHost.xaml.cs
@@ -211,7 +211,8 @@ internal sealed partial class VerticalTabHost : UserControl, ITabHost
                 getSnapSource: () => TabWindowActions.GetSnapSource(XamlRoot),
                 detachWithZone: (t, z) => TabWindowActions.DetachWithZone(XamlRoot, t, z));
 
-            var row = VisualTreeHelperEx.FindAncestor<NavigationViewItem>(source);
+            var row = (FrameworkElement?)VisualTreeHelperEx.FindAncestor<NavigationViewItem>(source)
+                ?? (FrameworkElement?)VisualTreeHelperEx.FindAncestor<VerticalTabPinnedRow>(source);
             if (row is not null)
             {
                 if (e.TryGetPosition(row, out Point tabPos))

--- a/windows/Ghostty/Tabs/VerticalTabPinnedRow.cs
+++ b/windows/Ghostty/Tabs/VerticalTabPinnedRow.cs
@@ -1,0 +1,141 @@
+using Ghostty.Core.Tabs;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+
+namespace Ghostty.Tabs;
+
+/// <summary>
+/// Icon-only row for a pinned tab in the fixed panel above the scrolling
+/// list. Deliberately not a <see cref="NavigationViewItem"/>: the panel
+/// must neither scroll nor take part in MUXC selection, so the row is a
+/// plain element the strip hosts in its PaneCustomContent. There is no
+/// room for a title, so it rides the tooltip, and the accessible name and
+/// the "Pinned" status sit on the row itself, which is the leaf the
+/// automation tree sees here.
+/// </summary>
+internal sealed partial class VerticalTabPinnedRow : Grid
+{
+    /// <summary>Row height. Fits the 48px compact pane with its inset.</summary>
+    internal const double RowHeight = 40;
+
+    /// <summary>The icon slot is a square, the one shape both pane widths agree on.</summary>
+    private const double IconSlotSize = 40;
+
+    private readonly Grid _iconSlot;
+    private readonly FontIcon _bell;
+    private IconElement? _icon;
+    private TextBlock? _iconFallback;
+
+    public VerticalTabPinnedRow(TabModel tab, SolidColorBrush accentBrush)
+    {
+        Tag = tab;
+        // Transparent, not null: a null background leaves the row's empty
+        // span to hit-test through to the pane, so clicks and presses off
+        // the icon would fall through entirely. Body rows hit-test
+        // full-bleed through their template; this is that parity.
+        Background = new SolidColorBrush(Microsoft.UI.Colors.Transparent);
+        Height = RowHeight;
+        // Same inset the body rows get through NavigationViewItemContentMargin.
+        Margin = new Thickness(4, 2, 0, 2);
+        // Body rows are ListItems because MUXC says so; say it here too, so
+        // a client hears one kind of thing on both sides of the boundary.
+        AutomationProperties.SetAutomationControlType(
+            this, AutomationControlType.ListItem);
+
+        _iconSlot = new Grid
+        {
+            Width = IconSlotSize,
+            Height = IconSlotSize,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        Children.Add(_iconSlot);
+
+        // Over the icon's corner, so the row reads as "this icon is ringing"
+        // whether the pane is 48px or 220px wide.
+        _bell = new FontIcon
+        {
+            Glyph = "\uEA8F",
+            FontSize = 9,
+            Foreground = accentBrush,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            VerticalAlignment = VerticalAlignment.Bottom,
+            Visibility = tab.BellRinging ? Visibility.Visible : Visibility.Collapsed,
+        };
+        _iconSlot.Children.Add(_bell);
+
+        Refresh(tab);
+    }
+
+    /// <summary>Swap the row's icon for a freshly built one.</summary>
+    public void SetIcon(IconElement? icon)
+    {
+        if (_icon is not null) _iconSlot.Children.Remove(_icon);
+        if (_iconFallback is not null) _iconSlot.Children.Remove(_iconFallback);
+        _icon = icon;
+        _iconFallback = null;
+
+        if (icon is not null)
+        {
+            // Below the bell (slot 0): the bell badge paints over the icon's
+            // corner, and a later child renders on top of an earlier one.
+            _iconSlot.Children.Insert(0, icon);
+        }
+        else
+        {
+            // An icon-only row with nothing in it is a blank slot: fall back
+            // to the title's initial, the same stand-in a collapsed body row
+            // reads as when the foreground process has no icon.
+            if (Tag is not TabModel tab) return;
+            _iconFallback = new TextBlock
+            {
+                Text = InitialOf(TabAccessibleText.Name(tab)),
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+            _iconSlot.Children.Insert(0, _iconFallback);
+        }
+    }
+
+    /// <summary>
+    /// The title's first character, as a whole character: a title opening
+    /// with an astral character is a surrogate pair, and halving one draws
+    /// U+FFFD where the initial should be.
+    /// </summary>
+    private static string InitialOf(string name)
+    {
+        if (name.Length == 0) return "?";
+        return char.IsHighSurrogate(name[0]) && name.Length > 1 && char.IsLowSurrogate(name[1])
+            ? name[..2]
+            : name[..1];
+    }
+
+    /// <summary>Apply the ink the icon draws with. The bell stays accent.</summary>
+    public void ApplyInk(Brush? foreground)
+    {
+        if (_icon is not null)
+        {
+            if (foreground is not null) _icon.Foreground = foreground;
+            else _icon.ClearValue(IconElement.ForegroundProperty);
+        }
+        if (_iconFallback is not null)
+        {
+            if (foreground is not null) _iconFallback.Foreground = foreground;
+            else _iconFallback.ClearValue(TextBlock.ForegroundProperty);
+        }
+    }
+
+    /// <summary>
+    /// Everything that follows the tab's title or transient state: the
+    /// tooltip, the bell, and the text an assistive client reads.
+    /// </summary>
+    public void Refresh(TabModel tab)
+    {
+        ToolTipService.SetToolTip(this, tab.EffectiveTitle);
+        AutomationProperties.SetName(this, TabAccessibleText.Name(tab));
+        AutomationProperties.SetItemStatus(this, TabAccessibleText.Status(tab));
+        _bell.Visibility = tab.BellRinging ? Visibility.Visible : Visibility.Collapsed;
+    }
+}

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -13,6 +13,7 @@ using Microsoft.UI.Composition;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Hosting;
 using Microsoft.UI.Xaml.Input;
@@ -109,6 +110,7 @@ internal sealed partial class VerticalTabStrip : UserControl
         InitializeComponent();
         _manager = manager;
 
+        BuildPinnedShelf();
         RebuildAllItems();
         SyncSelectionFromManager();
 
@@ -424,6 +426,17 @@ internal sealed partial class VerticalTabStrip : UserControl
     private SolidColorBrush? _rowSeparatorBrush;
     private readonly List<Border> _rowSeparators = new();
 
+    // The pinned shelf: header, fixed row panel, and the zone's boundary
+    // stroke, hosted as NavView.PaneCustomContent. Pinned rows are NOT
+    // MenuItems -- they must not scroll and must not take part in MUXC
+    // selection -- so they get their own container and their own registry.
+    private readonly StackPanel _pinnedShelf = new();
+    private readonly TextBlock _pinnedHeader = new();
+    private readonly StackPanel _pinnedPanel = new();
+    private readonly Border _boundaryStroke = new();
+    private readonly Dictionary<TabModel, VerticalTabPinnedRow> _pinnedRows = new();
+    private readonly Dictionary<TabModel, TabHooks> _pinnedHooks = new();
+
     /// <summary>
     /// Paint the strip lane, or leave it to the window backdrop.
     ///
@@ -531,16 +544,16 @@ internal sealed partial class VerticalTabStrip : UserControl
     }
 
     /// <summary>
-    /// One line in each gap between rows, skipping both gaps that touch the
-    /// selected row: those two edges are already drawn, in the accent, by the
-    /// selected row's own top and bottom stroke. Drawing them again puts two
-    /// lines a pixel apart.
+    /// One line in each gap between the scrolling list's rows, skipping both
+    /// gaps that touch the selected row: those two edges are already drawn,
+    /// in the accent, by the selected row's own top and bottom stroke.
+    /// Drawing them again puts two lines a pixel apart.
     ///
-    /// The gap after the last pinned row never skips and never takes the
-    /// row-separator brush: it is the pin zone's edge, drawn in the accent
-    /// at double height, and it is the only boundary the strip shows for
-    /// the zone (spec 5.1's section header and fixed panel are not built
-    /// here). It exists only while both zones do.
+    /// Only the list's gaps. The pinned rows live in the fixed panel above
+    /// the scroller, so the pin zone's edge is not a gap in this pool any
+    /// more: it is the boundary stroke along the shelf's bottom edge
+    /// (UpdatePinnedShelfChrome), which starts where the panel ends and the
+    /// list begins.
     ///
     /// Rebuilt rather than kept in sync per item, because the thing being
     /// mirrored is MUXC's arranged layout, and the only honest read of that
@@ -548,6 +561,12 @@ internal sealed partial class VerticalTabStrip : UserControl
     /// </summary>
     private void UpdateRowSeparators(bool selectionRowVisible)
     {
+        // The shelf rides this refresh on purpose: it is the pass every
+        // selection-placement and drag entry/exit path already calls, so
+        // the boundary stroke's brighten/dim never needs a caller of its
+        // own and cannot be forgotten on an exit path.
+        UpdatePinnedShelfChrome();
+
         // Pooled by index rather than rebuilt. This runs from the same
         // refresh the selection row rides, which the constructor keeps off
         // LayoutUpdated specifically so it does not allocate on every layout
@@ -561,26 +580,16 @@ internal sealed partial class VerticalTabStrip : UserControl
             return;
         }
 
-        // The boundary lives in the gap after the last pinned row, which
-        // is only a real gap while an unpinned tab exists below it.
-        var boundaryIndex = _manager.PinCount - 1;
-        var hasBoundary = boundaryIndex >= 0 && boundaryIndex + 1 < _manager.Tabs.Count;
-
         var tabs = _manager.Tabs;
-        for (var i = 0; i + 1 < tabs.Count; i++)
+        // The pinned prefix renders in the shelf, not in the list, so its
+        // slots have no gaps here to draw.
+        for (var i = _manager.PinCount; i + 1 < tabs.Count; i++)
         {
-            var boundary = hasBoundary && i == boundaryIndex;
-            if (boundary)
-            {
-                // The boundary marks the zone, not the row under it: it
-                // never skips, so the edge stays visible when the active
-                // row sits on it.
-            }
             // Only skip the gaps the selected row is actually covering. The
             // row is collapsed during a layout morph and on MUXC's first
             // frame, and skipping on those passes left two gaps with nothing
             // drawing them and nothing hiding them either.
-            else if (selectionRowVisible)
+            if (selectionRowVisible)
             {
                 if (ReferenceEquals(tabs[i], _manager.ActiveTab)) continue;
                 if (ReferenceEquals(tabs[i + 1], _manager.ActiveTab)) continue;
@@ -603,10 +612,8 @@ internal sealed partial class VerticalTabStrip : UserControl
             }
 
             // A null row-separator brush means this theme separates by
-            // shade and wants no lines; the boundary still draws, because
-            // it is the zone's edge and drag-to-pin needs it visible.
-            Brush? fill = boundary ? BoundaryStrokeBrush() : _rowSeparatorBrush;
-            if (fill is null) continue;
+            // shade and wants no lines at all between rows.
+            if (_rowSeparatorBrush is null) continue;
 
             Border line;
             if (used < _rowSeparators.Count)
@@ -623,11 +630,11 @@ internal sealed partial class VerticalTabStrip : UserControl
             }
 
             line.Width = Math.Max(0, ActualWidth - RowInsetLeft);
-            line.Height = boundary ? BoundaryStrokeHeight : 1;
-            line.Background = fill;
+            line.Height = 1;
+            line.Background = _rowSeparatorBrush;
             line.Visibility = Visibility.Visible;
             Canvas.SetLeft(line, RowInsetLeft);
-            Canvas.SetTop(line, bottom - RowInsetVertical - (boundary ? 1 : 0));
+            Canvas.SetTop(line, bottom - RowInsetVertical);
             used++;
         }
 
@@ -672,7 +679,7 @@ internal sealed partial class VerticalTabStrip : UserControl
         if (_drag is not null) return;
 
         if (_manager.ActiveTab is null
-            || !_items.TryGetValue(_manager.ActiveTab, out var item)
+            || RowElementOf(_manager.ActiveTab) is not { } item
             || item.ActualWidth <= 0
             || item.ActualHeight <= 0
             || ActualWidth <= 0)
@@ -867,6 +874,21 @@ internal sealed partial class VerticalTabStrip : UserControl
 
             ApplyItemTabColor(item, model);
         }
+
+        // Pinned rows carry the same ink rules with no MUXC resources to
+        // write: the icon draws in the row's foreground (full strength when
+        // the selection overlay sits behind it, muted otherwise), and the
+        // bell stays accent, exactly as on a body row.
+        foreach (var (model, row) in _pinnedRows)
+        {
+            var active = ReferenceEquals(model, _manager.ActiveTab);
+            row.ApplyInk(model.Color != TabColor.None
+                ? TabColorBrush.FromPackedRgb(TabColorPalette.ForegroundRgb(
+                    model.Color, active, _stripBackdropPacked))
+                : active
+                    ? ActiveRowChrome(model).Foreground
+                    : ResolveInactiveTextBrush());
+        }
     }
 
     private static void ApplyItemForeground(NavigationViewItem item, Brush? fg, bool active)
@@ -927,7 +949,7 @@ internal sealed partial class VerticalTabStrip : UserControl
             // the strip host becomes Visible (horizontal→vertical switch).
             if (!retryIfZeroBounds
                 || _manager.ActiveTab is null
-                || !_items.TryGetValue(_manager.ActiveTab, out var item)
+                || RowElementOf(_manager.ActiveTab) is not { } item
                 || (item.ActualWidth > 0 && item.ActualHeight > 0)
                 || ActualWidth <= 0)
             {
@@ -976,10 +998,20 @@ internal sealed partial class VerticalTabStrip : UserControl
         }
 
         if (_manager.ActiveTab is null) return;
-        if (!_items.TryGetValue(_manager.ActiveTab, out var item)) return;
 
         _syncing = true;
-        try { NavView.SelectedItem = item; }
+        try
+        {
+            // While the active tab is pinned it has no MenuItems entry at
+            // all, and MUXC has nothing that can be selected. Leaving the
+            // previous selection standing would keep a body row painted as
+            // selected while the strip's active chrome sits on a pinned
+            // row, so park the selection at null: the selection overlay is
+            // the active chrome for a pinned row and does not consult MUXC.
+            NavView.SelectedItem = _items.TryGetValue(_manager.ActiveTab, out var item)
+                ? item
+                : null;
+        }
         finally { _syncing = false; }
 
         ApplyAllItemTabColors();
@@ -993,22 +1025,34 @@ internal sealed partial class VerticalTabStrip : UserControl
     private FrameworkElement? _menuItemsScroller;
 
     /// <summary>
-    /// Vertical bounds of the scrolling row list, in RootGrid-relative
-    /// coordinates via <paramref name="reference"/>, or null while the
-    /// template has not been applied.
+    /// Vertical bounds of the container the active row lives in -- the
+    /// scrolling list for a body row, the pinned shelf for a pinned one --
+    /// in RootGrid-relative coordinates via <paramref name="reference"/>,
+    /// or null while the template has not been applied.
     /// </summary>
     /// <remarks>
-    /// Deliberately the scroller and not this control: with more tabs than
-    /// fit, the selected row scrolls out of the list while its layout offset
-    /// still reports where it would have been. A caller clipping to the
-    /// control instead clips to something that always contains the row, so
-    /// the clamp does nothing and a cover gets drawn across the pane at a
-    /// height with no tab beside it.
+    /// Deliberately the scroller and not this control for body rows: with
+    /// more tabs than fit, the selected row scrolls out of the list while
+    /// its layout offset still reports where it would have been. A caller
+    /// clipping to the control instead clips to something that always
+    /// contains the row, so the clamp does nothing and a cover gets drawn
+    /// across the pane at a height with no tab beside it.
     /// </remarks>
     internal (double Top, double Bottom)? SelectionViewport(UIElement reference)
     {
         _menuItemsScroller ??= FindDescendantByName(NavView, "MenuItemsScrollViewer");
-        if (_menuItemsScroller is not { ActualHeight: > 0 } scroller) return null;
+
+        // Clip to the container the active row actually lives in. A pinned
+        // active row sits ABOVE the scroller, so clamping it to the
+        // scrolling viewport produces an empty span and the seam cover
+        // collapses -- the pane-border join silently disappears for exactly
+        // the tabs the panel exists to hold. The shelf is fixed and fully
+        // visible, so its bounds are the right clip for its rows.
+        var container = _manager.ActiveTab is { } active
+                        && RowElementOf(active) is VerticalTabPinnedRow
+            ? (FrameworkElement?)_pinnedShelf
+            : _menuItemsScroller;
+        if (container is not { ActualHeight: > 0 } scroller) return null;
 
         try
         {
@@ -1042,7 +1086,13 @@ internal sealed partial class VerticalTabStrip : UserControl
         // the row off the finger. The next post-drag refresh catches up.
         if (_drag is not null) return;
         if (_manager.ActiveTab is null) return;
-        if (!_items.TryGetValue(_manager.ActiveTab, out var item)) return;
+        if (!_items.TryGetValue(_manager.ActiveTab, out var item))
+        {
+            // The active row is in the fixed pinned panel above the
+            // scroller: it is always on screen and there is no scroll
+            // position to reach it with.
+            return;
+        }
 
         item.StartBringIntoView(new BringIntoViewOptions
         {
@@ -1144,21 +1194,87 @@ internal sealed partial class VerticalTabStrip : UserControl
     private static uint PackColor(Color c)
         => ((uint)c.R << 16) | ((uint)c.G << 8) | c.B;
 
+    /// <summary>
+    /// The pinned section: a small-caps header, the fixed row panel, and
+    /// the zone boundary's stroke along the panel's bottom edge.
+    /// </summary>
+    /// <remarks>
+    /// The shelf rides <see cref="NavigationView.PaneCustomContent"/>
+    /// rather than a row of this control's root grid or a MenuItems entry,
+    /// and that placement is load-bearing. A root-grid row would sit
+    /// OUTSIDE the pane, so it would not collapse with it and would fight
+    /// MUXC's own pane/compact layout when the sidebar toggles. A
+    /// MenuItems entry scrolls with the list and joins MUXC selection,
+    /// which is exactly what a pinned section must not do. PaneCustomContent
+    /// is the slot MUXC already reserves inside the pane between the pane
+    /// toggle and the scrolling list: it never scrolls, it never selects,
+    /// it owns no part of the item template, and it tracks the pane width,
+    /// so the 40px icon rows fit both the expanded pane and the 48px
+    /// compact one.
+    /// </remarks>
+    private void BuildPinnedShelf()
+    {
+        // "Pinned" reads as a section title, not a row: small caps, fixed
+        // 24px band, offered only while pins exist (UpdatePinnedShelfChrome),
+        // and carrying heading semantics so an assistive client can jump to
+        // the section instead of walking into it.
+        _pinnedHeader.Text = "Pinned";
+        _pinnedHeader.Height = PinnedHeaderHeight;
+        _pinnedHeader.FontSize = 12;
+        _pinnedHeader.CharacterSpacing = 60;
+        _pinnedHeader.Margin = new Thickness(RowInsetLeft + 4, 0, 0, 0);
+        _pinnedHeader.VerticalAlignment = VerticalAlignment.Center;
+        _pinnedHeader.Visibility = Visibility.Collapsed;
+        Microsoft.UI.Xaml.Documents.Typography.SetCapitals(
+            _pinnedHeader, Microsoft.UI.Xaml.FontCapitals.SmallCaps);
+        AutomationProperties.SetName(_pinnedHeader, "Pinned");
+        AutomationProperties.SetHeadingLevel(
+            _pinnedHeader, AutomationHeadingLevel.Level2);
+
+        _boundaryStroke.Height = BoundaryStrokeHeight;
+        _boundaryStroke.IsHitTestVisible = false;
+        _boundaryStroke.Margin = new Thickness(RowInsetLeft, 0, 0, 0);
+        _boundaryStroke.Visibility = Visibility.Collapsed;
+
+        _pinnedShelf.Children.Add(_pinnedHeader);
+        _pinnedShelf.Children.Add(_pinnedPanel);
+        _pinnedShelf.Children.Add(_boundaryStroke);
+        _pinnedShelf.Visibility = Visibility.Collapsed;
+
+        NavView.PaneCustomContent = _pinnedShelf;
+    }
+
+    /// <summary>Height of the pinned section's header band.</summary>
+    private const double PinnedHeaderHeight = 24;
+
+    /// <summary>
+    /// The element rendering <paramref name="tab"/>, from whichever
+    /// container holds it. Every measurement (row centers, the selection
+    /// overlay, the separators) and every drag read resolves rows through
+    /// here, so a row's two possible homes differ in membership only: one
+    /// coordinate space -- this control's -- serves both, which is what
+    /// lets the untouched drag machine keep judging crossings across a
+    /// zone change.
+    /// </summary>
+    private FrameworkElement? RowElementOf(TabModel tab)
+        => _pinnedRows.TryGetValue(tab, out var pinned) ? pinned
+        : _items.TryGetValue(tab, out var item) ? item
+        : null;
+
     private void RebuildAllItems()
     {
         // Remove by what we hold, not by what the manager still has:
         // on a Reset the manager is already empty and rows we own would
-        // otherwise stay in MenuItems with their subscriptions live.
-        foreach (var tab in _hooks.Keys.ToArray())
+        // otherwise stay in their container with their subscriptions live.
+        foreach (var tab in _hooks.Keys.Concat(_pinnedHooks.Keys).ToArray())
             RemoveItem(tab);
         // Row order comes from the projector, the same source the
         // horizontal strip reconciles against, so the two strips cannot
-        // disagree by construction. Identical to Tabs while headers are
-        // off (which makes the swap behavior-neutral); the Add/Remove
-        // branches above stay index-honoring because with no headers the
-        // collection's indices ARE the projection's.
+        // disagree by construction. AddItem is membership-only, so adding
+        // in projection order lands every row in its container at its slot.
         foreach (var tab in TabStripProjection.Rows(_manager))
             AddItem(tab);
+        UpdatePinnedShelfChrome();
     }
 
     private void OnTabsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
@@ -1166,19 +1282,9 @@ internal sealed partial class VerticalTabStrip : UserControl
         switch (e.Action)
         {
             case NotifyCollectionChangedAction.Add:
-                // NewStartingIndex matters: TabManager.Move is RemoveAt +
-                // Insert, which ObservableCollection reports as Remove then
-                // Add, not Move. Appending here would drift the strip order
-                // away from the manager on every "Move Tab Left/Right".
                 if (e.NewItems is not null)
-                {
-                    var addIndex = e.NewStartingIndex;
                     foreach (TabModel tab in e.NewItems)
-                    {
-                        AddItem(tab, addIndex);
-                        if (addIndex >= 0) addIndex++;
-                    }
-                }
+                        AddItem(tab);
                 break;
             case NotifyCollectionChangedAction.Remove:
                 if (e.OldItems is not null)
@@ -1198,13 +1304,34 @@ internal sealed partial class VerticalTabStrip : UserControl
                         AddItem(tab);
                 break;
         }
+        // Membership above, order here. The event index was the order
+        // authority while every row was a MenuItems entry (the collection's
+        // indices were the projection's), but pinned rows live outside
+        // MenuItems, so a manager index counts slots the list does not
+        // hold. The projection is the one authority that still speaks for
+        // both containers, and ReconcileRowOrder is the pass that applies
+        // it -- after the churn of any Move (reported as Remove then Add)
+        // and after every other mutation above.
+        ReconcileRowOrder();
         SyncSelectionFromManager();
     }
 
-    private void AddItem(TabModel tab, int index = -1)
+    /// <summary>
+    /// Build the row <paramref name="tab"/> renders as, in the container
+    /// its pin flag names: the fixed panel for the pinned prefix, the
+    /// scrolling list for everything else. Membership only -- where the
+    /// row sits among its neighbours is ReconcileRowOrder's answer, taken
+    /// from the projection.
+    /// </summary>
+    private void AddItem(TabModel tab)
     {
-        if (_items.ContainsKey(tab)) return;
+        if (_items.ContainsKey(tab) || _pinnedRows.ContainsKey(tab)) return;
+        if (tab.IsPinned) AddPinnedRow(tab);
+        else AddBodyRow(tab);
+    }
 
+    private void AddBodyRow(TabModel tab)
+    {
         var row = new VerticalTabNavRow(tab, AccentBrush, OnRowCloseClick);
         var item = new NavigationViewItem
         {
@@ -1257,16 +1384,51 @@ internal sealed partial class VerticalTabStrip : UserControl
         // activates the wrong tab, and comes back around to assign
         // SelectedItem while MUXC is still inside its own notification.
         _syncing = true;
-        try
-        {
-            if (index >= 0 && index <= NavView.MenuItems.Count)
-                NavView.MenuItems.Insert(index, item);
-            else
-                NavView.MenuItems.Add(item);
-        }
+        try { NavView.MenuItems.Add(item); }
         finally { _syncing = false; }
 
         ApplyItemTabColor(item, tab);
+    }
+
+    private void AddPinnedRow(TabModel tab)
+    {
+        var row = new VerticalTabPinnedRow(tab, AccentBrush);
+        row.SetIcon(TabIconElementFactory.Create(tab.TabIcon));
+
+        // The same three subscriptions a body row takes, pointed at the
+        // pinned row instead: title and bell feed the tooltip and the a11y
+        // chrome, color re-inks the whole strip, and the icon rebuilds when
+        // the foreground process changes. (AddBodyRow carries the long
+        // version of the split rationale.)
+        var textBinding = AotBinding.Create(tab, _ =>
+        {
+            if (_pinnedRows.TryGetValue(tab, out var pinnedRow))
+                pinnedRow.Refresh(tab);
+        },
+        nameof(TabModel.EffectiveTitle),
+        nameof(TabModel.ShellReportedTitle),
+        nameof(TabModel.UserOverrideTitle),
+        nameof(TabModel.BellRinging));
+
+        var colorBinding = AotBinding.Create(tab, _ => RefreshTabColors(),
+            nameof(TabModel.Color));
+
+        var vm = tab.TabIcon;
+        PropertyChangedEventHandler iconHandler = (_, e) =>
+        {
+            if (e.PropertyName is not null
+                && e.PropertyName != nameof(TabIconViewModel.Icon)
+                && e.PropertyName != nameof(TabIconViewModel.IsMdl2Glyph)
+                && e.PropertyName != nameof(TabIconViewModel.Mdl2CodePoint))
+                return;
+            if (_pinnedRows.TryGetValue(tab, out var pinnedRow))
+                pinnedRow.SetIcon(TabIconElementFactory.Create(tab.TabIcon));
+        };
+        vm.PropertyChanged += iconHandler;
+
+        _pinnedRows[tab] = row;
+        _pinnedHooks[tab] = new TabHooks(textBinding, colorBinding, vm, iconHandler);
+        _pinnedPanel.Children.Add(row);
     }
 
     /// <summary>
@@ -1298,11 +1460,22 @@ internal sealed partial class VerticalTabStrip : UserControl
         if (_drag is { } drag && ReferenceEquals(tab, drag.Tab) && !_commitChurn)
             CancelDrag("closed");
 
+        // The row lives in exactly one container; take it out of that one.
+        // (The panel is not a MUXC selection surface, so its removal needs
+        // no fence -- only MenuItems removals can move MUXC's selection.)
+        if (_pinnedRows.Remove(tab, out var pinned))
+        {
+            _pinnedPanel.Children.Remove(pinned);
+            if (_pinnedHooks.Remove(tab, out var pinnedHooks))
+                pinnedHooks.Dispose();
+            return;
+        }
+
         if (!_items.TryGetValue(tab, out var item)) return;
 
-        // Fenced for the same reason as the insert in AddItem: removing the
-        // selected row moves MUXC's selection to a neighbour and reports it
-        // as the user's choice.
+        // Fenced for the same reason as the insert in AddBodyRow: removing
+        // the selected row moves MUXC's selection to a neighbour and
+        // reports it as the user's choice.
         _syncing = true;
         try { NavView.MenuItems.Remove(item); }
         finally { _syncing = false; }
@@ -1310,6 +1483,82 @@ internal sealed partial class VerticalTabStrip : UserControl
         _items.Remove(tab);
         if (_hooks.Remove(tab, out var hooks))
             hooks.Dispose();
+    }
+
+    /// <summary>
+    /// Bring both containers' row order back to the projection's. Rows are
+    /// reordered in place -- the element instance each dict holds is moved,
+    /// never rebuilt -- so a plain move churns nothing a drag is still
+    /// following that the Remove+Add pair did not churn already. A
+    /// membership skew (a dict holding a tab its container's projection no
+    /// longer names, or counts gone apart) is not something an order pass
+    /// can repair; that is what the rebuild is for.
+    /// </summary>
+    private void ReconcileRowOrder()
+    {
+        var rows = TabStripProjection.Rows(_manager);
+        var pinCount = _manager.PinCount;
+        var pinned = rows.Take(pinCount).ToList();
+        var body = rows.Skip(pinCount).ToList();
+
+        if (_pinnedRows.Count != pinned.Count || _items.Count != body.Count
+            || _pinnedPanel.Children.Count != pinned.Count
+            || NavView.MenuItems.Count != body.Count
+            || pinned.Any(t => !_pinnedRows.ContainsKey(t))
+            || body.Any(t => !_items.ContainsKey(t)))
+        {
+            RebuildAllItems();
+            return;
+        }
+
+        for (var i = 0; i < pinned.Count; i++)
+        {
+            var row = _pinnedRows[pinned[i]];
+            if (ReferenceEquals(_pinnedPanel.Children[i], row)) continue;
+            var idx = _pinnedPanel.Children.IndexOf(row);
+            if (idx >= 0) _pinnedPanel.Children.RemoveAt(idx);
+            _pinnedPanel.Children.Insert(i, row);
+        }
+
+        var items = NavView.MenuItems;
+        _syncing = true;
+        try
+        {
+            for (var i = 0; i < body.Count; i++)
+            {
+                var row = _items[body[i]];
+                if (ReferenceEquals(items[i], row)) continue;
+                var idx = items.IndexOf(row);
+                if (idx >= 0) items.RemoveAt(idx);
+                items.Insert(i, row);
+            }
+        }
+        finally { _syncing = false; }
+
+        UpdatePinnedShelfChrome();
+    }
+
+    /// <summary>
+    /// The shelf's two state-dependent bits: the header exists only while
+    /// pins do, and the boundary stroke marks the edge between the zones,
+    /// so it exists only while both do -- the same "both zones exist" gate
+    /// the in-list boundary stroke always had.
+    /// </summary>
+    private void UpdatePinnedShelfChrome()
+    {
+        var anyPins = _manager.PinCount > 0;
+        _pinnedShelf.Visibility = anyPins ? Visibility.Visible : Visibility.Collapsed;
+        // The header follows the shelf's gate: BuildPinnedShelf only parks
+        // it collapsed as the initial state, so this flip is the one thing
+        // that ever makes the 24px headline -- and its heading semantics --
+        // render.
+        _pinnedHeader.Visibility = anyPins ? Visibility.Visible : Visibility.Collapsed;
+
+        var bothZones = anyPins && _manager.PinCount < _manager.Tabs.Count;
+        _boundaryStroke.Visibility = bothZones ? Visibility.Visible : Visibility.Collapsed;
+        // Brightens while a drag is live, via BoundaryStrokeBrush's drag
+        // gate -- the aiming feedback the drag-to-pin gesture reads.
+        if (bothZones) _boundaryStroke.Background = BoundaryStrokeBrush();
     }
 
     private void OnNavSelectionChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)
@@ -1338,14 +1587,16 @@ internal sealed partial class VerticalTabStrip : UserControl
     }
 
     /// <summary>The row rendering <paramref name="tab"/>, if built.</summary>
-    internal FrameworkElement? TabElement(TabModel tab)
-        => _items.TryGetValue(tab, out var item) ? item : null;
+    internal FrameworkElement? TabElement(TabModel tab) => RowElementOf(tab);
 
     /// <summary>Resolve TabModel for a nav item hit-test target.</summary>
     internal TabModel? TabFromElement(DependencyObject? source)
     {
-        var item = VisualTreeHelperEx.FindAncestor<NavigationViewItem>(source);
-        return item?.Tag as TabModel;
+        // A row is either a NavigationViewItem in the scrolling list or a
+        // VerticalTabPinnedRow in the fixed panel; both carry the tab on Tag.
+        if (VisualTreeHelperEx.FindAncestor<NavigationViewItem>(source) is { } item)
+            return item.Tag as TabModel;
+        return VisualTreeHelperEx.FindAncestor<VerticalTabPinnedRow>(source)?.Tag as TabModel;
     }
 
     // -----------------------------------------------------------------
@@ -1403,6 +1654,11 @@ internal sealed partial class VerticalTabStrip : UserControl
         // the flags define.
         public required IReadOnlySet<TabModel> PreDragPinned;
         public required uint PointerId;
+        // The element the press resolved ownership through. The release's
+        // click path needs to know which CONTAINER the press landed in, and
+        // by release time a zone churn may already have moved the row: the
+        // press-time answer is the one that describes where the user aimed.
+        public FrameworkElement? PressRow;
         public double PressY;
         public double PressBaseCenter;
         // The arranged center the anchor currently assumes; the tick's
@@ -1458,11 +1714,14 @@ internal sealed partial class VerticalTabStrip : UserControl
         if (_selectionRowSuppressed) return;
 
         var source = e.OriginalSource as DependencyObject;
-        var item = VisualTreeHelperEx.FindAncestor<NavigationViewItem>(source);
+        // A row is either a NavigationViewItem in the list or a pinned row
+        // in the shelf; both carry the tab on Tag.
+        var item = (FrameworkElement?)VisualTreeHelperEx.FindAncestor<NavigationViewItem>(source)
+                ?? (FrameworkElement?)VisualTreeHelperEx.FindAncestor<VerticalTabPinnedRow>(source);
         if (item is null || item.Tag is not TabModel tab) return;
         // The close button owns its own presses; no drag grows out of one.
         if (VisualTreeHelperEx.FindAncestor<Button>(source) is not null) return;
-        if (!_items.TryGetValue(tab, out var owned) || !ReferenceEquals(owned, item)) return;
+        if (RowElementOf(tab) is not { } owned || !ReferenceEquals(owned, item)) return;
         if (_manager.Tabs.Count < 2) return;
 
         var point = e.GetCurrentPoint(this);
@@ -1479,6 +1738,7 @@ internal sealed partial class VerticalTabStrip : UserControl
             PreDragPinned = new HashSet<TabModel>(
                 _manager.Tabs.Where(t => t.IsPinned)),
             PointerId = e.Pointer.PointerId,
+            PressRow = owned,
             LastPointerY = point.Position.Y,
             PressY = point.Position.Y,
         };
@@ -1514,10 +1774,25 @@ internal sealed partial class VerticalTabStrip : UserControl
         var index = drag.Machine.Drop();
         if (index < 0)
         {
-            // Never lifted past the threshold: a click. Stand down
-            // without touching anything, so activation proceeds exactly
-            // as it would have.
+            // Never lifted past the threshold: a click. Stand down without
+            // touching anything, so activation proceeds exactly as it would
+            // have. For a shelf row, "as it would have" is HERE: the pinned
+            // panel is outside MUXC selection, so no SelectionChanged will
+            // ever carry the click to the manager. The same fenced
+            // activation the selection handler runs, for the rows it cannot
+            // hear; body clicks keep flowing through MUXC untouched.
             _drag = null;
+            if (drag.PressRow is VerticalTabPinnedRow
+                && !ReferenceEquals(drag.Tab, _manager.ActiveTab))
+            {
+                _syncing = true;
+                try { _manager.Activate(drag.Tab); }
+                finally { _syncing = false; }
+
+                ApplyAllItemTabColors();
+                RecolorNavItems();
+                RefreshSelectionChrome();
+            }
             return;
         }
         // Capture is not released here: a synchronous PointerCaptureLost
@@ -1550,7 +1825,7 @@ internal sealed partial class VerticalTabStrip : UserControl
 
     private void StartDragVisual(DragSession drag, PointerRoutedEventArgs e)
     {
-        if (!_items.TryGetValue(drag.Tab, out var item)) { CancelDrag("closed"); return; }
+        if (RowElementOf(drag.Tab) is not { } item) { CancelDrag("closed"); return; }
         if (!CapturePointer(e.Pointer)) { CancelDrag("capture"); return; }
 
         drag.Item = item;
@@ -1643,7 +1918,7 @@ internal sealed partial class VerticalTabStrip : UserControl
     /// </summary>
     private void RebindFollow(DragSession drag, double assumedCenter)
     {
-        if (!_items.TryGetValue(drag.Tab, out var item)) return;
+        if (RowElementOf(drag.Tab) is not { } item) return;
         drag.Item = item;
         if (!double.IsNaN(assumedCenter)) drag.AssumedCenter = assumedCenter;
         ElementCompositionPreview.SetIsTranslationEnabled(item, true);
@@ -1716,7 +1991,7 @@ internal sealed partial class VerticalTabStrip : UserControl
     // Neighbours currently riding a gap glide, by tab. Doubles as the
     // leak census: anything still in here after the drag's teardown is a
     // ghost the trace reports.
-    private readonly Dictionary<TabModel, (NavigationViewItem Item, CompositionScopedBatch Batch)>
+    private readonly Dictionary<TabModel, (FrameworkElement Item, CompositionScopedBatch Batch)>
         _gapMotion = new();
     private int _teardownFailures;
 
@@ -1782,7 +2057,7 @@ internal sealed partial class VerticalTabStrip : UserControl
     private void GlideRow(TabModel tab, double delta, CompositionScopedBatch batch)
     {
         if (_drag is not { } drag) return;
-        if (!_items.TryGetValue(tab, out var item)) return;
+        if (RowElementOf(tab) is not { } item) return;
         try
         {
             var visual = ElementCompositionPreview.GetElementVisual(item);
@@ -1888,6 +2163,23 @@ internal sealed partial class VerticalTabStrip : UserControl
         {
             var top = scroller.TransformToVisual(this)
                 .TransformPoint(new Windows.Foundation.Point(0, 0)).Y;
+            // The pinned shelf sits above the scroller, so a pointer over it
+            // reads as ABOVE the viewport: to the machine that is fromTop
+            // negative, the deepest point of the scroll-up band, and the
+            // strip would phantom-scroll up at full speed under a stationary
+            // finger resting on the panel. Nothing under the pointer there
+            // can reflow -- the shelf is fixed and outside the scroll
+            // content -- so the band is defined to start at the scroller's
+            // top edge and never above it.
+            if (drag.LastPointerY < top)
+            {
+                if (drag.LastAutoscrollSpeed != 0)
+                {
+                    drag.LastAutoscrollSpeed = 0;
+                    DragTrace("DRAG autoscroll speed=0");
+                }
+                return;
+            }
             var speed = drag.Machine.AutoscrollSpeed(
                 drag.LastPointerY, top, top + scroller.ActualHeight);
             if (Math.Abs(speed - drag.LastAutoscrollSpeed) > 0.5)
@@ -1928,7 +2220,7 @@ internal sealed partial class VerticalTabStrip : UserControl
     private void EvaluateDrag()
     {
         if (_drag is not { } drag) return;
-        if (!_manager.Tabs.Contains(drag.Tab) || !_items.ContainsKey(drag.Tab))
+        if (!_manager.Tabs.Contains(drag.Tab) || RowElementOf(drag.Tab) is null)
         {
             CancelDrag("closed");
             return;
@@ -1985,7 +2277,7 @@ internal sealed partial class VerticalTabStrip : UserControl
                 if (drag.HidesSelectionRow) UpdateSelectionRow();
                 else UpdateRowSeparators(selectionRowVisible: true);
             }
-            if (!_items.ContainsKey(drag.Tab)) { CancelDrag("closed"); return; }
+            if (RowElementOf(drag.Tab) is null) { CancelDrag("closed"); return; }
 
             // Move clamps at the pin boundary and no-ops on collapse, so
             // read the truth back: a crossing that did not land must not
@@ -2047,7 +2339,7 @@ internal sealed partial class VerticalTabStrip : UserControl
     /// </summary>
     private double RowCenterY(TabModel tab)
     {
-        if (!_items.TryGetValue(tab, out var item) || item.ActualHeight <= 0)
+        if (RowElementOf(tab) is not { } item || item.ActualHeight <= 0)
             return double.NaN;
         try
         {


### PR DESCRIPTION
Size-override: 1009 countable lines - this rung was already split once (the 5.5 destination preview is a stacked follow-up), and the overage is the review-mandated blocker fixes plus their mutation-checked polarity guards; neither the guards nor the why-comments were cut.

Pinned tabs move out of the scrolling list into a fixed non-scrolling shelf hosted in NavigationView.PaneCustomContent: small-caps 24px "Pinned" header (HeadingLevel 2, visible only while pins exist), 40px icon-only rows with full accessible text (name, "Pinned"/"Bell" ItemStatus, ListItem type, tooltip, bell badge, initial-letter fallback), and the 2px boundary stroke relocated to the shelf's bottom edge with unchanged semantics.

The drag machinery works across both containers untouched: one coordinate space via the strip-root resolver, all row reads through RowElementOf, projection-driven instance-preserving reconcile of both containers with skew rebuilds, MUXC selection fenced to null while a pinned tab is active (overlay places the selection chrome). Autoscroll clamps to zero while the pointer is over the shelf (a panel pointer measures negative fromTop - inside the band - and would otherwise scroll the body at up to 840 px/s). Clicking a shelf row activates it through the sub-threshold release path; the vertical seam cover clips to whichever container the active row lives in. Keyboard focusability of shelf rows is scheduled for the stacked preview PR.