### PR TITLE
tabs: chip drag, drop-on-chip join, and chip menus

### DIFF
--- a/windows/Ghostty.Core/Tabs/TabChipDrop.cs
+++ b/windows/Ghostty.Core/Tabs/TabChipDrop.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+
+namespace Ghostty.Core.Tabs;
+
+/// <summary>
+/// The horizontal drop's one mapping from "where the user aimed" to a
+/// manager index: where a completed drag's commit lands. At completion
+/// the strip holds TabView's own reorder, which is the only arrangement
+/// that describes the aim, while the manager has not moved yet. A raw
+/// strip slot is not a manager index there -- chips occupy slots, and
+/// the members a collapsed run hides occupy none -- so the host hands
+/// this map IDENTITIES (the tab or chip the drop came to rest beside or
+/// upon, read off the strip's own arrangement) and the map answers in
+/// manager space only.
+///
+/// Two drag shapes share the map. A chip drag moves the whole run
+/// (<see cref="GroupTarget"/>): the target is the left neighbour's run
+/// edge, minus the dragged run's own size when it started left of that
+/// edge, because <see cref="TabManager.MoveGroup"/>'s target counts the
+/// tabs that STAY ahead of the run. A tab dropped at a chip's slot
+/// either joins the run -- the caller decides that half by geometry --
+/// or positions beside it (<see cref="MemberTargetBefore"/> /
+/// <see cref="MemberTargetAfter"/>); a tab dropped at an ordinary slot
+/// needs no arithmetic here at all,
+/// <see cref="TabStripProjection.VisibleIndexToModelIndex"/> already
+/// names that tab.
+///
+/// This is the third strip-private mapping, and it gets the treatment
+/// the first two earned: the targets are pinned by executing them
+/// against a real manager and asserting final order, because a
+/// transposed boundary passes every source scan and every wiring pin.
+/// </summary>
+internal static class TabChipDrop
+{
+    /// <summary>
+    /// The <see cref="TabManager.MoveGroup"/> target when the chip of
+    /// <paramref name="dragged"/> came to rest after the strip element
+    /// named by (<paramref name="leftTab"/>, <paramref name="leftChip"/>)
+    /// -- the left neighbour as the strip ARRANGED it at rest, never a
+    /// slot re-read through the projection: between a chip's origin and
+    /// a downward rest, TabView shifts every strip slot left by one, so
+    /// a projector read there names the dragged run itself. Both nulls
+    /// name the strip head, whose landing <see cref="TabManager.MoveGroup"/>'s
+    /// clamp lifts clear of the pinned prefix.
+    /// </summary>
+    public static int GroupTarget(
+        TabManager manager, TabGroup dragged, TabModel? leftTab, TabGroup? leftChip)
+    {
+        ArgumentNullException.ThrowIfNull(manager);
+        ArgumentNullException.ThrowIfNull(dragged);
+        var run = manager.MembersOf(dragged);
+        if (run.Count == 0) return -1;
+
+        int edge;
+        if (leftChip is { } chip)
+        {
+            // A chip stands for its whole hidden run: the edge is past
+            // the last member, not past the chip the strip shows.
+            edge = manager.IndexOf(manager.MembersOf(chip)[^1]) + 1;
+        }
+        else if (leftTab is { } tab)
+        {
+            // A tab row runs to its run's end too: a member's hidden
+            // neighbours behind it are room the landing has to clear.
+            edge = manager.IndexOf(manager.RunOf(tab)[^1]) + 1;
+        }
+        else
+        {
+            // The strip head: no kept tab sits ahead.
+            return 0;
+        }
+
+        // The target counts tabs that stay ahead, and the dragged run's
+        // own members do not: when the run started left of the edge, its
+        // departure is room the landing does not wait for. A run coming
+        // from the right subtracts nothing -- the edge did not move.
+        int start = manager.IndexOf(run[0]);
+        return start < edge ? edge - run.Count : edge;
+    }
+
+    /// <summary>
+    /// The manager index a tab dropped at a chip's slot lands at when
+    /// the drop positions BEFORE the run instead of joining it: the
+    /// run's first member, hidden or not.
+    /// </summary>
+    public static int MemberTargetBefore(TabManager manager, TabGroup chip)
+    {
+        var run = Members(manager, chip);
+        return manager.IndexOf(run[0]);
+    }
+
+    /// <summary>
+    /// The manager index a tab dropped at a chip's slot lands at when
+    /// the drop positions AFTER the run instead of joining it: past the
+    /// run's last member, hidden or not.
+    /// </summary>
+    public static int MemberTargetAfter(TabManager manager, TabGroup chip)
+    {
+        var run = Members(manager, chip);
+        return manager.IndexOf(run[^1]) + 1;
+    }
+
+    private static IReadOnlyList<TabModel> Members(TabManager manager, TabGroup chip)
+    {
+        ArgumentNullException.ThrowIfNull(manager);
+        ArgumentNullException.ThrowIfNull(chip);
+        return manager.MembersOf(chip);
+    }
+}

--- a/windows/Ghostty.Core/Tabs/TabStripProjection.cs
+++ b/windows/Ghostty.Core/Tabs/TabStripProjection.cs
@@ -214,6 +214,30 @@ internal static class TabStripProjection
     }
 
     /// <summary>
