### PR TITLE
panes: startup glow on every tier

### DIFF
--- a/windows/Ghostty.Core/Config/WindowsOnlyKeys.cs
+++ b/windows/Ghostty.Core/Config/WindowsOnlyKeys.cs
@@ -43,6 +43,8 @@ public static class WindowsOnlyKeys
             "Strength of the gradient tint layer."),
         new("accent-color",
             "Color of the active tab background, focus border, and tab strip rail. When unset, the chrome follows cursor-color."),
+        new("pane-startup-glow",
+            "When true (default), a newly spawned pane's border glows while its shell starts up. The glow ends on the pane's first render, or after ten seconds."),
         new("vertical-tabs",
             "Tab strip orientation. When true, tabs render in a vertical sidebar instead of the default horizontal strip."),
         new("vertical-tabs-width",

--- a/windows/Ghostty.Core/Panes/PaneStartupGlowState.cs
+++ b/windows/Ghostty.Core/Panes/PaneStartupGlowState.cs
@@ -3,24 +3,126 @@ using Ghostty.Core.Config;
 
 namespace Ghostty.Core.Panes;
 
-/// <summary>STUB: no lifecycle yet, so the tests can only fail.</summary>
+/// <summary>
+/// Pure lifecycle for one pane's startup glow. Renders nothing; raises
+/// <see cref="StateChanged"/> so a WinUI renderer can react. The glow ends
+/// when the cap timer elapses. A single <see cref="ISchedulerTimer"/> is
+/// reused for both the cap and the fade window, so the whole lifecycle is
+/// testable with a fake timer.
+///
+/// Thread-safety: state transitions are guarded by an internal lock so the
+/// injected timer's callback (which may run on a threadpool thread) and the
+/// owner's calls (Start/Close/Dispose) cannot corrupt state.
+/// <see cref="StateChanged"/> is raised outside the lock; handlers that touch
+/// UI must still marshal onto the dispatcher.
+/// </summary>
 public sealed class PaneStartupGlowState : IDisposable
 {
     public enum Phase { Idle, Glowing, FadingOut }
 
+    private readonly object _gate = new();
+    private readonly ISchedulerTimer _timer;
+    private readonly TimeSpan _cap;
+    private readonly TimeSpan _fade;
+
+    public Phase Current { get; private set; } = Phase.Idle;
+
+    /// <summary>Raised on every phase change. May fire on a threadpool thread
+    /// (the production timer callback is not UI-thread); subscribers that touch
+    /// UI must marshal onto the dispatcher.</summary>
+    public event Action<Phase>? StateChanged;
+
     public PaneStartupGlowState(ISchedulerTimer timer, TimeSpan cap, TimeSpan fade)
     {
         ArgumentNullException.ThrowIfNull(timer);
+        _timer = timer;
+        _cap = cap;
+        _fade = fade;
+        _timer.Callback = OnTimerFired;
     }
 
-    public Phase Current => Phase.Idle;
+    /// <summary>Begin glowing. No-op if already past Idle. The caller is
+    /// responsible for deciding whether to start (enablement, pane size).</summary>
+    public void Start()
+    {
+        Phase? changed = null;
+        lock (_gate)
+        {
+            if (Current != Phase.Idle) return;
+            Current = Phase.Glowing;
+            changed = Phase.Glowing;
+            _timer.Schedule(_cap);
+        }
+        Raise(changed);
+    }
 
-#pragma warning disable CS0067
-    public event Action<Phase>? StateChanged;
-#pragma warning restore CS0067
+    /// <summary>The surface produced its first render: end the glow early.
+    /// No-op unless currently <see cref="Phase.Glowing"/> (Idle/FadingOut
+    /// ignore it). The fade timer supersedes the pending cap
+    /// (last-schedule-wins), so the cap is the fallback only for surfaces
+    /// that never render.</summary>
+    public void NotifyReady()
+    {
+        Phase? changed = null;
+        lock (_gate)
+        {
+            if (Current == Phase.Glowing) changed = BeginFadeLocked();
+        }
+        Raise(changed);
+    }
 
-    public void Start() { }
-    public void NotifyReady() { }
-    public void Close() { }
-    public void Dispose() { }
+    /// <summary>Pane closed: cancel any pending timer and return to Idle.</summary>
+    public void Close()
+    {
+        Phase? changed = null;
+        lock (_gate)
+        {
+            _timer.Cancel();
+            if (Current != Phase.Idle)
+            {
+                Current = Phase.Idle;
+                changed = Phase.Idle;
+            }
+        }
+        Raise(changed);
+    }
+
+    private void OnTimerFired()
+    {
+        Phase? changed = null;
+        lock (_gate)
+        {
+            switch (Current)
+            {
+                case Phase.Glowing: changed = BeginFadeLocked(); break;   // cap reached
+                case Phase.FadingOut:                                     // fade done
+                    Current = Phase.Idle;
+                    changed = Phase.Idle;
+                    break;
+            }
+        }
+        Raise(changed);
+    }
+
+    // Caller must hold _gate.
+    private Phase BeginFadeLocked()
+    {
+        Current = Phase.FadingOut;
+        _timer.Schedule(_fade);
+        return Phase.FadingOut;
+    }
+
+    private void Raise(Phase? changed)
+    {
+        if (changed is { } p) StateChanged?.Invoke(p);
+    }
+
+    public void Dispose()
+    {
+        // Cancel under the lock, but dispose the timer OUTSIDE it: the real
+        // timer's Dispose waits for an in-flight callback to finish, and that
+        // callback takes _gate. Disposing under the lock would deadlock.
+        lock (_gate) { _timer.Cancel(); }
+        _timer.Dispose();
+    }
 }

--- a/windows/Ghostty.Core/Panes/PaneStartupGlowState.cs
+++ b/windows/Ghostty.Core/Panes/PaneStartupGlowState.cs
@@ -1,0 +1,26 @@
+using System;
+using Ghostty.Core.Config;
+
+namespace Ghostty.Core.Panes;
+
+/// <summary>STUB: no lifecycle yet, so the tests can only fail.</summary>
+public sealed class PaneStartupGlowState : IDisposable
+{
+    public enum Phase { Idle, Glowing, FadingOut }
+
+    public PaneStartupGlowState(ISchedulerTimer timer, TimeSpan cap, TimeSpan fade)
+    {
+        ArgumentNullException.ThrowIfNull(timer);
+    }
+
+    public Phase Current => Phase.Idle;
+
+#pragma warning disable CS0067
+    public event Action<Phase>? StateChanged;
+#pragma warning restore CS0067
+
+    public void Start() { }
+    public void NotifyReady() { }
+    public void Close() { }
+    public void Dispose() { }
+}

--- a/windows/Ghostty.Core/Panes/PaneStartupGlowState.cs
+++ b/windows/Ghostty.Core/Panes/PaneStartupGlowState.cs
@@ -14,7 +14,10 @@ namespace Ghostty.Core.Panes;
 /// injected timer's callback (which may run on a threadpool thread) and the
 /// owner's calls (Start/Close/Dispose) cannot corrupt state.
 /// <see cref="StateChanged"/> is raised outside the lock; handlers that touch
-/// UI must still marshal onto the dispatcher.
+/// UI must still marshal onto the dispatcher. Delivery order is not
+/// guaranteed across threads either: each raise runs on whatever thread fired
+/// it, so the lock serializes the transitions but not the handlers that
+/// observe them.
 /// </summary>
 public sealed class PaneStartupGlowState : IDisposable
 {
@@ -24,6 +27,7 @@ public sealed class PaneStartupGlowState : IDisposable
     private readonly ISchedulerTimer _timer;
     private readonly TimeSpan _cap;
     private readonly TimeSpan _fade;
+    private bool _disposed;
 
     public Phase Current { get; private set; } = Phase.Idle;
 
@@ -41,14 +45,15 @@ public sealed class PaneStartupGlowState : IDisposable
         _timer.Callback = OnTimerFired;
     }
 
-    /// <summary>Begin glowing. No-op if already past Idle. The caller is
-    /// responsible for deciding whether to start (enablement, pane size).</summary>
+    /// <summary>Begin glowing. No-op if already past Idle, or once disposed.
+    /// The caller is responsible for deciding whether to start (enablement,
+    /// pane size).</summary>
     public void Start()
     {
         Phase? changed = null;
         lock (_gate)
         {
-            if (Current != Phase.Idle) return;
+            if (_disposed || Current != Phase.Idle) return;
             Current = Phase.Glowing;
             changed = Phase.Glowing;
             _timer.Schedule(_cap);
@@ -57,8 +62,8 @@ public sealed class PaneStartupGlowState : IDisposable
     }
 
     /// <summary>The surface produced its first render: end the glow early.
-    /// No-op unless currently <see cref="Phase.Glowing"/> (Idle/FadingOut
-    /// ignore it). The fade timer supersedes the pending cap
+    /// No-op unless currently <see cref="Phase.Glowing"/> (Idle/FadingOut/
+    /// disposed all ignore it). The fade timer supersedes the pending cap
     /// (last-schedule-wins), so the cap is the fallback only for surfaces
     /// that never render.</summary>
     public void NotifyReady()
@@ -66,17 +71,20 @@ public sealed class PaneStartupGlowState : IDisposable
         Phase? changed = null;
         lock (_gate)
         {
-            if (Current == Phase.Glowing) changed = BeginFadeLocked();
+            if (_disposed || Current != Phase.Glowing) return;
+            changed = BeginFadeLocked();
         }
         Raise(changed);
     }
 
-    /// <summary>Pane closed: cancel any pending timer and return to Idle.</summary>
+    /// <summary>Pane closed: cancel any pending timer and return to Idle.
+    /// No-op once disposed, where there is no timer left to cancel.</summary>
     public void Close()
     {
         Phase? changed = null;
         lock (_gate)
         {
+            if (_disposed) return;
             _timer.Cancel();
             if (Current != Phase.Idle)
             {
@@ -122,7 +130,16 @@ public sealed class PaneStartupGlowState : IDisposable
         // Cancel under the lock, but dispose the timer OUTSIDE it: the real
         // timer's Dispose waits for an in-flight callback to finish, and that
         // callback takes _gate. Disposing under the lock would deadlock.
-        lock (_gate) { _timer.Cancel(); }
+        lock (_gate)
+        {
+            if (_disposed) return;
+            _disposed = true;
+            // A disposed lifecycle is not glowing, and every later call is a
+            // no-op. Deliberately not raised: the owner is tearing down, and
+            // an Idle raise here would only re-enter it.
+            Current = Phase.Idle;
+            _timer.Cancel();
+        }
         _timer.Dispose();
     }
 }

--- a/windows/Ghostty.Tests/Panes/PaneStartupGlowStateTests.cs
+++ b/windows/Ghostty.Tests/Panes/PaneStartupGlowStateTests.cs
@@ -128,4 +128,51 @@ public class PaneStartupGlowStateTests
         s.Dispose();
         Assert.Equal(1, t.DisposeCount);
     }
+
+    [Fact]
+    public void Start_after_Dispose_is_a_no_op()
+    {
+        var (s, t, log) = Make();
+        s.Dispose();
+        s.Start();
+        Assert.Equal(PaneStartupGlowState.Phase.Idle, s.Current);
+        Assert.Equal(0, t.ScheduleCount);
+        Assert.Empty(log);
+    }
+
+    [Fact]
+    public void NotifyReady_after_Dispose_is_a_no_op()
+    {
+        var (s, t, log) = Make();
+        s.Dispose();
+        s.NotifyReady();
+        Assert.Equal(PaneStartupGlowState.Phase.Idle, s.Current);
+        Assert.Equal(0, t.ScheduleCount);
+        Assert.Empty(log);
+    }
+
+    [Fact]
+    public void Close_after_Dispose_is_a_no_op()
+    {
+        var (s, t, log) = Make();
+        s.Start();
+        s.Dispose();
+        var cancels = t.CancelCount;
+        s.Close();
+        Assert.Equal(PaneStartupGlowState.Phase.Idle, s.Current);
+        Assert.Equal(cancels, t.CancelCount);
+        // Nothing further raised: the Glowing entry is Start's.
+        Assert.Equal([PaneStartupGlowState.Phase.Glowing], log);
+    }
+
+    [Fact]
+    public void Dispose_twice_disposes_the_timer_once()
+    {
+        var t = new FakeTimer();
+        var s = new PaneStartupGlowState(t, Cap, Fade);
+        s.Dispose();
+        s.Dispose();
+        Assert.Equal(1, t.DisposeCount);
+        Assert.Equal(1, t.CancelCount);
+    }
 }

