### PR TITLE
panes: repair the startup glow against the WinUI 3 API surface

### DIFF
--- a/windows/Ghostty.Tests/Wiring/PaneStartupGlowWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/PaneStartupGlowWiringTests.cs
@@ -299,6 +299,10 @@ public class PaneStartupGlowWiringTests
     /// parsed file, because a unit test cannot build a compositor; the list is
     /// explicit so dropping one of them from Dispose has to delete a line
     /// here too.
+    ///
+    /// The stop collections are the deliberate absence: WinUI 3 gives
+    /// <c>CompositionColorGradientStopCollection</c> no Dispose, so releasing
+    /// the owning brush is the whole teardown they get.
     /// </summary>
     [Fact]
     public void Dispose_ReleasesEveryCompositionObjectTheGlowCreated()
@@ -311,7 +315,7 @@ public class PaneStartupGlowWiringTests
         foreach (var owner in new[]
                  {
                      "_shapeVisual", "_coreShape", "_haloShape", "_geometry",
-                     "_coreBrush", "_coreStops", "_haloBrush", "_haloStops",
+                     "_coreBrush", "_haloBrush",
                      "_fade", "_orbit", "_easing",
                  })
         {
@@ -323,6 +327,10 @@ public class PaneStartupGlowWiringTests
         var invokes = dispose.DescendantNodesAndSelf().OfType<InvocationExpressionSyntax>();
         foreach (var stops in new[] { "_coreStops", "_haloStops" })
             Assert.Contains(invokes, i => i.CalleeText() == "DisposeStops" && i.Arg(0) == stops);
+
+        // ...and the absence stays absent: a direct Dispose on the collection
+        // is the CS1061 that broke the build, so pin that it never comes back.
+        Assert.DoesNotContain(calls, c => c is "_coreStops.Dispose" or "_haloStops.Dispose");
 
         // Stopping an animation on a closed object throws, so the stops all
         // come before the first release.

--- a/windows/Ghostty/Panes/PaneStartupGlow.cs
+++ b/windows/Ghostty/Panes/PaneStartupGlow.cs
@@ -20,7 +20,7 @@ namespace Ghostty.Panes;
 /// Tuning constants (thickness, radius, stops, loop period) live here; the
 /// lifecycle timing (cap, fade) lives in PaneStartupGlowState.
 /// </summary>
-internal sealed class PaneStartupGlow : IDisposable
+internal sealed partial class PaneStartupGlow : IDisposable
 {
     private const float CoreThickness = 4f;
     private const float HaloThickness = 12f;
@@ -30,8 +30,10 @@ internal sealed class PaneStartupGlow : IDisposable
     private readonly FrameworkElement _mount;
     private readonly Compositor _compositor;
     private readonly ShapeVisual _shapeVisual;
-    private readonly SpriteShape _coreShape;
-    private readonly SpriteShape _haloShape;
+    // WinUI 3 prefixed the type (CompositionSpriteShape); only the factory
+    // kept the UWP-era name.
+    private readonly CompositionSpriteShape _coreShape;
+    private readonly CompositionSpriteShape _haloShape;
     private readonly CompositionRoundedRectangleGeometry _geometry;
     private readonly CompositionColorGradientStopCollection _coreStops;
     private readonly CompositionColorGradientStopCollection _haloStops;
@@ -178,13 +180,13 @@ internal sealed class PaneStartupGlow : IDisposable
         _geometry.Dispose();
 
         // Each brush's gradient graph. The stops are composition objects of
-        // their own and go before the collection holding them: enumerating a
-        // closed collection is the one order that would throw.
+        // their own and go before the brush holding them: enumerating a
+        // released collection is the one order that would throw. WinUI 3
+        // gives the stop collection itself no Dispose; releasing the brush
+        // releases it.
         DisposeStops(_coreStops);
-        _coreStops.Dispose();
         _coreBrush.Dispose();
         DisposeStops(_haloStops);
-        _haloStops.Dispose();
         _haloBrush.Dispose();
 
         // The animations themselves, the forever orbit included: left running


### PR DESCRIPTION
Windows tip does not build: #814 shipped PaneStartupGlow.cs against API names that do not exist in WinUI 3. Three faults, each verified against the WinAppSDK metadata (the interactive-experiences winmd, not the winui facade dll):

- The type is CompositionSpriteShape, not SpriteShape / ICompositionSpriteShape; only Compositor.CreateSpriteShape kept the UWP-era name.
- CompositionColorGradientStopCollection has no Dispose in WinUI 3 (it does not even derive from CompositionObject there). Releasing the owning brush is the teardown; the per-stop Disposes stay.
- CsWinRT1028 is WarningsAsErrors in Directory.Build.props, so the IDisposable-implementing class must be partial.

No behavior change: the creation path is byte-identical and the teardown order (stop collections via DisposeStops, then the brushes) is preserved. The wiring fact gains an absence pin so a future WinAppSDK that re-adds a collection Dispose still gets caught.