### PR TITLE
vtabs: the pinned-zone drop preview and a keyboard-reachable shelf

### DIFF
--- a/windows/Ghostty.Tests/Wiring/PinnedPanelWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/PinnedPanelWiringTests.cs
@@ -179,8 +179,7 @@ public class PinnedPanelWiringTests
     /// panel is outside selection -- so the drag machine's sub-threshold
     /// release is the only thing that can carry the activation. The
     /// press-time row decides which container the click landed in (by
-    /// release time a zone churn may have moved it), the activation is the
-    /// same fenced one the selection handler runs, and body clicks keep
+    /// release time a zone churn may have moved it), and body clicks keep
     /// flowing through MUXC untouched.
     /// </summary>
     [Fact]
@@ -196,18 +195,11 @@ public class PinnedPanelWiringTests
             .Single(i => i.Condition.ToString()
                 .Contains("drag.PressRow is VerticalTabPinnedRow"));
 
-        var activate = click.Calls("_manager.Activate").Single();
+        // The activation rides the one shared shelf seam -- Enter/Space
+        // takes the same path -- so both gestures are guaranteed the same
+        // fence. The seam's own polarity is pinned with the focus facts.
+        var activate = click.Calls("ActivateFromShelf").Single();
         Assert.Equal("drag.Tab", activate.Arg(0));
-
-        // Fenced like the selection handler's activation: Activate can
-        // surface a selection change synchronously, and an unfenced one
-        // re-enters as a choice the user did not make.
-        var fence = click.AssignsTo("_syncing")
-            .Where(a => a.Right.ToString() == "true")
-            .ToList();
-        Assert.Single(fence);
-        Assert.True(fence[0].Span.Start < activate.Span.Start,
-            "the activation must be fenced, not just performed");
     }
 
     /// <summary>