--- a/windows/Ghostty.Tests/Panes/PaneStartupGlowStateTests.cs
+++ b/windows/Ghostty.Tests/Panes/PaneStartupGlowStateTests.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using Ghostty.Core.Config;
+using Ghostty.Core.Panes;
+using Xunit;
+
+namespace Ghostty.Tests.Panes;
+
+public class PaneStartupGlowStateTests
+{
+    // Mirrors the FakeTimer in ConfigWriteSchedulerTests: records
+    // scheduling and lets the test fire the callback synchronously.
+    private sealed class FakeTimer : ISchedulerTimer
+    {
+        public Action? Callback { get; set; }
+        public TimeSpan? LastScheduled { get; private set; }
+        public int ScheduleCount { get; private set; }
+        public int CancelCount { get; private set; }
+        public int DisposeCount { get; private set; }
+        public void Schedule(TimeSpan delay) { LastScheduled = delay; ScheduleCount++; }
+        public void Cancel() { CancelCount++; }
+        public void Fire() => Callback?.Invoke();
+        public void Dispose() { DisposeCount++; }
+    }
+
+    private static readonly TimeSpan Cap = TimeSpan.FromMilliseconds(10000);
+    private static readonly TimeSpan Fade = TimeSpan.FromMilliseconds(250);
+
+    private static (PaneStartupGlowState s, FakeTimer t, List<PaneStartupGlowState.Phase> log) Make()
+    {
+        var t = new FakeTimer();
+        var s = new PaneStartupGlowState(t, Cap, Fade);
+        var log = new List<PaneStartupGlowState.Phase>();
+        s.StateChanged += p => log.Add(p);
+        return (s, t, log);
+    }
+
+    [Fact]
+    public void Start_enters_glowing_and_arms_cap()
+    {
+        var (s, t, log) = Make();
+        s.Start();
+        Assert.Equal(PaneStartupGlowState.Phase.Glowing, s.Current);
+        Assert.Equal(Cap, t.LastScheduled);
+        Assert.Equal([PaneStartupGlowState.Phase.Glowing], log);
+    }
+
+    [Fact]
+    public void Cap_elapses_fades_then_idles()
+    {
+        var (s, t, _) = Make();
+        s.Start();
+        t.Fire(); // cap elapsed
+        Assert.Equal(PaneStartupGlowState.Phase.FadingOut, s.Current);
+        t.Fire(); // fade complete
+        Assert.Equal(PaneStartupGlowState.Phase.Idle, s.Current);
+    }
+
+    [Fact]
+    public void Close_cancels_and_idles()
+    {
+        var (s, t, _) = Make();
+        s.Start();
+        s.Close();
+        Assert.Equal(PaneStartupGlowState.Phase.Idle, s.Current);
+        Assert.True(t.CancelCount >= 1);
+    }
+
+    [Fact]
+    public void Start_twice_does_not_rearm()
+    {
+        var (s, t, log) = Make();
+        s.Start();
+        s.Start();
+        Assert.Equal(1, t.ScheduleCount);
+        Assert.Equal([PaneStartupGlowState.Phase.Glowing], log);
+    }
+
+    [Fact]
+    public void Close_while_fading_out_idles()
+    {
+        var (s, t, _) = Make();
+        s.Start();
+        t.Fire(); // -> FadingOut
+        s.Close();
+        Assert.Equal(PaneStartupGlowState.Phase.Idle, s.Current);
+    }
+
+    [Fact]
+    public void NotifyReady_before_cap_fades_then_idles()
+    {
+        var (s, t, _) = Make();
+        s.Start();
+        s.NotifyReady(); // ready beat the cap
+        Assert.Equal(PaneStartupGlowState.Phase.FadingOut, s.Current);
+        Assert.Equal(Fade, t.LastScheduled); // fade timer supersedes the cap
+        t.Fire(); // fade complete
+        Assert.Equal(PaneStartupGlowState.Phase.Idle, s.Current);
+    }
+
+    [Fact]
+    public void NotifyReady_after_fade_started_is_ignored()
+    {
+        var (s, t, _) = Make();
+        s.Start();
+        t.Fire(); // cap elapsed -> FadingOut
+        var scheduledBefore = t.ScheduleCount;
+        s.NotifyReady(); // too late: already fading
+        Assert.Equal(PaneStartupGlowState.Phase.FadingOut, s.Current);
+        Assert.Equal(scheduledBefore, t.ScheduleCount); // did not re-arm
+    }
+
+    [Fact]
+    public void NotifyReady_before_start_is_ignored()
+    {
+        var (s, t, log) = Make();
+        s.NotifyReady(); // nothing glowing yet
+        Assert.Equal(PaneStartupGlowState.Phase.Idle, s.Current);
+        Assert.Equal(0, t.ScheduleCount);
+        Assert.Empty(log);
+    }
+
+    [Fact]
+    public void Dispose_disposes_timer()
+    {
+        var t = new FakeTimer();
+        var s = new PaneStartupGlowState(t, Cap, Fade);
+        s.Dispose();
+        Assert.Equal(1, t.DisposeCount);
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/PaneStartupGlowWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/PaneStartupGlowWiringTests.cs
@@ -103,6 +103,44 @@ public class PaneStartupGlowWiringTests
     }
 
     /// <summary>
+    /// A soft-closed leaf keeps its shell alive for undo but leaves the visual
+    /// tree at once, so its glow would keep orbiting a frozen rectangle until
+    /// the cap unless the branch closes the state itself. Stated against the
+    /// soft-close branch rather than the method as a whole: the hard-close
+    /// branch already reaches the glow through TeardownLeaf, so a method-wide
+    /// scan would keep passing with only that path left.
+    /// </summary>
+    [Fact]
+    public void CloseLeaf_SoftCloseBranch_ClosesTheClosingLeafGlow()
+    {
+        // Two overloads share the name, and ShellSource.Method refuses that,
+        // so name the one with the undoable flag.
+        var close = Host().Root.DescendantNodes().OfType<MethodDeclarationSyntax>()
+            .Single(m => m.Identifier.ValueText == "CloseLeaf"
+                         && m.ParameterList.Parameters.Count == 2);
+
+        var softClose = close.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "softClose");
+        var retained = Assert.IsType<BlockSyntax>(softClose.Statement);
+
+        // The undo snapshot stays in the branch; the glow close is added to
+        // it, not swapped for it.
+        Assert.Contains(retained.DescendantNodesAndSelf().OfType<InvocationExpressionSyntax>(),
+            i => i.CalleeText() == "CaptureForUndo");
+
+        var closed = Assert.Single(retained.DescendantNodes()
+            .OfType<InvocationExpressionSyntax>(),
+            i => i.CalleeText().EndsWith(".Close", System.StringComparison.Ordinal));
+
+        // The closed state is the CLOSING leaf's, resolved by that leaf's own
+        // terminal, so a sibling's glow cannot be closed in its place.
+        var guard = close.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString()
+                == "_glowStates.TryGetValue(leaf.Terminal(), out var closingGlow)");
+        Assert.Contains(closed, guard.DescendantNodes());
+    }
+
+    /// <summary>
     /// Window teardown sweeps whatever is still in flight. Stated against
     /// the glow dictionary rather than against the tree walk, because the
     /// tree walk is gated on every leaf already being closed and a glow is
@@ -202,20 +240,95 @@ public class PaneStartupGlowWiringTests
 
     /// <summary>
     /// The window pushes the glow config alongside the border colours, per
-    /// tab, in the same pass. A push from a later hook would land after a
-    /// newly created host's deferred Loaded, and that first pane would read
+    /// tab, in the same pass. Pinned against the enclosing loop rather than
+    /// the method as a whole, because that is the part that carries the
+    /// guarantee: hoisted above the loop the push configures no tab that
+    /// exists only as a loop iteration, and hoisted below it the push lands
+    /// after a newly created host's deferred Loaded, so that first pane reads
     /// the default (enabled, default colours) instead of the user's.
     /// </summary>
     [Fact]
