### PR TITLE
core: name the unit space for group drags

### DIFF
--- a/windows/Ghostty.Core/Tabs/TabGroupDragUnits.cs
+++ b/windows/Ghostty.Core/Tabs/TabGroupDragUnits.cs
@@ -1,0 +1,111 @@
+using System.Collections.Generic;
+
+namespace Ghostty.Core.Tabs;
+
+/// <summary>
+/// One slot in a group drag's unit space: an ungrouped tab, or a whole
+/// group represented by its header. The run is the atom -- a crossing
+/// swaps the dragged run past an entire neighbouring unit, never past
+/// one row of it, because a run that landed between another group's
+/// header and its members would split a run the projector cannot
+/// render (a header is always in front of all of its members).
+/// </summary>
+internal sealed class GroupDragUnit
+{
+    /// <summary>
+    /// The lone tab, or the run's first member. The run is found by
+    /// identity through this tab; index arithmetic into the manager is
+    /// how a direction bug hides, so nothing keys off it but First.
+    /// </summary>
+    internal required TabModel Rep;
+
+    /// <summary>The run's group, null for a lone tab.</summary>
+    internal required TabGroup? Group;
+
+    /// <summary>Manager index of the run's first member.</summary>
+    internal required int First;
+
+    /// <summary>Manager size of the run: one for a lone tab.</summary>
+    internal required int Count;
+}
+
+/// <summary>
+/// The unit space a vertical group drag speaks: body runs in manager
+/// order, one unit per run, with the MoveGroup targets a crossing maps
+/// to. The pinned prefix contributes nothing -- groups cannot be pinned
+/// and a run that crossed into the prefix would be clamped right back,
+/// so the units never offer a crossing the commit would refuse (the
+/// same no-false-promise rule the pin ghost obeys). MoveGroup's clamp
+/// stays as the backstop.
+///
+/// Hidden members change nothing here: collapse hides rows, and a run
+/// is one unit at its first member whether every member is visible or
+/// only the active one (Edge-135) or none. Geometry is the strip's to
+/// measure; this class is pure manager reading so the mapping and both
+/// target directions are unit-testable without a host.
+///
+/// This is the second strip-private mapping, and it gets the same
+/// treatment the first one earned: the target formulas are pinned by
+/// executing them against a real manager, because a flipped direction
+/// passes every source scan and every wiring pin.
+/// </summary>
+internal static class TabGroupDragUnits
+{
+    /// <summary>
+    /// The units, in manager order. Emitted at a run's first member only;
+    /// the walk is identity-driven (a HashSet, not an index comparison),
+    /// so contiguity is assumed, not enforced.
+    /// </summary>
+    internal static IReadOnlyList<GroupDragUnit> Build(TabManager manager)
+    {
+        var units = new List<GroupDragUnit>();
+        var seen = new HashSet<TabGroup>();
+        var tabs = manager.Tabs;
+        for (int i = 0; i < tabs.Count; i++)
+        {
+            var tab = tabs[i];
+            if (tab.IsPinned) continue;
+            if (tab.Group is { } group)
+            {
+                if (!seen.Add(group)) continue;
+                units.Add(new GroupDragUnit
+                {
+                    Rep = tab,
+                    Group = group,
+                    First = i,
+                    Count = manager.MembersOf(group).Count,
+                });
+            }
+            else
+            {
+                units.Add(new GroupDragUnit
+                {
+                    Rep = tab,
+                    Group = null,
+                    First = i,
+                    Count = 1,
+                });
+            }
+        }
+        return units;
+    }
+
+    /// <summary>
+    /// The MoveGroup target when the dragged run swaps DOWN past
+    /// <paramref name="pivot"/>: the run lands after the pivot's last
+    /// member, so the head's final index is the pivot's span plus the
+    /// room the dragged run's own departure leaves. Executing this is
+    /// the oracle -- the tests assert final manager order, not the
+    /// formula.
+    /// </summary>
+    internal static int TargetAfter(IReadOnlyList<GroupDragUnit> units, GroupDragUnit dragged, int pivot)
+        => units[pivot].First + units[pivot].Count - dragged.Count;
+
+    /// <summary>
+    /// The MoveGroup target when the dragged run swaps UP past
+    /// <paramref name="pivot"/>: the run lands before the pivot's first
+    /// member, whose index the dragged run's departure does not move.
+    /// </summary>
+    internal static int TargetBefore(IReadOnlyList<GroupDragUnit> units, int pivot)
+        => units[pivot].First;
+}