--- a/windows/Ghostty.Tests/Wiring/PinnedPreviewWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/PinnedPreviewWiringTests.cs
@@ -1,0 +1,204 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// The pin drop preview (5.5): an icon-only ghost slot promising where a
+/// body row dragged over the shelf would land. Three load-bearing
+/// properties are pinned here. The promise's polarity -- it exists only
+/// while the drop would actually deliver a pin, because a ghost that
+/// outlives its premise is a lie about where the row will end up. Its
+/// blindness to the manager -- the ghost is pixels, and the commit is the
+/// zone grammar's job. And the exit completeness -- every way a drag ends
+/// takes the ghost with it, or a promise outlives the gesture.
+///
+/// Wiring guards, not behaviour tests: where the ghost paints on a live
+/// drag is only observable on a live strip.
+/// </summary>
+public class PinnedPreviewWiringTests
+{
+    private static ShellSource Strip() => ShellSource.Load("Tabs.VerticalTabStrip.xaml.cs");
+
+    /// <summary>
+    /// Show means "the drop would pin": the dragged row is still unpinned,
+    /// pins exist, and its center is over the shelf. The pinned arm of the
+    /// gate is the one that goes wrong silently -- once the crossing has
+    /// committed, the real icon-only row is in the shelf following the
+    /// pointer, and a ghost alongside it promises a slot the real row
+    /// already holds. The shelf-bottom comparison is the "over the shelf"
+    /// half of the grammar, in the coordinates the machine judges
+    /// crossings in.
+    /// </summary>
+    [Fact]
+    public void ThePreview_ShowsOnlyWhileTheDropWouldPin()
+    {
+        var update = Strip().Method("UpdatePinPreview");
+
+        // The gate hides on every non-promise state, with the pinned test
+        // first: flipping it to `!drag.Tab.IsPinned` keeps the ghost up
+        // after the commit, which is the double-promise regression -- so
+        // the disjunct is pinned at the head of the condition, polarity
+        // included.
+        var gate = update.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString().Contains("drag.Tab.IsPinned"));
+        Assert.StartsWith(
+            "drag.Tab.IsPinned || _manager.PinCount == 0",
+            gate.Condition.ToString());
+        Assert.Contains("draggedCenter >= shelfBottom", gate.Condition.ToString());
+        Assert.Contains(
+            gate.Statement.DescendantNodesAndSelf().OfType<InvocationExpressionSyntax>(),
+            c => c.CalleeText() == "HidePinPreview");
+
+        // And the hide short-circuits the show: no branch past the gate
+        // may run while the gate holds.
+        var show = update.Calls("ShowPinPreview").Single();
+        Assert.True(gate.Span.End < show.Span.Start,
+            "the show must be unreachable while the hide-gate holds");
+
+        // The slot promises where the row will actually land: one row pitch
+        // down from the last pinned row's center, with BOTH of the rows'
+        // 2px vertical insets accounted. The ghost zeroes its own margin
+        // and a real row's top margin is half of where its center lands,
+        // so shorting either inset parks the ghost 2px proud of the slot
+        // and flashes at the handoff. The exact expression is the guard --
+        // the omission, not an inversion, is how this regresses.
+        Assert.Contains(
+            update.DescendantNodes().OfType<ArgumentSyntax>(),
+            a => a.Expression.ToString() ==
+                "lastCenter + VerticalTabPinnedRow.RowHeight / 2 "
+                + "+ 2 * RowInsetVertical");
+    }
+
+    /// <summary>
+    /// An unreadable measurement hides the ghost rather than moving it.
+    /// EvaluateDrag returns early when the dragged row has no arranged
+    /// truth this tick, which used to skip UpdatePinPreview entirely -- a
+    /// ghost left standing on the previous tick's promise. The early
+    /// return must hide first, and it must sit before the tick's show
+    /// call, so "no promise" is what an unreadable frame delivers.
+    /// </summary>
+    [Fact]
+    public void AnUnreadableMeasurement_HidesThePreview()
+    {
+        var evaluate = Strip().Method("EvaluateDrag");
+        var unreadable = evaluate.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "double.IsNaN(arranged)");
+        Assert.Contains(
+            unreadable.Statement.DescendantNodesAndSelf()
+                .OfType<InvocationExpressionSyntax>(),
+            c => c.CalleeText() == "HidePinPreview");
+        Assert.Contains(
+            unreadable.Statement.DescendantNodesAndSelf()
+                .OfType<ReturnStatementSyntax>(),
+            r => true);
+
+        // And the hide comes before the tick's show, so a tick either
+        // commits to a fresh promise or commits to none.
+        var show = evaluate.Calls("UpdatePinPreview").Single();
+        Assert.True(unreadable.Span.End < show.Span.Start,
+            "the unreadable-measurement hide must precede the tick's show");
+    }
+
+    /// <summary>
+    /// The ghost is strictly visual. None of the three state-machine
+    /// methods may touch the manager: the commit at drop flows through
+    /// Classify/SetPinned in the release path, and a preview that moved a
+    /// row would turn a promise into a mutation a cancel could not undo.
+    /// The ghost also never joins the pinned panel -- the reconcile counts
+    /// those children against the projection, and a ghost child would
+    /// fail every mid-drag commit into a full rebuild.
+    /// </summary>
+    [Fact]
+    public void ThePreview_IsPixelsOnly_NeverManagerState()
+    {
+        foreach (var method in new[]
+                 {
+                     "UpdatePinPreview", "ShowPinPreview", "HidePinPreview",
+                 })
+        {
+            var body = Strip().Method(method);
+            Assert.DoesNotContain(
+                body.DescendantNodes().OfType<InvocationExpressionSyntax>(),
+                c => c.CalleeText().StartsWith("_manager."));
+            Assert.DoesNotContain(
+                body.DescendantNodes().OfType<InvocationExpressionSyntax>(),
+                c => c.CalleeText() == "_pinnedPanel.Children.Add");
+        }
+
+        // The ghost lives in the overlay host instead, which no reconcile
+        // counts.
+        var show = Strip().Method("ShowPinPreview");
+        Assert.Single(show.Calls("PreviewHost.Children.Add"));
+    }
+
+    /// <summary>
+    /// The drop honours the promise the user can see, through the same
+    /// zone grammar the tick loop commits with: the ghost's visibility is
+    /// the gate, Classify names the op, and SetPinned relocates the row to
+    /// the prefix's last slot -- exactly where the ghost sat, so the hand
+    /// off shows no flash of wrong position. Committing without the gate
+    /// would pin rows dropped anywhere; committing without the grammar
+    /// would bypass the read-back.
+    /// </summary>
+    [Fact]
+    public void TheDrop_HonoursTheVisibleGhost_ThroughTheZoneGrammar()
+    {
+        var released = Strip().Method("OnDragPointerReleased");
+
+        var gate = released.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "_pinPreview is not null");
+        var classify = gate.Calls("TabPinBoundary.Classify").Single();
+        var setPinned = gate.Calls("_manager.SetPinned").Single();
+        Assert.True(classify.Span.Start < setPinned.Span.Start,
+            "the drop commit must classify before it pins, like the tick loop");
+
+        Assert.Equal("drag.Tab.IsPinned", classify.Arg(0));
+        Assert.Equal("_manager.PinCount - 1", classify.Arg(3));
+        Assert.Equal("drag.Tab", setPinned.Arg(0));
+        Assert.Equal("true", setPinned.Arg(1));
+
+        // The churn replaced the dragged row's element, so there is no
+        // live visual to settle: this path must land the row as a cut,
+        // not start a spring on a visual that is no longer in the tree.
+        var end = gate.Calls("EndDrag").Single();
+        Assert.Equal("settle: false", end.Arg(1));
+    }
+
+    /// <summary>
+    /// Every way a drag ends takes the ghost with it. EndDrag is the
+    /// shared tail -- the release drops through it, and every cancel
+    /// family (escape, capture loss, row close, layout switch, teardown)
+    /// funnels through CancelDrag into it -- so one hide there covers the
+    /// exit paths, and the fact ties each family to the funnel so a new
+    /// exit path cannot quietly skip it.
+    /// </summary>
+    [Fact]
+    public void EveryDragExit_ReachesTheHide()
+    {
+        var strip = Strip();
+
+        Assert.Single(strip.Method("EndDrag").Calls("HidePinPreview"));
+
+        // The cancel funnel ends at EndDrag, which is where the hide sits.
+        Assert.NotEmpty(strip.Method("CancelDrag").Calls("EndDrag"));
+
+        // Each exit family: escape, pointer cancel, capture loss, the
+        // mid-drag row close, the layout switch, and teardown.
+        Assert.NotEmpty(strip.Method("OnDragKeyDown").Calls("CancelDrag"));
+        Assert.NotEmpty(strip.Method("OnDragPointerCanceled").Calls("CancelDrag"));
+        Assert.NotEmpty(strip.Method("OnDragPointerCaptureLost").Calls("CancelDrag"));
+        Assert.NotEmpty(strip.Method("RemoveItem").Calls("CancelDrag"));
+        Assert.NotEmpty(strip.Method("SetSelectionRowSuppressed").Calls("CancelDrag"));
+        var unloaded = strip.Root.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Single(a => a.Left.ToString() == "Unloaded");
+        Assert.NotEmpty(unloaded.Right.Calls("CancelDrag"));
+
+        // And the show runs only from the coalesced tick: a preview that
+        // appeared from a raw pointer event would have no hide ordering
+        // against the machine's phases.
+        Assert.Single(strip.Method("EvaluateDrag").Calls("UpdatePinPreview"));
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/PinnedRowFocusWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/PinnedRowFocusWiringTests.cs
@@ -1,0 +1,254 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// The shelf's keyboard story. The pinned rows sit outside MUXC, so the
+/// body rows' focus traversal -- tab stops, arrows, selection-on-focus --
+/// does not reach them by itself: the row carries the tab stop and the
+/// peer that makes focus visible to a client, the strip's key handler
+/// walks the shelf and crosses the boundary at its edges, and activation
+/// takes the one fenced shelf seam. One seam into the shelf from the body
+/// (Up from the first body row); every other arrow stays MUXC's.
+///
+/// Wiring guards, not behaviour tests: traversal feel is only observable
+/// on a live strip; the manager-side pairing lives in TabManager tests.
+/// </summary>
+public class PinnedRowFocusWiringTests
+{
+    private static ShellSource Strip() => ShellSource.Load("Tabs.VerticalTabStrip.xaml.cs");
+
+    private static ShellSource Row() =>
+        ShellSource.Load("Tabs.VerticalTabPinnedRow.cs");
+
+    private static ShellSource Peer() =>
+        ShellSource.Load("Accessibility.VerticalTabPinnedRowAutomationPeer.cs");
+
+    /// <summary>
+    /// A shelf row must be reachable at all: the tab stop is what lets it
+    /// take focus, and the peer is what reports that focus to a client --
+    /// a plain Grid gets no peer, so without the override a screen reader
+    /// never hears that the shelf is where focus went. The peer types the
+    /// row ListItem (what MUXC types the body rows) and claims
+    /// focusability, or keyboard traversal skips the shelf entirely.
+    /// </summary>
+    [Fact]
+    public void ShelfRows_AreTabStops_AndReportFocusToClients()
+    {
+        var ctor = Row().Root.DescendantNodes().OfType<ConstructorDeclarationSyntax>()
+            .Single(c => c.Identifier.ValueText == "VerticalTabPinnedRow");
+        var tabStop = ctor.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Single(a => a.Left.ToString() == "IsTabStop");
+        Assert.Equal("true", tabStop.Right.ToString());
+
+        // The peer exists, and says ListItem + focusable. Flipping the
+        // control type or the focusability core is the "shelf is
+        // invisible to clients" regression.
+        Assert.Contains(
+            Row().Root.DescendantNodes().OfType<MethodDeclarationSyntax>(),
+            m => m.Identifier.ValueText == "OnCreateAutomationPeer");
+        var peer = Peer();
+        var controlType = peer.Method("GetAutomationControlTypeCore");
+        Assert.Contains(
+            "AutomationControlType.ListItem",
+            controlType.ExpressionBody!.ToString());
+        var focusable = peer.Method("IsKeyboardFocusableCore");
+        Assert.Contains("IsTabStop: true", focusable.ExpressionBody!.ToString());
+    }
+
+    /// <summary>
+    /// Enter and Space activate through the ONE shelf seam -- the same
+    /// fenced activation a shelf click takes -- and nothing else: no
+    /// selection write, no unfenced manager call. The fence matters
+    /// because Activate can surface a selection change synchronously, and
+    /// an unfenced one re-enters as a choice the user did not make. The
+    /// active-row guard keeps re-activating the active tab from repainting
+    /// the strip for no state change.
+    /// </summary>
+    [Fact]
+    public void EnterOrSpace_ActivatesThroughTheSharedFence()
+    {
+        var key = Strip().Method("OnPinnedRowKeyDown");
+
+        // Both keys, one arm, and it is the shared seam -- not a private
+        // Activate call that could drift from the click path.
+        var activate = key.Calls("ActivateFromShelf").Single();
+        Assert.Equal("tab", activate.Arg(0));
+        var arm = activate.Ancestors().OfType<SwitchSectionSyntax>().First();
+        Assert.Contains(
+            "Windows.System.VirtualKey.Enter or Windows.System.VirtualKey.Space",
+            arm.Labels.ToString());
+        var handled = arm.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.Left.ToString() == "e.Handled")
+            .ToList();
+        Assert.NotEmpty(handled);
+
+        // The seam itself: guarded, fenced, then the manager call.
+        var seam = Strip().Method("ActivateFromShelf");
+        var guard = seam.DescendantNodes().OfType<IfStatementSyntax>().Single();
+        Assert.Equal(
+            "ReferenceEquals(tab, _manager.ActiveTab)",
+            guard.Condition.ToString());
+        var managerActivate = seam.Calls("_manager.Activate").Single();
+        Assert.Equal("tab", managerActivate.Arg(0));
+        var fence = seam.AssignsTo("_syncing")
+            .Where(a => a.Right.ToString() == "true")
+            .ToList();
+        Assert.Single(fence);
+        Assert.True(fence[0].Span.Start < managerActivate.Span.Start,
+            "the activation must be fenced, not just performed");
+
+        // And the click path shares it: one seam, two callers.
+        Assert.NotEmpty(Strip().Method("OnDragPointerReleased")
+            .Calls("ActivateFromShelf"));
+    }
+
+    /// <summary>
+    /// Arrows cross the boundary only at its edges. Down past the last
+    /// pinned row lands on the FIRST body row, where MUXC's traversal
+    /// resumes; inside the shelf the neighbours are the panel's own
+    /// children, whose order the reconcile keeps equal to the projection.
+    /// Up from the first body row is the one seam INTO the shelf, and it
+    /// exists only while the shelf does -- without the pin gate the
+    /// interception would fork MUXC's traversal on every pin-free strip.
+    /// </summary>
+    [Fact]
+    public void Arrows_CrossTheBoundary_AtItsEdges_Only()
+    {
+        var strip = Strip();
+
+        // Out of the shelf downward, and only downward: the neighbour walk
+        // exits to the first body row on the DOWN edge alone.
+        var walk = strip.Method("FocusShelfNeighbour");
+        var exits = walk.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(c => c.CalleeText().EndsWith(".Focus"))
+            .ToList();
+        Assert.Equal(2, exits.Count);
+        var bodyExit = exits.Single(c => c.CalleeText() == "firstBody.Focus");
+        var bodyExitGate = bodyExit.Ancestors().OfType<IfStatementSyntax>()
+            .First(i => i.Condition.ToString().Contains("delta > 0"));
+        Assert.Contains("firstBody.Focus", bodyExitGate.Statement.ToString());
+        // The top edge is a stop, spelled as the bare false it returns.
+        Assert.Contains(walk.DescendantNodes().OfType<ReturnStatementSyntax>(),
+            r => r.Expression!.ToString() == "false");
+
+        // Into the shelf: Up from the FIRST body row only, and only while
+        // the shelf exists. First though, the stand-down the shelf handler
+        // already keeps: while a drag is live the keyboard belongs to it
+        // (Escape cancels), so the body seam must not fire under one.
+        var body = strip.Method("OnBodyRowKeyDown");
+        var standDown = body.DescendantNodes().OfType<IfStatementSyntax>().First();
+        Assert.Equal("_drag is not null", standDown.Condition.ToString());
+        Assert.Contains(
+            standDown.Statement.DescendantNodesAndSelf().OfType<ReturnStatementSyntax>(),
+            r => true);
+        var upGate = body.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "e.Key != Windows.System.VirtualKey.Up");
+        Assert.Contains(
+            upGate.Statement.DescendantNodesAndSelf().OfType<ReturnStatementSyntax>(),
+            r => true);
+        var pinGate = body.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "_manager.PinCount == 0");
+        Assert.Contains(
+            pinGate.Statement.DescendantNodesAndSelf().OfType<ReturnStatementSyntax>(),
+            r => true);
+
+        // The target is the LAST shelf row -- the geometric neighbour --
+        // and the key is claimed only after focus actually landed.
+        var focus = body.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Single(c => c.CalleeText().Contains("_pinnedPanel.Children[^1].Focus"));
+        Assert.Equal("FocusState.Programmatic", focus.Arg(0));
+        var claimed = body.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Single(a => a.Left.ToString() == "e.Handled");
+        Assert.True(focus.Span.Start < claimed.Span.Start,
+            "the key may be claimed only after focus landed on the shelf");
+    }
+
+    /// <summary>
+    /// The wiring is attached where the rows are built, so a row that
+    /// exists is a row that listens: the shelf rows get the key handler
+    /// and the focus visual, and the body items get the boundary seam --
+    /// each on its own container.
+    /// </summary>
+    [Fact]
+    public void TheHandlers_AreWiredWhereTheRowsAreBuilt()
+    {
+        var strip = Strip();
+
+        var pinned = strip.Method("AddPinnedRow");
+        var pinnedWiring = pinned.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.Left.ToString() is "row.KeyDown" or "row.GotFocus" or "row.LostFocus")
+            .Select(a => a.Left.ToString())
+            .ToList();
+        Assert.Equal(
+            new[] { "row.KeyDown", "row.GotFocus", "row.LostFocus" }, pinnedWiring);
+
+        var bodyItem = strip.Method("AddBodyRow");
+        var bodyWiring = bodyItem.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.Left.ToString() == "item.KeyDown")
+            .ToList();
+        Assert.Single(bodyWiring);
+
+        // The focus visual is the pane's hover-fill resource, resolved
+        // through the strip's theme resources -- not a second colour
+        // invented for focus. Pinned rows paint no hover state today, so
+        // this fill is focus's alone.
+        var visual = strip.Method("OnPinnedRowFocusVisual");
+        Assert.Single(visual.Calls("ResolveThemeBrush"));
+    }
+
+    /// <summary>
+    /// Focus survives the churn this strip rebuilds with. Making shelf rows
+    /// tab stops made them removable while focused: a keyboard unpin (or
+    /// any zone crossing) surfaces as Remove+Add, the removed element takes
+    /// focus with it, and the rebuilt one starts unfocused -- without a
+    /// hand-off the focus drops out of the strip entirely and the arrows
+    /// go dead until a click. The hand-off is polarity-guarded at both
+    /// ends: RemoveItem records the candidate only when the removed
+    /// element actually held focus (a rebuild that churns an unfocused row
+    /// must restore nothing), and AddItem restores only to the same tab's
+    /// fresh element, forgetting the candidate before it focuses so a
+    /// later unrelated churn cannot re-fire a stale one.
+    /// </summary>
+    [Fact]
+    public void AFocusedRow_RebuiltByChurn_TakesFocusWithIt()
+    {
+        var strip = Strip();
+
+        // Both removal arms record, and only when the row held focus: the
+        // exact texts are the polarity. Inverting either comparison makes
+        // the record fire for unfocused rows instead of focused ones.
+        var removes = strip.Method("RemoveItem").AssignsTo("_refocusTab").ToList();
+        Assert.Equal(2, removes.Count);
+        Assert.Equal(
+            new[]
+            {
+                "pinned.FocusState != FocusState.Unfocused",
+                "item.FocusState != FocusState.Unfocused",
+            },
+            removes.Select(a => a.Ancestors().OfType<IfStatementSyntax>().First()
+                .Condition.ToString()).ToArray());
+        Assert.All(removes, a => Assert.Equal("tab", a.Right.ToString()));
+
+        // The restore: gated on the same tab, and the candidate is dropped
+        // before the focus lands -- gate, forget, focus, in that order, or
+        // a churn of another tab could re-fire this one.
+        var add = strip.Method("AddItem");
+        var gate = add.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "!ReferenceEquals(_refocusTab, tab)");
+        Assert.Contains(
+            gate.Statement.DescendantNodesAndSelf().OfType<ReturnStatementSyntax>(),
+            r => true);
+        var forget = add.AssignsTo("_refocusTab").Single();
+        Assert.Equal("null", forget.Right.ToString());
+        var focus = add.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Single(c => c.CalleeText() == "RowElementOf(tab)?.Focus");
+        Assert.Equal("FocusState.Programmatic", focus.Arg(0));
+        Assert.True(
+            gate.Span.End < forget.Span.Start && forget.Span.Start < focus.Span.Start,
+            "the restore must gate, then forget, then focus");
+    }
+}