-    public void ApplyPerTabChrome_PushesTheGlowConfigWithTheBorderColors()
+    public void ApplyPerTabChrome_PushesTheGlowConfigInsideThePerTabLoop()
     {
-        var pushes = MainWindow().Method("ApplyPerTabChrome").Body!.Statements
-            .SelectMany(s => s.DescendantNodesAndSelf())
-            .OfType<InvocationExpressionSyntax>()
-            .Where(i => i.CalleeText().EndsWith("SetStartupGlowConfig", System.StringComparison.Ordinal))
+        var loop = Assert.Single(MainWindow().Method("ApplyPerTabChrome").Body!.Statements
+                .SelectMany(s => s.DescendantNodesAndSelf())
+                .OfType<ForEachStatementSyntax>(),
+            f => f.Expression.ToString() == "_tabManager.Tabs");
+
+        var push = Assert.Single(loop.Statement.DescendantNodesAndSelf()
+                .OfType<InvocationExpressionSyntax>(),
+            i => i.CalleeText().EndsWith("SetStartupGlowConfig", System.StringComparison.Ordinal));
+        Assert.Equal("_configService.PaneStartupGlow", push.Arg(0));
+    }
+
+    /// <summary>
+    /// The glow pass rides the leaf set UpdateHighlightPosition already walked
+    /// for the dim rects, and PositionGlowMount takes that leaf instead of
+    /// finding its own: the layout pass runs on every layout tick, so a
+    /// per-mount Leaves().FirstOrDefault() is a full tree traversal plus an
+    /// enumerator allocation per mount per tick, spent re-deriving an answer
+    /// the caller was holding. Both halves are pinned, because reverting
+    /// either one alone puts the walk back.
+    /// </summary>
+    [Fact]
+    public void UpdateHighlightPosition_GlowPass_ReusesTheLeavesItAlreadyWalked()
+    {
+        var host = Host();
+
+        var position = host.Method("PositionGlowMount");
+        Assert.Contains(position.ParameterList.Parameters,
+            p => p.Type?.ToString() == "LeafPane?");
+        Assert.DoesNotContain(position.DescendantNodesAndSelf().OfType<InvocationExpressionSyntax>(),
+            i => i.CalleeText() == "PaneTree.Leaves");
+
+        var glowPass = host.Method("UpdateHighlightPosition").DescendantNodesAndSelf()
+            .OfType<CommonForEachStatementSyntax>()
+            .Single(f => f.Expression.ToString() == "_glowMounts");
+
+        var calls = glowPass.Statement.DescendantNodesAndSelf().OfType<InvocationExpressionSyntax>();
+        Assert.DoesNotContain(calls, i => i.CalleeText() == "PaneTree.Leaves");
+        Assert.DoesNotContain(calls,
+            i => i.CalleeText().EndsWith("FirstOrDefault", System.StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Dispose releases every composition object the glow creates, not only
+    /// the ones it was first written with: a forever key-frame animation left
+    /// running keeps the compositor animating a brush nobody paints with, and
+    /// a gradient stop is a composition object in its own right. Stated as the
+    /// parsed file, because a unit test cannot build a compositor; the list is
+    /// explicit so dropping one of them from Dispose has to delete a line
+    /// here too.
+    /// </summary>
+    [Fact]
+    public void Dispose_ReleasesEveryCompositionObjectTheGlowCreated()
+    {
+        var dispose = ShellSource.Load("Panes.PaneStartupGlow.cs").Method("Dispose");
+        var calls = dispose.DescendantNodesAndSelf().OfType<InvocationExpressionSyntax>()
+            .Select(i => i.CalleeText())
             .ToList();
 
-        var push = Assert.Single(pushes);
-        Assert.Equal("_configService.PaneStartupGlow", push.Arg(0));
+        foreach (var owner in new[]
+                 {
+                     "_shapeVisual", "_coreShape", "_haloShape", "_geometry",
+                     "_coreBrush", "_coreStops", "_haloBrush", "_haloStops",
+                     "_fade", "_orbit", "_easing",
+                 })
+        {
+            Assert.Contains(calls, c => c == owner + ".Dispose");
+        }
+
+        // The stops are enumerated out of their collection, so each collection
+        // has to still be open when Dispose reaches it.
+        var invokes = dispose.DescendantNodesAndSelf().OfType<InvocationExpressionSyntax>();
+        foreach (var stops in new[] { "_coreStops", "_haloStops" })
+            Assert.Contains(invokes, i => i.CalleeText() == "DisposeStops" && i.Arg(0) == stops);
+
+        // Stopping an animation on a closed object throws, so the stops all
+        // come before the first release.
+        var stopped = calls.FindIndex(c => c.EndsWith(".StopAnimation", System.StringComparison.Ordinal));
+        var released = calls.FindIndex(c => c.EndsWith(".Dispose", System.StringComparison.Ordinal));
+        Assert.True(stopped >= 0 && stopped < released,
+            $"the first StopAnimation (index {stopped}) must come before the first Dispose (index {released})");
     }
 }

--- a/windows/Ghostty.Tests/Wiring/PaneStartupGlowWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/PaneStartupGlowWiringTests.cs
@@ -1,0 +1,220 @@
+using System.Linq;
+using Ghostty.Core.Config;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// The pane startup glow is a startup race in disguise, so its wiring is
+/// what can break silently: a spawn signal raised one statement too early,
+/// a mount positioned off the render-thread transform, a glow whose timer
+/// outlives the pane it was measuring.
+///
+/// The lifecycle itself is a pure state machine covered by
+/// <see cref="Ghostty.Tests.Panes.PaneStartupGlowStateTests"/>. What is
+/// only observable here is that the four pieces stay bolted together the
+/// way the fix left them.
+/// </summary>
+public class PaneStartupGlowWiringTests
+{
+    private static ShellSource Host() => ShellSource.Load("Panes.PaneHost.cs");
+
+    private static ShellSource Terminal() => ShellSource.Load("Controls.TerminalControl.xaml.cs");
+
+    private static ShellSource MainWindow() => ShellSource.Load("MainWindow.xaml.cs");
+
+    private static ShellSource ConfigService() => ShellSource.Load("Services.ConfigService.cs");
+
+    /// <summary>
+    /// SurfaceSpawned is the glow's start gun, and it is only correct at the
+    /// tail of OnLoaded: before that statement the surface either does not
+    /// exist or is not registered, and the handler would find no leaf to
+    /// mount the glow over. Raised a line earlier, the first pane opens
+    /// dark and nothing fails.
+    /// </summary>
+    [Fact]
+    public void SurfaceSpawned_IsRaised_AsTheLastStatementOfOnLoaded()
+    {
+        var body = Terminal().Method("OnLoaded").Body!.Statements;
+        Assert.True(body.Count > 1, "OnLoaded should have more than one statement");
+
+        var raise = body.OfType<ExpressionStatementSyntax>()
+            .Single(s => s.ToString().Contains("SurfaceSpawned"));
+        Assert.Equal(body.Last(), raise);
+    }
+
+    /// <summary>
+    /// A control whose surface is gone must not keep a subscriber that
+    /// starts glows. DisposeSurface nulls every other event for exactly
+    /// this reason; the new one has to be in that list.
+    /// </summary>
+    [Fact]
+    public void DisposeSurface_DropsTheSurfaceSpawnedSubscriber()
+    {
+        var body = Terminal().Method("DisposeSurface").Body!.Statements;
+
+        var assignments = body.SelectMany(s => s.DescendantNodesAndSelf())
+            .OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.Left.ToString() == "SurfaceSpawned")
+            .ToList();
+
+        var dropped = Assert.Single(assignments);
+        Assert.Equal("null", dropped.Right.ToString());
+    }
+
+    /// <summary>
+    /// Start on the surface spawn, end on the first render, both wired where
+    /// every leaf's control is born. Wiring one of them somewhere else (a
+    /// focus handler, a Loaded handler) would silently skip splits and
+    /// restored panes, which are the panes a glow is most useful on.
+    /// </summary>
+    [Fact]
+    public void CreateTerminal_WiresSpawnToStart_AndFirstRenderToEnd()
+    {
+        var body = Host().Method("CreateTerminal").Body!.Statements;
+
+        var wired = body.SelectMany(s => s.DescendantNodesAndSelf())
+            .OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.Right.ToString() is "OnLeafSurfaceSpawned" or "OnLeafFirstRender")
+            .Select(a => a.Left.ToString())
+            .ToList();
+
+        Assert.Equal(["t.SurfaceSpawned", "t.FirstRender"], wired);
+    }
+
+    /// <summary>
+    /// Closing a leaf tears down its glow. Without this the state machine's
+    /// timer keeps firing against a disposed control and the mount stays on
+    /// the overlay after the pane is gone.
+    /// </summary>
+    [Fact]
+    public void TeardownLeaf_TearsTheGlowDown()
+    {
+        Assert.Single(Host().Method("TeardownLeaf").Body!.Statements
+            .SelectMany(s => s.DescendantNodesAndSelf())
+            .OfType<InvocationExpressionSyntax>()
+            .Where(i => i.CalleeText() == "TeardownGlow"));
+    }
+
+    /// <summary>
+    /// Window teardown sweeps whatever is still in flight. Stated against
+    /// the glow dictionary rather than against the tree walk, because the
+    /// tree walk is gated on every leaf already being closed and a glow is
+    /// alive exactly in the window the gate excludes.
+    /// </summary>
+    [Fact]
+    public void DisposeAllLeaves_SweepsEveryLiveGlow()
+    {
+        var loops = Host().Method("DisposeAllLeaves").Body!.Statements
+            .SelectMany(s => s.DescendantNodesAndSelf())
+            .OfType<ForEachStatementSyntax>()
+            .Where(f => f.Expression.ToString() == "_glowStates.Keys.ToList()")
+            .ToList();
+
+        var sweep = Assert.Single(loops);
+        Assert.Contains(sweep.Statement.DescendantNodesAndSelf()
+            .OfType<InvocationExpressionSyntax>(), i => i.CalleeText() == "TeardownGlow");
+    }
+
+    /// <summary>
+    /// The glow rides just under the focus stroke, and the mount is sized in
+    /// the layout handler rather than from a one-shot spawn-time measurement
+    /// -- the leaf has almost never been arranged when its surface spawns.
+    /// </summary>
+    [Fact]
+    public void GlowMount_SitsUnderTheActiveBorder_AndIsTrackedByLayout()
+    {
+        var host = Host();
+
+        var zindex = host.Root.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(i => i.CalleeText() == "Canvas.SetZIndex")
+            .ToDictionary(i => i.Arg(0), i => i.Arg(1));
+
+        Assert.Equal("998", zindex["mount"]);
+        Assert.Equal("999", zindex["_activeBorderFrame"]);
+
+        // The mount is a child of the overlay, the same surface the active
+        // border draws on, so the two z-values are the whole ordering.
+        Assert.Contains(host.Root.DescendantNodes().OfType<InvocationExpressionSyntax>(),
+            i => i.CalleeText() == "_highlightOverlay.Children.Add" && i.Arg(0) == "mount");
+    }
+
+    /// <summary>
+    /// The mount is positioned from the layout-slot chain, never from
+    /// TransformToVisual: at cold start the idle compositor does not commit
+    /// the render-thread transform for ~750ms, so a transform-based mount
+    /// would strand at zero size and the first pane would open with no glow
+    /// at all. LeafLayoutBounds exists for the other overlay layers for the
+    /// same reason; the glow has to use it rather than grow a second answer.
+    /// </summary>
+    [Fact]
+    public void GlowMount_IsPositionedFromLayoutSlots()
+    {
+        var host = Host();
+
+        var position = host.Method("PositionGlowMount");
+        Assert.Single(position.DescendantNodesAndSelf().OfType<InvocationExpressionSyntax>()
+            .Where(i => i.CalleeText() == "LeafLayoutBounds"));
+        Assert.Empty(position.DescendantNodesAndSelf().OfType<InvocationExpressionSyntax>()
+            .Where(i => i.CalleeText().EndsWith("TransformToVisual", System.StringComparison.Ordinal)));
+
+        var leafBounds = host.Method("LeafLayoutBounds");
+        Assert.Contains(leafBounds.DescendantNodesAndSelf().OfType<InvocationExpressionSyntax>(),
+            i => i.CalleeText().EndsWith("LayoutInformation.GetLayoutSlot", System.StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// The kill switch has to be honored where the glow starts, not somewhere
+    /// downstream that a later refactor could drop: an enabled config that
+    /// still spawns a glow is a setting that lies.
+    /// </summary>
+    [Fact]
+    public void OnLeafSurfaceSpawned_ChecksEnablementBeforeAnythingElse()
+    {
+        var guards = Host().Method("OnLeafSurfaceSpawned").Body!.Statements
+            .OfType<IfStatementSyntax>()
+            .Select(i => i.Condition.ToString())
+            .ToList();
+
+        Assert.Contains("_startupGlowEnabled", guards);
+        Assert.True(
+            guards.IndexOf("_startupGlowEnabled") < guards.IndexOf("_glowStates.ContainsKey(terminal)"),
+            "the enablement guard must come before the already-glowing guard");
+    }
+
+    /// <summary>
+    /// The key is Windows-only, so libghostty calls it an unknown field and
+    /// only the app's own read makes it do anything. Registered or not, the
+    /// diagnostic noise is the difference between a setting and a bug report.
+    /// </summary>
+    [Fact]
+    public void PaneStartupGlow_IsARegisteredWindowsOnlyKey_DefaultingOn()
+    {
+        Assert.True(WindowsOnlyKeys.Contains("pane-startup-glow"));
+        Assert.Single(WindowsOnlyKeys.All, e => e.Key == "pane-startup-glow");
+
+        var read = ConfigService().Method("ReadFlagsCore").Calls("WindowsOnlyKeyParsers.ParseBool")
+            .Single(c => c.Arg(0).Contains("\"pane-startup-glow\""));
+        Assert.Equal("defaultValue: true", read.Arg(1));
+    }
+
+    /// <summary>
+    /// The window pushes the glow config alongside the border colours, per
+    /// tab, in the same pass. A push from a later hook would land after a
+    /// newly created host's deferred Loaded, and that first pane would read
+    /// the default (enabled, default colours) instead of the user's.
+    /// </summary>
+    [Fact]
+    public void ApplyPerTabChrome_PushesTheGlowConfigWithTheBorderColors()
+    {
+        var pushes = MainWindow().Method("ApplyPerTabChrome").Body!.Statements
+            .SelectMany(s => s.DescendantNodesAndSelf())
+            .OfType<InvocationExpressionSyntax>()
+            .Where(i => i.CalleeText().EndsWith("SetStartupGlowConfig", System.StringComparison.Ordinal))
+            .ToList();
+
+        var push = Assert.Single(pushes);
+        Assert.Equal("_configService.PaneStartupGlow", push.Arg(0));
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/PaneStartupGlowWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/PaneStartupGlowWiringTests.cs
@@ -98,8 +98,8 @@ public class PaneStartupGlowWiringTests
     {
         Assert.Single(Host().Method("TeardownLeaf").Body!.Statements
             .SelectMany(s => s.DescendantNodesAndSelf())
-            .OfType<InvocationExpressionSyntax>()
-            .Where(i => i.CalleeText() == "TeardownGlow"));
+            .OfType<InvocationExpressionSyntax>(),
+            i => i.CalleeText() == "TeardownGlow");
     }
 
     /// <summary>
@@ -155,10 +155,10 @@ public class PaneStartupGlowWiringTests
         var host = Host();
 
         var position = host.Method("PositionGlowMount");
-        Assert.Single(position.DescendantNodesAndSelf().OfType<InvocationExpressionSyntax>()
-            .Where(i => i.CalleeText() == "LeafLayoutBounds"));
-        Assert.Empty(position.DescendantNodesAndSelf().OfType<InvocationExpressionSyntax>()
-            .Where(i => i.CalleeText().EndsWith("TransformToVisual", System.StringComparison.Ordinal)));
+        var calls = position.DescendantNodesAndSelf().OfType<InvocationExpressionSyntax>();
+        Assert.Single(calls, i => i.CalleeText() == "LeafLayoutBounds");
+        Assert.DoesNotContain(calls,
+            i => i.CalleeText().EndsWith("TransformToVisual", System.StringComparison.Ordinal));
 
         var leafBounds = host.Method("LeafLayoutBounds");
         Assert.Contains(leafBounds.DescendantNodesAndSelf().OfType<InvocationExpressionSyntax>(),

--- a/windows/Ghostty.Tests/Wiring/PaneStartupGlowWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/PaneStartupGlowWiringTests.cs
@@ -26,6 +26,11 @@ public class PaneStartupGlowWiringTests
 
     private static ShellSource ConfigService() => ShellSource.Load("Services.ConfigService.cs");
 
+    private static string ZIndex(ShellSource source, string element) =>
+        source.Root.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Single(i => i.CalleeText() == "Canvas.SetZIndex" && i.Arg(0) == element)
+            .Arg(1);
+
     /// <summary>
     /// SurfaceSpawned is the glow's start gun, and it is only correct at the
     /// tail of OnLoaded: before that statement the surface either does not
@@ -127,12 +132,8 @@ public class PaneStartupGlowWiringTests
     {
         var host = Host();
 
-        var zindex = host.Root.DescendantNodes().OfType<InvocationExpressionSyntax>()
-            .Where(i => i.CalleeText() == "Canvas.SetZIndex")
-            .ToDictionary(i => i.Arg(0), i => i.Arg(1));
-
-        Assert.Equal("998", zindex["mount"]);
-        Assert.Equal("999", zindex["_activeBorderFrame"]);
+        Assert.Equal("998", ZIndex(host, "mount"));
+        Assert.Equal("999", ZIndex(host, "_activeBorderFrame"));
 
         // The mount is a child of the overlay, the same surface the active
         // border draws on, so the two z-values are the whole ordering.
@@ -177,9 +178,9 @@ public class PaneStartupGlowWiringTests
             .Select(i => i.Condition.ToString())
             .ToList();
 
-        Assert.Contains("_startupGlowEnabled", guards);
+        Assert.Contains("!_startupGlowEnabled", guards);
         Assert.True(
-            guards.IndexOf("_startupGlowEnabled") < guards.IndexOf("_glowStates.ContainsKey(terminal)"),
+            guards.IndexOf("!_startupGlowEnabled") < guards.IndexOf("_glowStates.ContainsKey(terminal)"),
             "the enablement guard must come before the already-glowing guard");
     }
 

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -681,6 +681,10 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     /// glow.</summary>
     public event EventHandler? FirstRender;
 
+    /// <summary>Raised once, right after this control's libghostty surface is
+    /// created and registered. PaneHost uses it to start the startup glow.</summary>
+    public event EventHandler? SurfaceSpawned;
+
     /// <summary>Raised from <see cref="DisposeSurface"/> while the surface is
     /// still valid, for holders of native state keyed on this control's
     /// surface pointer -- the window's inline theme picker keeps input,
@@ -930,6 +934,11 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
             this.Focus(FocusState.Programmatic);
         }
 
+        // Surface exists and is registered; tell the host the shell has
+        // spawned. Last statement of OnLoaded on purpose: the startup glow
+        // reads the control's bounds right after this, and anything that
+        // still has to happen first belongs above this line.
+        SurfaceSpawned?.Invoke(this, EventArgs.Empty);
     }
 
     private void DisableAncestorScrollViewerTabStop()
@@ -1107,6 +1116,7 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         ProgressChanged = null;
         PromptReady = null;
         FirstRender = null;
+        SurfaceSpawned = null;
         BellRang = null;
         BellAcknowledged = null;
         // Already raised above; dropping it here is for a subscriber that did

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -3043,6 +3043,13 @@ public sealed partial class MainWindow : Window
         var defaultBorder = Tabs.TabColorBrush.FromPackedRgb(LegibleChromeAccent(
             _configService.CursorColor ?? _configService.ForegroundColor));
 
+        // Startup glow: the lead is the theme foreground, the trail is
+        // whichever brush this tab's border ends up with below, so the sweep
+        // hands over to the same colour the pane settles into.
+        var glowFg = _configService.ForegroundColor;
+        var glowLead = Windows.UI.Color.FromArgb(
+            0xFF, (byte)(glowFg >> 16), (byte)(glowFg >> 8), (byte)glowFg);
+
         var active = _tabManager.ActiveTab;
         foreach (var tab in _tabManager.Tabs)
         {
@@ -3058,7 +3065,13 @@ public sealed partial class MainWindow : Window
                 borderBrush = defaultBorder;
             }
 
-            ((PaneHost)tab.PaneHost).SetActiveBorderBrush(borderBrush);
+            var paneHost = (PaneHost)tab.PaneHost;
+            paneHost.SetActiveBorderBrush(borderBrush);
+            // Has to land before a newly created PaneHost's first leaf raises
+            // its deferred Loaded/SurfaceSpawned, or the glow is configured
+            // too late to run: WinUI fires Loaded on a later dispatcher turn,
+            // after this method has returned.
+            paneHost.SetStartupGlowConfig(_configService.PaneStartupGlow, borderBrush.Color, glowLead);
         }
 
         _horizontalTabHost.RefreshTabColors();

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -854,6 +854,15 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
             // alive) so undo can resurrect it. The history entry retains
             // the leaf; teardown is deferred to eviction.
             CaptureForUndo(Core.Panes.PaneOpKind.Close);
+
+            // The retained shell keeps the surface alive, but the leaf still
+            // leaves the visual tree below, so a pane closed before its first
+            // render would otherwise keep its glow orbiting a frozen rectangle
+            // until the cap. Close the state here: Idle raises StateChanged,
+            // which enqueues the same TeardownGlow a fade ending would, and
+            // that stops the animation and lifts the mount off the overlay.
+            if (_glowStates.TryGetValue(leaf.Terminal(), out var closingGlow))
+                closingGlow.Close();
         }
         else
         {
@@ -969,7 +978,7 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         // this is only a guard against a future second raise landing here.
         if (_glowStates.ContainsKey(terminal)) return;
 
-        var leaf = PaneTree.Leaves(_root).FirstOrDefault(l => ReferenceEquals(l.Terminal(), terminal));
+        var leaf = LeafForTerminal(PaneTree.Leaves(_root), terminal);
         if (leaf is null) return;
 
         // Bounds may not be settled at spawn time (SurfaceSpawned fires from
@@ -1002,7 +1011,7 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
 
         // Size now if layout is already available (splitting an
         // already-laid-out window); otherwise the layout handler catches it.
-        PositionGlowMount(terminal, mount);
+        PositionGlowMount(terminal, mount, leaf);
     }
 
     private void OnLeafFirstRender(object? sender, EventArgs e)
@@ -1039,12 +1048,14 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     }
 
     // Position+size one glow mount over its leaf, enforcing the minimum-size