+    /// The group whose chip renders at visible slot
+    /// <paramref name="visibleIndex"/>, or null when the slot renders a
+    /// tab row or does not exist. The complement of
+    /// <see cref="VisibleIndexToModelIndex"/>'s -1, which its own doc
+    /// promises to route to "the slot's group": that answer says a chip
+    /// took the slot without saying which, and the drop-at-a-run fork
+    /// needs it said. Read through the projection because the members
+    /// were hidden at drop time -- a TabItems index cannot say which run
+    /// took the drop when the strip's own order has already been
+    /// reordered under it.
+    /// </summary>
+    public static TabGroup? VisibleGroupAt(TabManager manager, int visibleIndex)
+    {
+        var slot = 0;
+        foreach (var row in HorizontalRows(manager))
+        {
+            if (slot == visibleIndex)
+                return row is HorizontalRow.Chip { Group: { } group } ? group : null;
+            slot++;
+        }
+        return null;
+    }
+
+    /// <summary>
     /// Visible slot of the tab at manager index
     /// <paramref name="modelIndex"/>, or -1 when the index is out of range
     /// or the tab has no slot: a member hidden by a chip'd run renders

--- a/windows/Ghostty.Tests/Tabs/TabChipDropTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabChipDropTests.cs
@@ -1,0 +1,216 @@
+using System;
+using System.Linq;
+using Ghostty.Core.Tabs;
+using Xunit;
+
+namespace Ghostty.Tests.Tabs;
+
+/// <summary>
+/// The horizontal drop's slot-to-manager map, executed against a real
+/// manager. This is the third strip-private mapping, and a transposed
+/// boundary here passes every source scan and every wiring pin, so the
+/// targets are pinned by asserting FINAL ORDER after the commit the
+/// host really makes -- MoveGroup for a chip, Move for a positioning --
+/// not by re-deriving the arithmetic.
+/// </summary>
+public class TabChipDropTests
+{
+    private static TabManager NewManager(int count)
+    {
+        var mgr = new TabManager((_) => new FakePaneHost());
+        for (int i = 0; i < count; i++) mgr.NewTab();
+        return mgr;
+    }
+
+    // [t0, g1a, g1b, t3, t4, t5] -- a collapsed run (the active tab stays
+    // t0, so the run projects as a chip) flanked by lone tabs. Slots:
+    // 0=t0, 1=Chip(G1), 2=t3, 3=t4, 4=t5.
+    private static (TabManager Mgr, TabModel[] T, TabGroup G1) NewChipShape()
+    {
+        var mgr = NewManager(5);
+        var t = mgr.Tabs.ToArray();
+        var g1 = mgr.CreateGroup(t[1])!;
+        mgr.JoinGroup(t[2], g1);
+        mgr.CollapseGroup(g1, true);
+        return (mgr, t, g1);
+    }
+
+    // [g1a, g1b, t2, g2c, g2d, t5] -- two collapsed runs around a lone
+    // tab: the shape where a boundary read as "next slot" instead of
+    // "end of the left run" swaps two chips instead of moving one.
+    private static (TabManager Mgr, TabModel[] T, TabGroup G1, TabGroup G2) NewTwoChips()
+    {
+        var mgr = NewManager(5);
+        var t = mgr.Tabs.ToArray();
+        var g1 = mgr.CreateGroup(t[0])!;
+        mgr.JoinGroup(t[1], g1);
+        var g2 = mgr.CreateGroup(t[3])!;
+        mgr.JoinGroup(t[4], g2);
+        mgr.CollapseGroup(g1, true);
+        mgr.CollapseGroup(g2, true);
+        return (mgr, t, g1, g2);
+    }
+
+    [Fact]
+    public void GroupTarget_swaps_the_run_whole_past_a_lone_tab()
+    {
+        var (mgr, t, g1) = NewChipShape();
+
+        // Chip dragged rightward to rest between t4 and t5: the strip's
+        // left neighbour is t4, and the run lands whole past t4, members
+        // hidden.
+        var target = TabChipDrop.GroupTarget(mgr, g1, leftTab: t[4], leftChip: null);
+        mgr.MoveGroup(g1, target);
+
+        Assert.Equal(new[] { t[0], t[3], t[4], t[1], t[2], t[5] },
+            mgr.Tabs.ToArray());
+    }
+
+    [Fact]
+    public void GroupTarget_crosses_the_whole_left_run_when_the_left_neighbour_is_a_chip()
+    {
+        var (mgr, t, g1, g2) = NewTwoChips();
+
+        // Chip2 dragged left to rest right after Chip1: the neighbour
+        // stands for BOTH hidden members of G1, and the run must land
+        // past the whole of it, not between the members. Coming from the
+        // right, the departure adjustment must NOT apply -- the edge did
+        // not move.
+        var target = TabChipDrop.GroupTarget(mgr, g2, leftTab: null, leftChip: g1);
+        mgr.MoveGroup(g2, target);
+
+        Assert.Equal(new[] { t[0], t[1], t[3], t[4], t[2], t[5] },
+            mgr.Tabs.ToArray());
+    }
+
+    [Fact]
+    public void GroupTarget_coming_from_the_left_subtracts_the_runs_own_departure()
+    {
+        // [g1a, g1b, t2, g2c, g2d, t5, t6] -- two collapsed runs, and a
+        // KEPT tab after the rest point: at the strip's end MoveGroup's
+        // clamp absorbs the subtraction, so the rest sits mid-strip
+        // where the arithmetic alone decides the landing.
+        var mgr = NewManager(6);
+        var t = mgr.Tabs.ToArray();
+        var g1 = mgr.CreateGroup(t[0])!;
+        mgr.JoinGroup(t[1], g1);
+        var g2 = mgr.CreateGroup(t[3])!;
+        mgr.JoinGroup(t[4], g2);
+        mgr.CollapseGroup(g1, true);
+        mgr.CollapseGroup(g2, true);
+
+        // Chip2 dragged right to rest between t5 and t6: its own two
+        // members stop counting toward the landing -- without the
+        // subtraction the run files in past t6 and splits the tail.
+        var target = TabChipDrop.GroupTarget(mgr, g2, leftTab: t[5], leftChip: null);
+        mgr.MoveGroup(g2, target);
+
+        Assert.Equal(new[] { t[0], t[1], t[2], t[5], t[3], t[4], t[6] },
+            mgr.Tabs.ToArray());
+    }
+
+    [Fact]
+    public void GroupTarget_at_the_strip_head_lands_on_the_prefix_edge_never_inside_it()
+    {
+        var (mgr, t, g1) = NewChipShape();
+        mgr.SetPinned(t[0], true);
+
+        // A rest at the head names no neighbour: the map answers 0 and
+        // MoveGroup's clamp lifts the run to the prefix edge. Asserting
+        // final order is the whole point -- an off-by-one here would file
+        // the run INTO the pinned prefix, and the clamp is the backstop,
+        // not the mapping.
+        var target = TabChipDrop.GroupTarget(mgr, g1, leftTab: null, leftChip: null);
+        mgr.MoveGroup(g1, target);
+
+        Assert.Equal(new[] { t[0], t[1], t[2], t[3], t[4], t[5] },
+            mgr.Tabs.ToArray());
+        Assert.True(t[0].IsPinned);
+        Assert.False(t[1].IsPinned);
+    }
+
+    [Fact]
+    public void MemberTargetBefore_lands_before_the_whole_hidden_run()
+    {
+        var (mgr, t, g1) = NewChipShape();
+
+        // t3 dragged to just before the chip: it must land before BOTH
+        // hidden members, or it lands between the header and its run --
+        // a split the projector cannot render.
+        var target = TabChipDrop.MemberTargetBefore(mgr, g1);
+        mgr.Move(mgr.IndexOf(t[3]), target);
+
+        Assert.Equal(new[] { t[0], t[3], t[1], t[2], t[4], t[5] },
+            mgr.Tabs.ToArray());
+        Assert.Null(t[3].Group);
+    }
+
+    [Fact]
+    public void MemberTargetAfter_lands_past_the_whole_hidden_run()
+    {
+        var (mgr, t, g1) = NewChipShape();
+
+        // t4 dragged to just after the chip from two slots right of it:
+        // the landing clears the hidden members and stays unjoined.
+        var target = TabChipDrop.MemberTargetAfter(mgr, g1);
+        mgr.Move(mgr.IndexOf(t[4]), target);
+
+        Assert.Equal(new[] { t[0], t[1], t[2], t[4], t[3], t[5] },
+            mgr.Tabs.ToArray());
+        Assert.Null(t[4].Group);
+    }
+
+    // --- JoinGroup's collapse bit: the auto-expand is the manager's,
+    // so neither strip can forget it or fire it on a refused join. ---
+
+    [Fact]
+    public void An_actual_join_expands_the_collapsed_run_so_the_join_is_visible()
+    {
+        var (mgr, t, g1) = NewChipShape();
+        Assert.True(g1.IsCollapsed);
+
+        mgr.JoinGroup(t[3], g1);
+
+        Assert.Same(g1, t[3].Group);
+        Assert.False(g1.IsCollapsed);
+        // The joined member renders: an expanded run projects members,
+        // not a chip, so the drop's result is on screen.
+        var rows = TabStripProjection.HorizontalRows(mgr);
+        Assert.DoesNotContain(rows, r => r is TabStripProjection.HorizontalRow.Chip);
+        Assert.Contains(rows, r => r is TabStripProjection.HorizontalRow.Item
+            { Tab: { } tab } && ReferenceEquals(tab, t[3]));
+    }
+
+    [Fact]
+    public void An_already_member_join_leaves_the_collapse_bit_alone()
+    {
+        var (mgr, t, g1) = NewChipShape();
+
+        mgr.JoinGroup(t[1], g1);
+
+        Assert.True(g1.IsCollapsed);
+        Assert.Equal(new[] { t[0], t[1], t[2], t[3], t[4], t[5] },
+            mgr.Tabs.ToArray());
+    }
+
+    [Fact]
+    public void A_refused_join_leaves_the_collapse_bit_alone()
+    {
+        var (mgr, t, g1) = NewChipShape();
+        mgr.SetPinned(t[3], true);
+        // SetPinned relocates to the prefix boundary, which is slot 0
+        // here: that state is the baseline the refused join must leave
+        // exactly where it is.
+        var pinned = new[] { t[3], t[0], t[1], t[2], t[4], t[5] };
+        Assert.Equal(pinned, mgr.Tabs.ToArray());
+
+        // A pinned tab cannot join (the prefix outranks membership); the
+        // expansion rides the join that did not happen, so the bit and
+        // the run both stay as the user left them.
+        mgr.JoinGroup(t[3], g1);
+
+        Assert.True(g1.IsCollapsed);
+        Assert.Null(t[3].Group);
+        Assert.Equal(pinned, mgr.Tabs.ToArray());
+    }
+}

