### PR TITLE
tabs: group ops in the palette; rename and color as dialog ops

### DIFF
--- a/windows/Ghostty.Core/Input/PaneAction.cs
+++ b/windows/Ghostty.Core/Input/PaneAction.cs
@@ -144,4 +144,22 @@ public enum PaneAction
     // no keybind-catalog verb -- the palette entry is the keyboard path.
     PinTab = 66,
     UnpinTab = 67,
+
+    // Group operations on the ACTIVE TAB'S GROUP (ungrouped active tab is
+    // a silent no-op; the router's refusal guards decide the rest). Same
+    // palette-and-menu-only ruling as PinTab/UnpinTab: no KeyBindings
+    // match and no keybind-catalog verb -- catalog verbs for these are a
+    // separately approved follow-up. AddToGroup is deliberately absent:
+    // the palette has no group chooser, so joining stays a context-menu
+    // op until one exists. RenameGroup/ColorGroup are dialog ops: the
+    // router forwards them to the window, which owns the XamlRoot the
+    // dialog and the picker need.
+    NewGroupWithTab = 68,
+    RemoveFromGroup = 69,
+    CollapseGroup = 70,
+    ExpandGroup = 71,
+    DissolveGroup = 72,
+    CloseGroup = 73,
+    RenameGroup = 74,
+    ColorGroup = 75,
 }

--- a/windows/Ghostty.Core/Tabs/TabAccessibleText.cs
+++ b/windows/Ghostty.Core/Tabs/TabAccessibleText.cs
@@ -57,9 +57,27 @@ internal static class TabAccessibleText
     /// switcher, pane title) still agrees on.
     /// </summary>
     internal static string Status(bool isPinned, bool bellRinging)
+        => Status(isPinned, bellRinging, groupTitle: null, isCollapsed: false);
+
+    /// <summary>
+    /// The same state plus the membership the row renders under: a grouped
+    /// member carries "Group {title}" so a listener inside a long run
+    /// knows which run they are in -- the row's own title says nothing
+    /// about it, and the header row sits outside keyboard traversal of the
+    /// members. Collapsed rides along because the state is already in
+    /// hand at the call site; a collapsed member is hidden in the vertical
+    /// strip, so the segment mostly matters to clients reading the raw
+    /// tree, where the member still exists.
+    /// </summary>
+    internal static string Status(
+        bool isPinned, bool bellRinging, string? groupTitle, bool isCollapsed)
     {
-        if (!isPinned) return bellRinging ? "Bell" : string.Empty;
-        return bellRinging ? "Pinned, Bell" : "Pinned";
+        var segments = new List<string>();
+        if (isPinned) segments.Add("Pinned");
+        if (!string.IsNullOrEmpty(groupTitle)) segments.Add($"Group {groupTitle}");
+        if (isCollapsed) segments.Add("Collapsed");
+        if (bellRinging) segments.Add("Bell");
+        return string.Join(", ", segments);
     }
 
     /// <summary>
@@ -129,6 +147,22 @@ internal static class TabAccessibleText
     /// <summary>Spoken when a Close Group command starts.</summary>
     internal static string GroupCloseAnnouncement(TabGroup group, int memberCount)
         => $"Closing group {group.Title}, {memberCount} {Tabs(memberCount)}";
+
+    /// <summary>
+    /// Spoken when a rename command lands. The old title is pre-op data
+    /// (the router captures it before the set): after the rename the group
+    /// only knows its new name, and the listener needs the one they heard
+    /// to be told it changed.
+    /// </summary>
+    internal static string GroupRenamedAnnouncement(TabGroup group, string oldTitle)
+        => $"Group {oldTitle} renamed to {group.Title}";
+
+    /// <summary>
+    /// Spoken when a color command lands. The name is the palette's own
+    /// label, the same word the swatch tooltip shows.
+    /// </summary>
+    internal static string GroupColoredAnnouncement(TabGroup group, TabColor color)
+        => $"Group {group.Title} color set to {TabColorPalette.LocalizedName(color)}";
 
     private static string Tabs(int count) => count == 1 ? "tab" : "tabs";
 }

--- a/windows/Ghostty.Tests/Tabs/TabAccessibleTextTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabAccessibleTextTests.cs
@@ -234,6 +234,53 @@ public class TabAccessibleTextTests
     }
 
     /// <summary>
+    /// A grouped member announces its run: the row's own title says nothing
+    /// about which group it sits in, and inside a long list "which run am I
+    /// in" is exactly the question the status has to answer. Collapsed
+    /// composes rather than replaces -- a hidden member that also rings
+    /// must read both -- and an ungrouped member names no group at all.
+    /// </summary>
+    [Fact]
+    public void GroupStatus_NamesTheRun_AndComposesWithTheOtherSegments()
+    {
+        Assert.Equal(
+            "Group build",
+            TabAccessibleText.Status(isPinned: false, bellRinging: false,
+                groupTitle: "build", isCollapsed: false));
+        Assert.Equal(
+            "Group build, Collapsed",
+            TabAccessibleText.Status(isPinned: false, bellRinging: false,
+                groupTitle: "build", isCollapsed: true));
+        Assert.Equal(
+            "Pinned, Group build, Bell",
+            TabAccessibleText.Status(isPinned: true, bellRinging: true,
+                groupTitle: "build", isCollapsed: false));
+        Assert.Equal(
+            "Pinned",
+            TabAccessibleText.Status(isPinned: true, bellRinging: false,
+                groupTitle: null, isCollapsed: false));
+    }
+
+    /// <summary>
+    /// Rename and color speak the change, not just the fact: the rename
+    /// names both titles (a listener cannot follow "group renamed" with no
+    /// from), and the color uses the palette's own label, the same word
+    /// the swatch tooltip shows.
+    /// </summary>
+    [Fact]
+    public void RenameAndColorAnnouncements_NameWhatChanged()
+    {
+        var group = new TabGroup { Title = "build2" };
+
+        Assert.Equal(
+            "Group build renamed to build2",
+            TabAccessibleText.GroupRenamedAnnouncement(group, "build"));
+        Assert.Equal(
+            "Group build2 color set to Green",
+            TabAccessibleText.GroupColoredAnnouncement(group, TabColor.Green));
+    }
+
+    /// <summary>
     /// The vertical strip is where this was reported. The name has to be
     /// on the NavigationViewItem, not on the row inside it: the item is
     /// what surfaces as the ListItem.