-    // degradation. Called per-spawn and from the layout handler. When the leaf
-    // is too small or not yet laid out, the mount is collapsed to zero size so
-    // the glow is simply invisible (and reappears if the pane later grows).
-    private void PositionGlowMount(TerminalControl terminal, Canvas mount)
+    // degradation. Called per-spawn and from the layout handler, both of which
+    // already resolved the leaf; the layout pass walks the tree once for every
+    // overlay layer, so a lookup here would be a second traversal per mount
+    // per tick. When the leaf is too small or not yet laid out, the mount is
+    // collapsed to zero size so the glow is simply invisible (and reappears if
+    // the pane later grows).
+    private void PositionGlowMount(TerminalControl terminal, Canvas mount, LeafPane? leaf)
     {
-        var leaf = PaneTree.Leaves(_root).FirstOrDefault(l => ReferenceEquals(l.Terminal(), terminal));
         if (leaf is null) return;
 
         var ctl = leaf.Terminal();
@@ -1072,6 +1083,18 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         mount.Height = bounds.Height;
         if (_glows.TryGetValue(terminal, out var glow))
             glow.UpdateSize(new Vector2((float)bounds.Width, (float)bounds.Height));
+    }
+
+    // The one leaf of these whose control is this terminal, matched by
+    // reference rather than by any key the leaf does not have.
+    private static LeafPane? LeafForTerminal(IEnumerable<LeafPane> leaves, TerminalControl terminal)
+    {
+        foreach (var leaf in leaves)
+        {
+            if (ReferenceEquals(leaf.Terminal(), terminal)) return leaf;
+        }
+
+        return null;
     }
 
     private void CollapseGlowMount(TerminalControl terminal, Canvas mount)