--- a/windows/Ghostty.Tests/Tabs/TabStripProjectionTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabStripProjectionTests.cs
@@ -650,6 +650,21 @@ public class TabStripProjectionTests
     }
 
     [Fact]
+    public void VisibleGroupAt_names_only_chip_slots()
+    {
+        var (mgr, _, collapsed) = NewChipFixture();
+
+        // The complement of VisibleIndexToModelIndex's -1: the same slot
+        // answers which run took a drop there, and item slots or no slot
+        // at all answer null rather than a stranger's group.
+        Assert.Null(TabStripProjection.VisibleGroupAt(mgr, 0));
+        Assert.Same(collapsed, TabStripProjection.VisibleGroupAt(mgr, 5));
+        Assert.Null(TabStripProjection.VisibleGroupAt(mgr, 6));
+        Assert.Null(TabStripProjection.VisibleGroupAt(mgr, -1));
+        Assert.Null(TabStripProjection.VisibleGroupAt(mgr, 7));
+    }
+
+    [Fact]
     public void ModelIndexToVisibleIndex_answers_the_slot_or_minus_one_when_hidden()
     {
         var (mgr, _, _) = NewChipFixture();

--- a/windows/Ghostty.Tests/Wiring/TabStripSyncWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabStripSyncWiringTests.cs
@@ -345,32 +345,222 @@ public sealed class TabStripSyncWiringTests
     }
 
     [Fact]
