### PR TITLE
launch: defer what the app cannot serve yet, and let a warm session skip the splash

### DIFF
--- a/windows/Ghostty.Core/SingleInstance/LaunchDeferralQueue.cs
+++ b/windows/Ghostty.Core/SingleInstance/LaunchDeferralQueue.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+
+namespace Ghostty.Core.SingleInstance;
+
+/// <summary>
+/// Holds forwarded launches that arrived before the app could open a window
+/// for them, and hands them back once it can.
+///
+/// <para>It exists so a launch is never discarded. The secondary has already
+/// written the request down the pipe and exited believing it was served, so
+/// dropping one here is a window the user asked for that never appears, with
+/// no error anywhere they can see. A launch that cannot be acted on yet waits
+/// instead, and is replayed on the readiness edge.</para>
+///
+/// <para>Bounded by <see cref="Capacity"/>. The gap it bridges is the tail of
+/// startup, so a queue deep enough to reach the cap is not a queue worth
+/// growing: it is a sign the app is wedged. The OLDEST entry is the one
+/// evicted, because the newest is the launch the user is looking at and the
+/// oldest is the one most likely superseded by it.</para>
+///
+/// <para>Not thread-safe, and not meant to be. Both ends run on the UI
+/// thread: requests arrive through the single-instance callback's
+/// <c>TryEnqueue</c>, and <see cref="MarkReady"/> is called from
+/// <c>OnLaunched</c>. A lock would add nothing the dispatcher does not
+/// already guarantee.</para>
+/// </summary>
+public sealed class LaunchDeferralQueue
+{
+    /// <summary>
+    /// How many launches will wait. Sized for a user mashing a launcher while
+    /// the first window is still coming up, not for a backlog: eight queued
+    /// launches inside a sub-second gap is a wedged app, and the ninth is
+    /// honestly better reported than silently queued behind it.
+    /// </summary>
+    public const int Capacity = 8;
+
+    private readonly List<LaunchRequest> _pending = new();
+    private bool _ready;
+
+    /// <summary>How many launches are waiting.</summary>
+    public int Count => _pending.Count;
+
+    /// <summary>
+    /// Whether <see cref="MarkReady"/> has run. Once true, nothing is ever
+    /// held again: the app is past the point where it could not act, so a
+    /// launch reaching this queue afterwards is one the app cannot serve and
+    /// the caller has to report the loss.
+    /// </summary>
+    public bool IsReady => _ready;
+
+    /// <summary>Hold a launch for the readiness edge. Reports nothing about
+    /// the launch it may have evicted to make room; see the overload that
+    /// does. Returns false, holding nothing, once <see cref="MarkReady"/> has
+    /// run.</summary>
+    public bool Defer(LaunchRequest request) => Defer(request, out _);
+
+    /// <summary>
+    /// Hold a launch for the readiness edge. Returns false, holding nothing,
+    /// once <see cref="MarkReady"/> has run.
+    /// </summary>
+    /// <param name="request">The launch to hold.</param>
+    /// <param name="evicted">The launch dropped to make room, when
+    /// <see cref="Capacity"/> was already reached, otherwise null. Null
+    /// whenever the return is false, which is the one outcome that touches
+    /// nothing already held.</param>
+    /// <remarks>
+    /// Always makes room rather than refusing. From the caller's side the
+    /// question is only "will this one be replayed", so the return stays a
+    /// bool and the eviction travels separately as the thing that was lost.
+    /// </remarks>
+    public bool Defer(LaunchRequest request, out LaunchRequest? evicted)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        evicted = null;
+        if (_ready) return false;
+
+        if (_pending.Count >= Capacity)
+        {
+            evicted = _pending[0];
+            _pending.RemoveAt(0);
+        }
+
+        _pending.Add(request);
+        return true;
+    }
+
+    /// <summary>
+    /// Latch readiness and return everything held, oldest first. Idempotent:
+    /// a second call returns an empty list.
+    /// </summary>
+    /// <remarks>
+    /// The latch is a point of no return rather than a flag the caller could
+    /// unset. A request handed back and then deferred again by a re-entrant
+    /// call would land in a queue nobody drains, and returning it to a caller
+    /// that is itself mid-teardown is exactly the loss this type exists to
+    /// make loud instead of silent.
+    /// </remarks>
+    public IReadOnlyList<LaunchRequest> MarkReady()
+    {
+        _ready = true;
+
+        if (_pending.Count == 0) return Array.Empty<LaunchRequest>();
+        var drained = _pending.ToArray();
+        _pending.Clear();
+        return drained;
+    }
+}