@@ -245,7 +292,12 @@ public class TabAccessibleTextTests
         var apply = MethodBody(strip, "private static void ApplyItemTitleChrome");
 
         Assert.Contains("AutomationProperties.SetName(item, TabAccessibleText.Name(", apply);
-        Assert.Contains("AutomationProperties.SetItemStatus(item, TabAccessibleText.Status(", apply);
+        Assert.Contains("AutomationProperties.SetItemStatus(item,", apply);
+        // The status is the tab's; a grouped member adds the run it sits in.
+        Assert.Contains(
+            "TabAccessibleText.Status(tab.IsPinned, tab.BellRinging, group.Title, group.IsCollapsed)",
+            apply);
+        Assert.Contains("TabAccessibleText.Status(tab)", apply);
     }
 
     /// <summary>

--- a/windows/Ghostty.Tests/Wiring/VerticalTabGroupCommandsWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/VerticalTabGroupCommandsWiringTests.cs
@@ -239,9 +239,12 @@ public class VerticalTabGroupCommandsWiringTests
             .Single(a => a.Left.ToString() == "_strip.GroupToggleFromCommandRequested");
         Assert.Contains("RequestCollapseGroup", wiring.Right.ToString());
 
-        // One wiring, not one per gesture: the strip raises from the key
-        // path only (2b adds the UIA pattern to the same event).
-        Assert.Single(Strip().Root.Calls("GroupToggleFromCommandRequested?.Invoke"));
+        // One wiring, not one per gesture: the strip-wide raise set is
+        // exactly the key handler and the header item's UIA pattern
+        // forward (pinned next door in VerticalTabGroupHeaderWiringTests).
+        // Both are commands that announce; the pointer chevron toggles in
+        // place and raises nothing.
+        Assert.Equal(2, Strip().Root.Calls("GroupToggleFromCommandRequested?.Invoke").Count);
     }
 
     /// <summary>
@@ -274,5 +277,211 @@ public class VerticalTabGroupCommandsWiringTests
             declined.Statement.DescendantNodesAndSelf().OfType<BreakStatementSyntax>()
                 .Select(b => b.ToString()),
             s => s == "break;");