@@ -1603,9 +1626,11 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
 
         // Keep each live startup-glow mount tracked over its leaf while the
         // glow lasts. Cheap when the dictionary is empty (the common case
-        // once every pane has rendered).
+        // once every pane has rendered): the loop simply does not run, and
+        // each mount takes its leaf from the walk above rather than sending
+        // the tree through Leaves() again.
         foreach (var (terminal, mount) in _glowMounts)
-            PositionGlowMount(terminal, mount);
+            PositionGlowMount(terminal, mount, LeafForTerminal(currentLeaves, terminal));
     }
 
     private void PositionActiveBorderOverLeaf(LeafPane leaf)

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -97,6 +97,31 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     private readonly Dictionary<LeafPane, Rectangle> _dimRects = new();
     private FrameworkElement _treeRoot = null!; // assigned in ctor before use
 
+    // Startup-glow appearance/enablement, pushed from MainWindow
+    // (PaneHost has no config access of its own; this mirrors
+    // SetActiveBorderBrush). Read when a leaf's surface spawns.
+    private bool _startupGlowEnabled;
+    private Windows.UI.Color _startupGlowTrail = Microsoft.UI.Colors.DodgerBlue;
+    private Windows.UI.Color _startupGlowLead = Microsoft.UI.Colors.White;
+
+    // One startup-glow lifecycle per leaf's TerminalControl, alive only from
+    // surface spawn until the glow fades (or the pane closes). Three
+    // dictionaries keyed by the same control, added and removed in lockstep
+    // by TeardownGlow: the state machine (lifecycle), the composition
+    // renderer (drawing), and the mount Canvas that hosts the renderer's
+    // child visual in _highlightOverlay.
+    private readonly Dictionary<TerminalControl, Core.Panes.PaneStartupGlowState> _glowStates = new();
+    private readonly Dictionary<TerminalControl, PaneStartupGlow> _glows = new();
+    private readonly Dictionary<TerminalControl, Canvas> _glowMounts = new();
+
+    // Panes smaller than this in either dimension (DIPs) skip the glow.
+    private const double MinGlowDimension = 80.0;
+    // Fallback for surfaces that never reach first_render (a command that
+    // produces no output still renders, so hitting this means something is
+    // genuinely stuck, and a glow that never leaves is worse than none).
+    private static readonly TimeSpan GlowCapDuration = TimeSpan.FromMilliseconds(10000);
+    private static readonly TimeSpan GlowFadeDuration = TimeSpan.FromMilliseconds(250);
+
     // Top-right "restore" affordance shown only while a pane is zoomed,
     // styled like the quake pin button. Clicking it unzooms. The resting
     // glyph is a plain magnifier (status: this pane is magnified); on
@@ -275,6 +300,17 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         var resolved = brush ?? DefaultActiveBorderBrush;
         _activeBorderFrame.BorderBrush = resolved;
         _tabContentBorderFrame.BorderBrush = resolved;
+    }
+
+    /// <summary>Push startup-glow enablement and colors from MainWindow.
+    /// Mirrors <see cref="SetActiveBorderBrush"/>: PaneHost holds no config,
+    /// so the window hands down what a spawn needs. Affects future spawns
+    /// only; a glow already running keeps its colors.</summary>
+    public void SetStartupGlowConfig(bool enabled, Windows.UI.Color trail, Windows.UI.Color lead)
+    {
+        _startupGlowEnabled = enabled;
+        _startupGlowTrail = trail;
+        _startupGlowLead = lead;
     }
 
     /// <summary>
@@ -476,6 +512,12 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         // Force the overlay above any sibling in the host Grid so
         // the chrome never gets composited under the terminal.
         Canvas.SetZIndex(_highlightOverlay, 999);
+        // Inside the overlay, the active border sits above the startup-glow
+        // mounts (998, set in OnLeafSurfaceSpawned) so a freshly spawned
+        // pane glows just under its own focus stroke rather than over it.
+        // Children with no explicit ZIndex (the dim rects) stay at 0, below
+        // both, which is the order they already drew in.
+        Canvas.SetZIndex(_activeBorderFrame, 999);
 
         // The tab's own frame, around the whole terminal area rather than
         // around a leaf. The selected tab is drawn as a folder joined to