--- a/windows/Ghostty/Accessibility/VerticalTabPinnedRowAutomationPeer.cs
+++ b/windows/Ghostty/Accessibility/VerticalTabPinnedRowAutomationPeer.cs
@@ -1,0 +1,33 @@
+using Ghostty.Tabs;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation.Peers;
+
+namespace Ghostty.Accessibility;
+
+/// <summary>
+/// UIA peer for an icon-only pinned tab row. Reports ListItem, matching
+/// the body rows MUXC types for itself, and claims keyboard focusability
+/// explicitly: the row is a tab stop the strip's key handler moves focus
+/// through, and a peer that does not say so leaves the whole shelf
+/// invisible to a keyboard-only client's focus traversal.
+///
+/// The framework raises the focus-changed event through whatever peer the
+/// focused element reports, so this peer existing is what makes a screen
+/// reader track shelf focus at all.
+/// </summary>
+internal sealed partial class VerticalTabPinnedRowAutomationPeer
+    : FrameworkElementAutomationPeer
+{
+    public VerticalTabPinnedRowAutomationPeer(VerticalTabPinnedRow owner)
+        : base(owner) { }
+
+    protected override AutomationControlType GetAutomationControlTypeCore()
+        => AutomationControlType.ListItem;
+
+    protected override bool IsKeyboardFocusableCore()
+        => Owner is VerticalTabPinnedRow
+           {
+               IsTabStop: true,
+               Visibility: Visibility.Visible,
+           };
+}