+    }
+
+    /// <summary>
+    /// The palette is the keyboard path for the group ops (no default chord
+    /// ships, so the entry IS the keyboard gesture, exactly like Pin Tab):
+    /// one entry per op, and deliberately no Add To Group. The palette is
+    /// a flat command list with no chooser, so an entry there could only
+    /// pick the group for the user or dead-end; the member menu's submenu
+    /// stays that command's keyboard path.
+    /// </summary>
+    [Fact]
+    public void ThePalette_ListsTheGroupOps_AndAddsNoChooser()
+    {
+        var entries = ShellSource.Load("Commands.BuiltInCommandSource.cs")
+            .Root.Calls("AddPaneCommand").ToList();
+        foreach (var (op, label) in new[]
+                 {
+                     ("NewGroupWithTab", "New Group With Tab"),
+                     ("RemoveFromGroup", "Remove From Group"),
+                     ("CollapseGroup", "Collapse Group"),
+                     ("ExpandGroup", "Expand Group"),
+                     ("DissolveGroup", "Dissolve Group"),
+                     ("CloseGroup", "Close Group"),
+                     ("RenameGroup", "Rename Group"),
+                     ("ColorGroup", "Group Color"),
+                 })
+        {
+            var entry = entries.Single(e => e.Arg(1) == $"PaneAction.{op}");
+            Assert.Equal($"\"{label}\"", entry.Arg(2));
+        }
+
+        Assert.DoesNotContain(entries, e => e.Arg(1) == "PaneAction.AddToGroup");
+    }
+
+    /// <summary>
+    /// Palette dispatch resolves every group op against the ACTIVE tab's
+    /// group, and an ungrouped active tab falls out before any Request
+    /// runs. The guard is what keeps the ops listable unconditionally:
+    /// there is no palette shape for "grey out when ungrouped", so the
+    /// silence has to live here.
+    /// </summary>
+    [Fact]
+    public void PaletteDispatch_ActsOnTheActiveTabsGroup_AndFallsOutSilently()
+    {
+        var invoke = Router();
+
+        var collapse = invoke.Case("Invoke", "PaneAction.CollapseGroup");
+        var guarded = collapse.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "group is not null");
+        Assert.Contains("_tabs.ActiveTab?.Group", collapse.ToString());
+        // The target rides the action, not the live bit: collapse asks for
+        // collapsed and expand for expanded, so a same-state command is the
+        // Request's no-op instead of an accidental flip.
+        Assert.Equal("action == PaneAction.CollapseGroup",
+            guarded.Calls("RequestCollapseGroup").Single().Arg(1));
+
+        var dissolve = invoke.Case("Invoke", "PaneAction.DissolveGroup");
+        var fallOut = dissolve.DescendantNodes().OfType<IfStatementSyntax>()
+            .First(i => i.Condition.ToString() == "group is null");
+        Assert.Contains(
+            fallOut.Statement.DescendantNodesAndSelf().OfType<BreakStatementSyntax>()
+                .Select(b => b.ToString()),
+            s => s == "break;");
+        var arms = dissolve.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "action == PaneAction.DissolveGroup");
+        Assert.Contains("RequestDissolveGroup(group)", arms.Statement.ToString());
+        Assert.Contains("RequestCloseGroup(group)", arms.Else!.Statement.ToString());
+
+        var newGroup = invoke.Case("Invoke", "PaneAction.NewGroupWithTab");
+        Assert.Contains("_tabs.ActiveTab", newGroup.ToString());
+        Assert.Contains("RequestNewGroupWithTab(tab)", newGroup.ToString());
+
+        var dialogs = invoke.Case("Invoke", "PaneAction.RenameGroup");
+        var forward = dialogs.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "action == PaneAction.RenameGroup");
+        Assert.Contains("GroupRenameRequested?.Invoke(this, group)",
+            forward.Statement.ToString());
+        Assert.Contains("GroupColorRequested?.Invoke(this, group)",
+            forward.Else!.Statement.ToString());
+    }
+
+    /// <summary>
+    /// The dialog ops are plain INPC sets, so their guards are the whole
+    /// no-op story: a blank title, a group the manager no longer registers
+    /// (a dialog can outlive its dissolve), and the value already in place
+    /// each return before anything mutates or announces. The rename text
+    /// needs the OLD title, so it is captured before the set -- afterwards
+    /// the announcement could only say the new name twice.
+    /// </summary>
+    [Fact]
+    public void RenameAndColorRequests_GuardBeforeSet_BeforeRaise()
+    {
+        var rename = Router().Method("RequestRenameGroup");
+        var blank = rename.DescendantNodes().OfType<IfStatementSyntax>().First();
+        Assert.Equal("string.IsNullOrWhiteSpace(title)", blank.Condition.ToString());
+        var registered = rename.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "!_tabs.Groups.Contains(group)");
+        var sameTitle = rename.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "group.Title == title");
+        var capture = rename.DescendantNodes().OfType<LocalDeclarationStatementSyntax>()
+            .First(d => d.Declaration.Variables.Single().Identifier.ValueText == "old");
+        var set = rename.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Single(a => a.Left.ToString() == "group.Title");
+        var raise = rename.Calls("GroupChangedFromCommand?.Invoke").Single();
+        Assert.True(
+            blank.Span.Start < registered.Span.Start
+            && registered.Span.Start < sameTitle.Span.Start
+            && sameTitle.Span.Start < capture.Span.Start
+            && capture.Span.Start < set.Span.Start
+            && set.Span.Start < raise.Span.Start,
+            "every refusal must precede the set, and the old title must be " +
+            "captured before it is overwritten");
+        Assert.Contains("GroupCommandKind.Renamed", raise.ToString());
+        Assert.Contains("0, old)", raise.ToString());
+
+        var color = Router().Method("RequestColorGroup");
+        var sameColor = color.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "group.Color == color");
+        var colorSet = color.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Single(a => a.Left.ToString() == "group.Color");
+        var colorRaise = color.Calls("GroupChangedFromCommand?.Invoke").Single();
+        Assert.True(
+            sameColor.Span.Start < colorSet.Span.Start
+            && colorSet.Span.Start < colorRaise.Span.Start,
+            "a same-color pick is a no-op that announces nothing");
+        Assert.Contains("GroupCommandKind.Colored", colorRaise.ToString());
+    }
+
+    /// <summary>
+    /// The window hosts the dialog ops because only it owns a XamlRoot and
+    /// an anchor, and it hands the results back through the Requests so the
+    /// announce stays behind the guards. The picker hides before the raise:
+    /// a flyout left open over an applied color invites a second pick that
+    /// can only be the no-op the Request refuses.
+    /// </summary>
+    [Fact]
+    public void TheWindowHostsTheDialogOps_AndHandsResultsBackThroughTheRequests()
+    {
+        var window = Window();
+        var rename = window.Root.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Single(a => a.Left.ToString() == "_router.GroupRenameRequested");
+        Assert.Contains("RenameTabDialog", rename.Right.ToString());
+        Assert.Contains("_dialogs.Track(dlg)", rename.Right.ToString());
+        Assert.Contains("ContentDialogResult.Primary", rename.Right.ToString());
+        Assert.Contains("RequestRenameGroup(group, dlg.Result)", rename.Right.ToString());
+
+        var color = window.Root.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Single(a => a.Left.ToString() == "_router.GroupColorRequested");
+        Assert.Contains("TabColorPalettePicker", color.Right.ToString());
+        var hide = color.Right.Calls("pickerFlyout.Hide").Single();
+        var raise = color.Right.Calls("_router.RequestColorGroup").Single();
+        Assert.True(hide.Span.Start < raise.Span.Start,
+            "the picker closes before the Request runs");
+    }
+
+    /// <summary>
+    /// Renamed and Colored speak what changed, and each kind owns a named
+    /// arm: the trap arm behind them means the next kind added to the enum
+    /// fails the announce loudly instead of narrating nothing (or, with a
+    /// plain default, narrating a collapse that did not happen).
+    /// </summary>
+    [Fact]
+    public void RenamedAndColored_HaveNamedArms_AndTheTrapStays()
+    {
+        var announce = Window().Root.DescendantNodes().OfType<SwitchExpressionSyntax>()
+            .Single(s => s.ToString().Contains("GroupCommandKind"));
+        var arms = announce.Arms.Select(a => a.ToString()).ToList();
+        Assert.Contains(arms, a => a.Contains("GroupCommandKind.Renamed")
+            && a.Contains("GroupRenamedAnnouncement(e.Group, e.OldTitle!)"));
+        Assert.Contains(arms, a => a.Contains("GroupCommandKind.Colored")
+            && a.Contains("GroupColoredAnnouncement(e.Group, e.Group.Color)"));
+        Assert.Contains(arms, a => a.Contains("throw new UnreachableException"));
+    }
+
+    /// <summary>
+    /// The header menu is the full Rename/Color surface, as dialog ops: the
+    /// dialog's result routes through the Request (never a direct set), and
+    /// the color click reuses the per-tab picker core pointed at the
+    /// router. Both lead the menu; collapse stays below its separator.
+    /// </summary>
+    [Fact]
+    public void TheHeaderMenu_CarriesRenameAndColor_AsDialogOpsThroughTheRequests()
+    {
+        var menu = Builder().Method("BuildGroupMenu");
+
+        var renameRoute = menu.Calls("requestRenameGroup").Single();
+        Assert.Equal("dlg.Result", renameRoute.Arg(1));
+        var renameLambda = renameRoute.Ancestors()
+            .OfType<AnonymousFunctionExpressionSyntax>().First();
+        Assert.Contains("RenameTabDialog", renameLambda.ToString());
+        Assert.Contains("dialogs.Track(dlg)", renameLambda.ToString());
+        Assert.Contains("ContentDialogResult.Primary", renameLambda.ToString());
+        // A flyout can outlive its window; a dialog needs somewhere to show.
+        Assert.Contains("XamlRoot is null", renameLambda.ToString());
+
+        var colorRoute = menu.Calls("requestColorGroup").Single();
+        Assert.Equal("c", colorRoute.Arg(1));
+        Assert.Contains("ShowColorPicker(target, group.Color", menu.ToString());
+
+        Assert.True(colorRoute.Span.Start
+            < menu.Calls("requestCollapseGroup").Single().Span.Start,
+            "rename and color lead the menu");
+
+        // The per-tab half of the shared picker keeps its direct INPC set:
+        // a tab color has no command to announce, only a swatch to repaint.
+        Assert.Contains("color => tab.Color = color", Builder().Root.ToString());
     }
 }

