### PR TITLE
tabs: session save/restore for pins and groups

### DIFF
--- a/windows/Ghostty.Core/Session/SessionCapture.cs
+++ b/windows/Ghostty.Core/Session/SessionCapture.cs
@@ -1,4 +1,7 @@
+using System;
+using System.Collections.Generic;
 using Ghostty.Core.Panes;
+using Ghostty.Core.Tabs;
 
 namespace Ghostty.Core.Session;
 
@@ -13,17 +16,51 @@ internal static class SessionCapture
     // PathOf returns the empty path both for "is root" and "not found", so
     // passing a foreign node would serialize as the root path; callers only
     // ever pass live leaves of this tree, so the empty path always means root.
+    //
+    // isPinned/groupId ride the debounced session write. The reopen
+    // snapshot (CloseTab) keeps the defaults: a reopened tab comes back
+    // unpinned and ungrouped. DuplicateTab keeps them too -- its call
+    // site re-applies the clone's pin explicitly, and neither path
+    // carries group state.
     public static TabSession CaptureTab(
         PaneNode root,
         LeafPane activeLeaf,
         LeafPane? zoomed,
         string? profileId,
-        string? userTitle) => new()
+        string? userTitle,
+        bool isPinned = false,
+        Guid? groupId = null) => new()
         {
             ProfileId = profileId,
             UserTitle = userTitle,
             Tree = SessionTree.CaptureTree(root),
             ActiveLeafPath = SessionTree.PathOf(root, activeLeaf),
             ZoomedLeafPath = zoomed is null ? null : SessionTree.PathOf(root, zoomed),
+            IsPinned = isPinned,
+            GroupId = groupId,
         };
+
+    /// <summary>
+    /// The window's group registry as it must come back after a restart:
+    /// id, title, color, and the shared collapse bit. Membership is NOT
+    /// captured here -- members point at their group by
+    /// <see cref="TabSession.GroupId"/>, so the tab list already carries
+    /// it and a group whose every member failed to capture restores as
+    /// nothing.
+    /// </summary>
+    public static List<GroupSession> CaptureGroups(IReadOnlyList<TabGroup> groups)
+    {
+        var captured = new List<GroupSession>(groups.Count);
+        foreach (var group in groups)
+        {
+            captured.Add(new GroupSession
+            {
+                Id = group.Id,
+                Title = group.Title,
+                Color = group.Color,
+                Collapsed = group.IsCollapsed,
+            });
+        }
+        return captured;
+    }
 }

--- a/windows/Ghostty.Core/Tabs/TabGroup.cs
+++ b/windows/Ghostty.Core/Tabs/TabGroup.cs
@@ -19,7 +19,16 @@ namespace Ghostty.Core.Tabs;
 /// </summary>
 internal sealed class TabGroup
 {
-    public Guid Id { get; } = Guid.NewGuid();
+    public Guid Id { get; }
+
+    public TabGroup() => Id = Guid.NewGuid();
+
+    /// <summary>
+    /// Session restore's ctor: group identity survives restart, so the
+    /// saved id comes back AS the live one (<see
+    /// cref="TabManager.RestoreGroup"/>). Fresh groups mint their own.
+    /// </summary>
+    internal TabGroup(Guid id) => Id = id;
 
     /// <summary>Label shown on the vertical header row / horizontal chip.</summary>
     public string Title { get; set; } = "New group";

--- a/windows/Ghostty.Core/Tabs/TabManager.cs
+++ b/windows/Ghostty.Core/Tabs/TabManager.cs
@@ -522,6 +522,36 @@ internal sealed class TabManager
     }
 
     /// <summary>