--- a/windows/Ghostty/Tabs/VerticalTabPinnedRow.cs
+++ b/windows/Ghostty/Tabs/VerticalTabPinnedRow.cs
@@ -1,3 +1,4 @@
+using Ghostty.Accessibility;
 using Ghostty.Core.Tabs;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
@@ -40,6 +41,12 @@ internal sealed partial class VerticalTabPinnedRow : Grid
         Height = RowHeight;
         // Same inset the body rows get through NavigationViewItemContentMargin.
         Margin = new Thickness(4, 2, 0, 2);
+        // Keyboard parity with the body rows: MUXC's containers are tab
+        // stops with their own arrow traversal, and this row is outside
+        // MUXC, so it carries the tab stop itself and the strip's key
+        // handler moves focus across the boundary. The drop-preview ghost
+        // is built from this same class and turns the flag back off.
+        IsTabStop = true;
         // Body rows are ListItems because MUXC says so; say it here too, so
         // a client hears one kind of thing on both sides of the boundary.
         AutomationProperties.SetAutomationControlType(
@@ -111,6 +118,15 @@ internal sealed partial class VerticalTabPinnedRow : Grid
             ? name[..2]
             : name[..1];
     }
+
+    /// <summary>
+    /// The row has to be its own peer for focus to be visible to a client
+    /// at all: a plain Grid gets no peer, and without one the keyboard
+    /// focus this row takes raises no automation focus event, so a screen
+    /// reader never knows the shelf is where focus went.
+    /// </summary>
+    protected override AutomationPeer OnCreateAutomationPeer()
+        => new VerticalTabPinnedRowAutomationPeer(this);
 
     /// <summary>Apply the ink the icon draws with. The bell stays accent.</summary>
     public void ApplyInk(Brush? foreground)

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml
@@ -23,6 +23,15 @@
                     CornerRadius="0"/>
         </Canvas>
 