--- a/windows/Ghostty.Tests/Wiring/VerticalTabGroupHeaderWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/VerticalTabGroupHeaderWiringTests.cs
@@ -51,7 +51,7 @@ public class VerticalTabGroupHeaderWiringTests
     {
         var add = Strip().Method("AddGroupRow");
         var item = add.DescendantNodes().OfType<ObjectCreationExpressionSyntax>()
-            .Single(o => o.Type.ToString() == "NavigationViewItem");
+            .Single(o => o.Type.ToString() == "VerticalTabGroupHeaderItem");
         var initializers = item.Initializer!.Expressions.OfType<AssignmentExpressionSyntax>()
             .ToDictionary(a => a.Left.ToString(), a => a.Right.ToString());
         Assert.Equal("group", initializers["Tag"]);
@@ -313,5 +313,55 @@ public class VerticalTabGroupHeaderWiringTests
             restore.Calls("header.Focus").Single().Arg(0));
         // The shared toggle stays focus-free: only the pointer path repairs.
         Assert.Empty(strip.Method("ToggleGroup").Calls("RestoreFocusUnder"));
+    }
+
+    /// <summary>
+    /// The header's UIA ExpandCollapse pattern is the keyboard route in a
+    /// screen reader's hands. The item carries the toggle event and raises
+    /// it only from the pattern -- never from pointer, which toggles in
+    /// place -- and the strip forwards it to the command event the key
+    /// handler uses, which is the whole reason the pattern announces. The
+    /// peer mirrors the keyboard polarity (Expand asks for expanded) and
+    /// reads its state live off the group.
+    /// </summary>
+    [Fact]
+    public void TheUIAPattern_FeedsTheCommandEvent_WithTheKeyboardPolarity()
+    {
+        var add = Strip().Method("AddGroupRow");
+        var wiring = add.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Single(a => a.Left.ToString() == "item.GroupToggleRequested");
+        Assert.Contains("GroupToggleFromCommandRequested?.Invoke", wiring.Right.ToString());
+
+        var item = ShellSource.Load("Tabs.VerticalTabGroupHeaderItem.cs");
+        // One raiser, and it is pattern-only: nothing else in the item may
+        // toggle the group on its own.
+        Assert.Single(item.Root.Calls("GroupToggleRequested?.Invoke"));
+        var raiser = item.Method("RaiseGroupToggleFromPattern");
+        var guard = Assert.IsType<IfStatementSyntax>(raiser.Body!.Statements.Single());
+        Assert.Equal("Tag is TabGroup group", guard.Condition.ToString());
+        Assert.Contains("VerticalTabGroupHeaderItemAutomationPeer",
+            item.Method("OnCreateAutomationPeer").ExpressionBody!.ToString());
+
+        var peer = ShellSource.Load(
+            "Accessibility.VerticalTabGroupHeaderItemAutomationPeer.cs");
+        var pattern = Assert.IsType<ConditionalExpressionSyntax>(
+            peer.Method("GetPatternCore").ExpressionBody!.Expression);
+        Assert.Equal("patternInterface == PatternInterface.ExpandCollapse",
+            pattern.Condition.ToString());
+        Assert.Equal("this", pattern.WhenTrue.ToString());
+
+        var state = peer.Root.DescendantNodes().OfType<PropertyDeclarationSyntax>()
+            .Single(p => p.Identifier.ValueText == "ExpandCollapseState");
+        var polarity = Assert.IsType<ConditionalExpressionSyntax>(
+            state.ExpressionBody!.Expression);
+        Assert.Equal("ExpandCollapseState.Collapsed", polarity.WhenTrue.ToString());
+        Assert.Equal("ExpandCollapseState.Expanded", polarity.WhenFalse.ToString());
+
+        Assert.Contains("AutomationControlType.ListItem",
+            peer.Method("GetAutomationControlTypeCore").ExpressionBody!.ToString());
+        Assert.Contains("collapsed: false",
+            peer.Method("Expand").ExpressionBody!.ToString());
+        Assert.Contains("collapsed: true",
+            peer.Method("Collapse").ExpressionBody!.ToString());
     }
 }

