### PR TITLE
vtabs: group headers, collapse in place

### DIFF
--- a/windows/Ghostty.Core/Tabs/TabGroup.cs
+++ b/windows/Ghostty.Core/Tabs/TabGroup.cs
@@ -1,4 +1,6 @@
 using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace Ghostty.Core.Tabs;
 
@@ -7,17 +9,17 @@ namespace Ghostty.Core.Tabs;
 /// membership lives on <see cref="TabModel.Group"/> and the registry on
 /// <see cref="TabManager.Groups"/>, so a group with no members is an
 /// orphan the manager dissolves rather than state in its own right.
+/// Groups are never pinned: pinning a member removes it from the group,
+/// so a run always sits in the unpinned zone.
 ///
-/// Groups are never pinned: pinning a member removes it from the group
-/// (the Chrome rule <see cref="TabManager.SetPinned"/> applies), so a
-/// run always sits in the unpinned zone.
-///
-/// Plain get/set properties on purpose: the model invariants read these
-/// directly and mutate them through the manager, and the strips that
-/// will render title, color, and collapse state arrive in later PRs
-/// with whatever change plumbing they need at that point.
+/// Title, Color, and IsCollapsed raise <see cref="PropertyChanged"/>:
+/// the registry has no collection event of its own, so the group itself
+/// is the carrier. Membership is NOT carried here: it rides
+/// <see cref="TabModel.Group"/>'s own notification, and a dissolved
+/// group raises nothing because the strips re-read the projection that
+/// no longer names it.
 /// </summary>
-internal sealed class TabGroup
+internal sealed class TabGroup : INotifyPropertyChanged
 {
     public Guid Id { get; }
 
@@ -31,20 +33,35 @@ internal sealed class TabGroup
     internal TabGroup(Guid id) => Id = id;
 
     /// <summary>Label shown on the vertical header row / horizontal chip.</summary>
-    public string Title { get; set; } = "New group";
+    public string Title
+    {
+        get => field;
+        set { if (field != value) { field = value; Raise(); } }
+    } = "New group";
 
     /// <summary>
-    /// Swatch shared with the per-tab tint palette. Unlike a tab, a group
-    /// has no "no color" state to render (the rail and the chip are its
-    /// identity), so the default is the palette's first swatch rather
-    /// than <see cref="TabColor.None"/>.
+    /// Swatch shared with the per-tab tint palette: a group has no "no
+    /// color" state, so the default is the palette's first swatch.
     /// </summary>
-    public TabColor Color { get; set; } = TabColor.Blue;
+    public TabColor Color
+    {
+        get => field;
+        set { if (field != value) { field = value; Raise(); } }
+    } = TabColor.Blue;
 
     /// <summary>
     /// One bit shared by both strip modes, so a layout switch mid-collapse
-    /// needs no repair. Purely presentational: collapsing never mutates
-    /// the tab list and never touches activation.
+    /// needs no repair. Purely presentational: it never mutates the tab
+    /// list and never touches activation.
     /// </summary>
-    public bool IsCollapsed { get; set; }
+    public bool IsCollapsed
+    {
+        get => field;
+        set { if (field != value) { field = value; Raise(); } }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void Raise([CallerMemberName] string? name = null) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
 }

--- a/windows/Ghostty.Core/Tabs/TabManager.cs
+++ b/windows/Ghostty.Core/Tabs/TabManager.cs
@@ -750,7 +750,12 @@ internal sealed class TabManager
         }
     }
 
-    private List<TabModel> MembersOf(TabGroup group)
+    /// <summary>
+    /// The group's members in tab order. Public because a strip header
+    /// renders the member count, and the count rides the tabs: the
+    /// registry cannot answer it without this walk.
+    /// </summary>
+    public List<TabModel> MembersOf(TabGroup group)
     {
         var members = new List<TabModel>();
         foreach (var t in _tabs)

--- a/windows/Ghostty.Tests/Tabs/TabManagerPinGroupTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabManagerPinGroupTests.cs
@@ -614,6 +614,39 @@ public class TabManagerPinGroupTests
         Assert.Same(mgr.Tabs[2], mgr.ActiveTab);
     }
 
+    // --- Group change notification ---
+
+    /// <summary>
+    /// The group is the change carrier for its own chrome: the registry
+    /// has no collection event and membership rides TabModel.Group, so a
+    /// strip learning a header's label, swatch, or collapse bit changed
+    /// has nothing else to listen to. Same-value silence is half the
+    /// contract: a raising no-op write churns the strip for nothing.
+    /// </summary>
+    [Fact]
+    public void Group_property_changes_raise_and_same_value_writes_do_not()
+    {
+        var group = new TabGroup();
+        var raised = new List<string>();
+        group.PropertyChanged += (_, e) => raised.Add(e.PropertyName ?? "");
+
+        group.Title = "build";
+        group.Color = TabColor.Red;
+        group.IsCollapsed = true;
+        Assert.Equal(
+            new[] { nameof(TabGroup.Title), nameof(TabGroup.Color), nameof(TabGroup.IsCollapsed) },
+            raised);
+
+        group.Title = "build";
+        group.Color = TabColor.Red;
+        group.IsCollapsed = true;
+        Assert.Equal(3, raised.Count);
+
+        // Membership rides TabModel.Group, never the group.
+        new TabModel(new FakePaneHost()).Group = group;
+        Assert.Equal(3, raised.Count);
+    }
+
     // --- MoveGroup / MoveRun rotations ---
 
     [Fact]

--- a/windows/Ghostty.Tests/Wiring/PinnedPanelWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/PinnedPanelWiringTests.cs
@@ -140,27 +140,36 @@ public class PinnedPanelWiringTests
     /// longer be the order authority for the body. The reconcile applies
     /// the projection to both containers, repairs membership skew with a
     /// rebuild, fences the MUXC list it reorders, and refreshes the shelf.