@@ -728,6 +770,14 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     /// </summary>
     public void DisposeAllLeaves()
     {
+        // Tear down any in-flight startup glows first so their timers stop
+        // and their composition visuals are released promptly. Glows are
+        // keyed by TerminalControl independent of tree state, so this runs
+        // regardless of the _allLeavesClosed gate below. Snapshot the keys
+        // first: TeardownGlow mutates the dictionaries it is iterating.
+        foreach (var terminal in _glowStates.Keys.ToList())
+            TeardownGlow(terminal);
+
         // Tree walk is gated on _allLeavesClosed: every leaf was
         // already disposed one-by-one as the tree collapsed; _root
         // still references the last-closed leaf but walking it here
@@ -900,7 +950,136 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         t.CloseRequested -= OnTerminalCloseRequested;
         t.ContextMenuRequested -= OnTerminalContextMenuRequested;
         t.PwdChanged -= OnTerminalPwdChanged;
+        // Tear down the per-surface startup glow so its controller, renderer
+        // and mount do not outlive the disposed terminal. Runs before
+        // DisposeSurface so a glow timer that fires mid-teardown finds its
+        // dictionaries already empty instead of driving a visual whose mount
+        // is coming off the tree.
+        TeardownGlow(t);
         t.DisposeSurface();
+    }
+
+    // Startup glow -------------------------------------------------------
+
+    private void OnLeafSurfaceSpawned(object? sender, EventArgs e)
+    {
+        if (sender is not TerminalControl terminal) return;
+        if (!_startupGlowEnabled) return;
+        // One glow per control. SurfaceSpawned fires once per control, so
+        // this is only a guard against a future second raise landing here.
+        if (_glowStates.ContainsKey(terminal)) return;
+
+        var leaf = PaneTree.Leaves(_root).FirstOrDefault(l => ReferenceEquals(l.Terminal(), terminal));
+        if (leaf is null) return;
+
+        // Bounds may not be settled at spawn time (SurfaceSpawned fires from
+        // OnLoaded, before first layout). Create the mount and renderer at
+        // zero size now and let PositionGlowMount size them; the layout
+        // handler keeps them tracked until the glow ends.
+        var mount = new Canvas { IsHitTestVisible = false, Width = 0, Height = 0 };
+        // Just under the active border (999, set in BuildChrome).
+        Canvas.SetZIndex(mount, 998);
+        _highlightOverlay.Children.Add(mount);
+        _glowMounts[terminal] = mount;
+
+        var glow = new PaneStartupGlow(mount, new Vector2(0f, 0f),
+            _startupGlowTrail, _startupGlowLead);
+        _glows[terminal] = glow;
+
+        var state = new Core.Panes.PaneStartupGlowState(
+            new Ghostty.Core.Config.SystemSchedulerTimer(
+                Microsoft.Extensions.Logging.Abstractions.NullLogger<
+                    Ghostty.Core.Config.SystemSchedulerTimer>.Instance),
+            cap: GlowCapDuration,
+            fade: GlowFadeDuration);
+        // The timer callback runs on a threadpool thread; the visual tree
+        // only moves on the dispatcher thread.
+        state.StateChanged += phase => DispatcherQueue.TryEnqueue(() => OnGlowPhase(terminal, phase));
+        _glowStates[terminal] = state;
+
+        state.Start();
+        glow.StartGlow();
+
+        // Size now if layout is already available (splitting an
+        // already-laid-out window); otherwise the layout handler catches it.
+        PositionGlowMount(terminal, mount);
+    }
+
+    private void OnLeafFirstRender(object? sender, EventArgs e)
+    {
+        if (sender is not TerminalControl terminal) return;
+        // The pane produced renderable content for the first time: end this
+        // leaf's glow now rather than waiting out the cap. NotifyReady is a
+        // no-op if the glow already faded or never started, so a late or
+        // duplicate signal is harmless. FirstRender is raised on the UI
+        // thread, and the state machine is thread-safe regardless.
+        if (_glowStates.TryGetValue(terminal, out var state))
+            state.NotifyReady();
+    }
+
+    private void OnGlowPhase(TerminalControl terminal, Core.Panes.PaneStartupGlowState.Phase phase)
+    {
+        if (!_glows.TryGetValue(terminal, out var glow)) return;
+        switch (phase)
+        {
+            case Core.Panes.PaneStartupGlowState.Phase.FadingOut:
+                glow.BeginFadeOut(GlowFadeDuration);
+                break;
+            case Core.Panes.PaneStartupGlowState.Phase.Idle:
+                TeardownGlow(terminal);
+                break;
+        }
+    }
+
+    private void TeardownGlow(TerminalControl terminal)
+    {
+        if (_glowStates.Remove(terminal, out var state)) state.Dispose();
+        if (_glows.Remove(terminal, out var glow)) glow.Dispose();
+        if (_glowMounts.Remove(terminal, out var mount)) _highlightOverlay.Children.Remove(mount);
+    }
+
+    // Position+size one glow mount over its leaf, enforcing the minimum-size
+    // degradation. Called per-spawn and from the layout handler. When the leaf
+    // is too small or not yet laid out, the mount is collapsed to zero size so
+    // the glow is simply invisible (and reappears if the pane later grows).
+    private void PositionGlowMount(TerminalControl terminal, Canvas mount)
+    {
+        var leaf = PaneTree.Leaves(_root).FirstOrDefault(l => ReferenceEquals(l.Terminal(), terminal));
+        if (leaf is null) return;
+
+        var ctl = leaf.Terminal();
+        // Same "not laid out yet" guard the other overlay layers use.
+        if (ctl.ActualWidth <= 0 || ctl.ActualHeight <= 0)
+        {
+            CollapseGlowMount(terminal, mount);
+            return;
+        }
+
+        // LeafLayoutBounds walks layout slots rather than transforms: at cold
+        // start the render-thread transform is not committed by the idle
+        // compositor for ~750ms, so a TransformToVisual-based mount would
+        // strand at zero size until then (see LeafLayoutBounds).
+        var bounds = LeafLayoutBounds(ctl);
+        if (bounds.Width < MinGlowDimension || bounds.Height < MinGlowDimension)
+        {
+            CollapseGlowMount(terminal, mount);
+            return;
+        }
+
+        Canvas.SetLeft(mount, bounds.X);
+        Canvas.SetTop(mount, bounds.Y);
+        mount.Width = bounds.Width;
+        mount.Height = bounds.Height;
+        if (_glows.TryGetValue(terminal, out var glow))
+            glow.UpdateSize(new Vector2((float)bounds.Width, (float)bounds.Height));
+    }
+
+    private void CollapseGlowMount(TerminalControl terminal, Canvas mount)
+    {
+        mount.Width = 0;
+        mount.Height = 0;
+        if (_glows.TryGetValue(terminal, out var glow))
+            glow.UpdateSize(new Vector2(0f, 0f));
     }
 
     /// <summary>
@@ -1328,6 +1507,14 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         t.CloseRequested += OnTerminalCloseRequested;
         t.ContextMenuRequested += OnTerminalContextMenuRequested;
         t.PwdChanged += OnTerminalPwdChanged;
+        // Startup glow: begin the orbit when this leaf's surface spawns; end
+        // it on the FIRST of first_render (the pane produced renderable
+        // content, shell-agnostic) or the cap timer as the fallback. We use
+        // first_render rather than OSC 133 prompt-ready: prompt-ready depends
+        // on shell integration loading and varies per shell
+        // (cmd/pwsh/wsl/...), whereas first_render is universal.
+        t.SurfaceSpawned += OnLeafSurfaceSpawned;
+        t.FirstRender += OnLeafFirstRender;
         return t;
     }
 
@@ -1413,6 +1600,12 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
 
             PositionOverlayOverLeaf(dim, leaf, insetForStroke: false);
         }
+
+        // Keep each live startup-glow mount tracked over its leaf while the
+        // glow lasts. Cheap when the dictionary is empty (the common case
+        // once every pane has rendered).
+        foreach (var (terminal, mount) in _glowMounts)
+            PositionGlowMount(terminal, mount);
     }
 
     private void PositionActiveBorderOverLeaf(LeafPane leaf)

--- a/windows/Ghostty/Panes/PaneStartupGlow.cs
+++ b/windows/Ghostty/Panes/PaneStartupGlow.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Numerics;
+using Microsoft.UI.Composition;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Hosting;
+
+namespace Ghostty.Panes;
+
+/// <summary>
+/// Composition renderer for the pane startup glow: a rounded-rectangle border
+/// painted by a radial gradient whose center orbits the pane clockwise, so a
+/// soft bright segment sweeps the inner border. Driven imperatively by PaneHost
+/// (StartGlow / BeginFadeOut / Dispose) off the pure state machine.
+///
+/// Two stacked strokes give a glow that reads on ANY background (not just the
+/// dimmed inactive-pane film): a wide, soft, low-alpha <c>halo</c> for bloom,
+/// and a thin bright <c>core</c> for the sharp sweeping head. The whole ring
+/// also carries a faint base tint so it is visible the instant a pane opens.
+///
+/// Tuning constants (thickness, radius, stops, loop period) live here; the
+/// lifecycle timing (cap, fade) lives in PaneStartupGlowState.
+/// </summary>
+internal sealed class PaneStartupGlow : IDisposable
+{
+    private const float CoreThickness = 4f;
+    private const float HaloThickness = 12f;
+    private const float CornerRadius = 8f;
+    private static readonly TimeSpan LoopPeriod = TimeSpan.FromMilliseconds(1400);
+
+    private readonly FrameworkElement _mount;
+    private readonly Compositor _compositor;
+    private readonly ShapeVisual _shapeVisual;
+    private readonly CompositionRoundedRectangleGeometry _geometry;
+    private readonly CompositionRadialGradientBrush _coreBrush;
+    private readonly CompositionRadialGradientBrush _haloBrush;
+    private bool _disposed;
+
+    /// <param name="mount">An empty FrameworkElement (sized/positioned by
+    /// PaneHost over the leaf) that hosts this glow's child visual.</param>
+    /// <param name="size">Initial mount size in DIPs.</param>
+    /// <param name="trail">Trailing color (accent/cursor), passed fully opaque;
+    /// the gradient stops apply their own alpha for the halo/tail.</param>
+    /// <param name="lead">Leading-edge color (foreground), passed fully opaque;
+    /// the gradient stops apply their own alpha for the halo/tail.</param>
+    public PaneStartupGlow(FrameworkElement mount, Vector2 size,
+        Windows.UI.Color trail, Windows.UI.Color lead)
+    {
+        _mount = mount;
+        _compositor = ElementCompositionPreview.GetElementVisual(mount).Compositor;
+
+        // Core: bright leading head -> accent body -> faint accent base. The
+        // base alpha (not zero) keeps the whole ring softly lit so the glow is
+        // visible immediately, even over a bright focused-pane background.
+        _coreBrush = _compositor.CreateRadialGradientBrush();
+        _coreBrush.MappingMode = CompositionMappingMode.Relative;
+        _coreBrush.EllipseRadius = new Vector2(0.5f, 0.5f);
+        _coreBrush.EllipseCenter = new Vector2(0f, 0f);
+        _coreBrush.ColorStops.Add(_compositor.CreateColorGradientStop(0.0f, lead));
+        _coreBrush.ColorStops.Add(_compositor.CreateColorGradientStop(0.40f, trail));
+        _coreBrush.ColorStops.Add(_compositor.CreateColorGradientStop(
+            1.0f, Windows.UI.Color.FromArgb(70, trail.R, trail.G, trail.B)));
+
+        // Halo: wide, soft, low-alpha accent bloom following the same head.
+        _haloBrush = _compositor.CreateRadialGradientBrush();
+        _haloBrush.MappingMode = CompositionMappingMode.Relative;
+        _haloBrush.EllipseRadius = new Vector2(0.7f, 0.7f);
+        _haloBrush.EllipseCenter = new Vector2(0f, 0f);
+        _haloBrush.ColorStops.Add(_compositor.CreateColorGradientStop(
+            0.0f, Windows.UI.Color.FromArgb(150, trail.R, trail.G, trail.B)));
+        _haloBrush.ColorStops.Add(_compositor.CreateColorGradientStop(
+            0.6f, Windows.UI.Color.FromArgb(45, trail.R, trail.G, trail.B)));
+        _haloBrush.ColorStops.Add(_compositor.CreateColorGradientStop(
+            1.0f, Windows.UI.Color.FromArgb(0, trail.R, trail.G, trail.B)));
+
+        _geometry = _compositor.CreateRoundedRectangleGeometry();
+        _geometry.CornerRadius = new Vector2(CornerRadius, CornerRadius);
+        ApplyGeometrySize(size);
+
+        // Halo drawn first (under), bright core on top. Both stroke the same
+        // rounded-rect path.
+        var haloShape = _compositor.CreateSpriteShape(_geometry);
+        haloShape.StrokeThickness = HaloThickness;
+        haloShape.FillBrush = null;
+        haloShape.StrokeBrush = _haloBrush;
+
+        var coreShape = _compositor.CreateSpriteShape(_geometry);
+        coreShape.StrokeThickness = CoreThickness;
+        coreShape.FillBrush = null;
+        coreShape.StrokeBrush = _coreBrush;
+
+        _shapeVisual = _compositor.CreateShapeVisual();
+        _shapeVisual.Size = size;
+        _shapeVisual.Shapes.Add(haloShape);
+        _shapeVisual.Shapes.Add(coreShape);
+
+        ElementCompositionPreview.SetElementChildVisual(_mount, _shapeVisual);
+    }
+
+    /// <summary>Start the forever clockwise orbit (both halo and core in sync).</summary>
+    public void StartGlow()
+    {
+        if (_disposed) return;
+        var linear = _compositor.CreateLinearEasingFunction();
+        var orbit = _compositor.CreateVector2KeyFrameAnimation();
+        orbit.InsertKeyFrame(0.00f, new Vector2(0f, 0f), linear); // top-left
+        orbit.InsertKeyFrame(0.25f, new Vector2(1f, 0f), linear); // top-right
+        orbit.InsertKeyFrame(0.50f, new Vector2(1f, 1f), linear); // bottom-right
+        orbit.InsertKeyFrame(0.75f, new Vector2(0f, 1f), linear); // bottom-left
+        orbit.InsertKeyFrame(1.00f, new Vector2(0f, 0f), linear); // back to start
+        orbit.Duration = LoopPeriod;
+        orbit.IterationBehavior = AnimationIterationBehavior.Forever;
+        _coreBrush.StartAnimation("EllipseCenter", orbit);
+        _haloBrush.StartAnimation("EllipseCenter", orbit);
+    }
+
+    /// <summary>Fade the whole glow to transparent over <paramref name="duration"/>.
+    /// Caller disposes after.</summary>
+    public void BeginFadeOut(TimeSpan duration)
+    {
+        if (_disposed) return;
+        var fade = _compositor.CreateScalarKeyFrameAnimation();
+        fade.InsertKeyFrame(1f, 0f);
+        fade.Duration = duration;
+        _shapeVisual.StartAnimation("Opacity", fade);
+    }
+
+    /// <summary>Resize the glow when the leaf bounds change.</summary>
+    public void UpdateSize(Vector2 size)
+    {
+        if (_disposed) return;
+        _shapeVisual.Size = size;
+        ApplyGeometrySize(size);
+    }
+
+    private void ApplyGeometrySize(Vector2 size)
+    {
+        // Inset the geometry by half the WIDEST stroke (the halo) so the whole
+        // band stays inside the leaf bounds and nothing gets clipped by the
+        // shape visual's size.
+        var half = HaloThickness / 2f;
+        _geometry.Offset = new Vector2(half, half);
+        _geometry.Size = new Vector2(
+            Math.Max(0f, size.X - HaloThickness),
+            Math.Max(0f, size.Y - HaloThickness));
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _coreBrush.StopAnimation("EllipseCenter");
+        _haloBrush.StopAnimation("EllipseCenter");
+        _shapeVisual.StopAnimation("Opacity");
+        ElementCompositionPreview.SetElementChildVisual(_mount, null);
+        _shapeVisual.Dispose();
+        _geometry.Dispose();
+        _coreBrush.Dispose();
+        _haloBrush.Dispose();
+    }
+}