--- a/windows/Ghostty/Accessibility/VerticalTabGroupHeaderItemAutomationPeer.cs
+++ b/windows/Ghostty/Accessibility/VerticalTabGroupHeaderItemAutomationPeer.cs
@@ -1,0 +1,44 @@
+using Ghostty.Core.Tabs;
+using Ghostty.Tabs;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Automation.Provider;
+
+namespace Ghostty.Accessibility;
+
+/// <summary>
+/// UIA peer for a group header row: ListItem like the rows around it,
+/// plus the ExpandCollapse pattern -- the only way a keyboard-only or
+/// screen-reader client can fold and unfold a group. The header never
+/// selects, the chevron is a pointer target, and ItemStatus reports the
+/// state without offering a way to change it. Expand and collapse mirror
+/// the keyboard gesture's polarity and land on the same event, so the
+/// command announces and a collapse re-homes focus exactly like pressing
+/// Enter on the header.
+/// </summary>
+internal sealed partial class VerticalTabGroupHeaderItemAutomationPeer
+    : FrameworkElementAutomationPeer, IExpandCollapseProvider
+{
+    public VerticalTabGroupHeaderItemAutomationPeer(VerticalTabGroupHeaderItem owner)
+        : base(owner) { }
+
+    private VerticalTabGroupHeaderItem OwnerItem => (VerticalTabGroupHeaderItem)Owner;
+
+    protected override AutomationControlType GetAutomationControlTypeCore()
+        => AutomationControlType.ListItem;
+
+    protected override object? GetPatternCore(PatternInterface patternInterface)
+        => patternInterface == PatternInterface.ExpandCollapse
+            ? this
+            : base.GetPatternCore(patternInterface);
+
+    public ExpandCollapseState ExpandCollapseState
+        => OwnerItem.Tag is TabGroup { IsCollapsed: true }
+            ? ExpandCollapseState.Collapsed
+            : ExpandCollapseState.Expanded;
+
+    public void Expand() => OwnerItem.RaiseGroupToggleFromPattern(collapsed: false);
+
+    public void Collapse() => OwnerItem.RaiseGroupToggleFromPattern(collapsed: true);
+}

--- a/windows/Ghostty/Commands/BuiltInCommandSource.cs
+++ b/windows/Ghostty/Commands/BuiltInCommandSource.cs
@@ -67,6 +67,19 @@ internal sealed class BuiltInCommandSource : ICommandSource
         AddPaneCommand(commands, PaneAction.MoveTabLeft, "Move Tab Left", "Move the active tab one position left", CommandCategory.Tab);
         AddPaneCommand(commands, PaneAction.PinTab, "Pin Tab", "Pin the active tab into the pinned zone", CommandCategory.Tab, "\uE718");
         AddPaneCommand(commands, PaneAction.UnpinTab, "Unpin Tab", "Unpin the active tab from the pinned zone", CommandCategory.Tab, "\uE77A");
+        // Group ops act on the active tab's group and no-op silently when
+        // it is ungrouped, so every entry lists unconditionally (the pin
+        // pair lists the same way). No Add To Group here: the palette has
+        // no group chooser, and a chooser-less entry would either pick
+        // for the user or dead-end.
+        AddPaneCommand(commands, PaneAction.NewGroupWithTab, "New Group With Tab", "Start a group from the active tab", CommandCategory.Tab, "\uE71F");
+        AddPaneCommand(commands, PaneAction.RemoveFromGroup, "Remove From Group", "Take the active tab out of its group", CommandCategory.Tab, "\uE74D");
+        AddPaneCommand(commands, PaneAction.CollapseGroup, "Collapse Group", "Fold the active tab's group under its header", CommandCategory.Tab, "\uE70D");
+        AddPaneCommand(commands, PaneAction.ExpandGroup, "Expand Group", "Unfold the active tab's group", CommandCategory.Tab, "\uE70E");
+        AddPaneCommand(commands, PaneAction.DissolveGroup, "Dissolve Group", "Ungroup every member of the active tab's group", CommandCategory.Tab, "\uE74D");
+        AddPaneCommand(commands, PaneAction.CloseGroup, "Close Group", "Close every member of the active tab's group", CommandCategory.Tab, "\uE711");
+        AddPaneCommand(commands, PaneAction.RenameGroup, "Rename Group", "Rename the active tab's group", CommandCategory.Tab, "\uE8AC");
+        AddPaneCommand(commands, PaneAction.ColorGroup, "Group Color", "Pick a color for the active tab's group", CommandCategory.Tab, "\uE790");
         AddPaneCommand(commands, PaneAction.ToggleVerticalTabsPinned, "Toggle Vertical Tabs Pinned", "Pin or unpin the vertical tab sidebar", CommandCategory.Tab);
         AddTabLayoutSwitchCommand(commands);
         AddPaneCommand(commands, PaneAction.ToggleQuickTerminal, "Toggle Quake Terminal", "Show or hide the singleton drop-down terminal", CommandCategory.Terminal, icon: null, pathKey: "quake");

--- a/windows/Ghostty/Input/PaneActionRouter.cs
+++ b/windows/Ghostty/Input/PaneActionRouter.cs
@@ -335,6 +335,52 @@ internal sealed class PaneActionRouter
                     RequestPin(tab, action == PaneAction.PinTab);
                 break;
             }