+    /// Group headers join the projection's output: the desired sequence and
+    /// the visible set are one GroupedRows pass.
     /// </summary>
     [Fact]
     public void Order_ComesFromTheProjection_AndSkewRebuilds()
     {
         var reconcile = Strip().Method("ReconcileRowOrder");
 
-        Assert.Single(reconcile.Calls("TabStripProjection.Rows"));
+        // One consult, and it is the group-aware walk: a header projected
+        // but not rendered, or a hidden member the strip still shows, is
+        // exactly the drift this walk exists to catch.
+        Assert.Single(reconcile.Calls("TabStripProjection.GroupedRows"));
+        Assert.Empty(reconcile.Calls("TabStripProjection.Rows"));
         Assert.Single(reconcile.Calls("UpdatePinnedShelfChrome"));
         Assert.Single(reconcile.Calls("RebuildAllItems"));
 
-        // Skew is checked against BOTH registries. A condition that names
-        // only one of them passes a body container that drifted (or a panel
-        // one) straight into an indexer miss or a silently wrong order.
+        // Skew is checked against BOTH registries, plus the rows the
+        // projection named but the strip holds no element for -- counts can
+        // agree while a row is missing on both sides, and only the walk's
+        // miss flag sees that. Dropping any of these passes a drifted
+        // container straight into an indexer miss or a wrong order.
         var skew = reconcile.DescendantNodes().OfType<IfStatementSyntax>()
             .Single(i => i.DescendantNodes().OfType<InvocationExpressionSyntax>()
                              .Any(c => c.CalleeText() == "RebuildAllItems"));
         var condition = skew.Condition.ToString();
-        Assert.Contains("_pinnedRows.Count != pinned.Count", condition);
-        Assert.Contains("_items.Count != body.Count", condition);
-        Assert.Contains("_pinnedPanel.Children.Count != pinned.Count", condition);
-        Assert.Contains("NavView.MenuItems.Count != body.Count", condition);
+        Assert.Contains("missing", condition);
+        Assert.Contains("_pinnedRows.Count != pinCount", condition);
+        Assert.Contains("_items.Count != _manager.Tabs.Count - pinCount", condition);
+        Assert.Contains("_pinnedPanel.Children.Count != pinCount", condition);
+        Assert.Contains("NavView.MenuItems.Count != desired.Count", condition);
 
         // The MUXC list is fenced while the reconcile mutates it: reordering
         // under a live selection raises SelectionChanged for a row the user

--- a/windows/Ghostty.Tests/Wiring/TabPinZoneWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabPinZoneWiringTests.cs
@@ -77,14 +77,19 @@ public class TabPinZoneWiringTests
     /// The refused-crossing contract 3b landed applies to zone crossings
     /// too: a clamp that swallowed the placement updates the machine and
     /// BREAKS. A `continue` here would re-fire the identical refused
-    /// crossing forever, because Evaluate is pure per tick.
+    /// crossing forever, because Evaluate is pure per tick. The read-back
+    /// is manager truth (the crossing's translated destination, not the
+    /// machine's slot) plus the row's post-commit slot resolvability --
+    /// the machine speaks in visible slots, and a hidden collapsed member
+    /// shifts manager indices without shifting slots, so the slot is
+    /// re-derived from the fresh pairing, never the pre-commit one.
     /// </summary>
     [Fact]
     public void ARefusedCrossing_BreaksTheCommitLoop()
     {
         var refuse = Strip().Method("EvaluateDrag").DescendantNodes()
             .OfType<IfStatementSyntax>()
-            .Single(i => i.Condition.ToString() == "actual != crossing.To");
+            .Single(i => i.Condition.ToString() == "actual != managerTo || actualSlot < 0");
 
         Assert.True(
             refuse.Statement.DescendantNodesAndSelf().OfType<BreakStatementSyntax>().Any(),

--- a/windows/Ghostty.Tests/Wiring/TabStripSyncWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabStripSyncWiringTests.cs
@@ -248,7 +248,11 @@ public sealed class TabStripSyncWiringTests
     {
         var rebuild = ShellSource.Load(VerticalSource).Method("RebuildAllItems");
 
-        Assert.Single(rebuild.Calls("TabStripProjection.Rows"));
+        // Group-aware since the headers rung: the flat Rows list cannot
+        // name a header, and a rebuild that walked it would drop every
+        // group's header row from the strip.
+        Assert.Single(rebuild.Calls("TabStripProjection.GroupedRows"));
+        Assert.Empty(rebuild.Calls("TabStripProjection.Rows"));
     }
 
     // --- Unwired events: no detach path, no re-entrant validation ---

--- a/windows/Ghostty.Tests/Wiring/VerticalTabGroupHeaderWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/VerticalTabGroupHeaderWiringTests.cs
@@ -1,0 +1,306 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// The vertical strip's group headers, as wiring guards: rows land as
+/// top-level items in projection order (the spec's nested sketch cannot
+/// render Edge-135), the header's only interaction is the toggle, and the
+/// keyboard's shelf crossing never lands on a header. Model half: TabManagerPinGroupTests.
+/// </summary>
+public class VerticalTabGroupHeaderWiringTests
+{
+    private static ShellSource Strip() => ShellSource.Load("Tabs.VerticalTabStrip.xaml.cs");
+
+    private static ShellSource Header() =>
+        ShellSource.Load("Tabs.VerticalTabGroupHeaderRow.cs");
+
+    private static AssignmentExpressionSyntax Assign(SyntaxNode node, string left) =>
+        node.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Single(a => a.Left.ToString() == left);
+
+    /// <summary>The switch arms are the routing: one row kind per projection kind.</summary>
+    [Fact]
+    public void Headers_AreFlatTopLevelItems_InProjectionOrder()
+    {
+        var rebuild = Strip().Method("RebuildAllItems");
+        var walk = rebuild.Calls("TabStripProjection.GroupedRows").Single();
+        var cases = walk.Ancestors().OfType<ForEachStatementSyntax>().First()
+            .Statement.DescendantNodes().OfType<SwitchSectionSyntax>().ToList();
+        Assert.Equal(2, cases.Count);
+
+        var headerArm = cases.Single(s => s.Labels.ToString().Contains("ProjectedRow.Header"));
+        Assert.Contains("ProjectedRow.Header { Group: { } group }", headerArm.Labels.ToString());
+        Assert.Contains("AddGroupRow(group);", headerArm.ToString());
+
+        var itemArm = cases.Single(s => s.Labels.ToString().Contains("ProjectedRow.Item"));
+        Assert.Contains("ProjectedRow.Item { Tab: { } tab }", itemArm.Labels.ToString());
+        Assert.Contains("AddItem(tab);", itemArm.ToString());
+    }
+
+    /// <summary>
+    /// A selected header would blank the active row's paint while the
+    /// manager's active tab did not move; and the ItemStatus polarity is
+    /// the collapse bit -- expanded reads nothing, or the state sticks.
+    /// </summary>
+    [Fact]
+    public void TheHeaderItem_NeverSelects_AndItsChromeReadsTheCollapseBit()
+    {
+        var add = Strip().Method("AddGroupRow");
+        var item = add.DescendantNodes().OfType<ObjectCreationExpressionSyntax>()
+            .Single(o => o.Type.ToString() == "NavigationViewItem");
+        var initializers = item.Initializer!.Expressions.OfType<AssignmentExpressionSyntax>()
+            .ToDictionary(a => a.Left.ToString(), a => a.Right.ToString());
+        Assert.Equal("group", initializers["Tag"]);
+        Assert.Equal("false", initializers["SelectsOnInvoked"]);
+
+        var chrome = add.Calls("ApplyGroupChrome").Single();
+        Assert.True(chrome.Span.Start < Assign(add, "_headers[group]").Span.Start,
+            "the header's chrome must be applied before the row can be reached");
+        Assert.Contains("MembersOf(group).Count", item.ToString());
+
+        var apply = Strip().Method("ApplyGroupChrome");
+        var name = apply.Call("AutomationProperties.SetName");
+        Assert.Equal("item", name.Arg(0));
+        Assert.Equal("group.Title", name.Arg(1));
+
+        var status = apply.Call("AutomationProperties.SetItemStatus");
+        Assert.Equal("item", status.Arg(0));
+        Assert.Equal(@"group.IsCollapsed ? ""Collapsed"" : string.Empty", status.Arg(1));
+    }
+
+    /// <summary>
+    /// The toggle stands down under a drag, fences the MUXC list the
+    /// following reconcile mutates, and routes through the manager op --
+    /// never a direct IsCollapsed write (the complement polarity IS the
+    /// toggle: a same-direction write is invisible).
+    /// </summary>
+    [Fact]
+    public void TheToggle_StandsDownUnderDrag_Fences_AndRoutesThroughTheManager()
+    {
+        var toggle = Strip().Method("ToggleGroup");
+
+        var standDown = toggle.DescendantNodes().OfType<IfStatementSyntax>().First();
+        Assert.Equal("_drag is not null", standDown.Condition.ToString());
+        Assert.Contains(
+            standDown.Statement.DescendantNodesAndSelf().OfType<ReturnStatementSyntax>()
+                .Select(r => r.ToString()),
+            s => s == "return;");
+
+        var collapse = toggle.Call("_manager.CollapseGroup");
+        Assert.Equal("group", collapse.Arg(0));
+        Assert.Equal("!group.IsCollapsed", collapse.Arg(1));
+
+        var fence = toggle.AssignsTo("_syncing").Where(a => a.Right.ToString() == "true").ToList();
+        Assert.Single(fence);
+        Assert.True(fence[0].Span.Start < collapse.Span.Start,
+            "the toggle must be fenced like every other path that ends in a " +
+            "reconcile plus a selection sync");
+    }
+
+    /// <summary>
+    /// Pointer and keyboard both land on the one toggle, and the keyboard
+    /// claims the key BEFORE MUXC's list sees it -- or the same Enter also
+    /// arrives as ItemInvoked and toggles the group twice.
+    /// </summary>
+    [Fact]
+    public void BothGestures_FeedTheOneToggle_AndTheKeyboardClaimsTheKeyFirst()
+    {
+        var strip = Strip();
+
+        var invoked = strip.Method("OnNavItemInvoked");
+        var guard = invoked.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString().Contains("InvokedItemContainer"));
+        Assert.Contains(
+            "args.InvokedItemContainer is not NavigationViewItem { Tag: TabGroup group }",
+            guard.Condition.ToString());
+        Assert.Contains(
+            guard.Statement.DescendantNodesAndSelf().OfType<ReturnStatementSyntax>()
+                .Select(r => r.ToString()),
+            s => s == "return;");
+        Assert.Equal("group", invoked.Calls("ToggleGroup").Single().Arg(0));
+
+        var key = strip.Method("OnGroupHeaderKeyDown");
+        var keys = key.DescendantNodes().OfType<IfStatementSyntax>().First();
+        Assert.Contains("Windows.System.VirtualKey.Enter", keys.Condition.ToString());
+        Assert.Contains("Windows.System.VirtualKey.Space", keys.Condition.ToString());
+
+        var handled = Assign(key, "e.Handled");
+        Assert.Equal("true", handled.Right.ToString());
+        Assert.True(handled.Span.Start < key.Calls("ToggleGroup").Single().Span.Start,
+            "the key must be claimed before the toggle, or MUXC re-fires it as " +
+            "ItemInvoked and collapses the group twice");
+    }
+
+    /// <summary>
+    /// Membership has no manager event: TabModel.Group raising on the tab
+    /// drives its row's chrome immediately and defers layout to a coalesced
+    /// pass; the header binding watches the three properties its row
+    /// renders, and removal disposes the subscription behind the MUXC
+    /// fence -- one outliving its row keeps reconciling.
+    /// </summary>
+    [Fact]
+    public void TheGroupBindings_WatchTheRightProperties_AndReconcileCoalesced()
+    {
+        var strip = Strip();
+
+        var body = strip.Method("AddBodyRow");
+        var tabBinding = body.Calls("AotBinding.Create")
+            .Single(c => c.Arg(2).Contains("nameof(TabModel.Group)"));
+        Assert.Contains("OnTabGroupStateChanged", tabBinding.Arg(1).ToString());
+
+        var handler = strip.Method("OnTabGroupStateChanged");
+        Assert.True(
+            handler.Calls("ApplyItemTitleChrome").Single().Span.Start
+                < handler.Calls("ScheduleReconcile").Single().Span.Start,
+            "the row's own chrome is immediate; only the layout is deferred");
+
+        var schedule = strip.Method("ScheduleReconcile");
+        Assert.Equal("_reconcileScheduled",
+            schedule.DescendantNodes().OfType<IfStatementSyntax>().First().Condition.ToString());
+        var enqueue = schedule.Call("DispatcherQueue.TryEnqueue");
+        Assert.Contains("ReconcileRowOrder", enqueue.ArgumentList.Arguments[1].ToString());
+        Assert.Contains("SyncSelectionFromManager", enqueue.ArgumentList.Arguments[1].ToString());
+
+        var headerBinding = strip.Method("AddGroupRow").Calls("AotBinding.Create").Single();
+        Assert.Contains("nameof(TabGroup.IsCollapsed)", headerBinding.ArgumentList.ToString());
+        Assert.Contains("nameof(TabGroup.Title)", headerBinding.ArgumentList.ToString());
+        Assert.Contains("nameof(TabGroup.Color)", headerBinding.ArgumentList.ToString());
+        Assert.Contains("ScheduleReconcile", headerBinding.Arg(1).ToString());
+
+        var remove = strip.Method("RemoveGroupRow");
+        var fence = remove.AssignsTo("_syncing").Where(a => a.Right.ToString() == "true").ToList();
+        Assert.Single(fence);
+        var menuRemove = remove.Call("NavView.MenuItems.Remove");
+        Assert.True(fence[0].Span.Start < menuRemove.Span.Start,
+            "the header's removal fences MUXC selection like every other one");
+        Assert.True(remove.Calls("hooks.Dispose").Single().Span.Start > menuRemove.Span.Start,
+            "the subscription dies with the row, not before it");
+    }
+
+    /// <summary>
+    /// The 4b-2 seam the headers broke: the shelf crossing aims at the
+    /// first TAB row. Headers are top-level items now (a bare FirstOrDefault
+    /// selects a collapse affordance), and hidden collapsed members sit
+    /// ahead of the visible one, so visibility is in the predicate too.
+    /// </summary>
+    [Fact]
+    public void TheKeyboardCrossing_LandsOnAVisibleTabRow_NeverAHeader()
+    {
+        var strip = Strip();
+        var resolver = strip.Method("FirstBodyItem");
+
+        var body = resolver.DescendantNodes().OfType<LambdaExpressionSyntax>()
+            .Single(l => l.ExpressionBody is not null).ExpressionBody!.ToString();
+        Assert.Contains("i.Tag is TabModel", body);
+        Assert.Contains("i.Visibility == Visibility.Visible", body);
+        Assert.Contains("FirstOrDefault", resolver.ExpressionBody!.ToString());
+
+        Assert.Single(strip.Method("FocusShelfNeighbour").Calls("FirstBodyItem"));
+        Assert.Single(strip.Method("OnBodyRowKeyDown").Calls("FirstBodyItem"));
+    }
+
+    /// <summary>
+    /// The row renders the group in one Refresh; the chevron's arms are
+    /// matched through the parsed literals' decoded values, so the polarity
+    /// is the pin; the ink pass recolors text only -- the swatch is the
+    /// group's content, not chrome.
+    /// </summary>
+    [Fact]
+    public void TheHeaderRow_RendersTheGroup_AndKeepsItsSwatchOutOfTheInk()
+    {
+        var refresh = Header().Method("Refresh");
+        Assert.Contains("_title.Text = group.Title", refresh.ToString());
+        Assert.Contains("_count.Text = memberCount.ToString()", refresh.ToString());
+        Assert.Contains("TabColorPalette.Background(group.Color, selected: false)",
+            refresh.DescendantNodes().OfType<InvocationExpressionSyntax>()
+                .Single(i => i.CalleeText() == "TabColorPalette.Background").ToString());
+        Assert.Equal("group.IsCollapsed", refresh.Calls("SetChevron").Single().Arg(0));
+
+        // Collapsed points right (E76C), expanded down (E70D). Matched in
+        // raw source, where the escapes are plain ASCII text -- no decoded
+        // literal can be mangled in here, and flipping either arm fails.
+        Assert.Contains("collapsed ? \"\\uE76C\" : \"\\uE70D\"",
+            Header().Method("SetChevron").ExpressionBody!.ToString());
+
+        var ink = Header().Method("ApplyInk");
+        Assert.Equal(
+            new[] { "_title.Foreground", "_count.Foreground" },
+            ink.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+                .Select(a => a.Left.ToString()).ToList());
+    }
+
+    /// <summary>
+    /// The one "these rows belong to the header above" cue: grouped members
+    /// indent, ungrouped rows do not (inverting the ternary indents exactly
+    /// the rows with no header). Applied at build AND on the reconcile, or
+    /// a membership op leaves stale indents.
+    /// </summary>
+    [Fact]
+    public void GroupedRows_Indent_AndUngroupedRowsDoNot()
+    {
+        var strip = Strip();
+        var ternary = Assert.IsType<ConditionalExpressionSyntax>(
+            Assign(strip.Method("ApplyGroupInset"), "row.Margin").Right);
+        Assert.Equal("tab.Group is null", ternary.Condition.ToString());
+        Assert.Equal("default(Thickness)", ternary.WhenTrue.ToString());
+        Assert.Contains("GroupInsetLeft", ternary.WhenFalse.ToString());
+
+        Assert.Single(strip.Method("AddBodyRow").Calls("ApplyGroupInset"));
+        Assert.Single(strip.Method("ReconcileRowOrder").Calls("ApplyGroupInset"));
+    }
+
+    /// <summary>
+    /// The machine's index for a row is its SLOT, and DragSlots' pairing
+    /// runs slot -> manager, so resolving a row needs the inverse. Indexing
+    /// the pairing BY the manager index answers another row's slot -- past
+    /// a hidden run it is out of range (a plain press throws) or mis-seeds.
+    /// </summary>
+    [Fact]
+    public void SlotIndexOf_ResolvesTheInversePairing_NeverTheForwardList()
+    {
+        var strip = Strip();
+        var method = strip.Method("SlotIndexOf");
+        var ret = method.DescendantNodes().OfType<ReturnStatementSyntax>().Single();
+        Assert.Equal("manager >= 0 ? managerIndex.IndexOf(manager) : -1",
+            ret.Expression!.ToString());
+        Assert.DoesNotContain("managerIndex[_manager.IndexOf", method.ToString());
+
+        // The three machine-index sites (press, zone churn, drag tick) all
+        // resolve through the one inverse helper.
+        Assert.Equal(3, strip.Root.Calls("SlotIndexOf").Count());
+    }
+
+    /// <summary>
+    /// Collapse hides rows in place, so no churn hand-off saves focus: the
+    /// pointer toggle re-homes it on the header -- but only when the group
+    /// folding up is the one holding focus, and only on the collapse arm
+    /// (expand hides nothing).
+    /// </summary>
+    [Fact]
+    public void ThePointerToggle_RehomesFocus_OnlyWhenTheFoldingGroupHoldsIt()
+    {
+        var strip = Strip();
+        var invoked = strip.Method("OnNavItemInvoked");
+        var gate = invoked.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "!group.IsCollapsed");
+        Assert.True(gate.Span.Start < invoked.Calls("ToggleGroup").Single().Span.Start,
+            "the focus read must precede the toggle that hides the row");
+
+        var restore = strip.Method("RestoreFocusUnder");
+        var conditions = restore.DescendantNodes().OfType<IfStatementSyntax>()
+            .Select(i => i.Condition.ToString()).ToList();
+        Assert.Contains(conditions,
+            c => c.Contains("is not NavigationViewItem { Tag: TabModel focused }"));
+        Assert.Contains(conditions,
+            c => c == "!ReferenceEquals(focused.Group, group)");
+
+        Assert.Equal("FocusState.Programmatic",
+            restore.Calls("header.Focus").Single().Arg(0));
+        // The shared toggle stays focus-free: only the pointer path repairs.
+        Assert.Empty(strip.Method("ToggleGroup").Calls("RestoreFocusUnder"));
+    }
+}

--- a/windows/Ghostty/Tabs/VerticalTabGroupHeaderRow.cs
+++ b/windows/Ghostty/Tabs/VerticalTabGroupHeaderRow.cs
@@ -1,0 +1,103 @@
+using Ghostty.Core.Tabs;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+
+namespace Ghostty.Tabs;
+
+/// <summary>
+/// Row content for a vertical-strip group header: color swatch, title,
+/// member count, and the collapse chevron. The owning NavigationViewItem
+/// carries the group on its Tag and never selects. Flat by design: the
+/// spec's nested sketch cannot render Edge-135, and the chevron is ours
+/// for the same reason -- the strip drives it.
+/// </summary>
+internal sealed partial class VerticalTabGroupHeaderRow : Grid
+{
+    private readonly Border _swatch;
+    private readonly TextBlock _title;
+    private readonly TextBlock _count;
+    private readonly FontIcon _chevron;
+
+    public VerticalTabGroupHeaderRow(TabGroup group, int memberCount)
+    {
+        ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+        _swatch = new Border
+        {
+            Width = 10,
+            Height = 10,
+            CornerRadius = new CornerRadius(2),
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(0, 0, 6, 0),
+        };
+
+        _title = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            TextTrimming = TextTrimming.CharacterEllipsis,
+            Margin = new Thickness(0, 0, 4, 0),
+            Text = group.Title,
+        };
+
+        _count = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(0, 0, 4, 0),
+            Opacity = 0.7,
+            Text = memberCount.ToString(),
+        };
+
+        _chevron = new FontIcon
+        {
+            FontFamily = Application.Current.Resources.TryGetValue(
+                "SymbolThemeFontFamily", out var ff) && ff is FontFamily fam
+                ? fam
+                : null,
+            FontSize = 10,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+
+        Grid.SetColumn(_swatch, 0);
+        Grid.SetColumn(_title, 1);
+        Grid.SetColumn(_count, 2);
+        Grid.SetColumn(_chevron, 3);
+        Children.Add(_swatch);
+        Children.Add(_title);
+        Children.Add(_count);
+        Children.Add(_chevron);
+        // The swatch paints unconditionally: a group has no "no color" state.
+        Refresh(group, memberCount);
+    }
+
+    /// <summary>
+    /// Re-read the group's renderable state; the reconcile pass is the only
+    /// caller, so a change lands here once no matter which op moved it.
+    /// </summary>
+    internal void Refresh(TabGroup group, int memberCount)
+    {
+        _title.Text = group.Title;
+        _count.Text = memberCount.ToString();
+        _swatch.Background = TabColorBrush.From(
+            TabColorPalette.Background(group.Color, selected: false));
+        SetChevron(group.IsCollapsed);
+        ToolTipService.SetToolTip(this, group.Title);
+    }
+
+    /// <summary>Collapsed points right, expanded points down.</summary>
+    private void SetChevron(bool collapsed) =>
+        _chevron.Glyph = collapsed ? "\uE76C" : "\uE70D";
+
+    /// <summary>
+    /// Title and count ink on the strip's text-contrast answer. The swatch
+    /// keeps its own palette fill: the group color is content, not chrome.
+    /// </summary>
+    internal void ApplyInk(Brush foreground)
+    {
+        _title.Foreground = foreground;
+        _count.Foreground = foreground;
+    }
+}

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -31,10 +31,20 @@ internal sealed partial class VerticalTabStrip : UserControl
 {
     private const double RowInsetLeft = 4;
     private const double RowInsetVertical = 2;
+    // Grouped members indent under their header: collapse hides members,
+    // so this margin is the whole membership cue.
+    private const double GroupInsetLeft = 14;
 
     private readonly TabManager _manager;
     private readonly Dictionary<TabModel, NavigationViewItem> _items = new();
     private readonly Dictionary<TabModel, TabHooks> _hooks = new();
+    // Group headers. Top-level items like member rows (the flat projection
+    // is what renders Edge-135), so MenuItems walkers must expect them.
+    private readonly Dictionary<TabGroup, NavigationViewItem> _headers = new();
+    // The header's one subscription. Membership is deliberately not
+    // watched: it rides each member's own TabModel.Group notification, and
+    // the projection that no longer names a dissolved group retires the row.
+    private readonly Dictionary<TabGroup, AotBinding> _groupHooks = new();
     private bool _syncing;
     private bool _shellThemeActive;
     private ElementTheme _elementTheme = ElementTheme.Default;
@@ -52,20 +62,23 @@ internal sealed partial class VerticalTabStrip : UserControl
         new(Microsoft.UI.Colors.Transparent);
 
     /// <summary>
-    /// Per-row subscriptions. Held together so a row teardown cannot
-    /// release one and leak the others.
+    /// Per-row subscriptions, held together so a teardown cannot release
+    /// one and leak the others. The group binding is body-only: a pinned
+    /// tab cannot carry a group.
     /// </summary>
     private sealed record TabHooks(
         AotBinding Text,
         AotBinding Color,
         TabIconViewModel IconVm,
-        PropertyChangedEventHandler IconHandler)
+        PropertyChangedEventHandler IconHandler,
+        AotBinding? Group)
     {
         public void Dispose()
         {
             Text.Dispose();
             Color.Dispose();
             IconVm.PropertyChanged -= IconHandler;
+            Group?.Dispose();
         }
     }
 