+    /// Session restore's group op: recreate one saved group -- the saved
+    /// id comes back as the live id, so group identity survives restart
+    /// -- and gather <paramref name="members"/> into one run in saved
+    /// tab order. The saved collapse bit is applied AS SAVED: unlike
+    /// <see cref="JoinGroup"/>, restoring never auto-expands, which is
+    /// why restore comes through here and
+    /// <see cref="GroupTabs"/>-shaped membership, never the join.
+    ///
+    /// Repairs, never crashes, on corrupt saved state: a member that is
+    /// somehow both pinned and grouped is skipped here (membership
+    /// yields to the prefix), a member this manager does not own is
+    /// skipped, and a group none of whose members made it back
+    /// registers nothing -- Normalize then prunes it, so no orphan
+    /// header or chip can reach a strip.
+    /// </summary>
+    public TabGroup RestoreGroup(Guid id, string title, TabColor color,
+        bool collapsed, IReadOnlyList<TabModel> members)
+    {
+        ArgumentNullException.ThrowIfNull(members);
+        var group = new TabGroup(id)
+        {
+            Title = title,
+            Color = color,
+            IsCollapsed = collapsed,
+        };
+        GroupTabs(members, group);
+        return group;
+    }
+
+    /// <summary>
     /// Remove one tab from its group. The group dissolves if this was its
     /// last member, collapse state included. The tab keeps its position.
     /// </summary>

--- a/windows/Ghostty.Tests/Tabs/TabSessionPinGroupTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabSessionPinGroupTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Ghostty.Core.Session;
 using Ghostty.Core.Tabs;
 using Xunit;
@@ -6,14 +7,73 @@ using Xunit;
 namespace Ghostty.Tests.Tabs;
 
 /// <summary>
-/// Serialization surface for the pin/group fields of section 6 of the
-/// tab-reorder spec. Restore-side repair is wired by a later PR; this
-/// only proves the fields survive the source-generated round trip.
+/// Session surface for the pin/group fields of section 6 of the
+/// tab-reorder spec. The fields survive the source-generated round trip,
+/// the capture side fills them from a live manager, and the restore side
+/// -- RestoreGroup plus the pin-then-gather seeding order -- reproduces
+/// saved pins, groups, ids, and collapse bits, repairing corrupt saved
+/// state instead of crashing. The app-side orchestrator
+/// (SessionRestorer/MainWindow) is pinned by the wiring guard; the Core
+/// ops it drives are tested here, where managers can run.
 /// </summary>
 public class TabSessionPinGroupTests
 {
     private static TabSession Tab(bool pinned = false, Guid? groupId = null)
         => new TabSession { Tree = new LeafDto { ProfileId = "pwsh" }, IsPinned = pinned, GroupId = groupId };
+
+    private static TabManager NewManager(int extraTabs)
+    {
+        var mgr = new TabManager((_) => new FakePaneHost());
+        for (int i = 0; i < extraTabs; i++) mgr.NewTab();
+        return mgr;
+    }
+
+    // The capture call the way MainWindow makes it, per live tab.
+    private static TabSession Capture(TabModel tab)
+        => SessionCapture.CaptureTab(
+            tab.PaneHost.RootNode,
+            tab.PaneHost.ActiveLeaf,
+            tab.PaneHost.ZoomedLeaf,
+            tab.ProfileId,
+            tab.UserOverrideTitle,
+            tab.IsPinned,
+            tab.Group?.Id);
+
+    // The restore the way SessionRestorer drives it: flags first (the
+    // manager's Normalize folds pins into the prefix as tabs land, in
+    // saved order), then groups by saved id once every member is in.
+    private static TabManager Restore(SessionState state)
+    {
+        var window = Assert.Single(state.Windows);
+        var pairs = new List<(TabSession Source, TabModel Tab)>();
+        TabModel? seed = null;
+        var built = new List<TabModel>();
+        foreach (var dto in window.Tabs)
+        {
+            var tab = new TabModel(new FakePaneHost())
+            {
+                IsPinned = dto.IsPinned,
+                ProfileId = dto.ProfileId, // as BuildTab carries it
+            };
+            pairs.Add((dto, tab));
+            if (seed is null) seed = tab;
+            else built.Add(tab);
+        }
+        var mgr = new TabManager((_) => new FakePaneHost(), seed: seed);
+        foreach (var tab in built) mgr.AdoptTab(tab);
+        foreach (var groupDto in window.Groups)
+        {
+            var members = new List<TabModel>();
+            foreach (var (source, tab) in pairs)
+                if (source.GroupId == groupDto.Id)
+                    members.Add(tab);
+            mgr.RestoreGroup(groupDto.Id, groupDto.Title, groupDto.Color,
+                groupDto.Collapsed, members);
+        }
+        if (window.ActiveTabIndex >= 0 && window.ActiveTabIndex < mgr.Tabs.Count)
+            mgr.ActivateIndex(window.ActiveTabIndex);
+        return mgr;
+    }
 
     [Fact]
     public void RoundTrip_preserves_pins_group_refs_and_collapse_state()
@@ -89,5 +149,249 @@ public class TabSessionPinGroupTests
             Assert.False(t.IsPinned);
             Assert.Null(t.GroupId);
         });