--- a/windows/Ghostty/Panes/PaneStartupGlow.cs
+++ b/windows/Ghostty/Panes/PaneStartupGlow.cs
@@ -30,9 +30,16 @@ internal sealed class PaneStartupGlow : IDisposable
     private readonly FrameworkElement _mount;
     private readonly Compositor _compositor;
     private readonly ShapeVisual _shapeVisual;
+    private readonly SpriteShape _coreShape;
+    private readonly SpriteShape _haloShape;
     private readonly CompositionRoundedRectangleGeometry _geometry;
+    private readonly CompositionColorGradientStopCollection _coreStops;
+    private readonly CompositionColorGradientStopCollection _haloStops;
     private readonly CompositionRadialGradientBrush _coreBrush;
     private readonly CompositionRadialGradientBrush _haloBrush;
+    private readonly ScalarKeyFrameAnimation _fade;
+    private readonly Vector2KeyFrameAnimation _orbit;
+    private readonly LinearEasingFunction _easing;
     private bool _disposed;
 
     /// <param name="mount">An empty FrameworkElement (sized/positioned by
@@ -55,9 +62,10 @@ internal sealed class PaneStartupGlow : IDisposable
         _coreBrush.MappingMode = CompositionMappingMode.Relative;
         _coreBrush.EllipseRadius = new Vector2(0.5f, 0.5f);
         _coreBrush.EllipseCenter = new Vector2(0f, 0f);