+        <!-- Over NavView: the pin preview is a promise about a slot in the
+             pane, and a host behind the pane would vanish under every
+             painted fill. Hit-test invisible so the pane's own hover,
+             press, and scroll behavior under it never notices. -->
+        <Canvas x:Name="PreviewHost"
+                Canvas.ZIndex="2"
+                IsHitTestVisible="False"
+                Visibility="Collapsed"/>
+
         <controls:NavigationView x:Name="NavView"
                                  IsBackButtonVisible="Collapsed"
                                  IsSettingsVisible="False"

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -437,6 +437,20 @@ internal sealed partial class VerticalTabStrip : UserControl
     private readonly Dictionary<TabModel, VerticalTabPinnedRow> _pinnedRows = new();
     private readonly Dictionary<TabModel, TabHooks> _pinnedHooks = new();
 
+    // The drop preview: an icon-only ghost slot promising where a body row
+    // dragged over the shelf would land. It exists only while that promise
+    // is deliverable -- unpinned row, pointer over the shelf -- and it is
+    // strictly visual: it never touches manager state, and the drop that
+    // honours it still commits through the zone grammar (Classify /
+    // SetPinned / read-back), never through the ghost.
+    private VerticalTabPinnedRow? _pinPreview;
+
+    // The tab whose row held focus when a churn removed it, so the rebuilt
+    // row can take the focus with it (AddItem). Focus is unique, so at
+    // most one removal in a churn can set this; a candidate left over by a
+    // tab that never comes back is inert -- the restore is by reference.
+    private TabModel? _refocusTab;
+
     /// <summary>
     /// Paint the strip lane, or leave it to the window backdrop.
     ///