--- a/windows/Ghostty.Core/SingleInstance/LaunchSplashDecision.cs
+++ b/windows/Ghostty.Core/SingleInstance/LaunchSplashDecision.cs
@@ -1,0 +1,60 @@
+using System;
+
+namespace Ghostty.Core.SingleInstance;
+
+/// <summary>
+/// Whether the pre-XAML launch splash goes up for this launch.
+///
+/// <para>Split out of <see cref="SingleInstanceElection.ShouldShowLaunchSplash"/>
+/// so the warm half can be decided without holding a real mutex. The election
+/// owns "what kind of launch is this"; this owns "given that, does a splash
+/// earn its keep". The election's property is the only production caller, and
+/// the two-argument overload here is what a test drives, so the role table and
+/// the warm rule are checkable without the OS.</para>
+/// </summary>
+internal static class LaunchSplashDecision
+{
+    /// <summary>
+    /// Set before <c>Application.Start</c> by a layer that can answer whether
+    /// a warm session is already sitting there ready to attach. The decision
+    /// runs before WinUI exists, so whatever sits behind this must not need a
+    /// DispatcherQueue, a config handle or a window: it is asked once, from
+    /// <c>MainImpl</c>, on the way up.
+    ///
+    /// <para>Null by default, and null means "no idea, show the splash", which
+    /// is the behaviour every launch has always had. A throw from the probe is
+    /// read the same way, so a warm-session layer that is half built or fails
+    /// to answer costs a splash rather than a black rectangle.</para>
+    ///
+    /// <para>Nothing in this repository sets it yet. It is the seam the warm
+    /// session layer plugs into, and it is a static rather than a parameter
+    /// because the site that reads it has no way to be handed one.</para>
+    /// </summary>
+    internal static Func<bool>? WarmSessionProbe { get; set; }
+
+    /// <summary>Decide against the probe currently installed.</summary>
+    internal static bool ShouldShow(SingleInstanceRole role)
+        => ShouldShow(role, WarmSessionProbe);
+
+    /// <summary>
+    /// True unless a secondary is about to forward, where the splash would
+    /// cover the primary's window, or a warm session is ready to attach, where
+    /// it would only be a flash between two real frames.
+    /// </summary>
+    internal static bool ShouldShow(SingleInstanceRole role, Func<bool>? warmProbe)
+    {
+        if (role == SingleInstanceRole.Secondary) return false;
+        if (warmProbe is null) return true;
+
+        try
+        {
+            return !warmProbe();
+        }
+        catch (Exception)
+        {
+            // The probe is an optimisation; the splash is the guarantee. An
+            // answer we cannot get is an answer we do not act on.
+            return true;
+        }
+    }
+}

--- a/windows/Ghostty.Core/SingleInstance/SingleInstanceElection.cs
+++ b/windows/Ghostty.Core/SingleInstance/SingleInstanceElection.cs
@@ -75,8 +75,13 @@ public sealed class SingleInstanceElection : IDisposable
     /// A secondary must not, even for the moment before it forwards: the splash
     /// is full-size, opaque and topmost, and the window it would cover is the
     /// primary's. Every other role goes on to open a window of its own.
+    ///
+    /// The warm-session half lives in <see cref="LaunchSplashDecision"/>, which
+    /// reads a probe installed before <c>Application.Start</c>. Left null here,
+    /// so an election with no warm layer behind it answers exactly as it always
+    /// has.
     /// </remarks>
-    public bool ShouldShowLaunchSplash => Role != SingleInstanceRole.Secondary;
+    public bool ShouldShowLaunchSplash => LaunchSplashDecision.ShouldShow(Role);
 
     /// <summary>
     /// Hold the election. Creates nothing when <paramref name="enabled"/> is

--- a/windows/Ghostty.Tests.Windows/SingleInstance/SingleInstanceElectionTests.cs
+++ b/windows/Ghostty.Tests.Windows/SingleInstance/SingleInstanceElectionTests.cs
@@ -235,6 +235,41 @@ public sealed class SingleInstanceElectionTests
     }
 
     /// <summary>
+    /// The warm seam is read through this property, not alongside it, so a
+    /// decision type that drifted away from the election would still compile
+    /// and every launch would splash again. Pinned here rather than over the
+    /// decision type alone because this is the member the shell reads.
+    /// </summary>
+    [Fact]
+    public void TheSplashGate_ReadsTheInstalledWarmProbe()
+    {
+        var (election, incumbent) = ElectionWithRole(SingleInstanceRole.Primary);
+        try
+        {
+            LaunchSplashDecision.WarmSessionProbe = () => true;
+            try
+            {
+                Assert.False(election.ShouldShowLaunchSplash);
+            }
+            finally
+            {
+                LaunchSplashDecision.WarmSessionProbe = null;
+            }
+
+            // Reset rather than assumed: the false half only means something
+            // if the probe really is gone, and a leak here would suppress the
+            // splash for the rest of the run.
+            Assert.Null(LaunchSplashDecision.WarmSessionProbe);
+            Assert.True(election.ShouldShowLaunchSplash);
+        }
+        finally
+        {
+            election.Dispose();
+            incumbent?.Dispose();
+        }
+    }
+
+    /// <summary>
     /// Drive a real election into <paramref name="role"/>, so the theory above
     /// tests reachable states rather than a hand-built object.
     /// </summary>