+    }
+
+    // --- Capture side ---
+
+    [Fact]
+    public void CaptureTab_carries_the_pin_and_group_fields()
+    {
+        var mgr = NewManager(1);
+        var group = mgr.CreateGroup(mgr.Tabs[0]);
+        Assert.NotNull(group);
+        var groupedTab = mgr.Tabs[0];
+        var otherTab = mgr.Tabs[1];
+        mgr.SetPinned(otherTab, true); // relocates: refs, not indices
+
+        var grouped = Capture(groupedTab);
+        var pinned = Capture(otherTab);
+
+        Assert.Equal(group!.Id, grouped.GroupId);
+        Assert.False(grouped.IsPinned);
+        Assert.True(pinned.IsPinned);
+        Assert.Null(pinned.GroupId); // pinning ungrouped it; capture says so
+
+        // The defaults are the "no pin/group state" of the older format:
+        // a capture that does not ask for the fields stays clean.
+        var bare = SessionCapture.CaptureTab(
+            mgr.Tabs[0].PaneHost.RootNode, mgr.Tabs[0].PaneHost.ActiveLeaf,
+            null, "pwsh", null);
+        Assert.False(bare.IsPinned);
+        Assert.Null(bare.GroupId);
+    }
+
+    [Fact]
+    public void CaptureGroups_maps_identity_title_color_and_collapse()
+    {
+        var mgr = NewManager(2); // [A, B, C]
+        var first = mgr.CreateGroup(mgr.Tabs[0])!;
+        first.Title = "work";
+        first.Color = TabColor.Green;
+        var second = mgr.CreateGroup(mgr.Tabs[2])!;
+        mgr.CollapseGroup(second, true);
+
+        var captured = SessionCapture.CaptureGroups(mgr.Groups);
+
+        Assert.Equal(2, captured.Count);
+        Assert.Equal(first.Id, captured[0].Id);
+        Assert.Equal("work", captured[0].Title);
+        Assert.Equal(TabColor.Green, captured[0].Color);
+        Assert.False(captured[0].Collapsed);
+        Assert.Equal(second.Id, captured[1].Id);
+        Assert.True(captured[1].Collapsed);
+    }
+
+    // --- Restore side ---
+
+    [Fact]
+    public void RestoreGroup_recreates_the_saved_identity_and_gathers_members()
+    {
+        var mgr = NewManager(3); // [A, B, C, D]
+        mgr.SetPinned(mgr.Tabs[0], true);
+        var savedId = Guid.NewGuid();
+        var members = new[] { mgr.Tabs[3], mgr.Tabs[1] }; // saved order: D then B
+
+        var group = mgr.RestoreGroup(savedId, "work", TabColor.Teal,
+            collapsed: true, members);
+
+        // The saved id IS the live id -- group identity survives restart.
+        Assert.Equal(savedId, group.Id);
+        Assert.Equal("work", group.Title);
+        Assert.Equal(TabColor.Teal, group.Color);
+        Assert.True(group.IsCollapsed); // the saved bit, not an auto-expand
+        Assert.Contains(group, mgr.Groups);
+        AssertRunContiguous(mgr, group);
+        Assert.Same(group, mgr.Tabs[1].Group);
+        Assert.Same(group, mgr.Tabs[2].Group);
+    }
+
+    [Fact]
+    public void RestoreGroup_survives_a_saved_pin_and_group_collision()
+    {
+        var mgr = NewManager(2); // [A, B, C]
+        mgr.SetPinned(mgr.Tabs[0], true);
+        var pinned = mgr.Tabs[0]; // saved as BOTH pinned and grouped: corrupt
+
+        var group = mgr.RestoreGroup(Guid.NewGuid(), "corrupt", TabColor.Red,
+            collapsed: false, new[] { pinned, mgr.Tabs[1] });
+
+        // Membership yields to the prefix; nothing throws.
+        Assert.True(pinned.IsPinned);
+        Assert.Null(pinned.Group);
+        Assert.Same(group, mgr.Tabs[1].Group);
+        AssertRunContiguous(mgr, group);
+    }
+
+    [Fact]
+    public void RestoreGroup_with_no_restorable_member_registers_nothing()
+    {
+        var mgr = NewManager(1);
+        mgr.SetPinned(mgr.Tabs[0], true);
+
+        // Every member pinned: the group never registers, so no orphan
+        // header or chip can reach a strip.
+        var group = mgr.RestoreGroup(Guid.NewGuid(), "lost", TabColor.Blue,
+            collapsed: true, new[] { mgr.Tabs[0] });
+
+        Assert.Empty(mgr.Groups);
+        Assert.DoesNotContain(group, mgr.Groups);
+        Assert.Null(mgr.Tabs[0].Group);
+
+        // Neither does a member this manager does not own.
+        var stranger = mgr.RestoreGroup(Guid.NewGuid(), "lost", TabColor.Blue,
+            collapsed: false, new[] { new TabModel(new FakePaneHost()) });
+        Assert.Empty(mgr.Groups);
+        Assert.DoesNotContain(stranger, mgr.Groups);
+    }
+
+    [Fact]
+    public void A_saved_GroupId_matching_no_group_restores_ungrouped()
+    {
+        var real = Guid.NewGuid();
+        var phantom = Guid.NewGuid(); // carried by a tab, absent from Groups
+        var state = new SessionState
+        {
+            Windows =
+            {
+                new WindowSession
+                {
+                    Groups =
+                    {
+                        new GroupSession { Id = real, Title = "real", Color = TabColor.Blue },
+                    },
+                    Tabs =
+                    {
+                        Tab(groupId: phantom),
+                        Tab(groupId: real),
+                        Tab(groupId: real),
+                    },
+                },
+            },
+        };
+
+        var dst = Restore(state);
+
+        // The orphan reference repairs to ungrouped; the group whose id
+        // IS listed still forms around its own members.
+        Assert.Null(dst.Tabs[0].Group);
+        var group = Assert.Single(dst.Groups);
+        Assert.Equal(real, group.Id);
+        Assert.Same(group, dst.Tabs[1].Group);
+        Assert.Same(group, dst.Tabs[2].Group);
+        AssertRunContiguous(dst, group);
+    }
+
+    [Fact]
+    public void A_capture_restore_cycle_reproduces_pins_groups_and_collapse()
+    {
+        var src = NewManager(5); // [T0 .. T5]
+        src.SetPinned(src.Tabs[0], true);
+        src.SetPinned(src.Tabs[2], true); // two pins; the saved list breaks them apart below
+        var work = src.CreateGroup(src.Tabs[3])!;
+        src.JoinGroup(src.Tabs[4], work);
+        work.Title = "work";
+        work.Color = TabColor.Green;
+        var solo = src.CreateGroup(src.Tabs[5])!;
+        src.CollapseGroup(solo, true); // collapsed, holding the active tab
+        src.Activate(src.Tabs[5]);
+
+        // Identity the round trip carries per tab: pin/GroupId patterns
+        // are identical for two same-group members that swap, so only a
+        // per-tab value can catch that class of reordering.
+        for (int i = 0; i < src.Tabs.Count; i++)
+            src.Tabs[i].ProfileId = "profile-" + i;
+
+        var window = new WindowSession();
+        foreach (var tab in src.Tabs) window.Tabs.Add(Capture(tab));
+        window.Groups.AddRange(SessionCapture.CaptureGroups(src.Groups));
+        var soloDto = window.Tabs[5];
+
+        // A capture is always normalized (pins are a prefix), so the saved
+        // list is perturbed to the legacy shape an older file can carry:
+        // the second pin filed after an unpinned tab, [P, U, P, ...]. The
+        // restore must fold that back into the prefix without losing the
+        // saved relative order of the pins.
+        (window.Tabs[1], window.Tabs[2]) = (window.Tabs[2], window.Tabs[1]);
+        window.ActiveTabIndex = window.Tabs.IndexOf(soloDto);
+
+        var state = new SessionState { CleanShutdown = true };
+        state.Windows.Add(window);
+        var back = SessionSerializer.Deserialize(SessionSerializer.Serialize(state));
+        Assert.NotNull(back);
+        var dst = Restore(back!);
+
+        // Same arrangement, count for count. The per-index comparison is
+        // against the source arrangement: the fold has to land the pins
+        // back as T0 then T2 even though T2's saved slot sat after T1.
+        Assert.Equal(src.Tabs.Count, dst.Tabs.Count);
+        Assert.Equal(src.PinCount, dst.PinCount);
+        for (int i = 0; i < src.Tabs.Count; i++)
+        {
+            Assert.Equal(src.Tabs[i].ProfileId, dst.Tabs[i].ProfileId);
+            Assert.Equal(src.Tabs[i].IsPinned, dst.Tabs[i].IsPinned);
+            Assert.Equal(src.Tabs[i].Group?.Id, dst.Tabs[i].Group?.Id);
+        }
+        // The collapse bit came back exactly as saved, and the ids are
+        // the saved ids, not fresh ones.
+        var dstSolo = Assert.Single(dst.Groups, g => g.Id == solo.Id);
+        Assert.True(dstSolo.IsCollapsed);
+        Assert.Equal(solo.Title, dstSolo.Title);
+        var dstWork = Assert.Single(dst.Groups, g => g.Id == work.Id);
+        Assert.Equal(work.Title, dstWork.Title);
+        Assert.Equal(work.Color, dstWork.Color);
+        Assert.False(dstWork.IsCollapsed);
+        // The saved active tab is active again: a collapsed group holding
+        // it is the Edge-135 shape the strips project.
+        Assert.Same(dst.Tabs[5], dst.ActiveTab);
+        Assert.True(dst.HoldsActiveTab(dstSolo));
+    }
+
+    [Fact]
+    public void A_pin_only_session_restores_into_the_prefix_with_no_groups()
+    {
+        var state = new SessionState
+        {
+            Windows =
+            {
+                new WindowSession { Tabs = { Tab(), Tab(), Tab(pinned: true) } },
+            },
+        };
+
+        var dst = Restore(state);
+
+        Assert.Empty(dst.Groups);
+        Assert.Equal(3, dst.Tabs.Count);
+        Assert.Equal(1, dst.PinCount);
+        Assert.All(dst.Tabs, t => Assert.Null(t.Group));
+    }
+
+    private static void AssertRunContiguous(TabManager mgr, TabGroup group)
+    {
+        var positions = new List<int>();
+        for (int i = 0; i < mgr.Tabs.Count; i++)
+            if (ReferenceEquals(mgr.Tabs[i].Group, group))
+                positions.Add(i);
+        Assert.NotEmpty(positions);
+        Assert.Equal(positions[^1] - positions[0] + 1, positions.Count);
     }
 }