@@ -1328,6 +1342,18 @@ internal sealed partial class VerticalTabStrip : UserControl
         if (_items.ContainsKey(tab) || _pinnedRows.ContainsKey(tab)) return;
         if (tab.IsPinned) AddPinnedRow(tab);
         else AddBodyRow(tab);
+
+        // A churn rebuild (Move's Remove+Add, a pin relocation, a
+        // RebuildAllItems) removed the element that held focus and
+        // inserted a fresh one. Without this hand-off a keyboard unpin of
+        // the focused row drops focus out of the strip entirely -- the
+        // panel is not a control, nothing re-takes it, and the arrows go
+        // dead until a click. The candidate is only set by RemoveItem
+        // when the removed element actually held focus, so a plain
+        // rebuild that churns an unfocused row restores nothing.
+        if (!ReferenceEquals(_refocusTab, tab)) return;
+        _refocusTab = null;
+        RowElementOf(tab)?.Focus(FocusState.Programmatic);
     }
 
     private void AddBodyRow(TabModel tab)
@@ -1377,6 +1403,10 @@ internal sealed partial class VerticalTabStrip : UserControl
 
         _items[tab] = item;
         _hooks[tab] = new TabHooks(textBinding, colorBinding, vm, iconHandler);
+
+        // One seam into the shelf: Up from the first body row walks into
+        // it. Every other arrow reaches MUXC's own traversal untouched.
+        item.KeyDown += OnBodyRowKeyDown;
 
         // Fenced because an Insert before the current selection shifts what
         // MUXC considers selected and raises SelectionChanged for a tab the
@@ -1429,6 +1459,16 @@ internal sealed partial class VerticalTabStrip : UserControl
         _pinnedRows[tab] = row;
         _pinnedHooks[tab] = new TabHooks(textBinding, colorBinding, vm, iconHandler);
         _pinnedPanel.Children.Add(row);
+
+        // Outside MUXC, the row owns its own keyboard story: Enter/Space
+        // activate through the same fenced path a shelf click uses, and
+        // Up/Down walk within the shelf and across the boundary. The focus
+        // indicator is the pane's hover-fill resource -- pinned rows paint
+        // no hover state today, so the fill is focus's alone -- because
+        // the row has no focus rect of its own to lean on.
+        row.KeyDown += OnPinnedRowKeyDown;
+        row.GotFocus += OnPinnedRowFocusVisual;
+        row.LostFocus += OnPinnedRowFocusVisual;
     }
 
     /// <summary>
@@ -1465,6 +1505,10 @@ internal sealed partial class VerticalTabStrip : UserControl
         // no fence -- only MenuItems removals can move MUXC's selection.)
         if (_pinnedRows.Remove(tab, out var pinned))
         {
+            // Remember whether the row held focus before it goes: its
+            // replacement (same tab, rebuilt in the other container on a
+            // zone crossing) should take the focus with it (AddItem).
+            if (pinned.FocusState != FocusState.Unfocused) _refocusTab = tab;
             _pinnedPanel.Children.Remove(pinned);
             if (_pinnedHooks.Remove(tab, out var pinnedHooks))
                 pinnedHooks.Dispose();
@@ -1472,6 +1516,7 @@ internal sealed partial class VerticalTabStrip : UserControl
         }
 
         if (!_items.TryGetValue(tab, out var item)) return;
+        if (item.FocusState != FocusState.Unfocused) _refocusTab = tab;
 
         // Fenced for the same reason as the insert in AddBodyRow: removing
         // the selected row moves MUXC's selection to a neighbour and
@@ -1584,6 +1629,97 @@ internal sealed partial class VerticalTabStrip : UserControl
         ApplyAllItemTabColors();
         RecolorNavItems();
         RefreshSelectionChrome();
