### PR TITLE
tabs: group lifecycle ops and the group-aware projection

### DIFF
--- a/windows/Ghostty.Core/Tabs/TabManager.cs
+++ b/windows/Ghostty.Core/Tabs/TabManager.cs
@@ -386,6 +386,15 @@ internal sealed class TabManager
     /// <paramref name="targetIndex"/>, internal member order preserved.
     /// The run is clamped to land whole and clear of the pinned prefix;
     /// groups cannot be pinned.
+    ///
+    /// This is the single commit behind a whole-run crossing, and both
+    /// drag surfaces converge on it: the vertical header drag and the
+    /// horizontal chip drag hand over a MODEL index measured from
+    /// arranged positions at release (never an in-flight one), and the
+    /// clamp here is why neither caller needs pin math of its own. A
+    /// relocation raises one TabMoved per displaced member -- old index
+    /// from before the splice, new from after -- which the projector
+    /// reconciles; it is not a walkable sequence of single moves.
     /// </summary>
     public void MoveGroup(TabGroup group, int targetIndex)
     {
@@ -431,6 +440,11 @@ internal sealed class TabManager
     /// order) at the first member's position. Pinned members are skipped:
     /// the prefix outranks membership, the same rule <see cref="SetPinned"/>
     /// applies in the other direction.
+    ///
+    /// Membership only: the group's <see cref="TabGroup.IsCollapsed"/> bit
+    /// is never touched here -- the property the session restore hangs its
+    /// saved collapse state on (the auto-expanding join is
+    /// <see cref="JoinGroup"/>).
     /// </summary>
     public void GroupTabs(IReadOnlyList<TabModel> members, TabGroup group)
     {
@@ -451,6 +465,63 @@ internal sealed class TabManager
     }
 
     /// <summary>
+    /// New Group With Tab: a fresh group whose sole member is
+    /// <paramref name="tab"/>. The tab keeps its position and the gather
+    /// moves nothing (one member is already a run). Null when the tab is
+    /// pinned (the prefix outranks membership, the same refusal
+    /// <see cref="GroupTabs"/> applies) or not owned by this manager --
+    /// either way nothing is registered. The caller renames and colors the
+    /// returned group through its plain properties, which carry no
+    /// invariants to protect.
+    /// </summary>
+    public TabGroup? CreateGroup(TabModel tab)
+    {
+        ArgumentNullException.ThrowIfNull(tab);
+        if (!_tabs.Contains(tab) || tab.IsPinned) return null;
+        var group = new TabGroup();
+        GroupTabs(new[] { tab }, group);
+        return group;
+    }
+
+    /// <summary>
+    /// Add one tab to a group: the single-commit join behind the
+    /// drag-into-run drop, the Add to Group submenu, and a drop on a
+    /// collapsed chip. Joining a COLLAPSED group auto-expands it (Edge's
+    /// documented by-design rule), and the expand lives HERE -- manager
+    /// state, so neither strip mode has to remember it and a drag can
+    /// never carry it. The bit only moves when the join actually happened:
+    /// a refused join (pinned, foreign tab) or a tab that is already a
+    /// member leaves the user's collapse state exactly as they set it.
+    /// Session restore does not come through here -- it must preserve the
+    /// saved collapse bit, so it joins via <see cref="GroupTabs"/> instead.
+    /// </summary>
+    public void JoinGroup(TabModel tab, TabGroup group)
+    {
+        ArgumentNullException.ThrowIfNull(tab);
+        ArgumentNullException.ThrowIfNull(group);
+        bool wasMember = ReferenceEquals(tab.Group, group);
+        GroupTabs(new[] { tab }, group);
+        if (!wasMember && ReferenceEquals(tab.Group, group) && group.IsCollapsed)
+            group.IsCollapsed = false;
+    }
+
+    /// <summary>
+    /// Ungroup every member at once, in place: positions, activation, and
+    /// MRU are untouched, and the group -- collapse state included -- is
+    /// gone. The per-tab counterpart is <see cref="Ungroup"/>; this is the
+    /// Remove from Group command's op.
+    /// </summary>
+    public void DissolveGroup(TabGroup group)
+    {
+        ArgumentNullException.ThrowIfNull(group);
+        if (!_groups.Contains(group)) return;
+        foreach (var t in _tabs)
+            if (ReferenceEquals(t.Group, group))
+                t.Group = null;
+        Normalize();
+    }
+
+    /// <summary>
     /// Remove one tab from its group. The group dissolves if this was its
     /// last member, collapse state included. The tab keeps its position.
     /// </summary>
@@ -466,11 +537,45 @@ internal sealed class TabManager
     /// and the active member of a collapsed group keeps its row once the
     /// projector lands. Collapse state lives on the group so both strip
     /// modes share one bit.
+    ///
+    /// No accordion: activating a member of a collapsed group swaps which
+    /// member is visible and does NOT expand the group -- collapse state
+    /// stays exactly as the user set it, and the strips below read the bit
+    /// rather than any activation side effect. The strips also refuse to
+    /// project a fully-collapsed group that holds the active tab
+    /// (<see cref="HoldsActiveTab"/>), so selection is never hidden.
     /// </summary>
     public void CollapseGroup(TabGroup group, bool collapsed)
     {
         ArgumentNullException.ThrowIfNull(group);
         group.IsCollapsed = collapsed;
+    }
+
+    /// <summary>
+    /// Whether the group's run contains the active tab -- the model half
+    /// of the Edge-135 rule. A collapsed group holding the active tab is
+    /// never projected as fully collapsed: the vertical strip keeps the
+    /// active member's row visible and the horizontal strip projects no
+    /// chip for it, so selection is never hidden. Both strips ask here
+    /// rather than re-deriving membership.
+    /// </summary>
+    public bool HoldsActiveTab(TabGroup group)
+    {
+        ArgumentNullException.ThrowIfNull(group);
+        return ReferenceEquals(_activeTab.Group, group);
+    }
+
+    /// <summary>
+    /// Whether closing the group would close every tab in the window:
+    /// Close Group greys itself out then, the same rule as Move Tab to New
+    /// Window. The close itself stays shell-side -- sequential through the
+    /// per-tab confirmation path -- so the manager offers the guard, not
+    /// the command.
+    /// </summary>
+    public bool GroupHoldsEveryTab(TabGroup group)
+    {
+        ArgumentNullException.ThrowIfNull(group);
+        return _tabs.Count > 0 && MembersOf(group).Count == _tabs.Count;
     }
 
     /// <summary>

--- a/windows/Ghostty.Core/Tabs/TabStripProjection.cs
+++ b/windows/Ghostty.Core/Tabs/TabStripProjection.cs
@@ -79,4 +79,58 @@ internal static class TabStripProjection
         }
         return ops;
     }