-    public void The_drop_translates_its_slot_through_the_projection_and_refuses_chip_shaped_drops()
+    public void A_chip_drag_commits_MoveGroup_through_the_drop_map_and_never_Move()
     {
         var completed = ShellSource.Load(TabHostSource).Method("OnTabDragCompleted");
 
-        // The gate and the translation are one polarity: only a TAB drop
-        // maps its strip slot through the projection (a raw IndexOf is a
-        // slot, not a manager index -- chips occupy slots), because a chip
-        // has no manager index to move to.
-        var gate = completed.DescendantNodes().OfType<IfStatementSyntax>()
-            .First(i => i.Condition.ToString().Contains("item.Tag is not TabGroup", StringComparison.Ordinal));
-        var mapping = gate.Call("TabStripProjection.VisibleIndexToModelIndex");
+        // A chip drags its whole run, and the commit is MoveGroup even for
+        // a single-member run -- a Move here would relocate one member out
+        // of the run it is carrying and let Normalize re-gather the rest
+        // somewhere else. The strip's rest slot is not a manager index
+        // (chips occupy slots; hidden members occupy none), so the target
+        // comes from the drop map, never from the slot arithmetic.
+        var chipGate = completed.DescendantNodes().OfType<IfStatementSyntax>()
+            .First(i => i.Condition.ToString().Contains("item.Tag is TabGroup", StringComparison.Ordinal));
+        // Scope to the gate's own statement: the if node's descendants
+        // include its else arm, and the tab path's Move lives there.
+        var chipArm = chipGate.Statement;
+        var map = chipArm.Call("TabChipDrop.GroupTarget");
+        var commit = chipArm.Call("_manager.MoveGroup");
         Assert.True(
-            gate.DescendantNodes().Contains(mapping),
-            "The drop's slot translation must sit inside the chip-drag gate: a chip "
-            + "drop has no manager index to map to.");
+            commit.Arg(1) == "target" && map.SpanStart < commit.SpanStart,
+            "The chip drag must commit MoveGroup with the drop map's target, not a "
+            + "slot the strip happened to land on.");
+        Assert.True(
+            map.Arg(2) == "leftTab" && map.Arg(3) == "leftChip",
+            "The drop map must be fed the neighbour's IDENTITY, not a slot: on a "
+            + "downward move TabView shifts the strip slots left, and a slot "
+            + "re-read through the pre-drag projection names the dragged chip "
+            + "itself.");
 