+            // Group ops act on the active tab's group; an ungrouped active
+            // tab falls out silently, and each Request's own refusal guards
+            // (pinned refusal, same-state silence, landed-bit gate) decide
+            // the rest -- the palette adds no policy of its own.
+            case PaneAction.NewGroupWithTab:
+            {
+                var tab = _tabs.ActiveTab;
+                if (tab is not null) RequestNewGroupWithTab(tab);
+                break;
+            }
+            case PaneAction.RemoveFromGroup:
+            {
+                var tab = _tabs.ActiveTab;
+                if (tab is not null) RequestRemoveFromGroup(tab);
+                break;
+            }
+            case PaneAction.CollapseGroup:
+            case PaneAction.ExpandGroup:
+            {
+                var group = _tabs.ActiveTab?.Group;
+                if (group is not null)
+                    RequestCollapseGroup(group, action == PaneAction.CollapseGroup);
+                break;
+            }
+            case PaneAction.DissolveGroup:
+            case PaneAction.CloseGroup:
+            {
+                var group = _tabs.ActiveTab?.Group;
+                if (group is null) break;
+                if (action == PaneAction.DissolveGroup) RequestDissolveGroup(group);
+                else RequestCloseGroup(group);
+                break;
+            }
+            // Rename and color are dialog ops: the op itself is a plain
+            // INPC set, but opening the dialog and the picker needs a
+            // XamlRoot, so the window hosts them and hands the result
+            // back through the Request below.
+            case PaneAction.RenameGroup:
+            case PaneAction.ColorGroup:
+            {
+                var group = _tabs.ActiveTab?.Group;
+                if (group is null) break;
+                if (action == PaneAction.RenameGroup) GroupRenameRequested?.Invoke(this, group);
+                else GroupColorRequested?.Invoke(this, group);
+                break;
+            }
             default:
                 throw new ArgumentOutOfRangeException(nameof(action), action, null);
         }
@@ -422,6 +468,8 @@ internal sealed class PaneActionRouter
         Removed,
         Dissolved,
         Collapsed,
+        Renamed,
+        Colored,
     }
 
     /// <summary>
@@ -430,12 +478,16 @@ internal sealed class PaneActionRouter
     /// the announcement source falls back to the focused element).
     /// <paramref name="MemberCount"/> is PRE-op on purpose: it feeds
     /// Dissolved, and after the op the group owns no members to count.
+    /// <paramref name="OldTitle"/> is pre-op too: Renamed lands the new
+    /// title on the group, so the text could otherwise only say the new
+    /// name twice.
     /// </summary>
     internal readonly record struct GroupCommandData(
         GroupCommandKind Kind,
         TabGroup Group,
         TabModel? Tab,
-        int MemberCount);
+        int MemberCount,
+        string? OldTitle = null);
 
     /// <summary>
     /// Raised after a commanded group change has landed, for the window to
@@ -460,6 +512,22 @@ internal sealed class PaneActionRouter
     /// path, which needs a XamlRoot the manager and this router lack.
     /// </summary>
     public event EventHandler<TabGroup>? GroupCloseRequested;
+
+    /// <summary>
+    /// Raised when a command asks to rename a group. Rename is a dialog
+    /// op: the router has no XamlRoot to host RenameTabDialog, so the
+    /// window shows it and hands the result back through
+    /// <see cref="RequestRenameGroup"/>, which performs the set and the
+    /// announce. The menu path opens the same dialog directly.
+    /// </summary>
+    public event EventHandler<TabGroup>? GroupRenameRequested;
+
+    /// <summary>
+    /// Raised when a command asks to recolor a group. The palette picker
+    /// is a Flyout, so like rename this forwards to the window, which owns
+    /// both the XamlRoot and an element to anchor it on.
+    /// </summary>
+    public event EventHandler<TabGroup>? GroupColorRequested;
 
     /// <summary>
     /// New Group With Tab: a fresh group whose sole member is the given
@@ -546,6 +614,35 @@ internal sealed class PaneActionRouter
     {
         if (!_tabs.Groups.Contains(group)) return;
         GroupCloseRequested?.Invoke(this, group);
+    }
+
+    /// <summary>
+    /// Rename a group: a plain INPC set, no manager op -- the title lives
+    /// on the group alone and the strips re-read it through their group
+    /// bindings. A blank title, a group the manager no longer registers
+    /// (a dialog can outlive a dissolve), or the title the group already
+    /// has is a no-op that announces nothing.
+    /// </summary>
+    public void RequestRenameGroup(TabGroup group, string? title)
+    {
+        if (string.IsNullOrWhiteSpace(title)) return;
+        if (!_tabs.Groups.Contains(group)) return;
+        if (group.Title == title) return;
+        var old = group.Title;
+        group.Title = title;
+        GroupChangedFromCommand?.Invoke(this, new(GroupCommandKind.Renamed, group, null, 0, old));
+    }
+
+    /// <summary>
+    /// Recolor a group: the same plain-set shape as rename. Picking the
+    /// color the group already wears is a no-op that announces nothing.
+    /// </summary>
+    public void RequestColorGroup(TabGroup group, TabColor color)
+    {
+        if (!_tabs.Groups.Contains(group)) return;
+        if (group.Color == color) return;
+        group.Color = color;
+        GroupChangedFromCommand?.Invoke(this, new(GroupCommandKind.Colored, group, null, 0));
     }
 
     /// <summary>

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -31,6 +31,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.UI.Composition.SystemBackdrops;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Windows.Win32;
@@ -885,15 +886,19 @@ public sealed partial class MainWindow : Window
                     TabAccessibleText.GroupDissolvedAnnouncement(e.Group, e.MemberCount),
                 PaneActionRouter.GroupCommandKind.Collapsed =>
                     TabAccessibleText.GroupCollapseAnnouncement(e.Group),