--- a/windows/Ghostty.Tests/SingleInstance/LaunchDeferralQueueTests.cs
+++ b/windows/Ghostty.Tests/SingleInstance/LaunchDeferralQueueTests.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using Ghostty.Core.SingleInstance;
+using Xunit;
+
+namespace Ghostty.Tests.SingleInstance;
+
+public sealed class LaunchDeferralQueueTests
+{
+    private static LaunchRequest Req(string cwd = @"C:\tmp", params string[] args)
+        => new(cwd, args);
+
+    [Fact]
+    public void EmptyQueue_DrainsNothing()
+    {
+        var queue = new LaunchDeferralQueue();
+
+        Assert.Empty(queue.MarkReady());
+    }
+
+    // Identity, not just count: the request is handed to the primary verbatim
+    // and is the only record of what the user asked for, so anything the queue
+    // did to normalise it would be a silent edit of someone's command line.
+    [Fact]
+    public void HeldLaunches_ReplayOldestFirst_WithIdentityPreserved()
+    {
+        var queue = new LaunchDeferralQueue();
+        var first = Req(@"C:\a", "wintty", "--flag");
+        var second = Req(@"C:\b");
+        var third = Req(@"C:\c", "", "x:y");
+
+        Assert.True(queue.Defer(first));
+        Assert.True(queue.Defer(second));
+        Assert.True(queue.Defer(third));
+
+        var drained = queue.MarkReady();
+        Assert.Equal(3, drained.Count);
+        Assert.Same(first, drained[0]);
+        Assert.Same(second, drained[1]);
+        Assert.Same(third, drained[2]);
+    }
+
+    [Fact]
+    public void MarkReady_LatchesAndEmpties()
+    {
+        var queue = new LaunchDeferralQueue();
+        queue.Defer(Req());
+
+        Assert.False(queue.IsReady);
+        Assert.Equal(1, queue.Count);
+
+        Assert.Single(queue.MarkReady());
+        Assert.True(queue.IsReady);
+        Assert.Empty(queue.MarkReady());
+    }
+
+    // The whole reason the queue exists is that a launch the app could not act
+    // on must not be lost. Readiness is one-way, so a request turned away
+    // after it is the one case where a loss is unavoidable and has to be
+    // visible to the caller rather than parked where nobody will look.
+    [Fact]
+    public void AfterReadiness_NothingIsHeld()
+    {
+        var queue = new LaunchDeferralQueue();
+        queue.MarkReady();
+
+        Assert.False(queue.Defer(Req(), out var evicted));
+        Assert.Null(evicted);
+        Assert.Equal(0, queue.Count);
+    }
+
+    // Cap, not refusal: the ninth launch is held and the first is the one
+    // given up, because the newest is the launch the user is waiting on and
+    // the oldest is the one most likely superseded by it.
+    [Fact]
+    public void PastCapacity_TheOldestIsEvicted_AndTheNewestIsHeld()
+    {
+        var queue = new LaunchDeferralQueue();
+        var held = new List<LaunchRequest>();
+        for (var i = 0; i < LaunchDeferralQueue.Capacity; i++)
+        {
+            var req = Req($@"C:\n{i}");
+            held.Add(req);
+            Assert.True(queue.Defer(req, out var evicted));
+            Assert.Null(evicted);
+        }
+
+        var ninth = Req(@"C:\n-last");
+        Assert.True(queue.Defer(ninth, out var dropped));
+
+        Assert.Same(held[0], dropped);
+        Assert.Equal(LaunchDeferralQueue.Capacity, queue.Count);
+
+        var drained = queue.MarkReady();
+        Assert.Equal(LaunchDeferralQueue.Capacity, drained.Count);
+        Assert.Same(held[1], drained[0]);
+        Assert.Same(ninth, drained[^1]);
+    }
+
+    // Two overflows in a row have to move the front each time. Asserting on
+    // the working directory rather than on identity is what makes that
+    // visible: the same reference evicted twice would still satisfy a
+    // not-null check.
+    [Fact]
+    public void RepeatedOverflow_EvictsTheCurrentOldest_EachTime()
+    {
+        var queue = new LaunchDeferralQueue();
+        for (var i = 0; i < LaunchDeferralQueue.Capacity; i++)
+            queue.Defer(Req($@"C:\n{i}"));
+
+        queue.Defer(Req(@"C:\first-overflow"), out var first);
+        queue.Defer(Req(@"C:\second-overflow"), out var second);
+
+        Assert.Equal(@"C:\n0", first!.WorkingDirectory);
+        Assert.Equal(@"C:\n1", second!.WorkingDirectory);
+    }
+
+    [Fact]
+    public void NullRequest_Throws()
+    {
+        var queue = new LaunchDeferralQueue();
+
+        Assert.Throws<ArgumentNullException>(() => queue.Defer(null!));
+    }
+}