@@ -138,7 +151,16 @@ internal sealed partial class VerticalTabStrip : UserControl
         };
 
         _manager.Tabs.CollectionChanged += OnTabsCollectionChanged;
-        _manager.ActiveTabChanged += (_, _) => SyncSelectionFromManager();
+        _manager.ActiveTabChanged += (_, _) =>
+        {
+            // Activation inside a collapsed group swaps which member the
+            // projection keeps visible (Edge 135, no accordion), so the
+            // reconcile lands before the selection sync that targets it.
+            ReconcileRowOrder();
+            SyncSelectionFromManager();
+        };
+        // Headers select for nothing; their one interaction is the toggle.
+        NavView.ItemInvoked += OnNavItemInvoked;
 
         HookDragInput();
         Unloaded += (_, _) => CancelDrag("teardown");
@@ -903,6 +925,13 @@ internal sealed partial class VerticalTabStrip : UserControl
                     ? ActiveRowChrome(model).Foreground
                     : ResolveInactiveTextBrush());
         }
+
+        // Headers are never the active row, so their ink is always the
+        // muted text brush; the swatch keeps its own palette fill (the
+        // group color is content, not chrome).
+        foreach (var (_, item) in _headers)
+            if (item.Content is VerticalTabGroupHeaderRow header)
+                header.ApplyInk(ResolveInactiveTextBrush());
     }
 
     private static void ApplyItemForeground(NavigationViewItem item, Brush? fg, bool active)