+
+    /// <summary>
+    /// One row a strip renders, group-aware: a group's header, or a tab
+    /// row (grouped or not -- membership is the tab's own
+    /// <see cref="TabModel.Group"/>).
+    /// </summary>
+    public abstract record ProjectedRow
+    {
+        public sealed record Header(TabGroup Group) : ProjectedRow;
+
+        public sealed record Item(TabModel Tab) : ProjectedRow;
+    }
+
+    /// <summary>
+    /// The rows a strip renders for the manager's current state, groups
+    /// included. Order is <see cref="TabManager.Tabs"/> order with a
+    /// header in front of each run. Collapse hides members EXCEPT the
+    /// active one -- the Edge-135 rule (2.9 row 14) that keeps selection
+    /// never hidden -- so a collapsed group projects as its header plus
+    /// the active member's row, or the header alone when the run holds no
+    /// active tab: the fully-collapsed shape the vertical strip renders
+    /// as a childless header and the horizontal strip renders as a chip.
+    /// Activating a different member of a collapsed group swaps which
+    /// member survives here and nothing else; the collapse bit is never
+    /// touched by a projection.
+    ///
+    /// Contiguity (a manager invariant) is what puts each header in front
+    /// of all of its members; this walk does not re-order anything.
+    ///
+    /// The collapsed-with-active shape above is VERTICAL's. Horizontal's
+    /// is different -- the active member surfaces as a plain row and the
+    /// chip is suppressed (4.3) -- and that reading is PR 6's consumer,
+    /// not a second projection here.
+    /// </summary>
+    public static IReadOnlyList<ProjectedRow> GroupedRows(TabManager manager)
+    {
+        var rows = new List<ProjectedRow>(manager.Tabs.Count);
+        var headered = new HashSet<TabGroup>();
+        foreach (var tab in manager.Tabs)
+        {
+            if (tab.Group is { } group)
+            {
+                if (headered.Add(group))
+                    rows.Add(new ProjectedRow.Header(group));
+                if (!group.IsCollapsed || ReferenceEquals(tab, manager.ActiveTab))
+                    rows.Add(new ProjectedRow.Item(tab));
+            }
+            else
+            {
+                rows.Add(new ProjectedRow.Item(tab));
+            }
+        }
+        return rows;
+    }
 }