--- a/windows/Ghostty.Tests/SingleInstance/LaunchSplashDecisionTests.cs
+++ b/windows/Ghostty.Tests/SingleInstance/LaunchSplashDecisionTests.cs
@@ -1,0 +1,80 @@
+using System;
+using Ghostty.Core.SingleInstance;
+using Xunit;
+
+namespace Ghostty.Tests.SingleInstance;
+
+/// <summary>
+/// The role table and the warm rule, without an OS mutex in sight. The
+/// election's own theory over the same property lives in the Windows test
+/// project; this one covers the half a real election cannot reach, which is
+/// what a warm probe answers and what happens when it answers badly.
+/// </summary>
+public sealed class LaunchSplashDecisionTests
+{
+    [Theory]
+    [InlineData(SingleInstanceRole.Disabled, true)]
+    [InlineData(SingleInstanceRole.Primary, true)]
+    [InlineData(SingleInstanceRole.Failed, true)]
+    [InlineData(SingleInstanceRole.Secondary, false)]
+    public void WithNoProbeInstalled_TheAnswerIsTheRoleTableAlone(
+        SingleInstanceRole role, bool expected)
+    {
+        Assert.Equal(expected, LaunchSplashDecision.ShouldShow(role, warmProbe: null));
+    }
+
+    // The probe is the only thing that can suppress a splash on a launch that
+    // opens a window here, so a probe that says "warm" is a promise this type
+    // has to honour exactly: a splash that flashes over an already-warm attach
+    // is the defect this seam exists to remove.
+    [Fact]
+    public void AWarmAnswer_SuppressesTheSplash_OnALaunchThatWouldShowOne()
+    {
+        Assert.False(LaunchSplashDecision.ShouldShow(
+            SingleInstanceRole.Primary, warmProbe: () => true));
+        Assert.False(LaunchSplashDecision.ShouldShow(
+            SingleInstanceRole.Disabled, warmProbe: () => true));
+    }
+
+    [Fact]
+    public void AColdAnswer_KeepsTheSplash()
+    {
+        Assert.True(LaunchSplashDecision.ShouldShow(
+            SingleInstanceRole.Primary, warmProbe: () => false));
+    }
+
+    // A secondary forwards and exits, and the splash it would put up is
+    // full-size, opaque and topmost over the primary's window. No warm answer
+    // changes that, because the window being covered was never this process's.
+    [Fact]
+    public void ASecondary_NeverShowsASplash_EvenWhenNothingIsWarm()
+    {
+        Assert.False(LaunchSplashDecision.ShouldShow(
+            SingleInstanceRole.Secondary, warmProbe: () => false));
+    }
+
+    // Fail towards the splash. It comes down on its own once there is real
+    // content, so a probe that cannot answer costs a flash; the opposite
+    // failure, suppressing a splash behind a probe that throws, uncovers a
+    // black window with no way back.
+    [Fact]
+    public void AThrowingProbe_IsReadAsCold()
+    {
+        Assert.True(LaunchSplashDecision.ShouldShow(
+            SingleInstanceRole.Primary, warmProbe: () => throw new InvalidOperationException()));
+    }
+
+    // The probe is asked at most once per launch and the answer is used for
+    // that launch alone, so a probe with a side effect cannot be silently
+    // promoted into something polled.
+    [Fact]
+    public void TheProbeIsAskedOncePerDecision()
+    {
+        var asked = 0;
+
+        LaunchSplashDecision.ShouldShow(
+            SingleInstanceRole.Primary, warmProbe: () => { asked++; return false; });
+
+        Assert.Equal(1, asked);
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/LaunchDeferralWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/LaunchDeferralWiringTests.cs
@@ -21,7 +21,10 @@ namespace Ghostty.Tests.Wiring;
 /// </summary>
 public class LaunchDeferralWiringTests
 {
-    private static ShellSource OnLaunched() => ShellSource.Load("App.xaml.cs").Method("OnLaunched");
+    // MethodDeclarationSyntax, not ShellSource: Method() unwraps to the node,
+    // and every assertion below walks its body rather than the file.
+    private static MethodDeclarationSyntax OnLaunched()
+        => ShellSource.Load("App.xaml.cs").Method("OnLaunched");
 
     /// <summary>
     /// There has to be exactly one readiness edge, and it has to come after

--- a/windows/Ghostty.Tests/Wiring/LaunchDeferralWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/LaunchDeferralWiringTests.cs
@@ -1,0 +1,103 @@
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// A forwarded launch that arrives before the app can act on it now waits
+/// instead of vanishing, and the pre-XAML splash is skippable when a warm
+/// session is ready to attach. Both are timing, and timing is exactly what a
+/// test host cannot see, so these guards pin the shape: one readiness edge,
+/// reached after the server is listening, and a splash gated on a decision
+/// that can say no.
+///
+/// What they can catch: the drain deleted, or moved ahead of the server so a
+/// request still in flight is replayed into an app that has already begun
+/// coming down, or a splash shown without consulting the gate.
+///
+/// What they cannot catch: whether a deferred launch ever opens a window.
+/// That needs a second process forwarding over a real pipe.
+/// </summary>
+public class LaunchDeferralWiringTests
+{
+    private static ShellSource OnLaunched() => ShellSource.Load("App.xaml.cs").Method("OnLaunched");
+
+    /// <summary>
+    /// There has to be exactly one readiness edge, and it has to come after
+    /// the server is listening. Before the server starts there is nothing to
+    /// defer; after it, a request can be enqueued from a pipe thread while the
+    /// UI thread is still inside OnLaunched, and replaying the queue before
+    /// that point would take a launch that arrived legally and act on it in
+    /// whatever half-built state the app was in when the queue was drained.
+    /// </summary>
+    [Fact]
+    public void TheQueueIsDrained_AfterTheForwardingServerStarts()
+    {
+        var launched = OnLaunched();
+
+        var statements = launched.Body!.Statements;
+        var server = statements.TakeWhile(
+            s => !s.ToString().Contains("StartSingleInstanceServer()")).Count();
+        var drain = statements.TakeWhile(
+            s => !s.ToString().Contains("DrainDeferredLaunches()")).Count();
+
+        Assert.True(server < statements.Count, "OnLaunched no longer starts the forwarding server");
+        Assert.True(drain < statements.Count, "OnLaunched no longer drains the deferral queue");
+        Assert.True(
+            server < drain,
+            "the deferral queue is drained before the server starts, which replays "
+            + "launches that had not arrived yet");
+    }
+
+    /// <summary>
+    /// The drain is the readiness edge, so it must be reachable exactly once.
+    /// A second one means two places can latch readiness, and the queue's
+    /// contract is that the second call drains nothing -- a caller relying on
+    /// it to replay would silently drop whatever arrived in between.
+    /// </summary>
+    [Fact]
+    public void ThereIsExactlyOneDrainCall()
+    {
+        var app = ShellSource.Load("App.xaml.cs");
+
+        Assert.Single(app.Root.Calls("DrainDeferredLaunches"));
+    }
+
+    /// <summary>
+    /// The not-ready path has to end in the queue. Rewriting it back to a bare
+    /// return compiles, passes every unit test, and puts the silent launch
+    /// loss straight back: the secondary has already exited believing it was
+    /// served.
+    /// </summary>
+    [Fact]
+    public void TheNotReadyPathDefersRatherThanReturningBare()
+    {
+        var method = ShellSource.Load("App.xaml.cs").Method("OpenWindowFromLaunch");
+
+        Assert.NotNull(method.Call("_deferredLaunches.Defer"));
+    }
+
+    /// <summary>
+    /// The splash decision is made before WinUI starts and is the one place
+    /// that can say no. Gating on anything else, or inlining the role test,
+    /// leaves a warm session with a full-size topmost rectangle drawn over it
+    /// on its way up.
+    /// </summary>
+    [Fact]
+    public void TheSplashIsShownOnlyThroughTheGate()
+    {
+        var gui = ShellSource.Load("Program.cs").Method("StartGui");
+
+        var show = Assert.Single(gui.Calls("Ghostty.Shell.SplashWindow.Show"));
+
+        // The gate is a property read, so it parses as a member access rather
+        // than an invocation and has to be found through the if that guards
+        // the show. Reading the guard rather than the proximity of two spans
+        // is what stops a second unconditional Show from passing.
+        var gate = show.Ancestors().OfType<IfStatementSyntax>().FirstOrDefault();
+        Assert.True(
+            gate?.Condition.ToString().Contains("ShouldShowLaunchSplash") == true,
+            "SplashWindow.Show is not guarded by the launch-splash decision");
+    }
+}

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -98,6 +98,11 @@ public partial class App : Application
     // This field is the forwarding pipe server, which only a primary runs.
     private Ghostty.Hosting.SingleInstanceServer? _singleInstanceServer;
 
+    // Where a forwarded launch waits when nothing here can open a window for
+    // it yet. UI-thread only, and drained once, from OnLaunched; see
+    // DrainDeferredLaunches.
+    private readonly Ghostty.Core.SingleInstance.LaunchDeferralQueue _deferredLaunches = new();
+
 
     // The quake chord comes from the quick-terminal-key config value
     // (read via ConfigService.QuickTerminalKeyChord). QuickTerminalKeyChord.Default
@@ -828,15 +833,22 @@ public partial class App : Application
         // out and opened its own window, which is the whole thing
         // windows-single-instance is for.
         //
-        // Not earlier either, and this is the constraint that pins it here:
-        // OpenWindowFromLaunch drops a request outright if _configService,
-        // _loggerFactory, _lifetimeSupervisor or _bootstrapHost is still null,
-        // and the last of those is the line above. Listening before that turns
-        // a visible failure (the secondary cannot connect, so it opens its own
-        // window) into a silent one (it connects, exits, and its launch is
-        // discarded). Anything that wants to serve sooner has to make that
-        // drop a deferral first.
+        // Not earlier either. It used to be a correctness constraint: the
+        // drop inside OpenWindowFromLaunch turned a listener that came up
+        // too soon into a discarded launch, which is worse than the visible
+        // failure of a secondary that cannot connect and opens its own
+        // window. That drop is a deferral now, so an earlier listener would
+        // be safe; nothing wants it earlier, because every expensive step is
+        // below this line and a request served here still waits on the same
+        // window the splash is covering.
         StartSingleInstanceServer();
+
+        // Replay whatever arrived while the dependencies above were still
+        // being built. Today the server does not start until they exist, so
+        // this drains an empty queue; it is here rather than folded into the
+        // null check in OpenWindowFromLaunch because there has to be one
+        // readiness edge and it has to be findable.
+        DrainDeferredLaunches();
 
         // App-level: High Contrast is a system-wide state and config is
         // applied app-wide, so a single monitor drives the surface override.
@@ -1136,12 +1148,24 @@ public partial class App : Application
         if (_configService is null || _bootstrapHost is null
             || _lifetimeSupervisor is null || _loggerFactory is null)
         {
-            // Unreachable as things stand: the server does not start until
-            // every one of these exists, and this runs on the UI thread, which
-            // is inside OnLaunched until then. Kept because the cost of being
-            // wrong is a launch that vanishes with no window and no message --
-            // the secondary has already exited believing it was served.
-            Ghostty.Logging.StaticLoggers.App.LogSingleInstanceLaunchDropped();
+            // Reachable once the server listens before OnLaunched has finished
+            // building these, and after teardown has begun on a half-disposed
+            // app whose pipe callback is still enqueued. The secondary has
+            // already exited believing it was served, so what happens to the
+            // request here decides whether the user gets the window they asked
+            // for or nothing at all.
+            if (!_deferredLaunches.Defer(req, out var evicted))
+            {
+                // Only the post-readiness half of that: the edge in OnLaunched
+                // has already passed, so there is no later one to wait for.
+                Ghostty.Logging.StaticLoggers.App.LogSingleInstanceLaunchDropped();
+                return;
+            }
+
+            if (evicted is not null)
+                Ghostty.Logging.StaticLoggers.App.LogSingleInstanceLaunchEvicted();
+            else
+                Ghostty.Logging.StaticLoggers.App.LogSingleInstanceLaunchDeferred();
             return;
         }
 
@@ -1164,6 +1188,24 @@ public partial class App : Application
         HandleJumpListLaunch(
             Ghostty.Core.JumpList.JumpListLaunch.Parse(req.Args),
             req.WorkingDirectory);
+    }
+
+    /// <summary>
+    /// Open the windows for the launches that arrived before
+    /// <see cref="OpenWindowFromLaunch"/> could act on them. Called once, from
+    /// OnLaunched, at the readiness edge.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Ghostty.Core.SingleInstance.LaunchDeferralQueue.MarkReady"/>
+    /// latches, so a launch that re-defers part way through this loop, because
+    /// teardown nulled a dependency under it, is reported as lost rather than
+    /// parked for an edge that will never come. The queue is bounded and this
+    /// is its only drain, which is what keeps that an error and not a leak.
+    /// </remarks>
+    private void DrainDeferredLaunches()
+    {
+        foreach (var req in _deferredLaunches.MarkReady())
+            OpenWindowFromLaunch(req);
     }
 
     // Toast activation ---------------------------------------------------
@@ -2162,4 +2204,14 @@ internal static partial class AppLogExtensions
                    Level = LogLevel.Error,
                    Message = "Forwarded launch discarded: the app was not ready to open a window. The user's launch was lost.")]
     internal static partial void LogSingleInstanceLaunchDropped(this ILogger<App> logger);