+                PaneActionRouter.GroupCommandKind.Renamed =>
+                    TabAccessibleText.GroupRenamedAnnouncement(e.Group, e.OldTitle!),
+                PaneActionRouter.GroupCommandKind.Colored =>
+                    TabAccessibleText.GroupColoredAnnouncement(e.Group, e.Group.Color),
                 // A kind added later must pick its announcement arm: the
                 // trap fails the announce loudly rather than narrating a
                 // collapse that did not happen. (A default-less enum
                 // switch warns CS8524 even when fully covered.)
                 _ => throw new UnreachableException("unnamed GroupCommandKind"),
             };
-            // Dissolve is group-level, so it carries no tab: ride the
-            // focused element and fall back to the active tab's item, or
-            // Announce refuses the null and the op narrates nothing.
+            // Group-level kinds carry no tab: ride the focused element and
+            // fall back to the active tab's item, or Announce refuses the
+            // null and the op narrates nothing.
             UiaAnnouncer.Announce(
                 e.Tab is null
                     ? (FocusManager.GetFocusedElement(Content.XamlRoot) as FrameworkElement)
@@ -934,6 +939,42 @@ public sealed partial class MainWindow : Window
                 members = _tabManager.MembersOf(group);
                 if (members.Count > 0 && ReferenceEquals(members[0], first)) break;
             }
+        };
+
+        // Rename and color are dialog ops the router cannot host (no
+        // XamlRoot): the palette entry forwards here, the dialog or the
+        // picker collects the value, and the Request performs the plain
+        // INPC set and the announce. The header menu opens the same dialog
+        // directly.
+        _router.GroupRenameRequested += async (_, group) =>
+        {
+            if (Content?.XamlRoot is null) return;
+            var dlg = new RenameTabDialog(group.Title) { XamlRoot = Content.XamlRoot };
+            using (_dialogs.Track(dlg))
+            {
+                var res = await dlg.ShowAsync();
+                if (res == ContentDialogResult.Primary)
+                    _router.RequestRenameGroup(group, dlg.Result);
+            }
+        };
+
+        _router.GroupColorRequested += (_, group) =>
+        {
+            var anchor = _tabManager.ActiveTab is { } tab ? _tabHost.TabElement(tab) : null;
+            if (anchor is null) return;
+            var picker = new TabColorPalettePicker(group.Color);
+            var pickerFlyout = new Flyout
+            {
+                Content = picker,
+                Placement = FlyoutPlacementMode.Bottom,
+                ShouldConstrainToRootBounds = true,
+            };
+            picker.ColorSelected += (_, color) =>
+            {
+                pickerFlyout.Hide();
+                _router.RequestColorGroup(group, color);
+            };
+            pickerFlyout.ShowAt(anchor);
         };
 
         AppWindow.Changed += (_, args) =>

--- a/windows/Ghostty/Tabs/TabContextMenuBuilder.cs
+++ b/windows/Ghostty/Tabs/TabContextMenuBuilder.cs
@@ -229,22 +229,54 @@ internal static class TabContextMenuBuilder
 
     /// <summary>
     /// The header row's right-click menu (vertical only; horizontal grows