--- a/windows/Ghostty.Tests/Tabs/TabManagerPinGroupTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabManagerPinGroupTests.cs
@@ -358,6 +358,165 @@ public class TabManagerPinGroupTests
         Assert.Null(mgr.Tabs[0].Group);
     }
 
+    // --- Group lifecycle ops ---
+
+    [Fact]
+    public void CreateGroup_makes_the_tab_the_sole_member_in_place()
+    {
+        var mgr = NewManager(2); // [A, B, C]
+        var order = new List<TabModel>(mgr.Tabs);
+        int moved = 0;
+        mgr.TabMoved += (_, _) => moved++;
+
+        var group = mgr.CreateGroup(mgr.Tabs[1]);
+
+        Assert.NotNull(group);
+        Assert.Same(group, mgr.Tabs[1].Group);
+        Assert.Contains(group!, mgr.Groups);
+        Assert.Equal(order, mgr.Tabs); // the seed keeps its position
+        Assert.Equal(0, moved);
+        Assert.Equal("New group", group!.Title);
+        Assert.Equal(TabColor.Blue, group.Color);
+        Assert.False(group.IsCollapsed);
+    }
+
+    [Fact]
+    public void CreateGroup_refuses_a_pinned_tab_and_registers_nothing()
+    {
+        var mgr = NewManager(1);
+        mgr.SetPinned(mgr.Tabs[0], true);
+
+        Assert.Null(mgr.CreateGroup(mgr.Tabs[0]));
+        Assert.Null(mgr.Tabs[0].Group);
+        Assert.Empty(mgr.Groups);
+    }
+
+    [Fact]
+    public void CreateGroup_refuses_a_tab_the_manager_does_not_own()
+    {
+        var mgr = NewManager(0);
+        var stranger = new TabModel(new FakePaneHost());
+
+        Assert.Null(mgr.CreateGroup(stranger));
+        Assert.Empty(mgr.Groups);
+    }
+
+    [Fact]
+    public void JoinGroup_moves_the_tab_into_the_run()
+    {
+        var mgr = NewManager(3); // [A, B, C, D]
+        var group = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[1] }, group);
+        var a = mgr.Tabs[0];
+        var b = mgr.Tabs[1];
+        var c = mgr.Tabs[2];
+        var d = mgr.Tabs[3];
+
+        mgr.JoinGroup(d, group);
+
+        // The gather re-forms the run at the first member's position, in
+        // the members' relative order -- the same grammar GroupTabs uses.
+        Assert.Equal(new[] { a, b, d, c }, mgr.Tabs.ToArray());
+        AssertRunContiguous(mgr, group);
+    }
+
+    [Fact]
+    public void JoinGroup_auto_expands_a_collapsed_group()
+    {
+        var mgr = NewManager(2); // [A, B, C]
+        var group = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[0] }, group);
+        mgr.CollapseGroup(group, true);
+
+        mgr.JoinGroup(mgr.Tabs[2], group);
+
+        Assert.False(group.IsCollapsed); // the join is visible (2.9 row 17)
+        AssertRunContiguous(mgr, group);
+    }
+
+    [Fact]
+    public void JoinGroup_keeps_the_collapse_bit_when_nothing_joined()
+    {
+        var mgr = NewManager(2); // [A, B, C]
+        mgr.SetPinned(mgr.Tabs[0], true);
+        var group = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[1] }, group);
+        mgr.CollapseGroup(group, true);
+
+        // A refused join (pinned) must not expand...
+        mgr.JoinGroup(mgr.Tabs[0], group);
+        Assert.True(group.IsCollapsed);
+        Assert.Null(mgr.Tabs[0].Group);
+
+        // ...and neither may re-joining a member.
+        mgr.JoinGroup(mgr.Tabs[1], group);
+        Assert.True(group.IsCollapsed);
+    }
+
+    [Fact]
+    public void DissolveGroup_ungroups_every_member_in_place()
+    {
+        var mgr = NewManager(3); // [A, B, C, D]
+        var group = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[1], mgr.Tabs[2] }, group);
+        mgr.CollapseGroup(group, true);
+        var order = new List<TabModel>(mgr.Tabs);
+
+        mgr.DissolveGroup(group);
+
+        Assert.Equal(order, mgr.Tabs);
+        Assert.All(mgr.Tabs, t => Assert.Null(t.Group));
+        Assert.Empty(mgr.Groups);
+    }
+
+    [Fact]
+    public void DissolveGroup_of_an_unregistered_group_is_a_noop()
+    {
+        var mgr = NewManager(1);
+        var order = new List<TabModel>(mgr.Tabs);
+        int moved = 0;
+        mgr.TabMoved += (_, _) => moved++;
+
+        mgr.DissolveGroup(new TabGroup());
+
+        Assert.Equal(order, mgr.Tabs);
+        Assert.Equal(0, moved);
+        Assert.Empty(mgr.Groups);
+    }
+
+    [Fact]
+    public void HoldsActiveTab_flips_with_activation()
+    {
+        var mgr = NewManager(2); // [A, B, C]
+        var group = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[1], mgr.Tabs[2] }, group);
+        mgr.Activate(mgr.Tabs[0]); // start outside the group
+
+        Assert.False(mgr.HoldsActiveTab(group));
+        mgr.CollapseGroup(group, true);
+        mgr.Activate(mgr.Tabs[1]);
+
+        // The Edge-135 predicate the strips project from: a collapsed
+        // group holding the active tab is never rendered fully collapsed.
+        Assert.True(mgr.HoldsActiveTab(group));
+
+        mgr.Activate(mgr.Tabs[0]);
+        Assert.False(mgr.HoldsActiveTab(group));
+    }
+
+    [Fact]
+    public void GroupHoldsEveryTab_gates_the_close_group_command()
+    {
+        var mgr = NewManager(1);
+        var group = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[0], mgr.Tabs[1] }, group);
+
+        Assert.True(mgr.GroupHoldsEveryTab(group)); // nothing would survive
+
+        mgr.NewTab();
+        Assert.False(mgr.GroupHoldsEveryTab(group));
+    }
+
     // --- Collapse ---
 
     [Fact]