+
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.SingleInstance.LaunchDeferred,
+                   Level = LogLevel.Information,
+                   Message = "Forwarded launch deferred: no window could be opened yet. It will be replayed once one is ready.")]
+    internal static partial void LogSingleInstanceLaunchDeferred(this ILogger<App> logger);
+
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.SingleInstance.LaunchEvicted,
+                   Level = LogLevel.Error,
+                   Message = "Forwarded launch discarded: the deferral queue reached its cap and the oldest waiting launch was evicted. The user's launch was lost.")]
+    internal static partial void LogSingleInstanceLaunchEvicted(this ILogger<App> logger);
 }

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -833,21 +833,25 @@ public partial class App : Application
         // out and opened its own window, which is the whole thing
         // windows-single-instance is for.
         //
-        // Not earlier either. It used to be a correctness constraint: the
-        // drop inside OpenWindowFromLaunch turned a listener that came up
-        // too soon into a discarded launch, which is worse than the visible
-        // failure of a secondary that cannot connect and opens its own
-        // window. That drop is a deferral now, so an earlier listener would
-        // be safe; nothing wants it earlier, because every expensive step is
-        // below this line and a request served here still waits on the same
-        // window the splash is covering.
+        // Here, and not earlier, because every one of the four things
+        // OpenWindowFromLaunch needs is already built above this line. That
+        // stopped being a safety constraint when the drop inside it became a
+        // deferral: a request reaching the server before its dependencies
+        // existed used to be discarded, and now waits. So moving this call
+        // above the dependency block would be safe, and nothing wants it
+        // today -- everything expensive is below this line, and a request
+        // served here still waits on the same window the splash is covering.
+        // The wiring guard pins the drain coming after this call, which is
+        // what would keep a move of that kind honest rather than accidental.
         StartSingleInstanceServer();
 
