### PR TITLE
core: horizontal chip rows and the slot mapping

### DIFF
--- a/windows/Ghostty.Core/Tabs/TabStripProjection.cs
+++ b/windows/Ghostty.Core/Tabs/TabStripProjection.cs
@@ -108,10 +108,10 @@ internal static class TabStripProjection
     /// Contiguity (a manager invariant) is what puts each header in front
     /// of all of its members; this walk does not re-order anything.
     ///
-    /// The collapsed-with-active shape above is VERTICAL's. Horizontal's
-    /// is different -- the active member surfaces as a plain row and the
-    /// chip is suppressed (4.3) -- and that reading is PR 6's consumer,
-    /// not a second projection here.
+    /// The collapsed-with-active shape above is VERTICAL's. Horizontal
+    /// lowers these same rows -- see <see cref="HorizontalRows"/> -- so
+    /// the two strips read one walk and cannot disagree on what is
+    /// visible.
     /// </summary>
     public static IReadOnlyList<ProjectedRow> GroupedRows(TabManager manager)
     {
@@ -132,5 +132,110 @@ internal static class TabStripProjection
             }
         }
         return rows;
+    }
+
+    /// <summary>
+    /// One row the horizontal strip renders: the <see cref="GroupedRows"/>
+    /// sequence with each header lowered to the shape the strip draws.
+    /// </summary>
+    public abstract record HorizontalRow
+    {
+        /// <summary>
+        /// A collapsed run that does not hold the active tab, rendered as
+        /// ONE item. Its members are hidden and reachable only by
+        /// expanding.
+        /// </summary>
+        public sealed record Chip(TabGroup Group) : HorizontalRow;
+
+        /// <summary>
+        /// A tab rendered as itself: ungrouped, pinned, a member of an
+        /// expanded run, or the active member of a collapsed run.
+        /// </summary>
+        public sealed record Item(TabModel Tab) : HorizontalRow;
+    }
+
+    /// <summary>
+    /// The horizontal strip's reading. An expanded run contributes its
+    /// members alone -- the strip draws no header rows, and the run label
+    /// names a run the strip itself does not draw. A collapsed run
+    /// contributes one chip, except when the run holds the active tab:
+    /// the walk already projects that member as an item, and a chip
+    /// beside it would draw the same run twice, so the chip is suppressed
+    /// and the run reads as its member.
+    ///
+    /// The suppression is the reading's one deliberate loss: the other
+    /// members of an active-holding collapsed run appear nowhere in these
+    /// rows. That is why <see cref="ModelIndexToVisibleIndex"/> answers
+    /// -1 for them rather than a slot, and why the expansion invariant
+    /// these rows are tested under holds per chip'd run.
+    /// </summary>
+    public static IReadOnlyList<HorizontalRow> HorizontalRows(TabManager manager)
+    {
+        var rows = new List<HorizontalRow>(manager.Tabs.Count);
+        foreach (var projected in GroupedRows(manager))
+        {
+            switch (projected)
+            {
+                case ProjectedRow.Header { Group: { } group }:
+                    // The walk keeps the active member visible under its
+                    // header, so a chip here would show the run twice.
+                    if (group.IsCollapsed
+                        && !ReferenceEquals(manager.ActiveTab?.Group, group))
+                        rows.Add(new HorizontalRow.Chip(group));
+                    break;
+                case ProjectedRow.Item { Tab: { } tab }:
+                    rows.Add(new HorizontalRow.Item(tab));
+                    break;
+            }
+        }
+        return rows;
+    }
+
+    /// <summary>
+    /// Manager index of the tab rendered at visible slot
+    /// <paramref name="visibleIndex"/>, or -1 when the slot renders a chip
+    /// or is out of range. Chips are slots -- the strip's item collection
+    /// holds them -- so no TabItems index may be compared with a manager
+    /// index without crossing here first. The caller routes a -1 to the
+    /// slot's group instead: selecting a chip expands, dropping on a chip
+    /// joins.
+    /// </summary>
+    public static int VisibleIndexToModelIndex(TabManager manager, int visibleIndex)
+    {
+        var slot = 0;
+        foreach (var row in HorizontalRows(manager))
+        {
+            if (slot == visibleIndex)
+                return row is HorizontalRow.Item { Tab: { } tab }
+                    ? manager.IndexOf(tab) : -1;
+            slot++;
+        }
+        return -1;
+    }
+
+    /// <summary>
+    /// Visible slot of the tab at manager index
+    /// <paramref name="modelIndex"/>, or -1 when the index is out of range
+    /// or the tab has no slot: a member hidden by a chip'd run renders
+    /// nowhere, so there is nothing to select, bridge, or reorder for it.
+    /// Chips occupy slots, so every slot past a chip is one further along
+    /// than the manager index suggests -- the round trip through
+    /// <see cref="VisibleIndexToModelIndex"/> is identity in both
+    /// directions on exactly the slots and indices that exist, which the
+    /// tests pin by execution.
+    /// </summary>
+    public static int ModelIndexToVisibleIndex(TabManager manager, int modelIndex)
+    {
+        if (modelIndex < 0 || modelIndex >= manager.Tabs.Count) return -1;
+        var tab = manager.Tabs[modelIndex];
+        var slot = 0;
+        foreach (var row in HorizontalRows(manager))
+        {
+            if (row is HorizontalRow.Item { Tab: { } candidate }
+                && ReferenceEquals(candidate, tab))
+                return slot;
+            slot++;
+        }
+        return -1;
     }
 }