@@ -377,6 +536,82 @@ public class TabManagerPinGroupTests
         Assert.Equal(order, mgr.Tabs);
         mgr.CollapseGroup(group, false);
         Assert.False(group.IsCollapsed);
+    }
+
+    [Fact]
+    public void CollapseGroup_never_changes_the_active_tab()
+    {
+        var mgr = NewManager(2);
+        var group = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[1], mgr.Tabs[2] }, group);
+        mgr.Activate(mgr.Tabs[2]);
+        var active = mgr.ActiveTab;
+        int changes = 0;
+        mgr.ActiveTabChanged += (_, _) => changes++;
+
+        mgr.CollapseGroup(group, true);
+        mgr.CollapseGroup(group, false);
+
+        Assert.Same(active, mgr.ActiveTab);
+        Assert.Equal(0, changes);
+    }
+
+    [Fact]
+    public void Activating_a_member_of_a_collapsed_group_does_not_expand_it()
+    {
+        var mgr = NewManager(2);
+        var group = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[1], mgr.Tabs[2] }, group);
+        mgr.CollapseGroup(group, true);
+
+        // No accordion: activation swaps which member is visible; the
+        // user's collapse bit stays as they set it.
+        mgr.Activate(mgr.Tabs[2]);
+        Assert.Same(mgr.Tabs[2], mgr.ActiveTab);
+        Assert.True(group.IsCollapsed);
+    }
+
+    [Fact]
+    public void Normalize_repairs_a_collapsed_run_and_keeps_its_members()
+    {
+        var mgr = NewManager(3); // [A, B, C, D]
+        var group = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[1], mgr.Tabs[2] }, group);
+        mgr.CollapseGroup(group, true);
+        var a = mgr.Tabs[0];
+        var b = mgr.Tabs[1];
+        var c = mgr.Tabs[2];
+        var d = mgr.Tabs[3];
+
+        mgr.Move(1, 3); // pull B out past the run end
+
+        // Collapse is a bit, never a reordering: the repair re-gathers
+        // the run like any other, ejects no member, and leaves the bit.
+        AssertRunContiguous(mgr, group);
+        Assert.Equal(new[] { a, c, b, d }, mgr.Tabs.ToArray());
+        Assert.True(group.IsCollapsed);
+    }
+
+    [Fact]
+    public void Next_and_Prev_walk_linearly_through_a_collapsed_group()
+    {
+        var mgr = NewManager(2); // [A, B, C]
+        var group = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[1], mgr.Tabs[2] }, group);
+        mgr.CollapseGroup(group, true);
+        mgr.Activate(mgr.Tabs[0]);
+
+        // Navigation is linear in list order; collapse never makes the
+        // cycle skip members (the Chrome complaint Next/Prev exists to
+        // avoid).
+        mgr.Next();
+        Assert.Same(mgr.Tabs[1], mgr.ActiveTab);
+        mgr.Next();
+        Assert.Same(mgr.Tabs[2], mgr.ActiveTab);
+        mgr.Next();
+        Assert.Same(mgr.Tabs[0], mgr.ActiveTab);
+        mgr.Prev();
+        Assert.Same(mgr.Tabs[2], mgr.ActiveTab);
     }
 
     // --- MoveGroup / MoveRun rotations ---