-        // Replay whatever arrived while the dependencies above were still
-        // being built. Today the server does not start until they exist, so
-        // this drains an empty queue; it is here rather than folded into the
-        // null check in OpenWindowFromLaunch because there has to be one
-        // readiness edge and it has to be findable.
+        // Replay whatever the queue is holding. Today it holds nothing: the
+        // server does not start until every dependency exists, so no request
+        // can be waiting by the time this runs. It is still this method that
+        // latches readiness, because there has to be one edge and it has to
+        // be findable, and because that is what makes the branch in
+        // OpenWindowFromLaunch a net for a future earlier listener rather
+        // than a second decision site.
         DrainDeferredLaunches();
 
         // App-level: High Contrast is a system-wide state and config is
@@ -1108,22 +1112,33 @@ public partial class App : Application
         {
             _singleInstanceServer = new Ghostty.Hosting.SingleInstanceServer(
                 election.Names.Pipe,
-                req => _uiDispatcher?.TryEnqueue(() =>
+                req =>
                 {
-                    try
+                    // TryEnqueue answers false on a queue that is shutting
+                    // down, and reads null when the dispatcher is already
+                    // gone. Either way the request has nowhere to go, and
+                    // this is the only place that would ever know: the
+                    // secondary has already exited believing it was served.
+                    var queued = _uiDispatcher?.TryEnqueue(() =>
                     {
-                        OpenWindowFromLaunch(req);
-                    }
-                    catch (Exception ex)
-                    {
-                        // Enqueued from a pipe thread onto the UI thread, so
-                        // nothing above catches it: an escape here is an
-                        // unhandled UI-thread exception and the process goes
-                        // down. Losing one forwarded launch is the cheaper
-                        // failure.
-                        Ghostty.Logging.StaticLoggers.App.LogInboundLaunchFailed(ex);
-                    }
-                }),
+                        try
+                        {
+                            OpenWindowFromLaunch(req);
+                        }
+                        catch (Exception ex)
+                        {
+                            // Enqueued from a pipe thread onto the UI thread, so
+                            // nothing above catches it: an escape here is an
+                            // unhandled UI-thread exception and the process goes
+                            // down. Losing one forwarded launch is the cheaper
+                            // failure.
+                            Ghostty.Logging.StaticLoggers.App.LogInboundLaunchFailed(ex);
+                        }
+                    }) == true;
+
+                    if (!queued)
+                        Ghostty.Logging.StaticLoggers.App.LogSingleInstanceLaunchDropped();
+                },
                 _loggerFactory.CreateLogger<Ghostty.Hosting.SingleInstanceServer>());
             _singleInstanceServer.Start();
         }