+    }
+
+    /// <summary>
+    /// The activation a shelf row gets, from a click (the drag machine's
+    /// sub-threshold release) or from Enter/Space. The pinned panel is
+    /// outside MUXC selection, so no SelectionChanged will ever carry
+    /// either gesture to the manager: this is the same fenced activation
+    /// the selection handler runs, spoken for the rows it cannot hear.
+    /// </summary>
+    private void ActivateFromShelf(TabModel tab)
+    {
+        if (ReferenceEquals(tab, _manager.ActiveTab)) return;
+
+        _syncing = true;
+        try { _manager.Activate(tab); }
+        finally { _syncing = false; }
+
+        ApplyAllItemTabColors();
+        RecolorNavItems();
+        RefreshSelectionChrome();
+    }
+
+    private void OnPinnedRowKeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        // A drag owns the keyboard (Escape cancels it) and a drag never
+        // activates, so shelf keys stand down while one is live.
+        if (_drag is not null) return;
+        if (sender is not VerticalTabPinnedRow { Tag: TabModel tab }) return;
+        switch (e.Key)
+        {
+            case Windows.System.VirtualKey.Enter or Windows.System.VirtualKey.Space:
+                e.Handled = true;
+                ActivateFromShelf(tab);
+                break;
+            case Windows.System.VirtualKey.Down or Windows.System.VirtualKey.Up:
+                e.Handled = FocusShelfNeighbour(
+                    tab, e.Key == Windows.System.VirtualKey.Down ? 1 : -1);
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Walk the shelf, and cross the boundary at its edges. Panel order IS
+    /// projection order (ReconcileRowOrder keeps them equal), so indexes
+    /// here are the row's real neighbours. Down past the last pinned row
+    /// lands on the first body row, where MUXC's own arrow traversal takes
+    /// over; Up past the first stops -- the pane toggle above is MUXC's.
+    /// </summary>
+    private bool FocusShelfNeighbour(TabModel tab, int delta)
+    {
+        if (RowElementOf(tab) is not { } row) return false;
+        var i = _pinnedPanel.Children.IndexOf(row) + delta;
+        if (i >= 0 && i < _pinnedPanel.Children.Count)
+            return _pinnedPanel.Children[i].Focus(FocusState.Programmatic);
+
+        if (delta > 0
+            && NavView.MenuItems.OfType<NavigationViewItem>().FirstOrDefault()
+            is { } firstBody)
+            return firstBody.Focus(FocusState.Programmatic);
+
+        return false;
+    }
+
+    private void OnBodyRowKeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        // A drag owns the keyboard (Escape cancels it), here too.
+        if (_drag is not null) return;
+        // The one seam into the shelf from the body: Up from the FIRST
+        // body row, only while the shelf exists. Everything else -- every
+        // other key, every other row, no pins at all -- is MUXC's arrow
+        // traversal, which must stay exactly as it was.
+        if (e.Key != Windows.System.VirtualKey.Up) return;
+        if (_manager.PinCount == 0) return;
+        if (sender is not NavigationViewItem) return;
+        if (NavView.MenuItems.OfType<NavigationViewItem>().FirstOrDefault()
+            is not { } first || !ReferenceEquals(first, sender)) return;
+        if (_pinnedPanel.Children.Count == 0) return;
+        if (!_pinnedPanel.Children[^1].Focus(FocusState.Programmatic)) return;
+        e.Handled = true;
+    }
+
+    private void OnPinnedRowFocusVisual(object sender, RoutedEventArgs e)
+    {
+        if (sender is not VerticalTabPinnedRow row) return;
+        // The pane's hover-fill resource, reused as the focus indicator:
+        // pinned rows paint no hover state today, so this fill is focus's
+        // alone, and the row's FocusState is what picks it over the
+        // transparent rest state.
+        row.Background = row.FocusState == FocusState.Unfocused
+            ? TransparentBrush
+            : ResolveThemeBrush("SubtleFillColorSecondaryBrush");
     }
 
     /// <summary>The row rendering <paramref name="tab"/>, if built.</summary>
@@ -1778,21 +1914,37 @@ internal sealed partial class VerticalTabStrip : UserControl
             // touching anything, so activation proceeds exactly as it would
             // have. For a shelf row, "as it would have" is HERE: the pinned
             // panel is outside MUXC selection, so no SelectionChanged will
-            // ever carry the click to the manager. The same fenced
-            // activation the selection handler runs, for the rows it cannot
-            // hear; body clicks keep flowing through MUXC untouched.
+            // ever carry the click to the manager -- ActivateFromShelf is
+            // the fenced activation the selection handler runs, for the
+            // rows it cannot hear. Body clicks keep flowing through MUXC.
             _drag = null;
-            if (drag.PressRow is VerticalTabPinnedRow
-                && !ReferenceEquals(drag.Tab, _manager.ActiveTab))
+            if (drag.PressRow is VerticalTabPinnedRow)
+                ActivateFromShelf(drag.Tab);
+            return;
+        }
+        // Drop inside the pinned zone pins (5.5). The preview is the
+        // promise -- it shows only while the row is still unpinned and its
+        // center is over the shelf -- so honouring it at release is the
+        // same zone-grammar commit the tick loop runs: Classify names the
+        // op, SetPinned relocates to the prefix's last slot (exactly where
+        // the ghost sat), and the read-back traces what landed. The churn
+        // has replaced the dragged row's element, so there is no live
+        // visual to settle: the row lands as a cut, in the ghost's slot.
+        if (_pinPreview is not null)
+        {
+            var zone = TabPinBoundary.Classify(
+                drag.Tab.IsPinned, _manager.PinCount, _manager.Tabs.Count,
+                _manager.PinCount - 1);
+            if (zone.Op == TabPinZoneOp.Pin)
             {
-                _syncing = true;
-                try { _manager.Activate(drag.Tab); }
-                finally { _syncing = false; }
-
-                ApplyAllItemTabColors();
-                RecolorNavItems();
-                RefreshSelectionChrome();
+                _commitChurn = true;
+                try { _manager.SetPinned(drag.Tab, true); }
+                finally { _commitChurn = false; }
+                DragTrace(
+                    $"DRAG pin drop landed={_manager.IndexOf(drag.Tab)} " +
+                    $"to={zone.To}");
             }
+            EndDrag(drag, settle: false, velocity: 0);
             return;
         }
         // Capture is not released here: a synchronous PointerCaptureLost
@@ -2229,7 +2381,15 @@ internal sealed partial class VerticalTabStrip : UserControl
         drag.Machine.UpdateIndex(_manager.IndexOf(drag.Tab));
         RemeasureCenters(drag);
         double arranged = RowCenterY(drag.Tab);
-        if (double.IsNaN(arranged)) return;
+        if (double.IsNaN(arranged))
+        {
+            // The dragged row has no arranged truth this tick, so the
+            // preview's gate cannot be evaluated: an unreadable
+            // measurement is no promise, and a ghost left standing on a
+            // stale one outlives its premise.
+            HidePinPreview();
+            return;
+        }
         var draggedCenter = arranged + (drag.LastPointerY - drag.AnchorY);
 
         // Pre-commit arranged centers, one measurement per row: the gap
@@ -2314,6 +2474,118 @@ internal sealed partial class VerticalTabStrip : UserControl
                 if (drag.Properties is not null) ApplyAnchor(drag, drag.Properties);
             }
         }