@@ -597,6 +832,27 @@ public class TabManagerPinGroupTests
         Assert.False(dest.Tabs[2].IsPinned);
     }
 
+    [Fact]
+    public void An_adopted_tab_arrives_ungrouped_and_the_group_stays_home()
+    {
+        var src = NewManager(1); // [s0, s1]
+        var dest = NewManager(0); // [a]
+        var group = new TabGroup();
+        src.GroupTabs(new[] { src.Tabs[0], src.Tabs[1] }, group);
+
+        var adoptee = src.DetachTab(src.Tabs[1]);
+        dest.AdoptTab(adoptee);
+
+        // Membership does not travel: the group belongs to the source
+        // window's registry, so the adoptee arrives ungrouped while the
+        // source run survives with its remaining member.
+        Assert.Null(adoptee.Group);
+        Assert.DoesNotContain(adoptee, src.Tabs);
+        AssertRunContiguous(src, group);
+        Assert.Contains(group, src.Groups);
+        Assert.Empty(dest.Groups);
+    }
+
     // --- The invariants hold across arbitrary op sequences ---
 
     [Fact]
@@ -608,7 +864,7 @@ public class TabManagerPinGroupTests
 
         for (int step = 0; step < 300; step++)
         {
-            switch (random.Next(11))
+            switch (random.Next(15))
             {
                 case 0:
                     mgr.SetPinned(mgr.Tabs[random.Next(mgr.Tabs.Count)], random.Next(2) == 0);
@@ -657,6 +913,24 @@ public class TabManagerPinGroupTests
                         mgr.AdoptTab(adoptee);
                     }
                     break;
+                case 11:
+                    mgr.CreateGroup(mgr.Tabs[random.Next(mgr.Tabs.Count)]);
+                    break;
+                case 12:
+                    if (mgr.Groups.Count > 0)
+                        mgr.JoinGroup(mgr.Tabs[random.Next(mgr.Tabs.Count)],
+                            mgr.Groups[random.Next(mgr.Groups.Count)]);
+                    break;
+                case 13:
+                    if (mgr.Groups.Count > 0)
+                        mgr.DissolveGroup(mgr.Groups[random.Next(mgr.Groups.Count)]);
+                    break;
+                case 14:
+                    if (mgr.Groups.Count > 0)
+                        mgr.CollapseGroup(
+                            mgr.Groups[random.Next(mgr.Groups.Count)],
+                            random.Next(2) == 0);
+                    break;
             }
 
             AssertInvariantsHold(mgr);