@@ -1148,12 +1163,15 @@ public partial class App : Application
         if (_configService is null || _bootstrapHost is null
             || _lifetimeSupervisor is null || _loggerFactory is null)
         {
-            // Reachable once the server listens before OnLaunched has finished
-            // building these, and after teardown has begun on a half-disposed
-            // app whose pipe callback is still enqueued. The secondary has
-            // already exited believing it was served, so what happens to the
-            // request here decides whether the user gets the window they asked
-            // for or nothing at all.
+            // Reachable today only in teardown, on a half-disposed app whose
+            // pipe callback is still enqueued: the forwarding server does not
+            // start until every one of these exists, so nothing reaches here
+            // during startup. Written as a net rather than an assertion
+            // because the server is free to move above the dependency block,
+            // and the day it does, a request arriving early waits here instead
+            // of vanishing. The secondary has already exited believing it was
+            // served either way, so this branch decides whether the user gets
+            // the window they asked for or nothing at all.
             if (!_deferredLaunches.Defer(req, out var evicted))
             {
                 // Only the post-readiness half of that: the edge in OnLaunched
@@ -1204,8 +1222,22 @@ public partial class App : Application
     /// </remarks>
     private void DrainDeferredLaunches()
     {
+        // MarkReady has already emptied the queue by the time the loop runs,
+        // so a throw out of one replay would take every launch behind it and
+        // unwind OnLaunched to the fatal path. Same contract as the pipe
+        // callback above: one launch failing costs that launch, not the
+        // process and not the launches queued behind it.
         foreach (var req in _deferredLaunches.MarkReady())
-            OpenWindowFromLaunch(req);
+        {
+            try
+            {
+                OpenWindowFromLaunch(req);
+            }
+            catch (Exception ex)
+            {
+                Ghostty.Logging.StaticLoggers.App.LogInboundLaunchFailed(ex);
+            }
+        }
     }
 
     // Toast activation ---------------------------------------------------

--- a/windows/Ghostty/Logging/LogEvents.cs
+++ b/windows/Ghostty/Logging/LogEvents.cs
@@ -106,6 +106,8 @@ internal static class LogEvents
         public const int ServerStartFailed = 2905;
         public const int InboundLaunchFailed = 2906;
         public const int LaunchDropped     = 2907;
+        public const int LaunchDeferred    = 2908;
+        public const int LaunchEvicted     = 2909;
     }
 
     // 3000-3099: Inspector

--- a/windows/Ghostty/Shell/LaunchIconCoordinator.cs
+++ b/windows/Ghostty/Shell/LaunchIconCoordinator.cs
@@ -26,7 +26,11 @@ namespace Ghostty.Shell;
 /// produced content, so a surface whose shell never writes anything
 /// will never raise it. Hence the grace period: once composition has
 /// happened, the splash waits a bounded time for the surface and then
-/// gives up rather than outstaying its welcome.</para>
+/// gives up rather than outstaying its welcome. The bound is shorter
+/// than the coldest compose-to-present gap on record, so a start that
+/// slow now shows the last of the gap through; the trade is deliberate,
+/// because the grace is spent only by a surface with nothing to say and
+/// a splash held over a ready app is its own defect.</para>
 ///
 /// <para>Lifted out of MainWindow for the same reason as
 /// <see cref="LayoutCoordinator"/>: the window is a composition root,
@@ -36,11 +40,21 @@ internal sealed class LaunchIconCoordinator
 {
     /// <summary>
     /// How long to wait for the surface to present after WinUI has
-    /// composed. Sized to cover the observed compose-to-present gap with
-    /// headroom; past this the splash comes down regardless, on the
+    /// composed. Sized to hold over most of the cold compose-to-present
+    /// gap without outstaying a warm start, where the surface has content
+    /// almost immediately and the splash is the only thing left to
+    /// dismiss; past this the splash comes down regardless, on the
     /// assumption the surface has nothing to draw.
     /// </summary>
-    private const int SurfaceGraceMs = 2500;
+    /// <remarks>
+    /// Only a surface that never raises <c>first_render</c> waits the whole
+    /// grace out. A shell that writes anything dismisses the splash the
+    /// moment its first frame presents, so the cap binds on the empty
+    /// surface and on nothing else -- which is why it can be shorter than
+    /// the coldest gap ever observed and still not cost a normal start its
+    /// coverage.
+    /// </remarks>
+    private const int SurfaceGraceMs = 1500;
 
     private readonly DispatcherQueue _dispatcher;
 

--- a/windows/Ghostty/Shell/LaunchIconCoordinator.cs
+++ b/windows/Ghostty/Shell/LaunchIconCoordinator.cs
@@ -26,11 +26,10 @@ namespace Ghostty.Shell;
 /// produced content, so a surface whose shell never writes anything
 /// will never raise it. Hence the grace period: once composition has
 /// happened, the splash waits a bounded time for the surface and then
-/// gives up rather than outstaying its welcome. The bound is shorter
-/// than the coldest compose-to-present gap on record, so a start that
-/// slow now shows the last of the gap through; the trade is deliberate,
-/// because the grace is spent only by a surface with nothing to say and
-/// a splash held over a ready app is its own defect.</para>
+/// gives up rather than outstaying its welcome. That is the only case
+/// the bound is reached in, so shortening it risks only a surface with
+/// nothing to say, and a splash held over an app that is ready to show
+/// itself is its own defect.</para>
 ///
 /// <para>Lifted out of MainWindow for the same reason as
 /// <see cref="LayoutCoordinator"/>: the window is a composition root,
@@ -40,19 +39,16 @@ internal sealed class LaunchIconCoordinator
 {
     /// <summary>
     /// How long to wait for the surface to present after WinUI has
-    /// composed. Sized to hold over most of the cold compose-to-present
-    /// gap without outstaying a warm start, where the surface has content
-    /// almost immediately and the splash is the only thing left to
-    /// dismiss; past this the splash comes down regardless, on the
+    /// composed. Past this the splash comes down regardless, on the
     /// assumption the surface has nothing to draw.
     /// </summary>
     /// <remarks>
-    /// Only a surface that never raises <c>first_render</c> waits the whole
-    /// grace out. A shell that writes anything dismisses the splash the
-    /// moment its first frame presents, so the cap binds on the empty
-    /// surface and on nothing else -- which is why it can be shorter than
-    /// the coldest gap ever observed and still not cost a normal start its
-    /// coverage.
+    /// The bound is reached in exactly one case: composition happened and
+    /// <c>first_render</c> never did, because the surface has nothing to
+    /// draw. A shell that writes anything dismisses the splash the moment
+    /// its first frame presents, well inside this, so the shorter value
+    /// costs a content-less surface the last stretch of its wait and costs
+    /// a normal start nothing at all.
     /// </remarks>
     private const int SurfaceGraceMs = 1500;
 


### PR DESCRIPTION
Warm sessions, P3. Four changes, all base-tier, all plumbing: nothing
here changes what a user sees unless a warm session layer is there to
answer.

## Launch deferral in OpenWindowFromLaunch

`OpenWindowFromLaunch` dropped a request when `_configService`,
`_loggerFactory`, `_lifetimeSupervisor` or `_bootstrapHost` was still
null. The secondary has already written the request down the pipe and
exited believing it was served, so the drop was a window the user asked
for that never appeared. #631 calls it "the one failure that costs a user
their launch with nothing to show for it" and left it in place because it
was unreachable: the forwarding server does not start until the last of
those four exists, which is the same constraint that pins the server to
the end of `OnLaunched`.

The drop is a deferral now. Requests that arrive before the app can act
wait in `LaunchDeferralQueue` and are replayed on the readiness edge, so
serving a forwarded launch sooner stops being a correctness question and
becomes a performance one.

Details that were decisions rather than defaults:

- **Eight, and it makes room rather than refusing.** The gap it bridges is
  the tail of startup, so a queue deep enough to reach the cap is a sign
  the app is wedged. The OLDEST entry is the one given up, because the
  newest is the launch the user is looking at and the oldest is the one
  most likely superseded by it.
- **One readiness edge, and it does not come back.** `MarkReady` latches.
  A request turned away after it is reported as lost rather than parked
  for an edge that will never come, which is the post-teardown case where
  a pipe callback lands on a half-disposed app.
- **No lock.** Both ends run on the UI thread, so a lock would add nothing
  the dispatcher does not already guarantee.

Not wired to sessiond here. This is the precondition, not the move.

## Warm-detection hook on ShouldShowLaunchSplash

`ShouldShowLaunchSplash` was a role test, so every launch that would open
a window here put the pre-XAML splash up first. It now reads
`LaunchSplashDecision.WarmSessionProbe`, an `internal static
Func<bool>?` settable before `Application.Start`.

- The decision still runs in `StartGui`, before WinUI exists, so whatever
  sits behind the probe must not need a DispatcherQueue, a config handle
  or a window.
- Null is the default and null means show the splash. A throw from the
  probe reads the same way, deliberately: the splash comes down on its own
  once there is real content, so an unanswered probe costs a flash, while
  the opposite failure uncovers a black window with no way back.
- Nothing in this repository sets it yet. This is the seam the sessions
  layer plugs into.

## Surface grace 2.5s to 1.5s

`SurfaceGraceMs` is how long the splash holds over a window that has
composed but not presented. Nothing spends it except a surface that never
raises `first_render`: a shell that writes anything dismisses the splash
the moment its first frame presents, well inside a second. The whole of
the extra headroom was therefore a cost paid only by an empty surface, in
the one case where a splash held over a ready app is itself the defect.

A cold start slower than 1.5s now shows the tail of the gap rather than
the splash covering it. That is the trade, stated in the comment rather
than inherited.

## #763

Not included. It is three sources of truth for the pre-config background:
a `ghostty_builtin_theme_background` export out of `wintty_theme.zig`, a
`SplashWindow` that reads it instead of hardcoding `0x131620`/`0xF4F6FB`,
an `OsTheme` path for the splash instead of the registry read, and a
`BackgroundFollowsOsTheme` that sees conditional user themes. None of
that is in these files, and the first item is a Zig-side export. Left
open.

## Files

- `windows/Ghostty.Core/SingleInstance/LaunchDeferralQueue.cs` (new)
- `windows/Ghostty.Core/SingleInstance/LaunchSplashDecision.cs` (new)
- `windows/Ghostty.Core/SingleInstance/SingleInstanceElection.cs`
- `windows/Ghostty/App.xaml.cs`
- `windows/Ghostty/Logging/LogEvents.cs`
- `windows/Ghostty/Shell/LaunchIconCoordinator.cs`
- `windows/Ghostty.Tests/SingleInstance/LaunchDeferralQueueTests.cs` (new)
- `windows/Ghostty.Tests/SingleInstance/LaunchSplashDecisionTests.cs` (new)
- `windows/Ghostty.Tests/Wiring/LaunchDeferralWiringTests.cs` (new)
- `windows/Ghostty.Tests.Windows/SingleInstance/SingleInstanceElectionTests.cs`

## Verification

Targeted only, per the epic process. No full-suite run, no `just signoff`,
no Windows ladder on this host.

- `LaunchDeferralQueueTests`, 7 tests, and `LaunchSplashDecisionTests`, 5
  tests and 4 theory rows: all green. These two files compile against
  nothing but `LaunchRequest` and `SingleInstanceRole`, so they were
  compiled with the real xunit 2.9.2 assemblies and executed outside the
  test host; the cap behaviour they pin (oldest evicted, newest held,
  count stays at `Capacity`) is the part most worth having run.
- `LaunchDeferralWiringTests`, 4 tests: source-shape guards over
  `App.xaml.cs` and `Program.cs`. Every query they make was run against
  the real parsed sources as written, which is how `StartGui` turned out
  to be the splash decision site rather than `MainImpl`, and how the
  repeated-overflow expectation in the queue test got corrected before it
  could be committed wrong.
- `SingleInstanceElectionTests.TheSplashGate_ReadsTheInstalledWarmProbe`
  needs a real mutex and so has not run; it extends an existing theory
  rather than replacing one, and the existing rows are untouched.

Compile-plausible rather than compiled for the WinUI half: `App.xaml.cs`
and `LaunchIconCoordinator.cs` parse clean under the same DEMO+DEBUG
preprocessor set the wiring tests use, but they need .NET 10 and the
Windows legs. Deferred to the end-of-series fix loop.