-        _coreBrush.ColorStops.Add(_compositor.CreateColorGradientStop(0.0f, lead));
-        _coreBrush.ColorStops.Add(_compositor.CreateColorGradientStop(0.40f, trail));
-        _coreBrush.ColorStops.Add(_compositor.CreateColorGradientStop(
+        _coreStops = _coreBrush.ColorStops;
+        _coreStops.Add(_compositor.CreateColorGradientStop(0.0f, lead));
+        _coreStops.Add(_compositor.CreateColorGradientStop(0.40f, trail));
+        _coreStops.Add(_compositor.CreateColorGradientStop(
             1.0f, Windows.UI.Color.FromArgb(70, trail.R, trail.G, trail.B)));
 
         // Halo: wide, soft, low-alpha accent bloom following the same head.
@@ -65,11 +73,12 @@ internal sealed class PaneStartupGlow : IDisposable
         _haloBrush.MappingMode = CompositionMappingMode.Relative;
         _haloBrush.EllipseRadius = new Vector2(0.7f, 0.7f);
         _haloBrush.EllipseCenter = new Vector2(0f, 0f);
-        _haloBrush.ColorStops.Add(_compositor.CreateColorGradientStop(
+        _haloStops = _haloBrush.ColorStops;
+        _haloStops.Add(_compositor.CreateColorGradientStop(
             0.0f, Windows.UI.Color.FromArgb(150, trail.R, trail.G, trail.B)));
-        _haloBrush.ColorStops.Add(_compositor.CreateColorGradientStop(
+        _haloStops.Add(_compositor.CreateColorGradientStop(
             0.6f, Windows.UI.Color.FromArgb(45, trail.R, trail.G, trail.B)));
-        _haloBrush.ColorStops.Add(_compositor.CreateColorGradientStop(
+        _haloStops.Add(_compositor.CreateColorGradientStop(
             1.0f, Windows.UI.Color.FromArgb(0, trail.R, trail.G, trail.B)));
 
         _geometry = _compositor.CreateRoundedRectangleGeometry();
@@ -78,20 +87,37 @@ internal sealed class PaneStartupGlow : IDisposable
 
         // Halo drawn first (under), bright core on top. Both stroke the same
         // rounded-rect path.
-        var haloShape = _compositor.CreateSpriteShape(_geometry);
-        haloShape.StrokeThickness = HaloThickness;
-        haloShape.FillBrush = null;
-        haloShape.StrokeBrush = _haloBrush;
+        _haloShape = _compositor.CreateSpriteShape(_geometry);
+        _haloShape.StrokeThickness = HaloThickness;
+        _haloShape.FillBrush = null;
+        _haloShape.StrokeBrush = _haloBrush;
 
-        var coreShape = _compositor.CreateSpriteShape(_geometry);
-        coreShape.StrokeThickness = CoreThickness;
-        coreShape.FillBrush = null;
-        coreShape.StrokeBrush = _coreBrush;
+        _coreShape = _compositor.CreateSpriteShape(_geometry);
+        _coreShape.StrokeThickness = CoreThickness;
+        _coreShape.FillBrush = null;
+        _coreShape.StrokeBrush = _coreBrush;
 
         _shapeVisual = _compositor.CreateShapeVisual();
         _shapeVisual.Size = size;
-        _shapeVisual.Shapes.Add(haloShape);
-        _shapeVisual.Shapes.Add(coreShape);
+        _shapeVisual.Shapes.Add(_haloShape);
+        _shapeVisual.Shapes.Add(_coreShape);
+
+        // Animations are built here rather than at start/fade time so that
+        // Dispose owns every composition object this class creates. Nothing
+        // is lost: the orbit's key frames are fixed (four corners, clockwise),
+        // the fade's target is fixed (transparent), and only the two
+        // durations wait for their caller.
+        _easing = _compositor.CreateLinearEasingFunction();
+        _orbit = _compositor.CreateVector2KeyFrameAnimation();
+        _orbit.InsertKeyFrame(0.00f, new Vector2(0f, 0f), _easing); // top-left
+        _orbit.InsertKeyFrame(0.25f, new Vector2(1f, 0f), _easing); // top-right
+        _orbit.InsertKeyFrame(0.50f, new Vector2(1f, 1f), _easing); // bottom-right
+        _orbit.InsertKeyFrame(0.75f, new Vector2(0f, 1f), _easing); // bottom-left
+        _orbit.InsertKeyFrame(1.00f, new Vector2(0f, 0f), _easing); // back to start
+        _orbit.Duration = LoopPeriod;
+        _orbit.IterationBehavior = AnimationIterationBehavior.Forever;
+        _fade = _compositor.CreateScalarKeyFrameAnimation();
+        _fade.InsertKeyFrame(1f, 0f);
 
         ElementCompositionPreview.SetElementChildVisual(_mount, _shapeVisual);
     }
@@ -100,17 +126,8 @@ internal sealed class PaneStartupGlow : IDisposable
     public void StartGlow()
     {
         if (_disposed) return;
-        var linear = _compositor.CreateLinearEasingFunction();
-        var orbit = _compositor.CreateVector2KeyFrameAnimation();
-        orbit.InsertKeyFrame(0.00f, new Vector2(0f, 0f), linear); // top-left
-        orbit.InsertKeyFrame(0.25f, new Vector2(1f, 0f), linear); // top-right
-        orbit.InsertKeyFrame(0.50f, new Vector2(1f, 1f), linear); // bottom-right
-        orbit.InsertKeyFrame(0.75f, new Vector2(0f, 1f), linear); // bottom-left
-        orbit.InsertKeyFrame(1.00f, new Vector2(0f, 0f), linear); // back to start
-        orbit.Duration = LoopPeriod;
-        orbit.IterationBehavior = AnimationIterationBehavior.Forever;
-        _coreBrush.StartAnimation("EllipseCenter", orbit);
-        _haloBrush.StartAnimation("EllipseCenter", orbit);
+        _coreBrush.StartAnimation("EllipseCenter", _orbit);
+        _haloBrush.StartAnimation("EllipseCenter", _orbit);
     }
 
     /// <summary>Fade the whole glow to transparent over <paramref name="duration"/>.
@@ -118,10 +135,8 @@ internal sealed class PaneStartupGlow : IDisposable
     public void BeginFadeOut(TimeSpan duration)
     {
         if (_disposed) return;
-        var fade = _compositor.CreateScalarKeyFrameAnimation();
-        fade.InsertKeyFrame(1f, 0f);
-        fade.Duration = duration;
-        _shapeVisual.StartAnimation("Opacity", fade);
+        _fade.Duration = duration;
+        _shapeVisual.StartAnimation("Opacity", _fade);
     }
 
     /// <summary>Resize the glow when the leaf bounds change.</summary>
@@ -148,13 +163,41 @@ internal sealed class PaneStartupGlow : IDisposable
     {
         if (_disposed) return;
         _disposed = true;
+
+        // Animations stop before the objects they drive, then owners go
+        // before their dependents: the visual that holds both shapes, the
+        // shapes, and the geometry they both stroke.
         _coreBrush.StopAnimation("EllipseCenter");
         _haloBrush.StopAnimation("EllipseCenter");
         _shapeVisual.StopAnimation("Opacity");
         ElementCompositionPreview.SetElementChildVisual(_mount, null);
+
         _shapeVisual.Dispose();
+        _coreShape.Dispose();
+        _haloShape.Dispose();
         _geometry.Dispose();
+
+        // Each brush's gradient graph. The stops are composition objects of
+        // their own and go before the collection holding them: enumerating a
+        // closed collection is the one order that would throw.
+        DisposeStops(_coreStops);
+        _coreStops.Dispose();
         _coreBrush.Dispose();
+        DisposeStops(_haloStops);
+        _haloStops.Dispose();
         _haloBrush.Dispose();
+
+        // The animations themselves, the forever orbit included: left running
+        // it keeps the compositor animating the property of a brush nobody
+        // paints with, for the rest of the window's life.
+        _fade.Dispose();
+        _orbit.Dispose();
+        _easing.Dispose();
+    }
+
+    private static void DisposeStops(CompositionColorGradientStopCollection stops)
+    {
+        foreach (var stop in stops)
+            stop.Dispose();
     }
 }

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -66,6 +66,10 @@ internal sealed partial class ConfigService : IConfigService, Ghostty.Core.Profi
         = Ghostty.Core.Config.WindowsOnlyKeyParsers.VerticalTabsWidthDefault;
     public bool VerticalTabsPinned { get; private set; }
     public bool VerticalTabsHoverExpand { get; private set; }
+    // A newly spawned pane's border glows while its shell starts up.
+    // Default true; `pane-startup-glow = false` turns it off. Read by
+    // MainWindow and pushed to each PaneHost with the tab border colors.
+    public bool PaneStartupGlow { get; private set; } = true;
     public bool CommandPaletteGroupCommands { get; private set; }
     public bool WindowsHighContrast { get; private set; } = true;
     public string CommandPaletteBackground { get; private set; } = "acrylic";
@@ -964,6 +968,9 @@ internal sealed partial class ConfigService : IConfigService, Ghostty.Core.Profi
         VerticalTabsHoverExpand = WindowsOnlyKeyParsers.ParseBool(
             GetFileValue("vertical-tabs-hover-expand", ""),
             defaultValue: false);
+        PaneStartupGlow = WindowsOnlyKeyParsers.ParseBool(
+            GetFileValue("pane-startup-glow", ""),
+            defaultValue: true);
         CommandPaletteGroupCommands = WindowsOnlyKeyParsers.ParseBool(
             GetFileValue("command-palette-group-commands", ""),
             defaultValue: false);


### PR DESCRIPTION
## What this is

P1 of the warm-sessions epic: the Pro-only pane startup glow, ported into the base repo so every tier (oss, sponsor, pro, pro-legacy) gets it. A newly spawned pane strokes its border with a bright segment that orbits clockwise while its shell starts up, then fades the moment the pane produces its first render.

Three pieces, same split as the Pro overlay:

- `windows/Ghostty.Core/Panes/PaneStartupGlowState.cs` - pure lifecycle (Idle / Glowing / FadingOut) over an injected `ISchedulerTimer`. Renders nothing.
- `windows/Ghostty/Panes/PaneStartupGlow.cs` - composition renderer: two stacked strokes (wide low-alpha halo, thin bright core) on one rounded-rect path, with the gradient center orbiting on a forever 1400ms vector2 keyframe.
- `windows/Ghostty/Panes/PaneHost.cs` - the wiring: mount Canvas per leaf, phase changes marshalled onto the dispatcher, teardown on leaf close and on window teardown.

## Invariants preserved

**The mount is positioned from layout slots, never from a transform.** `PositionGlowMount` reads through the existing `LeafLayoutBounds`, which walks `LayoutInformation.GetLayoutSlot()` up the ancestor chain. `TransformToVisual` reflects the render-thread transform, which the idle compositor does not commit for ~750ms at cold start, so a transform-based mount would strand the first pane's glow at zero size exactly when it is most wanted. The layout chain is also why the mount is a child of `_highlightOverlay` (the Canvas the active border already draws on) rather than a sibling.

**Show on `SurfaceSpawned`, hide on `FirstRender`.** `SurfaceSpawned` is new and is raised as the last statement of `TerminalControl.OnLoaded`, after the surface is created and registered - before that there is no leaf to mount over. The end trigger is `first_render`, which base already raises, and not OSC 133 prompt-ready: prompt-ready depends on shell integration and varies per shell (cmd, pwsh, wsl), while a rendered pane is rendered whatever the shell is. `NotifyReady` is a no-op once fading, so a late or duplicate signal is harmless.

**No sessiond anywhere.** The glow binds to libghostty surface events only. No session, transport or daemon type appears in any of the three files; it works for a pane that has never heard of the daemon, and it keeps working if the daemon is not running.

Fallback and degradation: a 10000ms cap fades the glow for a surface that never renders, the fade is 250ms, and panes under 80 DIP in either dimension skip it (the mount collapses to zero and comes back if the pane grows). Layering: mount at z 998, the active border frame now pinned at 999 inside the same overlay, so the glow reads as just under the focus stroke.

## Config

`pane-startup-glow`, default true, registered in `WindowsOnlyKeys` so libghostty's "unknown field" diagnostic stays out of the settings notice list. `ConfigService` parses it in `ReadFlagsCore` alongside the other Windows-only keys, and `MainWindow.ApplyPerTabChrome` pushes it per tab via `SetStartupGlowConfig`, in the same pass that sets the border colours and before any new host's deferred `Loaded` can fire. The glow's trail colour is the tab's border colour, so the sweep hands over to the colour the pane settles into; the lead is the theme foreground.

## Tests

TDD: the `PaneStartupGlowState` tests landed first against a stub (7 failed, 2 passed), then the state machine.

- `windows/Ghostty.Tests/Panes/PaneStartupGlowStateTests.cs` - the whole lifecycle arc against a fake timer: cap then fade then idle, close during fade, close cancel, start-twice does not re-arm, ready before the cap supersedes the cap timer, ready after fade started and before start are both ignored, dispose.
- `windows/Ghostty.Tests/Wiring/PaneStartupGlowWiringTests.cs` - the wiring that can fail silently: the raise is the last statement of `OnLoaded`; `DisposeSurface` drops the subscriber; `CreateTerminal` wires spawn to start and `FirstRender` to end; `TeardownLeaf` tears the glow down; `DisposeAllLeaves` sweeps `_glowStates` outside the `_allLeavesClosed` gate; mount at z 998 under the active border at 999; the mount is positioned from `LeafLayoutBounds` and contains no `TransformToVisual`; the enablement guard precedes the already-glowing guard; the key is registered with default true; `ApplyPerTabChrome` pushes `_configService.PaneStartupGlow`.

## Signoff

Host ryzen7pro, worktree `C:\wt\p1glow`, `just signoff` at head `7f42d3000792ff51965de1b7a761a3ed8ad78c39`.

```
signoff: scoped to 9 changed path(s)
signoff: legs: windows-tests
signoff: running windows-tests: just test-win
Passed!  - Failed:     0, Passed:  2928, Skipped:     1, Total:  2929, Duration: 13 s - Ghostty.Tests.dll (net10.0)
Passed!  - Failed:     0, Passed:    46, Skipped:    12, Total:    58, Duration: 1 s - Ghostty.Tests.Windows.dll (net10.0)
signoff: windows-tests -> rc=0 (30.2s)
signoff: PASS recorded for 7f42d30007 at C:/Users/Alessandro/CODE/OSS/wintty/.git\pr-signoff\7f42d3000792ff51965de1b7a761a3ed8ad78c39.json
```

First run of the same ladder had one failure in `Ghostty.Tests.Bench.HarnessTests.RunThroughputIteration_ThrowsOnEndOfStreamBeforeTerminator` (TimeoutException instead of EndOfStreamException); that test passes in isolation and the rerun above is green. It is a load-sensitive bench probe untouched by this diff.


Size-override: 1112 countable lines, but the implementation is two small files (PaneStartupGlowState.cs, PaneStartupGlow.cs); the remainder is test bulk (9 state-machine tests plus 14 Roslyn wiring guards) and their fixture boilerplate.