@@ -683,8 +957,14 @@ public class TabManagerPinGroupTests
             Assert.Equal(positions[^1] - positions[0] + 1, positions.Count);
         }
         foreach (var tab in mgr.Tabs)
+        {
             if (tab.Group is not null)
                 Assert.Contains(tab.Group, mgr.Groups);
+            // Groups never pin: unreachable through the manager (SetPinned
+            // ungroups, GroupTabs skips pinned), so this is checker
+            // defense-in-depth for the fuzz.
+            Assert.False(tab.IsPinned && tab.Group is not null);
+        }
     }
 
     private static void AssertRunContiguous(TabManager mgr, TabGroup group)

--- a/windows/Ghostty.Tests/Tabs/TabStripProjectionTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabStripProjectionTests.cs
@@ -102,6 +102,95 @@ public class TabStripProjectionTests
         Assert.Equal(expected, rows); // the projection did not move under its reader
     }
 
+    // --- GroupedRows ---
+
+    private static List<TabModel> ItemsOf(IReadOnlyList<TabStripProjection.ProjectedRow> rows)
+    {
+        var items = new List<TabModel>(rows.Count);
+        foreach (var row in rows)
+            if (row is TabStripProjection.ProjectedRow.Item item)
+                items.Add(item.Tab);
+        return items;
+    }
+
+    [Fact]
+    public void GroupedRows_interleaves_headers_and_expands_back_to_tabs()
+    {
+        var mgr = NewManager(3); // [A, B, C, D]
+        mgr.SetPinned(mgr.Tabs[0], true);
+        var group = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[1], mgr.Tabs[2] }, group);
+
+        var rows = TabStripProjection.GroupedRows(mgr);
+
+        // Pin prefix first, then the header in front of its run, then the
+        // ungrouped tail -- and the items, read straight off, are Tabs.
+        Assert.Collection(rows,
+            r => Assert.Equal(mgr.Tabs[0], Assert.IsType<TabStripProjection.ProjectedRow.Item>(r).Tab),
+            r => Assert.Equal(group, Assert.IsType<TabStripProjection.ProjectedRow.Header>(r).Group),
+            r => Assert.Equal(mgr.Tabs[1], Assert.IsType<TabStripProjection.ProjectedRow.Item>(r).Tab),
+            r => Assert.Equal(mgr.Tabs[2], Assert.IsType<TabStripProjection.ProjectedRow.Item>(r).Tab),
+            r => Assert.Equal(mgr.Tabs[3], Assert.IsType<TabStripProjection.ProjectedRow.Item>(r).Tab));
+        Assert.Equal(mgr.Tabs.ToArray(), ItemsOf(rows));
+    }
+
+    [Fact]
+    public void A_collapsed_group_hides_every_member_except_the_active_one()
+    {
+        var mgr = NewManager(2); // [A, B, C]
+        var group = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[1], mgr.Tabs[2] }, group);
+        mgr.Activate(mgr.Tabs[2]);
+
+        mgr.CollapseGroup(group, true);
+        var rows = TabStripProjection.GroupedRows(mgr);
+
+        // The Edge-135 rule at the seam the strips project from: the
+        // header stays, the active member's row stays under it, the
+        // inactive member is gone. The ungrouped leading tab renders on.
+        Assert.Equal(new[] { mgr.Tabs[0], mgr.Tabs[2] }, ItemsOf(rows));
+        Assert.IsType<TabStripProjection.ProjectedRow.Header>(rows[1]);
+    }
+
+    [Fact]
+    public void A_collapsed_group_without_the_active_member_projects_header_only()
+    {
+        var mgr = NewManager(2); // [A, B, C]
+        var group = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[1], mgr.Tabs[2] }, group);
+        mgr.Activate(mgr.Tabs[0]); // the active tab sits outside the run
+
+        mgr.CollapseGroup(group, true);
+        var rows = TabStripProjection.GroupedRows(mgr);
+
+        // The fully-collapsed shape: vertical renders a childless header,
+        // horizontal renders its chip from the same rows. Only the
+        // ungrouped tab survives beside it.
+        Assert.Equal(2, rows.Count);
+        Assert.Equal(group,
+            Assert.IsType<TabStripProjection.ProjectedRow.Header>(rows[1]).Group);
+        Assert.Equal(new[] { mgr.Tabs[0] }, ItemsOf(rows));
+    }
+
+    [Fact]
+    public void Activating_across_a_collapsed_group_swaps_the_visible_member()
+    {
+        var mgr = NewManager(2); // [A, B, C]
+        var group = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[1], mgr.Tabs[2] }, group);
+        mgr.CollapseGroup(group, true);
+
+        mgr.Activate(mgr.Tabs[1]);
+        Assert.Equal(new[] { mgr.Tabs[0], mgr.Tabs[1] },
+            ItemsOf(TabStripProjection.GroupedRows(mgr)));
+        Assert.True(group.IsCollapsed);
+
+        mgr.Activate(mgr.Tabs[2]);
+        Assert.Equal(new[] { mgr.Tabs[0], mgr.Tabs[2] },
+            ItemsOf(TabStripProjection.GroupedRows(mgr)));
+        Assert.True(group.IsCollapsed); // no accordion: the bit never moved
+    }
+
     // --- Diff ---
 
     [Fact]


### PR DESCRIPTION
Model half of groups (5.4) -- zero strip UI. PR 1 landed TabGroup, MoveGroup, CollapseGroup and the session JSON fields; this fills the gaps:

- CreateGroup / JoinGroup / DissolveGroup as single-commit ops; join auto-expands only on an actual join. GroupTabs, the restore path, never touches the collapse bit.
- HoldsActiveTab (the active-member-visible predicate) and GroupHoldsEveryTab (the Close Group grey-out rule).
- TabStripProjection.GroupedRows: header before each run, never inside the pin prefix, collapsed = header + active member or header alone, never reorders.
- Pins stay 2.9 row 9: pin wins, membership yields (SetPinned auto-ungroups); only the group direction refuses.

Strip wiring (headers, collapse, entry points, group drag) is the next PR.