--- a/windows/Ghostty.Tests/Tabs/TabStripProjectionTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabStripProjectionTests.cs
@@ -385,4 +385,315 @@ public class TabStripProjectionTests
         Assert.NotEmpty(positions);
         Assert.Equal(positions[^1] - positions[0] + 1, positions.Count);
     }
+
+    // --- HorizontalRows ---
+
+    private static List<TabModel> TabsOf(IReadOnlyList<TabStripProjection.HorizontalRow> rows)
+    {
+        var tabs = new List<TabModel>(rows.Count);
+        foreach (var row in rows)
+            if (row is TabStripProjection.HorizontalRow.Item item)
+                tabs.Add(item.Tab);
+        return tabs;
+    }
+
+    private static List<TabGroup> ChipsOf(IReadOnlyList<TabStripProjection.HorizontalRow> rows)
+    {
+        var groups = new List<TabGroup>();
+        foreach (var row in rows)
+            if (row is TabStripProjection.HorizontalRow.Chip chip)
+                groups.Add(chip.Group);
+        return groups;
+    }
+
+    // [P, U, A1, A2, U, B1, B2, U]: a pinned prefix, an expanded run and a
+    // collapsed run, with the active tab outside every run -- so every
+    // collapsed run renders as a chip and the only hidden tabs are that
+    // run's members.
+    private static (TabManager Mgr, TabGroup Expanded, TabGroup Collapsed) NewChipFixture()
+    {
+        var mgr = NewManager(7);
+        mgr.SetPinned(mgr.Tabs[0], true);
+        var expanded = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[2], mgr.Tabs[3] }, expanded);
+        var collapsed = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[5], mgr.Tabs[6] }, collapsed);
+        mgr.CollapseGroup(collapsed, true);
+        mgr.Activate(mgr.Tabs[7]);
+        return (mgr, expanded, collapsed);
+    }
+
+    // [U, B1, B2, U, C1, C2]: two collapsed runs, the active tab inside
+    // the second -- so the second renders as its member and only the
+    // first renders as a chip.
+    private static (TabManager Mgr, TabGroup B, TabGroup C) NewTwinFixture()
+    {
+        var mgr = NewManager(5);
+        var b = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[1], mgr.Tabs[2] }, b);
+        var c = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[4], mgr.Tabs[5] }, c);
+        mgr.CollapseGroup(b, true);
+        mgr.CollapseGroup(c, true);
+        mgr.Activate(mgr.Tabs[5]);
+        return (mgr, b, c);
+    }
+
+    // [P, B1, B2, C1, C2, U]: two ADJACENT collapsed runs starting
+    // directly after the pin prefix, the active tab in the ungrouped tail
+    // -- so the strip runs chip-beside-chip.
+    private static (TabManager Mgr, TabGroup B, TabGroup C) NewAdjacentChipsFixture()
+    {
+        var mgr = NewManager(5);
+        mgr.SetPinned(mgr.Tabs[0], true);
+        var b = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[1], mgr.Tabs[2] }, b);
+        var c = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[3], mgr.Tabs[4] }, c);
+        mgr.CollapseGroup(b, true);
+        mgr.CollapseGroup(c, true);
+        mgr.Activate(mgr.Tabs[5]);
+        return (mgr, b, c);
+    }
+
+    // [A1, A2, D1, D2, C1, C2]: every tab grouped and every group
+    // collapsed, the active tab mid-strip in D -- the degenerate edge,
+    // chips everywhere except the one item the Edge-135 walk keeps
+    // visible.
+    private static (TabManager Mgr, TabGroup A, TabGroup D, TabGroup C) NewAllCollapsedFixture()
+    {
+        var mgr = NewManager(5);
+        var a = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[0], mgr.Tabs[1] }, a);
+        var d = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[2], mgr.Tabs[3] }, d);
+        var c = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[4], mgr.Tabs[5] }, c);
+        mgr.CollapseGroup(a, true);
+        mgr.CollapseGroup(d, true);
+        mgr.CollapseGroup(c, true);
+        mgr.Activate(mgr.Tabs[3]);
+        return (mgr, a, d, c);
+    }
+
+    [Fact]
+    public void HorizontalRows_of_an_ungrouped_strip_are_Rows_as_items()
+    {
+        var mgr = NewManager(2); // [A, B, C]
+
+        var rows = TabStripProjection.HorizontalRows(mgr);
+
+        // No groups, no lowering: the horizontal reading is the flat one.
+        Assert.Equal(mgr.Tabs.ToArray(), TabsOf(rows));
+        Assert.Empty(ChipsOf(rows));
+    }
+
+    [Fact]
+    public void An_expanded_group_projects_as_its_members_alone()
+    {
+        var mgr = NewManager(3); // [A, B, C, D]
+        mgr.SetPinned(mgr.Tabs[0], true);
+        var group = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[1], mgr.Tabs[2] }, group);
+
+        var rows = TabStripProjection.HorizontalRows(mgr);
+
+        // The strip draws no header rows: an expanded run is its members
+        // in strip order, which is why the run label names a run the
+        // strip itself does not draw.
+        Assert.Equal(mgr.Tabs.ToArray(), TabsOf(rows));
+        Assert.Empty(ChipsOf(rows));
+    }
+
+    [Fact]
+    public void ChipRows_expanded_back_to_members_reconstruct_Tabs()
+    {
+        var (mgr, _, collapsed) = NewChipFixture();
+
+        // The horizontal form of the expansion invariant: substitute each
+        // chip with its run's members in manager order and the rows are
+        // Tabs again. This holds because the fixture's active tab sits
+        // outside every collapsed run; the active-holding run is the one
+        // deliberate loss, pinned by the next fact.
+        var expanded = new List<TabModel>();
+        foreach (var row in TabStripProjection.HorizontalRows(mgr))
+        {
+            switch (row)
+            {
+                case TabStripProjection.HorizontalRow.Chip { Group: { } group }:
+                    expanded.AddRange(mgr.MembersOf(group));
+                    break;
+                case TabStripProjection.HorizontalRow.Item { Tab: { } tab }:
+                    expanded.Add(tab);
+                    break;
+            }
+        }
+
+        Assert.Equal(mgr.Tabs.ToArray(), expanded);
+        Assert.Equal(new[] { collapsed },
+            ChipsOf(TabStripProjection.HorizontalRows(mgr)));
+    }
+
+    [Fact]
+    public void Adjacent_chip_runs_expand_back_to_tabs_in_order()
+    {
+        var (mgr, b, c) = NewAdjacentChipsFixture();
+        var rows = TabStripProjection.HorizontalRows(mgr);
+
+        // Two chips in a row, the first sitting directly after the pin
+        // prefix; only the pin and the ungrouped tail render as items.
+        Assert.Equal(new[] { b, c }, ChipsOf(rows));
+        Assert.Equal(new[] { mgr.Tabs[0], mgr.Tabs[5] }, TabsOf(rows));
+
+        // Benign by construction today; this and the next fact are
+        // regression insurance for exactly the substitution bugs
+        // chip-blind TabItems code could mask once the strip trusts these
+        // rows without crossing the slot mapping.
+        var expanded = new List<TabModel>();
+        foreach (var row in rows)
+        {
+            switch (row)
+            {
+                case TabStripProjection.HorizontalRow.Chip { Group: { } group }:
+                    expanded.AddRange(mgr.MembersOf(group));
+                    break;
+                case TabStripProjection.HorizontalRow.Item { Tab: { } tab }:
+                    expanded.Add(tab);
+                    break;
+            }
+        }
+
+        Assert.Equal(mgr.Tabs.ToArray(), expanded);
+    }
+
+    [Fact]
+    public void An_all_collapsed_strip_expands_back_to_tabs_minus_its_hidden_members()
+    {
+        var (mgr, a, d, c) = NewAllCollapsedFixture();
+        var rows = TabStripProjection.HorizontalRows(mgr);
+
+        // Every run collapsed: chips everywhere except the active
+        // member's item -- a literal chips-only strip is unreachable,
+        // because the walk always keeps that one item visible.
+        Assert.Equal(new[] { a, c }, ChipsOf(rows));
+        Assert.Equal(new[] { mgr.Tabs[3] }, TabsOf(rows));
+
+        // Same insurance as the adjacent-chips fact, plus the loss made
+        // explicit: reconstruction is Tabs minus exactly the non-active
+        // members of the run that hides behind its active member.
+        var expanded = new List<TabModel>();
+        foreach (var row in rows)
+        {
+            switch (row)
+            {
+                case TabStripProjection.HorizontalRow.Chip { Group: { } group }:
+                    expanded.AddRange(mgr.MembersOf(group));
+                    break;
+                case TabStripProjection.HorizontalRow.Item { Tab: { } tab }:
+                    expanded.Add(tab);
+                    break;
+            }
+        }
+
+        var expected = new List<TabModel>(mgr.Tabs);
+        expected.Remove(mgr.Tabs[2]); // D's hidden member: the one loss
+        Assert.Equal(expected, expanded);
+    }
+
+    [Fact]
+    public void A_collapsed_run_holding_the_active_tab_shows_the_member_and_no_chip()
+    {
+        var (mgr, b, c) = NewTwinFixture();
+
+        var rows = TabStripProjection.HorizontalRows(mgr);
+
+        // B, collapsed without the active tab, is its chip; C, collapsed
+        // WITH it, is its member alone -- a chip beside the member would
+        // draw the same run twice. C's other member appears nowhere: the
+        // reading's one deliberate loss.
+        Assert.Equal(new[] { mgr.Tabs[0], mgr.Tabs[3], mgr.Tabs[5] }, TabsOf(rows));
+        Assert.Equal(new[] { b }, ChipsOf(rows));
+        Assert.True(c.IsCollapsed); // no accordion: the bit never moved
+    }
+
+    [Fact]
+    public void Activating_across_a_collapsed_run_swaps_the_member_for_a_chip_and_back()
+    {
+        var (mgr, b, c) = NewTwinFixture();
+
+        mgr.Activate(mgr.Tabs[1]); // into B: B loses its chip, C gains one
+
+        var rows = TabStripProjection.HorizontalRows(mgr);
+        Assert.Equal(new[] { mgr.Tabs[0], mgr.Tabs[1], mgr.Tabs[3] }, TabsOf(rows));
+        Assert.Equal(new[] { c }, ChipsOf(rows));
+
+        mgr.Activate(mgr.Tabs[5]); // home again: the fixture's shape returns
+        Assert.Equal(new[] { mgr.Tabs[0], mgr.Tabs[3], mgr.Tabs[5] },
+            TabsOf(TabStripProjection.HorizontalRows(mgr)));
+        Assert.Equal(new[] { b },
+            ChipsOf(TabStripProjection.HorizontalRows(mgr)));
+        Assert.True(b.IsCollapsed && c.IsCollapsed);
+    }
+
+    [Fact]
+    public void VisibleIndexToModelIndex_crosses_chips_and_answers_minus_one_for_them()
+    {
+        var (mgr, _, _) = NewChipFixture();
+        // Slots 0-4 are items, slot 5 is the collapsed run's chip, slot 6
+        // is the tail tab.
+        Assert.Equal(0, TabStripProjection.VisibleIndexToModelIndex(mgr, 0));
+        Assert.Equal(4, TabStripProjection.VisibleIndexToModelIndex(mgr, 4));
+        Assert.Equal(7, TabStripProjection.VisibleIndexToModelIndex(mgr, 6));
+        Assert.Equal(-1, TabStripProjection.VisibleIndexToModelIndex(mgr, 5));
+        Assert.Equal(-1, TabStripProjection.VisibleIndexToModelIndex(mgr, -1));
+        Assert.Equal(-1, TabStripProjection.VisibleIndexToModelIndex(mgr, 7));
+    }
+
+    [Fact]
+    public void ModelIndexToVisibleIndex_answers_the_slot_or_minus_one_when_hidden()
+    {
+        var (mgr, _, _) = NewChipFixture();
+
+        Assert.Equal(0, TabStripProjection.ModelIndexToVisibleIndex(mgr, 0));
+        Assert.Equal(6, TabStripProjection.ModelIndexToVisibleIndex(mgr, 7));
+        // The chip'd run's members render nowhere.
+        Assert.Equal(-1, TabStripProjection.ModelIndexToVisibleIndex(mgr, 5));
+        Assert.Equal(-1, TabStripProjection.ModelIndexToVisibleIndex(mgr, 6));
+        Assert.Equal(-1, TabStripProjection.ModelIndexToVisibleIndex(mgr, -1));
+        Assert.Equal(-1, TabStripProjection.ModelIndexToVisibleIndex(mgr, 8));
+    }
+
+    [Fact]
+    public void The_slot_mapping_round_trips_in_both_directions()
+    {
+        var (mgr, _, collapsed) = NewChipFixture();
+        var rows = TabStripProjection.HorizontalRows(mgr);
+
+        for (var i = 0; i < mgr.Tabs.Count; i++)
+        {
+            var slot = TabStripProjection.ModelIndexToVisibleIndex(mgr, i);
+            if (slot < 0)
+            {
+                // Only a member of the chip'd run has no slot; anything
+                // else answering -1 would strand a real row's bridge.
+                Assert.True(ReferenceEquals(mgr.Tabs[i].Group, collapsed));
+                continue;
+            }
+            Assert.Equal(i, TabStripProjection.VisibleIndexToModelIndex(mgr, slot));
+        }
+
+        for (var s = 0; s < rows.Count; s++)
+        {
+            var model = TabStripProjection.VisibleIndexToModelIndex(mgr, s);
+            if (rows[s] is TabStripProjection.HorizontalRow.Item { Tab: { } tab })
+            {
+                Assert.Equal(mgr.IndexOf(tab), model);
+                Assert.Equal(s, TabStripProjection.ModelIndexToVisibleIndex(mgr, model));
+            }
+            else
+            {
+                Assert.Equal(-1, model); // a chip is a slot, never a model
+            }
+        }
+    }
 }


### PR DESCRIPTION
The horizontal host's projection lowering: a collapsed group renders one chip row unless it holds the active tab, whose member stays visible (Edge-135 rule; the chip suppression is the reading's one deliberate loss). VisibleIndexToModelIndex and ModelIndexToVisibleIndex are the only sanctioned crossing between TabItems slots and manager indices, with -1 for chip slots and hidden members. The audit invariant lands in its lossy-by-design form: substituting chips with their members reconstructs Tabs for every chip-rendered run, with adjacency and degenerate all-collapsed fixtures as insurance for the chip-blind consumers the next PR adds. Pure Core; the TabHost machinery consuming it lands next.