-    /// a chip equivalent in PR 6). Collapse routes through the router so
-    /// the command announces and the strip re-homes focus under the folding
-    /// run; Close Group greys out exactly when the group's members are all
-    /// the window's tabs, the same rule as Move Tab to New Window. Built
-    /// fresh per right-click, so the collapse label reads the live bit --
-    /// but the label still re-evaluates on Opening, because the header can
-    /// be toggled (chevron) between build and open.
+    /// a chip equivalent in PR 6). Rename and color are dialog ops like
+    /// the per-tab menu's: the item hosts the dialog and hands the result
+    /// to the router, so a commanded rename announces and a drag-performed
+    /// title change stays silent. Collapse routes through the router so
+    /// the command announces and the strip re-homes focus under the
+    /// folding run; Close Group greys out exactly when the group's members
+    /// are all the window's tabs, the same rule as Move Tab to New Window.
+    /// Built fresh per right-click, so the collapse label reads the live
+    /// bit -- but the label still re-evaluates on Opening, because the
+    /// header can be toggled (chevron) between build and open.
     /// </summary>
     public static MenuFlyout BuildGroupMenu(
         TabManager manager,
         TabGroup group,
+        DialogTracker dialogs,
         Action<TabGroup, bool> requestCollapseGroup,
         Action<TabGroup> requestDissolveGroup,
-        Action<TabGroup> requestCloseGroup)
+        Action<TabGroup> requestCloseGroup,
+        Action<TabGroup, string?> requestRenameGroup,
+        Action<TabGroup, TabColor> requestColorGroup)
     {
         var flyout = new MenuFlyout();
+
+        var rename = new MenuFlyoutItem { Text = "Rename Group" };
+        rename.Click += async (_, _) =>
+        {
+            var target = flyout.Target;
+            if (target?.XamlRoot is null) return;
+            var dlg = new RenameTabDialog(group.Title) { XamlRoot = target.XamlRoot };
+            using (dialogs.Track(dlg))
+            {
+                var res = await dlg.ShowAsync();
+                if (res == ContentDialogResult.Primary)
+                    requestRenameGroup(group, dlg.Result);
+            }
+        };
+        flyout.Items.Add(rename);
+
+        var color = new MenuFlyoutItem { Text = "Group Color..." };
+        color.Click += (_, _) =>
+        {
+            var target = flyout.Target as FrameworkElement;
+            if (target is null) return;
+            ShowColorPicker(target, group.Color, c => requestColorGroup(group, c));
+        };
+        flyout.Items.Add(color);
+
+        flyout.Items.Add(new MenuFlyoutSeparator());
 
         var collapse = new MenuFlyoutItem
         {
@@ -274,11 +306,15 @@ internal static class TabContextMenuBuilder
     }
 
     private static void ShowColorPicker(FrameworkElement anchor, TabModel tab)
+        => ShowColorPicker(anchor, tab.Color, color => tab.Color = color);
+
+    private static void ShowColorPicker(
+        FrameworkElement anchor, TabColor initial, Action<TabColor> apply)
     {
         // Build the secondary flyout fresh each invocation. Cheap, and
         // avoids any stale selection-ring state from the previous
         // right-click.
-        var picker = new TabColorPalettePicker(tab.Color);
+        var picker = new TabColorPalettePicker(initial);
         var subFlyout = new Flyout
         {
             Content = picker,
@@ -288,7 +324,7 @@ internal static class TabContextMenuBuilder
 
         picker.ColorSelected += (_, color) =>
         {
-            tab.Color = color;
+            apply(color);
             subFlyout.Hide();
         };
 

--- a/windows/Ghostty/Tabs/VerticalTabGroupHeaderItem.cs
+++ b/windows/Ghostty/Tabs/VerticalTabGroupHeaderItem.cs
@@ -1,0 +1,35 @@
+using Ghostty.Accessibility;
+using Ghostty.Core.Tabs;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Ghostty.Tabs;
+
+/// <summary>
+/// The NavigationViewItem a group header renders as, and the only seam a
+/// custom automation peer can be attached through: a plain
+/// NavigationViewItem lets a screen reader read the collapse state off
+/// ItemStatus but offers no pattern to change it. The item carries the
+/// toggle EVENT rather than toggling itself, so a pattern invoke lands on
+/// the same command path the keyboard gesture uses -- through the strip
+/// to the router, which announces. The pointer chevron keeps its direct,
+/// silent toggle.
+/// </summary>
+internal sealed partial class VerticalTabGroupHeaderItem : NavigationViewItem
+{
+    public VerticalTabGroupHeaderItem()
+    {
+    }
+
+    /// <summary>Raised by the UIA ExpandCollapse pattern only, never by pointer.</summary>
+    internal event EventHandler<(TabGroup Group, bool Collapsed)>? GroupToggleRequested;
+
+    protected override AutomationPeer OnCreateAutomationPeer()
+        => new VerticalTabGroupHeaderItemAutomationPeer(this);
+
+    internal void RaiseGroupToggleFromPattern(bool collapsed)
+    {
+        if (Tag is TabGroup group)
+            GroupToggleRequested?.Invoke(this, (group, collapsed));
+    }
+}

--- a/windows/Ghostty/Tabs/VerticalTabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabHost.xaml.cs
@@ -216,9 +216,12 @@ internal sealed partial class VerticalTabHost : UserControl, ITabHost
             var groupFlyout = TabContextMenuBuilder.BuildGroupMenu(
                 _manager,
                 group,
+                _dialogs,
                 requestCollapseGroup: _router.RequestCollapseGroup,
                 requestDissolveGroup: _router.RequestDissolveGroup,
-                requestCloseGroup: _router.RequestCloseGroup);
+                requestCloseGroup: _router.RequestCloseGroup,
+                requestRenameGroup: _router.RequestRenameGroup,
+                requestColorGroup: _router.RequestColorGroup);
 
             var header = (FrameworkElement?)VisualTreeHelperEx.FindAncestor<NavigationViewItem>(source);
             if (header is not null && e.TryGetPosition(header, out Point groupPos))

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -1531,7 +1531,9 @@ internal sealed partial class VerticalTabStrip : UserControl
     {
         ToolTipService.SetToolTip(item, tab.EffectiveTitle);
         AutomationProperties.SetName(item, TabAccessibleText.Name(tab));
-        AutomationProperties.SetItemStatus(item, TabAccessibleText.Status(tab));
+        AutomationProperties.SetItemStatus(item, tab.Group is { } group
+            ? TabAccessibleText.Status(tab.IsPinned, tab.BellRinging, group.Title, group.IsCollapsed)
+            : TabAccessibleText.Status(tab));
     }
 
     private void OnRowCloseClick(object sender, RoutedEventArgs e)
@@ -1586,12 +1588,17 @@ internal sealed partial class VerticalTabStrip : UserControl
     private void AddGroupRow(TabGroup group)
     {
         if (_headers.ContainsKey(group)) return;
-        var item = new NavigationViewItem
+        var item = new VerticalTabGroupHeaderItem
         {
             Tag = group,
             SelectsOnInvoked = false,
             Content = new VerticalTabGroupHeaderRow(group, _manager.MembersOf(group).Count),
         };
+        // The header's UIA ExpandCollapse pattern is keyboard-equivalent:
+        // it lands on the strip's command event (routes through the
+        // router, announces), never on the chevron's direct toggle.
+        item.GroupToggleRequested += (_, e) =>
+            GroupToggleFromCommandRequested?.Invoke(this, e);
         ApplyGroupChrome(item, group);
 
         var binding = AotBinding.Create(group, _ => ScheduleReconcile(),


### PR DESCRIPTION
Group operations become palette commands (Category.Tab, no default keybinds, no catalog verbs): New Group With Tab, Remove From Group, Collapse Group, Expand Group, Dissolve Group, Close Group, Rename Group, Color Group. Each rides the same router Requests the context menus use and acts on the active tab's group; ungrouped or refused commands fall out silently. Add To Group stays context-menu-only - the palette has no chooser, and a chooser-less entry would either pick a group for the user or dead-end.

Rename and Color are dialog ops: the router raises a request, the window hosts RenameTabDialog / the color picker flyout and hands the result back through RequestRenameGroup / RequestColorGroup, which guard (blank title, unregistered group, same title/color) before the plain INPC set and the announcement. The header context menu opens the same dialog and picker.

Group headers gain a UIA ExpandCollapse peer that raises the strip's existing command event, so a screen reader's collapse/expand announces and re-homes focus exactly like the keyboard gesture; the pointer chevron stays silent. TabAccessibleText.Status gains a 4-arg overload so grouped members announce their group title and collapsed state.