@@ -1280,14 +1309,28 @@ internal sealed partial class VerticalTabStrip : UserControl
         // Remove by what we hold, not by what the manager still has:
         // on a Reset the manager is already empty and rows we own would
         // otherwise stay in their container with their subscriptions live.
+        foreach (var group in _groupHooks.Keys.ToArray())
+            RemoveGroupRow(group);
         foreach (var tab in _hooks.Keys.Concat(_pinnedHooks.Keys).ToArray())
             RemoveItem(tab);
         // Row order comes from the projector, the same source the
         // horizontal strip reconciles against, so the two strips cannot
-        // disagree by construction. AddItem is membership-only, so adding
-        // in projection order lands every row in its container at its slot.
-        foreach (var tab in TabStripProjection.Rows(_manager))
-            AddItem(tab);
+        // disagree by construction. Headers and member rows land as
+        // top-level items in projection order -- flat, because the
+        // Edge-135 shape cannot render nested (MUXC hides every child of
+        // a collapsed item, and the rule keeps the active member visible).
+        foreach (var projected in TabStripProjection.GroupedRows(_manager))
+        {
+            switch (projected)
+            {
+                case TabStripProjection.ProjectedRow.Header { Group: { } group }:
+                    AddGroupRow(group);
+                    break;
+                case TabStripProjection.ProjectedRow.Item { Tab: { } tab }:
+                    AddItem(tab);
+                    break;
+            }
+        }
         UpdatePinnedShelfChrome();
     }
 