--- a/windows/Ghostty.Tests/Wiring/TabGroupSessionSaveWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabGroupSessionSaveWiringTests.cs
@@ -1,0 +1,52 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// The SAVE half of the group session. The restore side runs on managers
+/// that unit tests can drive (TabSessionPinGroupTests), but the save side
+/// is MainWindow.CaptureSession, which only exists where WinUI does --
+/// so the wiring facts live here, against the parsed source. The
+/// load-bearing wiring is two-fold: every captured tab carries its pin
+/// flag and its group id (a capture that drops the id dissolves the
+/// group on the next launch), and the window's group registry is
+/// captured beside the tabs, because membership alone cannot restore a
+/// group's identity, title, color, or collapse bit.
+/// </summary>
+public class TabGroupSessionSaveWiringTests
+{
+    private static ShellSource MainWindow() => ShellSource.Load("MainWindow.xaml.cs");
+
+    [Fact]
+    public void TheSavePath_carries_pin_group_and_the_registry()
+    {
+        var capture = MainWindow().Method("CaptureSession");
+
+        // Every tab's capture names its pin flag and its group id, in
+        // that order, as the capture op's trailing arguments. Exact texts:
+        // a negated flag or a renamed receiver would still "mention" the
+        // field and pass a substring check while saving the wrong state.
+        var captureTab = capture.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Single(c => c.CalleeText().EndsWith("SessionCapture.CaptureTab",
+                StringComparison.Ordinal));
+        Assert.Equal("tab.IsPinned", captureTab.Arg(5));
+        Assert.Equal("tab.Group?.Id", captureTab.Arg(6));
+
+        // And the registry rides with them: membership (GroupId) cannot
+        // restore a group on its own -- the Groups list is where id,
+        // title, color, and the shared collapse bit live.
+        var addGroups = capture.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(c => c.CalleeText() == "win.Groups.AddRange").ToList();
+        Assert.Single(addGroups);
+        var registryArg = Assert.IsType<InvocationExpressionSyntax>(
+            addGroups[0].ArgumentList.Arguments[0].Expression);
+        Assert.True(
+            registryArg.CalleeText().EndsWith("SessionCapture.CaptureGroups",
+                StringComparison.Ordinal),
+            "the registry must be captured through SessionCapture.CaptureGroups");
+        Assert.Equal("_tabManager.Groups", registryArg.Arg(0));
+    }
+}

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -548,9 +548,12 @@ public sealed partial class MainWindow : Window
         // it rebuilds at least one tab; otherwise fall through to the normal
         // "fresh tab (or seedTab) via the factory" path.
         List<TabModel>? restoredTabs = null;