-        // The refuse: the move is gated on the mapped index, so a drop that
-        // came to rest AT a chip's slot maps to -1 and refuses outright --
-        // the reconcile after the gate restores the strip. A later rung
-        // routes chip-shaped drops into joins.
-        var move = completed.Call("_manager.Move");
+        // The neighbour's identity is read off the strip's own final
+        // arrangement, from the slot LEFT of the rest. The transposed
+        // read (slot + 1) is the boundary flip this rung exists to make
+        // impossible, so the argument is pinned verbatim.
+        var neighbour = chipArm.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Single(c => c.CalleeText().EndsWith("ContainerFromIndex", StringComparison.Ordinal));
+        Assert.True(
+            neighbour.ArgumentList.ToString() == "(slot - 1)",
+            "The left neighbour must be read from slot - 1, the strip's own "
+            + "arrangement: slot + 1 is the transposed boundary, and a projector "
+            + "slot read is the pre-drag order the drag just overruled.");
+
+        // A rest the strip cannot name a neighbour for is skew: the whole
+        // commit sits behind that refusal rather than guessing at the
+        // strip head, and behind the map's own -1, since MoveGroup clamps
+        // a guess into a landing.
+        Assert.True(
+            map.Ancestors().OfType<IfStatementSyntax>()
+                .Any(a => a.Condition.ToString() == "known"),
+            "The commit must be refused when the left neighbour is unresolvable: "
+            + "a guessed head target yanks the run to the front of the strip.");
+        Assert.True(
+            commit.Ancestors().OfType<IfStatementSyntax>()
+                .Any(a => a.Condition.ToString() == "target >= 0"),
+            "The MoveGroup commit must sit behind the map's refusal (target >= 0): "
+            + "a strip the projection cannot describe is the reconcile's, not the "
+            + "drop map's to guess at.");
+
+        Assert.Empty(chipArm.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(c => c.CalleeText().EndsWith(".Move", StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public void A_tab_drop_moves_through_the_projection_and_forks_at_chip_slots()
+    {
+        var completed = ShellSource.Load(TabHostSource).Method("OnTabDragCompleted");
+
+        // The tab path is exactly the chip gate's else arm: one of the two
+        // owns every drop. The translation is still the projection's (a
+        // raw IndexOf is a slot, not a manager index -- chips occupy
+        // slots), and the move is still gated on the mapped index.
+        var chipGate = completed.DescendantNodes().OfType<IfStatementSyntax>()
+            .First(i => i.Condition.ToString().Contains("item.Tag is TabGroup", StringComparison.Ordinal));
+        var tabArm = chipGate.Else?.Statement;
+        Assert.True(
+            tabArm is not null,
+            "The chip gate must carry the tab path as its else arm: neither drop "
+            + "shape may fall through both arms or between them.");
+        Assert.Single(
+            tabArm!.DescendantNodes().OfType<InvocationExpressionSyntax>()
+                .Where(c => c.CalleeText().EndsWith(
+                    "TabStripProjection.VisibleIndexToModelIndex", StringComparison.Ordinal)));
+
+        var move = tabArm.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Single(c => c.CalleeText().EndsWith(".Move", StringComparison.Ordinal));
         Assert.True(
             move.Ancestors().OfType<IfStatementSyntax>()
                 .Any(a => a.Condition.ToString() == "newIndex >= 0"),
-            "The drop's move must be gated on the mapped index (newIndex >= 0): a "
-            + "chip-slot rest maps to -1 and must refuse, not clamp.");
+            "The tab drop's move must be gated on the mapped index (newIndex >= 0).");
+
+        // A slot that maps to a chip is the join fork's, and the fork
+        // lives in its own method so its pins read one story below.
+        var newIndexGate = move.Ancestors().OfType<IfStatementSyntax>()
+            .First(a => a.Condition.ToString() == "newIndex >= 0");
+        Assert.True(
+            newIndexGate.Else?.Statement.DescendantNodes()
+                .OfType<InvocationExpressionSyntax>()
+                .Any(c => c.CalleeText().EndsWith("ResolveDropAtChip", StringComparison.Ordinal))
+            == true,
+            "The unmapped arm (-1, a chip's slot) must route to the drop-at-a-run "
+            + "fork; refusing outright would bounce every drop a chip borders.");
+    }
+
+    [Fact]
+    public void A_drop_on_a_chip_joins_through_the_projector_and_only_by_geometry()
+    {
+        var fork = ShellSource.Load(TabHostSource).Method("ResolveDropAtChip");
+
+        // The run that took the drop comes from the projection: the
+        // members were hidden at drop time, so no TabItems index can say
+        // which run a chip slot names.
+        Assert.Empty(fork.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(c => c.CalleeText().EndsWith("TabItems.IndexOf", StringComparison.Ordinal)));
+        Assert.Single(fork.Calls("TabStripProjection.VisibleGroupAt"));
+
+        // ON the chip joins, and only ON: the same -1 slot also serves a
+        // drop parked beside the chip, and only the recorded pointer
+        // geometry tells those apart. An unconditional join would swallow
+        // every positioning drop a chip borders.
+        var join = fork.Call("_manager.JoinGroup");
+        Assert.True(
+            join.Ancestors().OfType<IfStatementSyntax>()
+                .Any(a => a.Condition.ToString().Contains("Contains(_lastDropPosition)",
+                    StringComparison.Ordinal)),
+            "The join must be gated on the pointer landing inside the chip's bounds: "
+            + "a drop beside the chip positions, it does not join.");
+
+        // Beside the chip positions relative to the run's edge -- both
+        // directions present, and through Move, never a membership write.
+        Assert.Single(fork.Calls("TabChipDrop.MemberTargetBefore"));
+        Assert.Single(fork.Calls("TabChipDrop.MemberTargetAfter"));
+        var beside = fork.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Single(c => c.CalleeText().EndsWith(".Move", StringComparison.Ordinal));
+        Assert.True(
+            beside.SpanStart > join.SpanStart,
+            "The positioning move must be the fork's second arm, after the join.");
+    }
+
+    [Fact]
+    public void The_strip_accepts_only_its_own_drags_and_records_the_drop_point()
+    {
+        var src = ShellSource.Load(TabHostSource);
+        var over = src.Method("OnTabStripDragOver");
+        var drop = src.Method("OnTabStripDrop");
+
+        // Both handlers open with the live-drag guard: an external drag
+        // must stay declined, which an untouched accepted operation does.
+        foreach (var handler in new[] { over, drop })
+        {
+            var guard = handler.Body!.Statements.First() as IfStatementSyntax;
+            Assert.True(
+                guard?.Condition is PrefixUnaryExpressionSyntax not
+                    && not.Operand is IdentifierNameSyntax id
+                    && id.Identifier.ValueText == "_stripDragActive"
+                    && guard.Statement is ReturnStatementSyntax { Expression: null },
+                handler.Identifier.ValueText + " must open with `if (!_stripDragActive) "
+                + "return;`: accepting a foreign drag lets a drop the strip never "
+                + "started write state.");
+        }
+
+        var accept = over.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .First(a => a.Left.ToString().EndsWith("AcceptedOperation", StringComparison.Ordinal));
+        Assert.True(
+            accept.Right.ToString().Contains("DataPackageOperation.Move", StringComparison.Ordinal),
+            "The strip accepts Move only: the accept exists so TabStripDrop fires "
+            + "with the pointer position the join fork reads.");
+
+        // The drop records and stops there -- the commit is OnTabDrag-
+        // Completed's, and neither handler may move anything itself.
+        var record = drop.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .First(a => a.Left is IdentifierNameSyntax lid
+                        && lid.Identifier.ValueText == "_lastDropPosition");
+        Assert.True(
+            record.DescendantNodes().OfType<InvocationExpressionSyntax>()
+                .Any(c => c.CalleeText().EndsWith("GetPosition", StringComparison.Ordinal)),
+            "The recorded point must come from the drop event's position.");
+        Assert.Empty(drop.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(c => c.CalleeText().EndsWith(".Move", StringComparison.Ordinal)
+                        || c.CalleeText().EndsWith("JoinGroup", StringComparison.Ordinal)));
+        Assert.Empty(over.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(c => c.CalleeText().EndsWith(".Move", StringComparison.Ordinal)
+                        || c.CalleeText().EndsWith("JoinGroup", StringComparison.Ordinal)));
+
+        // The handlers are wired in markup, where the code-behind sweep
+        // cannot see them (the TabDroppedOutside pin's lesson).
+        var xaml = ReadEmbedded(TabHostXaml);
+        Assert.True(
+            xaml.Contains("TabStripDragOver", StringComparison.Ordinal)
+                && xaml.Contains("TabStripDrop", StringComparison.Ordinal),
+            "TabHost.xaml must wire TabStripDragOver and TabStripDrop: without the "
+            + "drop the fork never gets a pointer position and refuses every join.");
+    }
+
+    [Fact]
+    public void The_chip_carries_the_group_menu_through_the_router()
+    {
+        var addChip = ShellSource.Load(TabHostSource).Method("AddGroupChip");
+        var menu = addChip.Call("TabContextMenuBuilder.BuildGroupMenu");
+
+        // The menu is the chip's ContextFlyout: while the run is folded,
+        // the chip is the run's only surface, so the group commands live
+        // there and nowhere else.
+        Assert.True(
+            menu.Ancestors().OfType<AssignmentExpressionSyntax>()
+                .Any(a => a.Left.ToString() == "ContextFlyout"),
+            "BuildGroupMenu must be attached as the chip's ContextFlyout.");
+
+        // Every item routes through the router, which is where the
+        // announcement is guaranteed; a direct manager call here would
+        // move group state silently.
+        var args = menu.ArgumentList.ToString();
+        foreach (var route in new[] { "RequestCollapseGroup", "RequestDissolveGroup",
+                     "RequestCloseGroup", "RequestRenameGroup", "RequestColorGroup" })
+        {
+            Assert.True(
+                args.Contains(route, StringComparison.Ordinal),
+                $"The chip menu's {route} must route through the router.");
+        }
     }
 
     [Fact]

--- a/windows/Ghostty/Tabs/TabHost.xaml
+++ b/windows/Ghostty/Tabs/TabHost.xaml
@@ -60,6 +60,8 @@
             TabCloseRequested="OnTabCloseRequested"
             ContextRequested="OnTabViewContextRequested"
             SelectionChanged="OnSelectionChanged"
+            TabStripDragOver="OnTabStripDragOver"
+            TabStripDrop="OnTabStripDrop"
             TabDragCompleted="OnTabDragCompleted">
             <controls:TabView.TabStripHeader>
                 <branding:AppIconBadge x:Name="IconBadgeHost" />

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -16,6 +17,7 @@ using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
 using Ghostty.Core.Windows;
 using Microsoft.UI.Xaml.Media;
+using Windows.ApplicationModel.DataTransfer;
 using Windows.Foundation;
 
 namespace Ghostty.Tabs;
@@ -364,6 +366,21 @@ internal sealed partial class TabHost : UserControl, ITabHost
             Content = null,
             IsClosable = false,
             Tag = group,
+            // While the run is folded, the chip IS the run's surface: the
+            // group commands live here. BuildGroupMenu is host-agnostic
+            // (the vertical header uses the same builder), and every item
+            // routes through the router, so a commanded rename, color,
+            // collapse or close announces exactly like the vertical's --
+            // a direct manager call here would move state silently.
+            ContextFlyout = TabContextMenuBuilder.BuildGroupMenu(
+                _manager,
+                group,
+                _dialogs,
+                requestCollapseGroup: _router.RequestCollapseGroup,
+                requestDissolveGroup: _router.RequestDissolveGroup,
+                requestCloseGroup: _router.RequestCloseGroup,
+                requestRenameGroup: _router.RequestRenameGroup,
+                requestColorGroup: _router.RequestColorGroup),
         };
         _chipByGroup[group] = new ChipVisuals(chip, title, count, swatch, chevron);
         group.PropertyChanged += OnGroupPropertyChanged;
@@ -1246,9 +1263,19 @@ internal sealed partial class TabHost : UserControl, ITabHost
     /// </summary>
     private bool _stripDragActive;
 
+    // The drop point, and whether it is this drag's. Recorded by
+    // OnTabStripDrop for the drop-at-a-run fork in OnTabDragCompleted,
+    // which carries no position of its own; the flag is the guard that
+    // makes the record honest -- a release off the strip fires no
+    // TabStripDrop, so the last drag's stale point must not answer for
+    // this one. Invalidated at drag start and consumed at completion.
+    private Windows.Foundation.Point _lastDropPosition;
+    private bool _dropPositionValid;
+
     private void OnTabDragStarting(TabView sender, TabViewTabDragStartingEventArgs args)
     {
         _stripDragActive = true;
+        _dropPositionValid = false;
         // Hidden synchronously: the drag is live from this call onward,
         // and anything the strip does from here moves slots the manager
         // has not agreed to yet.
@@ -1258,27 +1285,83 @@ internal sealed partial class TabHost : UserControl, ITabHost
     private void OnTabDragCompleted(TabView sender, TabViewTabDragCompletedEventArgs args)
     {
         _stripDragActive = false;
-        if (args.Item is TabViewItem item && item.Tag is not TabGroup)
+        _dropPositionValid = false;
+        if (args.Item is TabViewItem item)
         {
-            // The strip's slot is not a manager index: chips occupy slots
-            // too, so the raw IndexOf would land past every run left of
-            // the drop. The projection translates, and a drop that came
-            // to rest AT a chip's slot refuses outright -- the chip keeps
-            // its slot and the reconcile restores the strip. A later rung
-            // routes chip-shaped drops into joins.
-            var slot = TabViewControl.TabItems.IndexOf(item);
-            var newIndex = TabStripProjection.VisibleIndexToModelIndex(_manager, slot);
-            if (newIndex >= 0)
+            if (item.Tag is TabGroup draggedGroup)
             {
-                foreach (var (model, vi) in _itemByModel)
+                // A chip drags its whole run. The strip's slot is not a
+                // manager index: chips occupy slots too, and the members
+                // a collapsed run hides occupy none. The commit is
+                // MoveGroup even for a single-member run, so a chip drag
+                // can never split the run it is carrying.
+                //
+                // The left neighbour is the element the strip arranged at
+                // slot - 1, read as an identity and never as a slot: on a
+                // downward move TabView shifts every strip slot left
+                // between the origin and the rest, so re-reading slot - 1
+                // through the pre-drag projection names the dragged chip
+                // itself.
+                var slot = TabViewControl.TabItems.IndexOf(item);
+                TabModel? leftTab = null;
+                TabGroup? leftChip = null;
+                var known = slot <= 0;
+                if (!known
+                    && TabViewControl.ContainerFromIndex(slot - 1) is TabViewItem neighbour)
                 {
-                    if (vi == item)
+                    if (neighbour.Tag is TabGroup neighbourChip)
                     {
-                        var oldIndex = _manager.IndexOf(model);
-                        if (oldIndex != newIndex && oldIndex >= 0)
-                            _manager.Move(oldIndex, newIndex);
-                        break;
+                        leftChip = neighbourChip;
+                        known = true;
                     }
+                    else
+                    {
+                        foreach (var (model, vi) in _itemByModel)
+                        {
+                            if (vi != neighbour) continue;
+                            leftTab = model;
+                            known = true;
+                            break;
+                        }
+                    }
+                }
+
+                // A rest whose left neighbour the strip cannot name is
+                // skew the reconcile owns: refuse the commit rather than
+                // guess at the strip head.
+                if (known)
+                {
+                    var target =
+                        TabChipDrop.GroupTarget(_manager, draggedGroup, leftTab, leftChip);
+                    if (target >= 0) _manager.MoveGroup(draggedGroup, target);
+                }
+            }
+            else
+            {
+                // The strip's slot is not a manager index: chips occupy
+                // slots too, so the raw IndexOf would land past every run
+                // left of the drop. The projection translates; a slot that
+                // maps back to a tab commits the move the strip previewed,
+                // and a slot that maps to a chip falls to the
+                // drop-at-a-run fork.
+                var slot = TabViewControl.TabItems.IndexOf(item);
+                var newIndex = TabStripProjection.VisibleIndexToModelIndex(_manager, slot);
+                if (newIndex >= 0)
+                {
+                    foreach (var (model, vi) in _itemByModel)
+                    {
+                        if (vi == item)
+                        {
+                            var oldIndex = _manager.IndexOf(model);
+                            if (oldIndex != newIndex && oldIndex >= 0)
+                                _manager.Move(oldIndex, newIndex);
+                            break;
+                        }
+                    }
+                }
+                else
+                {
+                    ResolveDropAtChip(item, slot);
                 }
             }
         }
@@ -1291,6 +1374,102 @@ internal sealed partial class TabHost : UserControl, ITabHost
         // scan.
         ReconcileStripOrder();
         QueueBridgeUpdate();
+    }
+
+    /// <summary>
+    /// A tab dropped at a slot the projection names with a chip: the drop
+    /// landed at a collapsed run. Geometry splits the fork. ON the chip
+    /// joins the run -- and the join is visible, because JoinGroup is the
+    /// manager's own auto-expanding join, so the run the tab actually
+    /// joined unfolds on the same commit. BESIDE the chip positions the
+    /// tab relative to the run's edge without joining: the run's hidden
+    /// members are room the landing clears either way.
+    ///
+    /// The group comes from the projection, never from the strip's item
+    /// order: the members are hidden at drop time, so no TabItems index
+    /// can say which run took the drop. A slot the projection does not
+    /// name, or a drop with no usable point (released off the strip,
+    /// where TabStripDrop never fired), refuses outright and the
+    /// reconcile after the commit restores the strip.
+    /// </summary>
+    private void ResolveDropAtChip(TabViewItem dragged, int slot)
+    {
+        if (TabStripProjection.VisibleGroupAt(_manager, slot) is not { } chipGroup
+            || !_chipByGroup.TryGetValue(chipGroup, out var chip))
+            return;
+
+        TabModel? dropped = null;
+        foreach (var (model, vi) in _itemByModel)
+        {
+            if (vi == dragged) { dropped = model; break; }
+        }
+        if (dropped is null) return;
+
+        var bounds = DropPointIn(chip.Item);
+        if (bounds is null) return;
+
+        if (bounds.Value.Contains(_lastDropPosition))
+        {
+            _manager.JoinGroup(dropped, chipGroup);
+            return;
+        }
+
+        var before = _lastDropPosition.X < bounds.Value.X + bounds.Value.Width / 2;
+        var beside = before
+            ? TabChipDrop.MemberTargetBefore(_manager, chipGroup)
+            : TabChipDrop.MemberTargetAfter(_manager, chipGroup);
+        var oldIndex = _manager.IndexOf(dropped);
+        if (beside >= 0 && oldIndex >= 0 && oldIndex != beside)
+            _manager.Move(oldIndex, beside);
+    }
+
+    /// <summary>
+    /// The recorded drop point against <paramref name="target"/>'s
+    /// arranged bounds, or null when there is nothing to compare: the
+    /// drag released off the strip (no TabStripDrop, no point) or the
+    /// bounds read failed. Null is not a join and not a side -- the fork
+    /// refuses and the reconcile speaks, because a geometry guess would
+    /// join a tab the user parked beside a run.
+    /// </summary>
+    private Rect? DropPointIn(TabViewItem target)
+    {
+        if (!_dropPositionValid) return null;
+        try
+        {
+            var origin = target.TransformToVisual(TabViewControl)
+                .TransformPoint(new Point(0, 0));
+            return new Rect(origin, new Size(target.ActualWidth, target.ActualHeight));
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException
+            or System.Runtime.InteropServices.COMException or NullReferenceException)
+        {
+            // The item is not in the tree yet, or is leaving it. There is
+            // no honest answer without geometry.
+            return null;
+        }
+    }
+
+    private void OnTabStripDragOver(object sender, DragEventArgs e)
+    {
+        // Only this strip's own tab drags are drop material: an external
+        // drag has no reorder to land and must stay declined, which an
+        // untouched accepted-operation does. The accept exists so the
+        // drop has somewhere to land -- and so TabStripDrop fires with
+        // the pointer position the drop-at-a-run fork reads.
+        if (!_stripDragActive) return;
+        e.AcceptedOperation = DataPackageOperation.Move;
+        e.Handled = true;
+    }
+
+    private void OnTabStripDrop(object sender, DragEventArgs e)
+    {
+        // Record, nothing else. The commit belongs to OnTabDragCompleted
+        // -- TabView fires this first, then completes the drag -- and the
+        // strip's own reorder is already TabView's, applied in its live
+        // preview.
+        if (!_stripDragActive) return;
+        _lastDropPosition = e.GetPosition(TabViewControl);
+        _dropPositionValid = true;
     }
 
     /// <summary>


### PR DESCRIPTION
PR 6 of the tab ladder, fourth rung (6a-iv): completes the horizontal chip grammar. Facts ride in this rung (770 countable, under the cap).

- Chip drag = MoveGroup: a completed chip drag resolves its target from the strip's final arrangement -- the left neighbour is read as an identity via ContainerFromIndex, never as a slot re-read through the pre-drag projection (which names the dragged chip itself after TabView's mid-drag shift). GroupTarget subtracts the dragged run's own departure when it started left of the edge; a chip neighbour stands for its whole hidden run. Unresolvable neighbour = refuse; the reconcile reverts the strip.
- Drop-on-chip join: ResolveDropAtChip forks on release geometry -- a point inside the chip's bounds joins the group (manager auto-expands on an actual join only); a point beside positions relative to the run without joining; a release off the strip refuses. The recorded drop point is invalidated at drag start, so no drop is ever answered by the previous drag's geometry.
- Chip menus: the chip's ContextFlyout is the shared BuildGroupMenu -- Collapse/Expand, Dissolve, Close (greyed by GroupHoldsEveryTab), Rename, Color -- routed through the action router like every other entry point.
- TabDroppedOutside stays unwired, per its pin.

TabChipDrop (Core, pure) + facts: 11 mutations applied-red-reverted by the implementer, 4 reproduced by the reviewer, each red exactly under its regression.