@@ -1388,6 +1431,11 @@ internal sealed partial class VerticalTabStrip : UserControl
         var colorBinding = AotBinding.Create(tab, _ => RefreshTabColors(),
             nameof(TabModel.Color));
 
+        // Membership has no manager event: TabModel.Group raising is the
+        // only carrier. Deferred so a multi-tab op coalesces.
+        var groupBinding = AotBinding.Create(tab, _ => OnTabGroupStateChanged(tab),
+            nameof(TabModel.Group));
+
         var vm = tab.TabIcon;
         PropertyChangedEventHandler iconHandler = (_, e) =>
         {
@@ -1402,7 +1450,8 @@ internal sealed partial class VerticalTabStrip : UserControl
         vm.PropertyChanged += iconHandler;
 
         _items[tab] = item;
-        _hooks[tab] = new TabHooks(textBinding, colorBinding, vm, iconHandler);
+        _hooks[tab] = new TabHooks(textBinding, colorBinding, vm, iconHandler, groupBinding);
+        ApplyGroupInset(item, tab);
 
         // One seam into the shelf: Up from the first body row walks into
         // it. Every other arrow reaches MUXC's own traversal untouched.
@@ -1457,7 +1506,7 @@ internal sealed partial class VerticalTabStrip : UserControl
         vm.PropertyChanged += iconHandler;
 
         _pinnedRows[tab] = row;
-        _pinnedHooks[tab] = new TabHooks(textBinding, colorBinding, vm, iconHandler);
+        _pinnedHooks[tab] = new TabHooks(textBinding, colorBinding, vm, iconHandler, Group: null);
         _pinnedPanel.Children.Add(row);
 
         // Outside MUXC, the row owns its own keyboard story: Enter/Space
@@ -1531,34 +1580,218 @@ internal sealed partial class VerticalTabStrip : UserControl
     }
 
     /// <summary>