+        // One restorer for both halves: BuildTabs records the saved-tab
+        // pairing the group restore reads back, so the seeding block and
+        // the group block must use the same instance.
+        var restorer = new Ghostty.Session.SessionRestorer(_factory, App.ProfileRegistry);
         if (restore is { Tabs.Count: > 0 })
         {
-            var restorer = new Ghostty.Session.SessionRestorer(_factory, App.ProfileRegistry);
             var built = restorer.BuildTabs(restore);
             if (built.Count > 0) restoredTabs = built;
         }
@@ -563,6 +566,12 @@ public sealed partial class MainWindow : Window
                 closedTabs: ClosedTabsStore);
             for (int i = 1; i < restoredTabs.Count; i++)
                 _tabManager.AdoptTab(restoredTabs[i]);
+            // Group state needs every member in the manager first: the
+            // restore gathers runs, so it comes after the seeding loop
+            // and rebuilds the saved ids, titles, colors, and collapse
+            // bits. Restore never auto-expands; JoinGroup is not on this
+            // path.
+            restorer.RestoreGroups(_tabManager, restore!);
             if (restore!.ActiveTabIndex >= 0 && restore.ActiveTabIndex < restoredTabs.Count)
                 _tabManager.ActivateIndex(restore.ActiveTabIndex);
         }