+
+        UpdatePinPreview(drag, draggedCenter);
+    }
+
+    // -----------------------------------------------------------------
+    // The pin drop preview (5.5): while a body row is dragged over the
+    // shelf and has not yet committed its crossing, an icon-only ghost
+    // slot sits in the shelf at the position the drop would land. The
+    // state machine is show/move/hide: shown and re-positioned from the
+    // coalesced drag tick, hidden by EndDrag -- the shared tail of the
+    // drop and every cancel -- and it never touches manager state. Once
+    // the crossing DOES commit, the real icon-only row is in the shelf
+    // following the pointer, and the ghost would promise a slot the real
+    // row already holds; the gate below hides it on that tick.
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// Re-derive the ghost from this tick's truth. The promise is only
+    /// alive while the dragged row is still unpinned, pins exist, and the
+    /// row's center is over the shelf; any other state hides it. An
+    /// unreadable measurement also hides it -- a ghost at a stale position
+    /// is a wrong promise, and no ghost is the honest one.
+    /// </summary>
+    private void UpdatePinPreview(DragSession drag, double draggedCenter)
+    {
+        var shelfBottom = ShelfBottomY();
+        if (drag.Tab.IsPinned || _manager.PinCount == 0
+            || double.IsNaN(shelfBottom) || draggedCenter >= shelfBottom)
+        {
+            HidePinPreview();
+            return;
+        }
+
+        var pins = TabStripProjection.Rows(_manager)
+            .Take(_manager.PinCount).ToList();
+        if (pins.Count == 0) { HidePinPreview(); return; }
+        if (RowElementOf(pins[^1]) is not { } last) { HidePinPreview(); return; }
+        var lastCenter = RowCenterY(pins[^1]);
+        if (double.IsNaN(lastCenter) || last.ActualWidth <= 0)
+        {
+            HidePinPreview();
+            return;
+        }
+
+        // The slot after the last pinned row: one row pitch down from its
+        // center (40px row + 2+2 margins), at the rows' own inset. Both
+        // vertical insets: the ghost zeroes its own margin, and the real
+        // row's 2px top margin is half of where its center actually
+        // lands -- shorting one leaves the ghost 2px proud of the slot
+        // and flashes at the handoff.
+        ShowPinPreview(drag,
+            top: lastCenter + VerticalTabPinnedRow.RowHeight / 2 + 2 * RowInsetVertical,
+            left: RowInsetLeft,
+            width: last.ActualWidth);
+    }
+
+    private double ShelfBottomY()
+    {
+        try
+        {
+            return _pinnedShelf.TransformToVisual(this)
+                .TransformPoint(new Windows.Foundation.Point(0, _pinnedShelf.ActualHeight)).Y;
+        }
+        catch (Exception ex) when (IsLayoutReadFailure(ex))
+        {
+            return double.NaN;
+        }
+    }
+
+    /// <summary>
+    /// Build the ghost fresh for this promise: a real pinned row shape
+    /// (the destination state, icon-only) at half strength, untouchable --
+    /// no hit testing, no tab stop, and out of the raw accessibility view
+    /// so a client never hears a tab that does not exist yet.
+    /// </summary>
+    private void ShowPinPreview(DragSession drag, double top, double left, double width)
+    {
+        if (_pinPreview is null)
+        {
+            var ghost = new VerticalTabPinnedRow(drag.Tab, AccentBrush)
+            {
+                IsHitTestVisible = false,
+                IsTabStop = false,
+                Opacity = 0.5,
+                Margin = new Thickness(0),
+                HorizontalAlignment = HorizontalAlignment.Left,
+            };
+            AutomationProperties.SetAccessibilityView(
+                ghost, AccessibilityView.Raw);
+            _pinPreview = ghost;
+            PreviewHost.Children.Add(ghost);
+            PreviewHost.Visibility = Visibility.Visible;
+        }
+
+        _pinPreview.SetIcon(TabIconElementFactory.Create(drag.Tab.TabIcon));
+        _pinPreview.Width = width;
+        Canvas.SetLeft(_pinPreview, left);
+        Canvas.SetTop(_pinPreview, top);
+    }
+
+    /// <summary>
+    /// Take the promise back. EndDrag is the one place: drop and every
+    /// cancel family (escape, capture loss, row close, layout switch,
+    /// teardown) tear the gesture down here, so the ghost cannot outlive
+    /// the drag that promised it.
+    /// </summary>
+    private void HidePinPreview()
+    {
+        if (_pinPreview is null) return;
+        PreviewHost.Children.Remove(_pinPreview);
+        _pinPreview = null;
+        PreviewHost.Visibility = Visibility.Collapsed;
     }
 
     private (double Center, double[] Centers) MeasureRows(TabModel dragged)
@@ -2366,6 +2638,7 @@ internal sealed partial class VerticalTabStrip : UserControl
         _drag = null;
         StopAutoscroll(drag);
         DetachGapMotion();
+        HidePinPreview();
         var settled = false;
         try
         {


### PR DESCRIPTION
5.5's last vertical piece plus the shelf's keyboard story:

- Drag preview: an icon-only ghost marks the slot a drop would take while the drag is over the pinned zone. Pixels only -- no manager calls, outside the reconcile skew checks and hit-testing. Shows only while the drop would pin, hides on every drag terminal, and the release commits where the ghost sat (through the zone grammar's stable in-zone slot).
- Shelf rows are tab stops: arrows cross the shelf/body boundary at its edges, Enter/Space activates through the shared fence, Escape still cancels an active drag, and a row churned out from under focus (unpin) carries focus to its rebuilt element.