-    /// Bring both containers' row order back to the projection's. Rows are
-    /// reordered in place -- the element instance each dict holds is moved,
-    /// never rebuilt -- so a plain move churns nothing a drag is still
-    /// following that the Remove+Add pair did not churn already. A
-    /// membership skew (a dict holding a tab its container's projection no
-    /// longer names, or counts gone apart) is not something an order pass
-    /// can repair; that is what the rebuild is for.
+    /// Build the header row <paramref name="group"/> renders as. It never
+    /// selects, so selection chrome stays on the member rows around it.
+    /// </summary>
+    private void AddGroupRow(TabGroup group)
+    {
+        if (_headers.ContainsKey(group)) return;
+        var item = new NavigationViewItem
+        {
+            Tag = group,
+            SelectsOnInvoked = false,
+            Content = new VerticalTabGroupHeaderRow(group, _manager.MembersOf(group).Count),
+        };
+        ApplyGroupChrome(item, group);
+
+        var binding = AotBinding.Create(group, _ => ScheduleReconcile(),
+            nameof(TabGroup.IsCollapsed), nameof(TabGroup.Title), nameof(TabGroup.Color));
+        _headers[group] = item;
+        _groupHooks[group] = binding;
+
+        // Keyboard invoke: handled HERE, before MUXC's list sees the key,
+        // or the same Enter also arrives as ItemInvoked and toggles twice.
+        item.KeyDown += OnGroupHeaderKeyDown;
+
+        _syncing = true;
+        try { NavView.MenuItems.Add(item); }
+        finally { _syncing = false; }
+    }
+
+    private void RemoveGroupRow(TabGroup group)
+    {
+        if (!_headers.Remove(group, out var item)) return;
+        // One fence rule for every MenuItems mutation.
+        _syncing = true;
+        try { NavView.MenuItems.Remove(item); }
+        finally { _syncing = false; }
+        if (_groupHooks.Remove(group, out var hooks))
+            hooks.Dispose();
+    }
+
+    /// <summary>
+    /// Everything on the header item that follows the group: tooltip, name,
+    /// and the collapse state on ItemStatus. (The ExpandCollapse pattern is
+    /// 5b-2's, with the group commands.)
+    /// </summary>
+    private static void ApplyGroupChrome(NavigationViewItem item, TabGroup group)
+    {
+        ToolTipService.SetToolTip(item, group.Title);
+        AutomationProperties.SetName(item, group.Title);
+        AutomationProperties.SetItemStatus(
+            item, group.IsCollapsed ? "Collapsed" : string.Empty);
+    }
+
+    /// <summary>
+    /// Grouped members indent, ungrouped rows do not. Collapse re-parents
+    /// nothing: a member leaving a group un-indents through this same pass.
+    /// </summary>
+    private void ApplyGroupInset(NavigationViewItem item, TabModel tab)
+    {
+        if (item.Content is not VerticalTabNavRow row) return;
+        row.Margin = tab.Group is null
+            ? default(Thickness)
+            : new Thickness(GroupInsetLeft, 0, 0, 0);
+    }
+
+    private void OnTabGroupStateChanged(TabModel tab)
+    {
+        // Chrome is immediate; the layout answer is the deferred reconcile,
+        // so a multi-tab op coalesces.
+        if (_items.TryGetValue(tab, out var item))
+        {
+            ApplyItemTitleChrome(item, tab);
+            ApplyGroupInset(item, tab);
+        }
+        ScheduleReconcile();
+    }
+
+    private bool _reconcileScheduled;
+
+    /// <summary>
+    /// Group changes arrive one property at a time (no manager event behind
+    /// them); one dispatcher pass keeps a burst from running a reconcile
+    /// per mutation.
+    /// </summary>
+    private void ScheduleReconcile()
+    {
+        if (_reconcileScheduled) return;
+        _reconcileScheduled = true;
+        DispatcherQueue.TryEnqueue(DispatcherQueuePriority.Normal, () =>
+        {
+            _reconcileScheduled = false;
+            ReconcileRowOrder();
+            SyncSelectionFromManager();
+        });
+    }
+
+    /// <summary>
+    /// The header's only interaction. A drag stands it down, as every other
+    /// row mutation: collapsing reorders visible rows under a live gesture.
+    /// </summary>
+    private void ToggleGroup(TabGroup group)
+    {
+        if (_drag is not null) return;
+        _syncing = true;
+        try { _manager.CollapseGroup(group, !group.IsCollapsed); }
+        finally { _syncing = false; }
+    }
+
+    private void OnNavItemInvoked(NavigationView sender, NavigationViewItemInvokedEventArgs args)
+    {
+        // Body rows activate through SelectionChanged; a header cannot
+        // raise that (SelectsOnInvoked=false), so ItemInvoked is the
+        // pointer path for the toggle and nothing else.
+        if (args.InvokedItemContainer is not NavigationViewItem { Tag: TabGroup group })
+            return;
+        // Pointer-only: the keyboard toggle already sits on the header,
+        // so only this path can hide the row that holds focus.
+        if (!group.IsCollapsed) RestoreFocusUnder(group);
+        ToggleGroup(group);
+    }
+
+    /// <summary>
+    /// Collapse hides member rows in place -- no churn, so the _refocusTab
+    /// hand-off in AddItem never fires and a focused member's focus would
+    /// drop unmanaged. Land it on the group's header, and only when the
+    /// folding group is the one holding focus: an unrelated collapse must
+    /// not move focus at all.
+    /// </summary>
+    private void RestoreFocusUnder(TabGroup group)
+    {
+        if (FocusManager.GetFocusedElement()
+            is not NavigationViewItem { Tag: TabModel focused }) return;
+        if (!ReferenceEquals(focused.Group, group)) return;
+        if (_headers.TryGetValue(group, out var header))
+            header.Focus(FocusState.Programmatic);
+    }
+
+    private void OnGroupHeaderKeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        if (e.Key is not (Windows.System.VirtualKey.Enter or Windows.System.VirtualKey.Space))
+            return;
+        e.Handled = true;
+        if (sender is NavigationViewItem { Tag: TabGroup group })
+            ToggleGroup(group);
+    }
+
+    /// <summary>
+    /// The first body row a keyboard crossing can land on: a visible
+    /// top-level TAB. Both filters are load-bearing: headers are top-level
+    /// too, and hidden collapsed members sit ahead of the visible one.
+    /// </summary>
+    private NavigationViewItem? FirstBodyItem() =>
+        NavView.MenuItems.OfType<NavigationViewItem>().FirstOrDefault(
+            i => i.Tag is TabModel && i.Visibility == Visibility.Visible);
+
+    /// <summary>
+    /// Bring both containers' rows back to the projection's: order in
+    /// place (elements moved, never rebuilt, so a drag survives), collapse
+    /// as visibility (the active member lands under its header -- Edge-135),
+    /// header contents re-read. Membership skew is the rebuild's job.
     /// </summary>
     private void ReconcileRowOrder()
     {
-        var rows = TabStripProjection.Rows(_manager);
         var pinCount = _manager.PinCount;
-        var pinned = rows.Take(pinCount).ToList();
-        var body = rows.Skip(pinCount).ToList();
+        // Desired MenuItems sequence and the visible set, from ONE walk of
+        // the projection: headers at their run's start, rows in tab order,
+        // pinned items skipped (the shelf renders them).
+        var desired = new List<NavigationViewItem>(NavView.MenuItems.Count);
+        var shown = new HashSet<TabModel>();
+        var missing = false;
+        foreach (var projected in TabStripProjection.GroupedRows(_manager))
+        {
+            switch (projected)
+            {
+                case TabStripProjection.ProjectedRow.Header { Group: { } group }:
+                    if (!_headers.TryGetValue(group, out var header))
+                    {
+                        missing = true;
+                        break;
+                    }
+                    desired.Add(header);
+                    break;
+                case TabStripProjection.ProjectedRow.Item { Tab: { } tab }:
+                    if (tab.IsPinned) continue; // the shelf renders the prefix
+                    shown.Add(tab);
+                    if (!_items.TryGetValue(tab, out var item))
+                    {
+                        missing = true;
+                        break;
+                    }
+                    desired.Add(item);
+                    break;
+            }
+            if (missing) break;
+        }
 
-        if (_pinnedRows.Count != pinned.Count || _items.Count != body.Count
-            || _pinnedPanel.Children.Count != pinned.Count
-            || NavView.MenuItems.Count != body.Count
-            || pinned.Any(t => !_pinnedRows.ContainsKey(t))
-            || body.Any(t => !_items.ContainsKey(t)))
+        // A projection-named row the strip holds no element for is skew an
+        // order pass cannot repair -- counts can agree while a row is
+        // missing on both sides -- so the miss flag joins the counts.
+        if (missing
+            || _pinnedRows.Count != pinCount
+            || _items.Count != _manager.Tabs.Count - pinCount
+            || _pinnedPanel.Children.Count != pinCount
+            || NavView.MenuItems.Count != desired.Count)
         {
             RebuildAllItems();
             return;
         }
 
-        for (var i = 0; i < pinned.Count; i++)
+        for (var i = 0; i < pinCount; i++)
         {
-            var row = _pinnedRows[pinned[i]];
+            var tab = _manager.Tabs[i];
+            var row = _pinnedRows[tab];
             if (ReferenceEquals(_pinnedPanel.Children[i], row)) continue;
             var idx = _pinnedPanel.Children.IndexOf(row);
             if (idx >= 0) _pinnedPanel.Children.RemoveAt(idx);
@@ -1569,16 +1802,32 @@ internal sealed partial class VerticalTabStrip : UserControl
         _syncing = true;
         try
         {
-            for (var i = 0; i < body.Count; i++)
+            for (var i = 0; i < desired.Count; i++)
             {
-                var row = _items[body[i]];
-                if (ReferenceEquals(items[i], row)) continue;
-                var idx = items.IndexOf(row);
+                if (ReferenceEquals(items[i], desired[i])) continue;
+                var idx = items.IndexOf(desired[i]);
                 if (idx >= 0) items.RemoveAt(idx);
-                items.Insert(i, row);
+                items.Insert(i, desired[i]);
             }
         }
         finally { _syncing = false; }
+
+        // Which rows show: the projection's items, pinned ones excluded
+        // (they live in the shelf; their list entries are their visibility
+        // anyway -- there are none). This assignment is the whole toggle.
+        foreach (var (tab, item) in _items)
+        {
+            var want = shown.Contains(tab) ? Visibility.Visible : Visibility.Collapsed;
+            if (item.Visibility != want) item.Visibility = want;
+            ApplyGroupInset(item, tab);
+        }
+
+        foreach (var (group, header) in _headers)
+        {
+            if (header.Content is VerticalTabGroupHeaderRow row)
+                row.Refresh(group, _manager.MembersOf(group).Count);
+            ApplyGroupChrome(header, group);
+        }
 
         UpdatePinnedShelfChrome();
     }
@@ -1684,9 +1933,7 @@ internal sealed partial class VerticalTabStrip : UserControl
         if (i >= 0 && i < _pinnedPanel.Children.Count)
             return _pinnedPanel.Children[i].Focus(FocusState.Programmatic);
 
-        if (delta > 0
-            && NavView.MenuItems.OfType<NavigationViewItem>().FirstOrDefault()
-            is { } firstBody)
+        if (delta > 0 && FirstBodyItem() is { } firstBody)
             return firstBody.Focus(FocusState.Programmatic);
 
         return false;
@@ -1703,8 +1950,7 @@ internal sealed partial class VerticalTabStrip : UserControl
         if (e.Key != Windows.System.VirtualKey.Up) return;
         if (_manager.PinCount == 0) return;
         if (sender is not NavigationViewItem) return;
-        if (NavView.MenuItems.OfType<NavigationViewItem>().FirstOrDefault()
-            is not { } first || !ReferenceEquals(first, sender)) return;
+        if (FirstBodyItem() is not { } first || !ReferenceEquals(first, sender)) return;
         if (_pinnedPanel.Children.Count == 0) return;
         if (!_pinnedPanel.Children[^1].Focus(FocusState.Programmatic)) return;
         e.Handled = true;
@@ -1861,7 +2107,8 @@ internal sealed partial class VerticalTabStrip : UserControl
         if (_manager.Tabs.Count < 2) return;
 
         var point = e.GetCurrentPoint(this);
-        var machine = new TabDragReorder(_manager.Tabs.Count, _manager.IndexOf(tab));
+        var (_, managerIndex) = DragSlots();
+        var machine = new TabDragReorder(managerIndex.Count, SlotIndexOf(managerIndex, tab));
         machine.Press(point.Position.Y);
         // Each begin..settle pair owns its census: a teardown failure in
         // one drag must not inflate the ghost count of the next.
@@ -1983,7 +2230,7 @@ internal sealed partial class VerticalTabStrip : UserControl
         drag.Item = item;
         drag.MotionOn = TabStripMotion.Enabled(SystemAnimationsEnabled(), _highContrast);
         drag.HidesSelectionRow = ReferenceEquals(drag.Tab, _manager.ActiveTab);
-        drag.Machine.UpdateIndex(_manager.IndexOf(drag.Tab));
+        drag.Machine.UpdateIndex(SlotIndexOf(DragSlots().ManagerIndex, drag.Tab));
         try
         {
             var (center, centers) = MeasureRows(drag.Tab);
@@ -2098,7 +2345,7 @@ internal sealed partial class VerticalTabStrip : UserControl
     /// </summary>
     private void RemeasureCenters(DragSession drag)
     {
-        var rows = TabStripProjection.Rows(_manager);
+        var (rows, _) = DragSlots();
         var centers = new double[rows.Count];
         for (int i = 0; i < rows.Count; i++)
         {
@@ -2157,7 +2404,10 @@ internal sealed partial class VerticalTabStrip : UserControl
     /// exactly as it was.
     ///
     /// The delta is measured between the pre-commit arranged centers of
-    /// the two slots involved, so scroll motion cancels out of it.
+    /// the two slots involved, so scroll motion cancels out of it. Both
+    /// sides are slot lists (visible rows only): a hidden member of a
+    /// collapsed group has no arranged center to glide from, and an
+    /// invisible row animating to a slot it does not paint is a ghost.
     /// </summary>
     private void StartGapGlides(IReadOnlyList<TabModel> beforeRows,
         IReadOnlyList<double> beforeCenters, TabModel dragged)
@@ -2165,7 +2415,7 @@ internal sealed partial class VerticalTabStrip : UserControl
         if (_drag is not { } drag || !drag.MotionOn) return;
         if (drag.Glide is null || drag.Visual is null) return;
 
-        var afterRows = TabStripProjection.Rows(_manager);
+        var (afterRows, _) = DragSlots();
         CompositionScopedBatch? batch = null;
         for (int i = 0; i < afterRows.Count; i++)
         {
@@ -2378,7 +2628,8 @@ internal sealed partial class VerticalTabStrip : UserControl
             return;
         }
 
-        drag.Machine.UpdateIndex(_manager.IndexOf(drag.Tab));
+        var (_, managerIndex) = DragSlots();
+        drag.Machine.UpdateIndex(SlotIndexOf(managerIndex, drag.Tab));
         RemeasureCenters(drag);
         double arranged = RowCenterY(drag.Tab);
         if (double.IsNaN(arranged))
@@ -2396,7 +2647,7 @@ internal sealed partial class VerticalTabStrip : UserControl
         // glides read their slot deltas out of this frame, so every delta
         // is scroll-consistent and layout-race-free (arrange cannot run
         // mid-tick).
-        var beforeRows = TabStripProjection.Rows(_manager);
+        var (beforeRows, _) = DragSlots();
         var beforeCenters = new double[beforeRows.Count];
         for (int i = 0; i < beforeRows.Count; i++)
             beforeCenters[i] = RowCenterY(beforeRows[i]);
@@ -2404,15 +2655,24 @@ internal sealed partial class VerticalTabStrip : UserControl
         var committed = false;
         while (drag.Machine.Evaluate(draggedCenter) is { } crossing)
         {
+            // The machine speaks in visible slots, the manager in tabs;
+            // a slot the pairing does not name is refused, never guessed.
+            var managerTo = crossing.To >= 0 && crossing.To < managerIndex.Count
+                ? managerIndex[crossing.To]
+                : -1;
+            if (managerTo < 0)
+            {
+                drag.Machine.UpdateIndex(crossing.To);
+                DragTrace($"DRAG unmapped {crossing.From}->{crossing.To}");
+                break;
+            }
             var from = _manager.IndexOf(drag.Tab);
-            // The pinned prefix is a slot range to the machine; a crossing
-            // that lands on the far side of it is a zone change Move alone
-            // would clamp away. SetPinned first relocates the row to the
-            // boundary (end of the prefix pinning down, first unpinned slot
-            // pinning up), and the Move then places it at the crossing's
-            // slot inside the new zone -- the drop position, not append-last.
+            // A crossing over the pin boundary is a zone change Move alone
+            // would clamp away: SetPinned first relocates the row to the
+            // boundary, then the Move places it at the crossing's slot in
+            // the new zone -- the drop position, not append-last.
             var zone = TabPinBoundary.Classify(
-                drag.Tab.IsPinned, _manager.PinCount, _manager.Tabs.Count, crossing.To);
+                drag.Tab.IsPinned, _manager.PinCount, _manager.Tabs.Count, managerTo);
             _commitChurn = true;
             try
             {
@@ -2424,35 +2684,35 @@ internal sealed partial class VerticalTabStrip : UserControl
                     from = _manager.IndexOf(drag.Tab);
                     if (from < 0) { CancelDrag("closed"); return; }
                 }
-                _manager.Move(from, crossing.To);
+                _manager.Move(from, managerTo);
             }
             finally { _commitChurn = false; }
             if (zone.Op != TabPinZoneOp.None)
             {
-                // The boundary is the thing this gesture aims at, so the
-                // one commit that moves it repaints it now rather than
-                // leaving the stroke at its pre-crossing gap until the
-                // drag ends. Ordinary moves keep the deliberate mid-drag
-                // freeze: nothing about the boundary changed for them.
+                // The boundary is what this gesture aims at, so the one
+                // commit that moves it repaints it now; ordinary moves keep
+                // the deliberate mid-drag freeze.
                 if (drag.HidesSelectionRow) UpdateSelectionRow();
                 else UpdateRowSeparators(selectionRowVisible: true);
             }
             if (RowElementOf(drag.Tab) is null) { CancelDrag("closed"); return; }
 
-            // Move clamps at the pin boundary and no-ops on collapse, so
-            // read the truth back: a crossing that did not land must not
-            // re-anchor the row to a slot it never reached -- the next
-            // tick would re-cross it for the rest of the gesture. Tell
-            // the machine where the row actually is, skip the rebind,
-            // and break: re-evaluating now would re-fire the identical
-            // refused crossing.
+            // Move clamps at the boundary and no-ops on collapse, so read
+            // the truth back: a crossing that did not land must not
+            // re-anchor the row to a slot it never reached. The pairing is
+            // re-walked post-commit -- the move displaced other rows, so
+            // the pre-commit pairing is stale past any hidden member.
+            var (nowRows, nowIndex) = DragSlots();
             var actual = _manager.IndexOf(drag.Tab);
-            if (actual != crossing.To)
+            var actualSlot = nowIndex.IndexOf(actual);
+            if (actual != managerTo || actualSlot < 0)
             {
-                drag.Machine.UpdateIndex(actual);
+                if (actualSlot >= 0) drag.Machine.UpdateIndex(actualSlot);
                 DragTrace($"DRAG refused {crossing.From}->{crossing.To}");
                 break;
             }
+            drag.Machine.UpdateIndex(actualSlot);
+            managerIndex = nowIndex;
             RebindFollow(drag, beforeCenters[crossing.To]);
             committed = true;
             DragTrace($"DRAG commit {crossing.From}->{crossing.To}");
@@ -2588,9 +2848,48 @@ internal sealed partial class VerticalTabStrip : UserControl
         PreviewHost.Visibility = Visibility.Collapsed;
     }
 
+    /// <summary>
+    /// The drag machine's slots: every row with a position on screen, in
+    /// manager order, paired with its manager index (SLOT -> MANAGER).
+    /// Collapse-as-visibility is what creates the rows this list omits:
+    /// a hidden member has no arranged center, and a NaN center would
+    /// swallow every crossing past the group, so the machine speaks slots
+    /// and its crossing contract holds in their presence. The inverse
+    /// lookup is <see cref="SlotIndexOf"/>.
+    /// </summary>
+    private (List<TabModel> Rows, List<int> ManagerIndex) DragSlots()
+    {
+        var rows = new List<TabModel>(_manager.Tabs.Count);
+        var managerIndex = new List<int>(_manager.Tabs.Count);
+        var tabs = _manager.Tabs;
+        for (int i = 0; i < tabs.Count; i++)
+        {
+            var tab = tabs[i];
+            if (tab.Group is { } group && group.IsCollapsed
+                && !ReferenceEquals(tab, _manager.ActiveTab))
+                continue; // hidden under a collapsed header: no slot at all
+            rows.Add(tab);
+            managerIndex.Add(i);
+        }
+        return (rows, managerIndex);
+    }
+
+    /// <summary>
+    /// MANAGER -> SLOT: the inverse of DragSlots' SLOT -> MANAGER pairing.
+    /// A drag knows its row by manager position while the machine speaks
+    /// slots; indexing the list BY the manager index answers a different
+    /// row's slot -- the first row past a hidden run is out of range or a
+    /// stranger. -1 when the tab holds no slot.
+    /// </summary>
+    private int SlotIndexOf(List<int> managerIndex, TabModel tab)
+    {
+        var manager = _manager.IndexOf(tab);
+        return manager >= 0 ? managerIndex.IndexOf(manager) : -1;
+    }
+
     private (double Center, double[] Centers) MeasureRows(TabModel dragged)
     {
-        var rows = TabStripProjection.Rows(_manager);
+        var (rows, _) = DragSlots();
         var centers = new double[rows.Count];
         int draggedIndex = -1;
         for (int i = 0; i < rows.Count; i++)


### PR DESCRIPTION
Vertical rendering half of groups (5.4), split 1 of 3:

- Group headers render flat as top-level rows -- MUXC hides children of a collapsed item, so the nested sketch could not render the active-member-visible rule. Collapse is a visibility bit: hidden members keep their list slot, and activating a hidden member swaps the visible one without expanding.
- TabGroup raises Title/Color/IsCollapsed; body rows react immediately on chrome, coalesced on layout; headers re-read through the reconcile.
- Keyboard resolvers land on visible tab rows, never headers or hidden rows; pointer toggle re-homes focus when the folding group holds it; toggle stands down under an active drag and routes fenced through CollapseGroup.
- Drag slot-space translation: with any row hidden the machine speaks slot indices and crossings translate to manager indices; unmapped slots refuse loudly. Fixes a press-crash near collapsed groups.

Size-override: review-mandated crash-blocker fix plus its regression guards on a rung already split three ways.

Group-creation UI is the next PR; headers are exercisable today via session restore.