@@ -4036,8 +4045,14 @@ public sealed partial class MainWindow : Window
                 tab.PaneHost.ActiveLeaf,
                 tab.PaneHost.ZoomedLeaf,
                 tab.ProfileId,
-                tab.UserOverrideTitle));
+                tab.UserOverrideTitle,
+                tab.IsPinned,
+                tab.Group?.Id));
         }
+        // Membership rides the tabs (GroupId); the registry supplies the
+        // groups' identity, title, color, and shared collapse bit.
+        win.Groups.AddRange(Ghostty.Core.Session.SessionCapture.CaptureGroups(
+            _tabManager.Groups));
         return win;
     }
 

--- a/windows/Ghostty/Session/SessionRestorer.cs
+++ b/windows/Ghostty/Session/SessionRestorer.cs
@@ -16,6 +16,11 @@ internal sealed class SessionRestorer
 {
     private readonly PaneHostFactory _factory;
     private readonly IProfileRegistry? _registry;
+    // The saved tab paired with the model built from it, in saved order.
+    // Group membership is a saved TAB field (GroupId), and BuildTab skips
+    // tabs whose tree would not rebuild, so the pairing -- not list
+    // position -- is what maps members back onto their group.
+    private readonly List<(TabSession Source, TabModel Tab)> _built = new();
 
     public SessionRestorer(PaneHostFactory factory, IProfileRegistry? registry)
     {
@@ -26,12 +31,42 @@ internal sealed class SessionRestorer
     public List<TabModel> BuildTabs(WindowSession window)
     {
         var result = new List<TabModel>();
+        _built.Clear();
         foreach (var tabDto in window.Tabs)
         {
             if (BuildTab(tabDto) is { } tab)
+            {
                 result.Add(tab);
+                _built.Add((tabDto, tab));
+            }
         }
         return result;
+    }
+
+    /// <summary>
+    /// Rebuild the saved groups into <paramref name="manager"/> through
+    /// <see cref="TabManager.RestoreGroup"/>: the saved id, title, color,
+    /// and collapse bit come back exactly, and saved membership follows
+    /// each tab's GroupId. Must run AFTER every tab from the paired
+    /// <see cref="BuildTabs"/> call is in the manager -- the gather is a
+    /// manager mutation and needs the full membership present. Restore
+    /// never goes through JoinGroup: that op auto-expands on a join, and
+    /// the saved collapse bit must survive the restore untouched.
+    /// A saved GroupId with no matching <c>Groups</c> entry restores
+    /// ungrouped; a group none of whose members rebuilt is never
+    /// registered.
+    /// </summary>
+    public void RestoreGroups(TabManager manager, WindowSession window)
+    {
+        foreach (var groupDto in window.Groups)
+        {
+            var members = new List<TabModel>();
+            foreach (var (source, tab) in _built)
+                if (source.GroupId == groupDto.Id)
+                    members.Add(tab);
+            manager.RestoreGroup(groupDto.Id, groupDto.Title, groupDto.Color,
+                groupDto.Collapsed, members);
+        }
     }
 
     /// <summary>
@@ -65,6 +100,13 @@ internal sealed class SessionRestorer
             tab.AttachProfileSnapshot(tabSnap);
         if (tabDto.UserTitle is not null)
             tab.UserOverrideTitle = tabDto.UserTitle;
+
+        // Pin flag first, order later: the flag is written directly (the
+        // property's documented contract) and the manager's Normalize
+        // folds each pinned tab to the prefix end as it is seeded, in
+        // saved order -- so the prefix comes back in the saved relative
+        // order without a walk of SetPinned calls.
+        tab.IsPinned = tabDto.IsPinned;
 
         return tab;
     }


### PR DESCRIPTION
Second half of the groups model split (5.4): the session JSON fields PR 1 shipped finally get filled and read.

- Save: CaptureTab carries isPinned/groupId; CaptureGroups snapshots the registry. Reopen snapshots and Duplicate Tab keep their own behavior -- the clone's pin is re-applied at its call site, and no path carries group state.
- Restore: SessionRestorer pairs saved tabs to built models and restores groups via RestoreGroup. Saved ids are live ids after restart; the collapse bit arrives as-saved (restore never routes through JoinGroup, which auto-expands); membership is tolerant -- phantom GroupIds restore ungrouped, groups with no restorable member register nothing.
- Corrupt saved state (pinned+grouped) repairs through existing Normalize semantics; old sessions without the Groups field restore byte-identically.
- Multi-pin saved order reproduces through the prefix fold; per-index identity pinned by the cycle fact.