--- a/windows/Ghostty.Tests/Tabs/TabGroupDragUnitsTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabGroupDragUnitsTests.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Ghostty.Core.Tabs;
+using Xunit;
+
+namespace Ghostty.Tests.Tabs;
+
+/// <summary>
+/// The unit space a vertical group drag speaks, and the two MoveGroup
+/// targets its crossings map to. This is strip-private mapping of
+/// exactly the kind 5b-1's lesson is about: a flipped direction here
+/// passes every source scan and every wiring pin, so the target
+/// formulas are pinned by EXECUTING them against a real manager and
+/// asserting the final order -- the drag commits through MoveGroup, and
+/// a wrong target is a wrong order, visibly.
+/// </summary>
+public class TabGroupDragUnitsTests
+{
+    private static TabManager NewManager(int count)
+    {
+        var mgr = new TabManager((_) => new FakePaneHost());
+        for (int i = 0; i < count; i++) mgr.NewTab();
+        return mgr;
+    }
+
+    // [t0, g1a, g1b, t3, g2a, g2b, g2c, t7] -- two runs of different
+    // sizes around lone tabs, the shape that exposes an off-by-one or a
+    // row-swap treated as a run-swap. The manager seeds one tab, so
+    // seven extra makes the eight the indices below speak of.
+    private static (TabManager Mgr, TabModel[] T, TabGroup G1, TabGroup G2) NewMixed()
+    {
+        var mgr = NewManager(7);
+        var t = mgr.Tabs.ToArray();
+        var g1 = mgr.CreateGroup(t[1])!;
+        mgr.JoinGroup(t[2], g1);
+        var g2 = mgr.CreateGroup(t[4])!;
+        mgr.JoinGroup(t[5], g2);
+        mgr.JoinGroup(t[6], g2);
+        return (mgr, t, g1, g2);
+    }
+
+    [Fact]
+    public void Build_names_one_unit_per_run_in_manager_order()
+    {
+        var (mgr, t, g1, g2) = NewMixed();
+
+        var units = TabGroupDragUnits.Build(mgr);
+
+        Assert.Equal(5, units.Count);
+        Assert.Null(units[0].Group);
+        Assert.Equal(0, units[0].First);
+        Assert.Equal(1, units[0].Count);
+        Assert.Same(g1, units[1].Group);
+        Assert.Equal(1, units[1].First);
+        Assert.Equal(2, units[1].Count);
+        Assert.Same(t[1], units[1].Rep);
+        Assert.Null(units[2].Group);
+        Assert.Equal(3, units[2].First);
+        Assert.Same(t[3], units[2].Rep);
+        Assert.Same(g2, units[3].Group);
+        Assert.Equal(4, units[3].First);
+        Assert.Equal(3, units[3].Count);
+        Assert.Null(units[4].Group);
+        Assert.Equal(7, units[4].First);
+    }
+
+    [Fact]
+    public void Build_skips_the_pinned_prefix_and_keeps_body_firsts()
+    {
+        var (mgr, t, _, _) = NewMixed();
+        mgr.SetPinned(t[0], true);
+
+        var units = TabGroupDragUnits.Build(mgr);
+
+        // The prefix contributes no unit, and every body First counts
+        // manager slots, pinned ones included: the mapping is into the
+        // manager, not into the unit list.
+        Assert.Equal(4, units.Count);
+        Assert.Equal(new[] { 1, 3, 4, 7 }, units.Select(u => u.First).ToArray());
+    }
+
+    [Fact]
+    public void Collapse_changes_nothing()
+    {
+        var (mgr, _, _, g2) = NewMixed();
+        mgr.CollapseGroup(g2, true);
+
+        // One unit per run whether every member is visible, only the
+        // active one is, or none is: hidden members have no geometry,
+        // but the run is still one atom the drag moves.
+        var units = TabGroupDragUnits.Build(mgr);
+        Assert.Equal(5, units.Count);
+
+        // The collapsed run's own span is the formula input collapse
+        // could plausibly bend -- counting visible members would read
+        // 1 here and silently over-cross once the strip rides it.
+        Assert.Equal(4, units[3].First);
+        Assert.Equal(3, units[3].Count);
+    }
+
+    [Fact]
+    public void TargetAfter_swaps_whole_runs_and_lands_whole()
+    {
+        var (mgr, t, g1, _) = NewMixed();
+        var units = TabGroupDragUnits.Build(mgr);
+
+        // g1 down past the lone tab at 3: head lands at 3 + 1 - 2.
+        var target = TabGroupDragUnits.TargetAfter(units, units[1], pivot: 2);
+        Assert.Equal(2, target);
+        mgr.MoveGroup(g1, target);
+
+        Assert.Equal(new[] { t[0], t[3], t[1], t[2], t[4], t[5], t[6], t[7] },
+            mgr.Tabs.ToArray());
+    }
+
+    [Fact]
+    public void TargetAfter_crosses_an_entire_neighbour_run()
+    {
+        var (mgr, t, g1, g2) = NewMixed();
+        var units = TabGroupDragUnits.Build(mgr);
+
+        // g1 down past g2 (three members): the head lands after the
+        // whole neighbour run, never inside it.
+        var target = TabGroupDragUnits.TargetAfter(units, units[1], pivot: 3);
+        Assert.Equal(5, target);
+        mgr.MoveGroup(g1, target);
+
+        Assert.Equal(new[] { t[0], t[3], t[4], t[5], t[6], t[1], t[2], t[7] },
+            mgr.Tabs.ToArray());
+    }
+
+    [Fact]
+    public void TargetBefore_lands_before_the_pivot_run()
+    {
+        var (mgr, t, _, g2) = NewMixed();
+        var units = TabGroupDragUnits.Build(mgr);
+
+        // g2 up past g1: its head lands at g1's first slot, the whole
+        // run before the pivot run.
+        var target = TabGroupDragUnits.TargetBefore(units, pivot: 1);
+        Assert.Equal(1, target);
+        mgr.MoveGroup(g2, target);
+
+        Assert.Equal(new[] { t[0], t[4], t[5], t[6], t[1], t[2], t[3], t[7] },
+            mgr.Tabs.ToArray());
+    }
+
+    [Fact]
+    public void TargetBefore_at_the_first_unit_lands_on_the_clamp_low_edge()
+    {
+        var (mgr, t, _, g2) = NewMixed();
+        var units = TabGroupDragUnits.Build(mgr);
+
+        // g2 up past unit 0: the pivot's First IS the clamp-low bound
+        // (nothing pinned, so 0). The commit must ride the edge
+        // exactly -- not a slot short into a refused crossing, not a
+        // clamped near-miss.
+        var target = TabGroupDragUnits.TargetBefore(units, pivot: 0);
+        Assert.Equal(0, target);
+        mgr.MoveGroup(g2, target);
+
+        Assert.Equal(new[] { t[4], t[5], t[6], t[0], t[1], t[2], t[3], t[7] },
+            mgr.Tabs.ToArray());
+    }
+
+    [Fact]
+    public void TargetAfter_at_the_last_unit_lands_on_the_clamp_top_edge()
+    {
+        var (mgr, t, g1, _) = NewMixed();
+        var units = TabGroupDragUnits.Build(mgr);
+
+        // g1 down past the last unit: 7 + 1 - 2 is exactly the clamp
+        // top for a two-member run in eight tabs, so the run lands on
+        // the final two slots whole and the formula needs no extra
+        // clamping to be in range.
+        var target = TabGroupDragUnits.TargetAfter(units, units[1], pivot: 4);
+        Assert.Equal(6, target);
+        mgr.MoveGroup(g1, target);
+
+        Assert.Equal(new[] { t[0], t[3], t[4], t[5], t[6], t[7], t[1], t[2] },
+            mgr.Tabs.ToArray());
+    }
+
+    [Fact]
+    public void Down_then_up_round_trips()
+    {
+        var (mgr, _, g1, _) = NewMixed();
+        var before = mgr.Tabs.ToArray();
+
+        var units = TabGroupDragUnits.Build(mgr);
+        mgr.MoveGroup(g1, TabGroupDragUnits.TargetAfter(units, units[1], pivot: 2));
+
+        var after = TabGroupDragUnits.Build(mgr);
+        int home = after.Select((u, i) => (u, i)).First(p => ReferenceEquals(p.u.Group, g1)).i;
+        mgr.MoveGroup(g1, TabGroupDragUnits.TargetBefore(after, pivot: home - 1));
+
+        Assert.Equal(before, mgr.Tabs.ToArray());
+    }
+
+    [Fact]
+    public void A_single_unit_strip_has_nothing_to_reorder()
+    {
+        var mgr = NewManager(1);
+        var g = mgr.CreateGroup(mgr.Tabs[0])!;
+        mgr.JoinGroup(mgr.Tabs[1], g);
+
+        // Two tabs, one run: the strip refuses to arm a drag, because
+        // the machine needs two units to swap.
+        Assert.Single(TabGroupDragUnits.Build(mgr));
+    }
+}


### PR DESCRIPTION
First half of the split rung 5b: one unit per body run for group drags (pinned prefix contributes none), with TargetAfter/TargetBefore as the only crossing-to-index mapping a MoveGroup commit needs. The oracle executes every formula against a real manager and commits, including the collapsed-run span and both clamp edges. The strip integration that consumes it lands as the follow-up half.