### PR TITLE
tabs: the group run label, the group rail, and the pin zone's chrome

### DIFF
--- a/windows/Ghostty.Core/Tabs/TabRunLabelShape.cs
+++ b/windows/Ghostty.Core/Tabs/TabRunLabelShape.cs
@@ -1,0 +1,211 @@
+namespace Ghostty.Core.Tabs;
+
+/// <summary>
+/// The horizontal group run label's geometry and show/hide rules, in the
+/// one place that needs no WinUI host to pin by test.
+///
+/// The label is visual sugar over an expanded run: the rail carries
+/// no inline name, so the name floats above the run instead. The element
+/// that renders it lives in the shell; everything about WHERE it sits and
+/// WHEN it shows is here, so the rules are executable without a strip --
+/// the same split TabChipDrop uses for the drop map.
+/// </summary>
+public static class TabRunLabelShape
+{
+    /// <summary>The label's fixed height. Content never grows it.</summary>
+    public const double HeightPx = 24;
+
+    /// <summary>
+    /// Clearance between the label's bottom edge and the rail line: the
+    /// label floats 4px above the run's 2px top rail, close enough to read
+    /// as belonging to the run, far enough not to touch it.
+    /// </summary>
+    public const double RailGapPx = 4;
+
+    /// <summary>
+    /// The group title ellipsizes past this rather than stretching the
+    /// label; the run's own width caps it again from below.
+    /// </summary>
+    public const double TitleMaxWidthPx = 240;
+
+    /// <summary>Hover shows the label after the classic TTDT_INIT delay.</summary>
+    public const int HoverShowMs = 500;
+
+    /// <summary>
+    /// Pointer-out grace: moving between a run's own members exits one tab
+    /// and enters the next, and the label must not flicker across the gap.
+    /// </summary>
+    public const int LeaveGraceMs = 150;
+
+    /// <summary>
+    /// A keyboard show (selection landing on a grouped member) is a
+    /// courtesy, not a hover: it shows for this long, then fades itself.
+    /// </summary>
+    public const int KeyboardShowMs = 1200;
+
+    /// <summary>The Fade token: 83ms linear in and out.</summary>
+    public const int FadeMs = 83;
+
+    /// <summary>
+    /// Where the label sits for a run occupying <paramref name="runLeft"/>,
+    /// <paramref name="runTop"/>, <paramref name="runWidth"/> in the host
+    /// surface's own coordinates. Left-aligned to the run's first member
+    /// and never wider than the run -- a label wider than what it names
+    /// reads as pointing at the neighbours. The title ellipsizes within.
+    /// </summary>
+    public static (double Left, double Top, double Width) Place(
+        double runLeft, double runTop, double runWidth)
+    {
+        var width = double.IsFinite(runWidth) && runWidth > 0 ? runWidth : 0;
+        return (runLeft, runTop - RailGapPx - HeightPx, width);
+    }
+
+    /// <summary>
+    /// The fade duration for one transition. Motion on, the Fade token;
+    /// motion off, zero -- a cut. State never waits on the animation
+    /// completing either way (the caller collapses on completion, so a
+    /// zero duration is simply the same path one frame later).
+    /// </summary>
+    public static TimeSpan FadeDuration(bool motionOn)
+        => TimeSpan.FromMilliseconds(motionOn ? FadeMs : 0);
+}
+
+/// <summary>
+/// The label's show/hide rule machine, one instance per horizontal strip.
+/// Pure: events go in, a phase comes out, and the host translates phase
+/// changes into element ops and timer arms. It holds no timers itself --
+/// Core has no dispatcher -- so every arm is the host's doing and a missed
+/// arm is visible in review rather than swallowed in a callback.
+/// </summary>
+public sealed class TabRunLabelRules
+{
+    /// <summary>
+    /// Idle = hidden and nothing pending. HoverPending = the show delay is
+    /// running. Shown = visible. GracePending = the pointer just left and
+    /// the grace is running.
+    /// </summary>
+    public enum Phase { Idle, HoverPending, Shown, GracePending }
+
+    public Phase Current { get; private set; } = Phase.Idle;
+
+    /// <summary>
+    /// A drag is live anywhere that matters. While it is, hover and
+    /// keyboard shows are refused -- and the hide that ended whatever was
+    /// showing was a cut, so the label can never overlap the drag ghost.
+    /// </summary>
+    public bool DragLive { get; private set; }
+
+    /// <summary>
+    /// The most recent hide was demanded as a cut (a drag start), until
+    /// the drag ends. The host reads this at the same instant it reads
+    /// Current, so it can only matter on a transition into Idle.
+    /// </summary>
+    public bool CutOnHide { get; private set; }
+
+    /// <summary>
+    /// The current showing was requested by the keyboard rule, not hover:
+    /// the host arms its auto-hide for that case and not the hover one.
+    /// </summary>
+    public bool KeyboardShown { get; private set; }
+
+    /// <summary>Pointer entered a run's member.</summary>
+    public Phase HoverEnter()
+    {
+        if (DragLive) return Current;
+        KeyboardShown = false;
+        Current = Current == Phase.Shown ? Phase.Shown : Phase.HoverPending;
+        return Current;
+    }
+
+    /// <summary>Pointer left a run's member.</summary>
+    public Phase HoverExit()
+    {
+        if (DragLive) return Current;
+        Current = Current switch
+        {
+            Phase.Shown => Phase.GracePending,
+            Phase.HoverPending => Phase.Idle,
+            _ => Current,
+        };
+        return Current;
+    }
+
+    /// <summary>The show delay fired.</summary>
+    public Phase HoverTimerFired()
+    {
+        if (DragLive) { Current = Phase.Idle; return Current; }
+        if (Current == Phase.HoverPending) Current = Phase.Shown;
+        return Current;
+    }
+
+    /// <summary>The pointer-out grace fired.</summary>
+    public Phase GraceTimerFired()
+    {
+        if (Current == Phase.GracePending) Current = Phase.Idle;
+        return Current;
+    }
+
+    /// <summary>
+    /// Selection landed on a grouped member of an expanded run. This is
+    /// the keyboard rule: show now, auto-hide after KeyboardShowMs. A
+    /// selection change is also a hide rule for whatever showed before --
+    /// the host hides the old run's label on the same event before
+    /// consulting this one.
+    /// </summary>
+    public Phase KeyboardRequested()
+    {
+        if (DragLive) return Current;
+        KeyboardShown = true;
+        Current = Phase.Shown;
+        return Current;
+    }
+
+    /// <summary>The keyboard auto-hide fired.</summary>
+    public Phase KeyboardTimerFired()
+    {
+        if (Current == Phase.Shown && KeyboardShown) Current = Phase.Idle;
+        return Current;
+    }
+
+    /// <summary>
+    /// A drag started anywhere in the strip -- either strip: the hide is
+    /// part of the drag start's own dispatch pass, which is what keeps
+    /// the label from ever overlapping the drag ghost. Everything pending
+    /// dies here; nothing defers it.
+    /// </summary>
+    public Phase DragStarting()
+    {
+        DragLive = true;
+        CutOnHide = true;
+        KeyboardShown = false;
+        Current = Phase.Idle;
+        return Current;
+    }
+
+    /// <summary>The drag ended. Hover may show again.</summary>
+    public Phase DragEnded()
+    {
+        DragLive = false;
+        CutOnHide = false;
+        return Current;
+    }
+
+    /// <summary>The showing group collapsed.</summary>
+    public Phase Collapsed() => EndShow();
+
+    /// <summary>The selection moved.</summary>
+    public Phase SelectionChanged() => EndShow();
+
+    /// <summary>A layout switch was requested.</summary>
+    public Phase LayoutSwitchRequested() => EndShow();
+
+    /// <summary>The window deactivated.</summary>
+    public Phase Deactivated() => EndShow();
+
+    private Phase EndShow()
+    {
+        KeyboardShown = false;
+        Current = Phase.Idle;
+        return Current;
+    }
+}

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -473,7 +473,12 @@ public sealed partial class MainWindow : Window
             Activated += (_, args) =>
             {
                 if (args.WindowActivationState != Microsoft.UI.Xaml.WindowActivationState.Deactivated)
+                {
                     App.NoteRegularWindowActivated(this);
+                }
+                // The Deactivated arm carries no bookkeeping; the run
+                // label's hide rule for it is wired below, once the hosts
+                // exist.
             };
         }
 
@@ -809,6 +814,34 @@ public sealed partial class MainWindow : Window
             activeTab: () => _tabManager.Tabs.Count > 0 ? _tabManager.ActiveTab : null,
             impact: NudgeWindowForImpact);
         _layout.Snap(_verticalTabsVisible);
+
+        // The horizontal strip's group run label lives here, on the morph
+        // canvas: the one overlay both strips are measured in, above the
+        // chrome, hit-test-transparent so it can never take a click that
+        // belongs to the strip beneath. The window owns it because three
+        // of its hide rules are the window's to know -- the vertical
+        // strip's drag start, a layout switch request, and deactivation.
+        _runLabel = new TabRunLabel();
+        TabMorphLayer.Children.Add(_runLabel);
+        _runLabel.MotionEnabled = () => TabStripMotion.Enabled(
+            SystemAnimationsEnabled(), HighContrastChromeActive);
+        _horizontalTabHost.AttachRunLabel(_runLabel);
+        _verticalTabHost.DragVisualStarted += () =>
+            _horizontalTabHost.CloseRunLabelForDrag();
+        _verticalTabHost.DragVisualEnded += () =>
+            _horizontalTabHost.EndRunLabelDrag();
+        // Deactivation is the last window-owned hide rule: whatever run
+        // the label was naming belongs to a window the user is no longer
+        // looking at. Through the strip's machine door, not a bare element
+        // hide -- the door lands the machine on Idle, which cancels the
+        // pending timers a bare hide would leave armed to surface the
+        // label later on a window nobody is looking at.
+        Activated += (_, args) =>
+        {
+            if (args.WindowActivationState
+                == Microsoft.UI.Xaml.WindowActivationState.Deactivated)
+                _horizontalTabHost.CloseRunLabelForDeactivation();
+        };
         // The strip that starts hidden has never realized its tab
         // containers, so the first switch to it would have nothing for the
         // active-tab morph to aim at.
@@ -1985,6 +2018,11 @@ public sealed partial class MainWindow : Window
         if (_layout.IsSwitching) return;
         var toVertical = !_verticalTabsVisible;
 
+        // The run label is anchored to the outgoing strip's arrangement
+        // and reads pointer state the switch invalidates: it hides by
+        // rule before the morph starts, not after it lands.
+        _horizontalTabHost.CloseRunLabelForLayoutSwitch();
+
         // Persist through the shared debounced scheduler so rapid
         // toggling (Ctrl+Shift+, held down, or the context-menu
         // sibling firing at the same time as the settings toggle)
@@ -3006,6 +3044,29 @@ public sealed partial class MainWindow : Window
     }
 
     private readonly Microsoft.UI.Xaml.Shapes.Rectangle _verticalSeamCover;
+
+    // The horizontal strip's group run label, hosted on TabMorphLayer.
+    // Built here rather than in XAML so it stays code-built and
+    // non-focusable by construction -- visual sugar, no automation
+    // surface, no light-dismiss plumbing to fight.
+    private TabRunLabel? _runLabel;
+
+    /// <summary>
+    /// The motion gate the run label reads per fade. Same sources as the
+    /// strips: OS animation effects on, and High Contrast composed through
+    /// HighContrastState, never raw IsActive.
+    /// </summary>
+    private static bool SystemAnimationsEnabled()
+    {
+        try { return new Windows.UI.ViewManagement.UISettings().AnimationsEnabled; }
+        catch (Exception ex) when (ex is InvalidOperationException
+            or System.Runtime.InteropServices.COMException or NullReferenceException)
+        {
+            // Unreadable is not "off": fail open, as VerticalTabStrip and
+            // App.xaml.cs both do in packaged/sandboxed contexts.
+            return true;
+        }
+    }
 
     /// <summary>
     /// How far back into the selected row the vertical seam cover starts.

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -50,6 +50,25 @@ internal sealed partial class TabHost : UserControl, ITabHost
     // above alone no longer describe what TabItems holds.
     private readonly Dictionary<TabGroup, ChipVisuals> _chipByGroup = new();
 
+    // The 2px group rail per tab, in the header's top slot. Kept like the
+    // header TextBlock so a group change repaints the live element instead
+    // of rebuilding the header.
+    private readonly Dictionary<TabModel, Microsoft.UI.Xaml.Shapes.Rectangle>
+        _railByModel = new();
+
+    // The group run label. The rule machine decides; ApplyLabelPhase
+    // translates each phase into timer arms and element ops. The element
+    // lives on the window's morph canvas -- MainWindow attaches it here --
+    // because the hide rules come from both strips and the window, and the
+    // morph canvas is the one coordinate space all three already share.
+    private readonly TabRunLabelRules _labelRules = new();
+    private TabRunLabel? _runLabel;
+    private TabRunLabelRules.Phase _labelPhase = TabRunLabelRules.Phase.Idle;
+    private TabGroup? _labelGroup;
+    private readonly Microsoft.UI.Dispatching.DispatcherQueueTimer _labelShowTimer;
+    private readonly Microsoft.UI.Dispatching.DispatcherQueueTimer _labelGraceTimer;
+    private readonly Microsoft.UI.Dispatching.DispatcherQueueTimer _labelKeyboardTimer;
+
     /// <summary>
     /// The renderable parts of one chip, kept so INPC updates land on the
     /// live elements instead of rebuilding the header -- the same reason
@@ -102,8 +121,8 @@ internal sealed partial class TabHost : UserControl, ITabHost
         // strip stays in step while hidden; RefreshSeam re-derives the
         // whole pass as belt and braces.
         _manager.TabAdded += (_, t) => { AddItem(t); ReconcileChips(); ReconcileStripOrder(); SelectActive(); QueueBridgeUpdate(); };
-        _manager.TabRemoved += (_, t) => { RemoveItem(t); ReconcileChips(); ReconcileStripOrder(); QueueBridgeUpdate(); };
-        _manager.TabMoved += (_, e) => { MoveItem(e.tab, e.to); ReconcileChips(); ReconcileStripOrder(); QueueBridgeUpdate(); };
+        _manager.TabRemoved += (_, t) => { RemoveItem(t); ReconcileChips(); ReconcileStripOrder(); ApplyPinZoneChrome(); QueueBridgeUpdate(); };
+        _manager.TabMoved += (_, e) => { MoveItem(e.tab, e.to); ReconcileChips(); ReconcileStripOrder(); ApplyPinZoneChrome(); QueueBridgeUpdate(); };
         _manager.ActiveTabChanged += (_, _) => { ReconcileChips(); ReconcileStripOrder(); SelectActive(); QueueBridgeUpdate(); };
 
         // Every one of the calls above can run before the strip has arranged,
@@ -118,6 +137,18 @@ internal sealed partial class TabHost : UserControl, ITabHost
         // order, so the cover (placed from the active item's slot) is
         // suppressed for the drag and re-placed at the drop.
         TabViewControl.TabDragStarting += OnTabDragStarting;
+
+        // The run label's timers. Each stops itself before translating, so
+        // a timer that fires twice in a pass cannot double-apply.
+        _labelShowTimer = DispatcherQueue.CreateTimer();
+        _labelShowTimer.Interval = TimeSpan.FromMilliseconds(TabRunLabelShape.HoverShowMs);
+        _labelShowTimer.Tick += (_, _) => { _labelShowTimer.Stop(); ApplyLabelPhase(_labelRules.HoverTimerFired()); };
+        _labelGraceTimer = DispatcherQueue.CreateTimer();
+        _labelGraceTimer.Interval = TimeSpan.FromMilliseconds(TabRunLabelShape.LeaveGraceMs);
+        _labelGraceTimer.Tick += (_, _) => { _labelGraceTimer.Stop(); ApplyLabelPhase(_labelRules.GraceTimerFired()); };
+        _labelKeyboardTimer = DispatcherQueue.CreateTimer();
+        _labelKeyboardTimer.Interval = TimeSpan.FromMilliseconds(TabRunLabelShape.KeyboardShowMs);
+        _labelKeyboardTimer.Tick += (_, _) => { _labelKeyboardTimer.Stop(); ApplyLabelPhase(_labelRules.KeyboardTimerFired()); };
 
         // TabView.TabItemsChanged stays unwired on purpose. It fires for
         // this control's own writes as much as for TabView's, so a
@@ -170,6 +201,27 @@ internal sealed partial class TabHost : UserControl, ITabHost
         // would drag a UI dependency into Ghostty.Core. The presenter
         // subscribes to the TabIconViewModel's INPC events directly.
         var iconRow = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 0 };
+
+        // The pin mark: Segoe Fluent E718 in the leading slot of the
+        // icon row. Equal-width keeps a pinned tab full-size -- shrinking
+        // it to the icon alone would read as a different kind of slot, not
+        // a pinned tab -- so this glyph is the pinned tab's only inline
+        // marker. Collapsed until the tab pins; the IsPinned branch below
+        // is the only thing that shows it.
+        var pinGlyph = new FontIcon
+        {
+            Glyph = "\uE718", // Segoe Fluent / MDL2 "Pin"
+            // FontIcon's default FontFamily is not guaranteed to be the
+            // symbol font, so pin it explicitly (as the close button and
+            // the bell do) or the glyph can render as nothing.
+            FontFamily = (Microsoft.UI.Xaml.Media.FontFamily)
+                Application.Current.Resources["SymbolThemeFontFamily"],
+            FontSize = 12,
+            Margin = new Thickness(0, 0, 6, 0),
+            VerticalAlignment = VerticalAlignment.Center,
+            Visibility = tab.IsPinned ? Visibility.Visible : Visibility.Collapsed,
+        };
+        iconRow.Children.Add(pinGlyph);
         var iconHost = new TabIconPresenter
         {
             VerticalAlignment = VerticalAlignment.Center,
@@ -200,8 +252,20 @@ internal sealed partial class TabHost : UserControl, ITabHost
         };
         iconRow.Children.Add(bellGlyph);
 
+        // The group rail: a 2px line in the group's color in the header's
+        // TOP slot. The progress bar owns the bottom slot; the two
+        // never fight. Collapsed until a chrome pass finds a group to
+        // paint -- membership, not this build loop, decides its color.
+        var rail = new Microsoft.UI.Xaml.Shapes.Rectangle
+        {
+            Height = 2,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            Visibility = Visibility.Collapsed,
+        };
+        headerPanel.Children.Add(rail);
         headerPanel.Children.Add(iconRow);
         headerPanel.Children.Add(headerBar);
+        _railByModel[tab] = rail;
 
         var item = new TabViewItem
         {
@@ -224,6 +288,13 @@ internal sealed partial class TabHost : UserControl, ITabHost
             DataContext = tab,
         };
         ApplyItemAccessibleText(item, tab);
+        // Hover anywhere on the run shows the label. The handlers
+        // ride every member item and guard at entry: a tab that is not in
+        // an expanded run is not a run surface. Crossing between members
+        // of one run fires Exited then Entered, which is exactly what the
+        // 150ms grace exists to absorb.
+        item.PointerEntered += (_, _) => OnRunMemberPointerEntered(tab);
+        item.PointerExited += (_, _) => ApplyLabelPhase(_labelRules.HoverExit());
         tab.PropertyChanged += (_, e) =>
         {
             if (e.PropertyName == nameof(TabModel.EffectiveTitle) ||
@@ -262,6 +333,9 @@ internal sealed partial class TabHost : UserControl, ITabHost
                 // (the boundary tab pinning up, the last pinned tab
                 // unpinning), so a relocation-path refresh alone would
                 // leave the boundary tab's status stale for life.
+                pinGlyph.Visibility = tab.IsPinned
+                    ? Visibility.Visible
+                    : Visibility.Collapsed;
                 ApplyItemAccessibleText(item, tab);
             }
             else if (e.PropertyName == nameof(TabModel.Group))
@@ -270,8 +344,14 @@ internal sealed partial class TabHost : UserControl, ITabHost
                 // chip presence, chip counts, and the order they sit in
                 // all re-read. A join into a chip'd run also strands this
                 // tab's slot; the reconcile's rebuild is what removes it.
+                // The rail re-derives on the next chrome pass, which the
+                // reconcile's SelectActive neighbors already run -- but a
+                // move that lands neither selection nor chip still needs
+                // the line to follow the tab, so paint it here too.
                 ReconcileChips();
                 ReconcileStripOrder();
+                ApplyTabChrome(item, headerPanel, tab,
+                    ReferenceEquals(tab, _manager.ActiveTab));
             }
         };
         _itemByModel[tab] = item;
@@ -298,7 +378,120 @@ internal sealed partial class TabHost : UserControl, ITabHost
         TabViewControl.TabItems.Remove(item);
         _itemByModel.Remove(tab);
         _headerTextByModel.Remove(tab);
+        _railByModel.Remove(tab);
         // PaneHost detach from the shared container is MainWindow's job.
+    }
+
+    // -----------------------------------------------------------------
+    // The group run label. The rules live in
+    // TabRunLabelRules (Core, host-free); this half only translates each
+    // phase into timer arms and element ops. Every event lands in
+    // ApplyLabelPhase, so a hide rule cannot be forgotten by arriving
+    // through a door the strip did not expect.
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// Attach the window-owned label element. MainWindow builds and hosts
+    /// it on the morph canvas -- the surface both strips are measured in
+    /// and the window already owns -- and hands it over here.
+    /// </summary>
+    internal void AttachRunLabel(TabRunLabel label) => _runLabel = label;
+
+    /// <summary>
+    /// The cross-host hide: the vertical strip's drag start reaches this
+    /// through the window, in the same dispatch pass as its own lift. The
+    /// label cannot know about the vertical strip and must not -- the
+    /// window owns the fact that both strips share one drag surface.
+    /// </summary>
+    internal void CloseRunLabelForDrag() => ApplyLabelPhase(_labelRules.DragStarting());
+
+    /// <summary>
+    /// The cross-host lift: the vertical drag ended, so the refusal stops.
+    /// Without this the machine's DragLive flag has no off-switch on the
+    /// vertical path -- the first vertical drag would kill the label for
+    /// the session, hover and keyboard shows alike. The horizontal drag
+    /// has no counterpart here: its own completed handler applies this
+    /// same rule in its body.
+    /// </summary>
+    internal void EndRunLabelDrag() => ApplyLabelPhase(_labelRules.DragEnded());
+
+    /// <summary>
+    /// Deactivation is a hide rule for the run label: whatever run it was
+    /// naming belongs to a window the user is no longer looking at. It
+    /// goes through the machine, not a bare element hide -- a bare hide
+    /// leaves the phase pending and its timers armed, and the label
+    /// surfaces again on a window nobody is looking at.
+    /// </summary>
+    internal void CloseRunLabelForDeactivation()
+        => ApplyLabelPhase(_labelRules.Deactivated());
+
+    /// <summary>
+    /// A layout switch was requested. A hide rule in its own right: the
+    /// label is anchored to this strip's arrangement, and the switch is
+    /// about to replace both.
+    /// </summary>
+    internal void CloseRunLabelForLayoutSwitch()
+        => ApplyLabelPhase(_labelRules.LayoutSwitchRequested());
+
+    private void OnRunMemberPointerEntered(TabModel tab)
+    {
+        if (tab.Group is not { } group || group.IsCollapsed) return;
+        if (_chipByGroup.ContainsKey(group)) return;
+        _labelGroup = group;
+        ApplyLabelPhase(_labelRules.HoverEnter());
+    }
+
+    /// <summary>
+    /// The one door every label event goes through. Each target phase
+    /// names its own timer work and element op, so the translation is
+    /// total: nothing pending survives into a phase that should not carry
+    /// it, and Idle reads the machine's cut flag -- a drag start hides as
+    /// a cut, everything else as a fade.
+    /// </summary>
+    private void ApplyLabelPhase(TabRunLabelRules.Phase to)
+    {
+        _labelPhase = to;
+        switch (to)
+        {
+            case TabRunLabelRules.Phase.HoverPending:
+                _labelGraceTimer.Stop();
+                _labelKeyboardTimer.Stop();
+                _labelShowTimer.Stop();
+                _labelShowTimer.Start();
+                break;
+            case TabRunLabelRules.Phase.Shown:
+                _labelShowTimer.Stop();
+                _labelGraceTimer.Stop();
+                _labelKeyboardTimer.Stop();
+                if (_labelRules.KeyboardShown) _labelKeyboardTimer.Start();
+                ShowRunLabel();
+                break;
+            case TabRunLabelRules.Phase.GracePending:
+                _labelShowTimer.Stop();
+                _labelKeyboardTimer.Stop();
+                _labelGraceTimer.Stop();
+                _labelGraceTimer.Start();
+                break;
+            case TabRunLabelRules.Phase.Idle:
+                _labelShowTimer.Stop();
+                _labelGraceTimer.Stop();
+                _labelKeyboardTimer.Stop();
+                _runLabel?.Hide(_labelRules.CutOnHide);
+                break;
+        }
+    }
+
+    private void ShowRunLabel()
+    {
+        if (_runLabel is null || _labelGroup is not { } group) return;
+        var members = _manager.MembersOf(group);
+        if (members.Count == 0) return;
+        // The label spans the run: anchored at the head, sized by the
+        // tail. Both elements come from the strip's own map -- the same
+        // identity lookup TabElement serves -- never from strip order.
+        if (_itemByModel.TryGetValue(members[0], out var head)
+            && _itemByModel.TryGetValue(members[^1], out var tail))
+            _runLabel.ShowFor(group, members.Count, head, tail);
     }
 
     // -----------------------------------------------------------------
@@ -428,11 +621,37 @@ internal sealed partial class TabHost : UserControl, ITabHost
             // the chip and the members render as themselves; collapsing
             // mints one when the run does not hold the active tab. Title
             // and color are in-place refreshes and fall through to one.
+            // A collapse is a hide rule for the label: the run it named
+            // is about to stop being a run of visible members.
+            ApplyLabelPhase(_labelRules.Collapsed());
             ReconcileChips();
             ReconcileStripOrder();
             return;
         }
         RefreshChip(group);
+        // The run's members carry the group's name and color on their own
+        // chrome now; the same single-door pass the chip's swatch rides
+        // repaints them, so a recolor never leaves a two-tone run.
+        RefreshRunRails(group);
+    }
+
+    /// <summary>
+    /// Re-derive the chrome of every member of one expanded run. The rail
+    /// and the tint both read the group, so a group change re-runs the
+    /// same per-item pass a selection runs -- one door, no per-element
+    /// special cases to forget.
+    /// </summary>
+    private void RefreshRunRails(TabGroup group)
+    {
+        foreach (var member in _manager.MembersOf(group))
+        {
+            if (_itemByModel.TryGetValue(member, out var item)
+                && item.Header is StackPanel headerPanel)
+            {
+                ApplyTabChrome(item, headerPanel, member,
+                    ReferenceEquals(member, _manager.ActiveTab));
+            }
+        }
     }
 
     /// <summary>
@@ -673,6 +892,42 @@ internal sealed partial class TabHost : UserControl, ITabHost
         _suppressSelectionEvent = true;
         TabViewControl.SelectedItem = item;
         _suppressSelectionEvent = false;
+        OnSelectionLanded(item);
+    }
+
+    /// <summary>
+    /// The label's selection rule, run only when the strip's selection
+    /// actually landed somewhere new. One door for every path that moves
+    /// the active tab -- TabView keyboard selection, move_tab, Ctrl+Tab,
+    /// MRU, a click. Reverse sync suppresses SelectionChanged, so the
+    /// event cannot carry this; this is what always runs. The old run's
+    /// label hides (the selection hide rule); a landing INSIDE an
+    /// expanded run is the keyboard show, 1200ms then faded. A click on
+    /// a member takes that restart path rather than hover's: the phase
+    /// at click time is still HoverPending, so the landing cancels the
+    /// armed 500ms and shows at once as the courtesy. Only a label
+    /// already Shown is left alone -- re-selecting into its run must not
+    /// stretch the courtesy into a stuck label.
+    /// </summary>
+    private void OnSelectionLanded(TabViewItem item)
+    {
+        if (_runLabel is null) return;
+        var active = _manager.ActiveTab;
+        if (active?.Group is { } group && !group.IsCollapsed
+            && !_chipByGroup.ContainsKey(group))
+        {
+            if (!ReferenceEquals(group, _labelGroup)
+                || _labelPhase != TabRunLabelRules.Phase.Shown)
+            {
+                ApplyLabelPhase(_labelRules.SelectionChanged());
+                _labelGroup = group;
+                ApplyLabelPhase(_labelRules.KeyboardRequested());
+            }
+        }
+        else if (_labelPhase != TabRunLabelRules.Phase.Idle)
+        {
+            ApplyLabelPhase(_labelRules.SelectionChanged());
+        }
     }
 
     private static readonly SolidColorBrush TransparentHeaderSelected =
@@ -696,6 +951,9 @@ internal sealed partial class TabHost : UserControl, ITabHost
                 selectedItem = viewItem;
         }
         RecolorTabText();
+        // The stroke's ink is the accent resolved per call: the theme
+        // refresh is what re-reads it.
+        ApplyPinZoneChrome();
         RefreshTabViewTheme();
         if (selectedItem is not null)
             NudgeTabViewItemVisual(selectedItem);
@@ -1037,7 +1295,83 @@ internal sealed partial class TabHost : UserControl, ITabHost
         }
         SetItemHeaderBrush(viewItem, "TabViewSelectedItemBorderBrush", selectedBorder);
 
+        // The group rail rides every chrome pass, so a join, a leave, or a
+        // color change each land on a pass that already runs. Painted
+        // through the chip swatch's palette path: a group has no "no
+        // color" state, and the rail is the run's identity mark, not a
+        // theme choice for the user to override per color.
+        if (_railByModel.TryGetValue(tab, out var rail))
+        {
+            if (tab.Group is { } group)
+            {
+                rail.Fill = TabColorBrush.From(
+                    TabColorPalette.Background(group.Color, selected: false));
+                rail.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                rail.Visibility = Visibility.Collapsed;
+            }
+        }
+
         headerPanel.Background = TransparentHeaderSelected;
+    }
+
+    /// <summary>
+    /// The pin zone's edge, horizontal: a 1px right border stroke on
+    /// the LAST pinned tab, nothing on its neighbours. One writer owns the
+    /// border -- this pass -- so a stale stroke has exactly one place to
+    /// come from and every drag exit lands here to clear it. The predicate
+    /// reads manager truth: during a drag the strip's order is TabView's
+    /// preview, and the zone edge is the manager's prefix length, not the
+    /// preview's.
+    ///
+    /// The brighten/dim is the vertical stroke's semantics (4b-1), alpha
+    /// for alpha: dim at 0x59 while idle, bright at 0xE6 while a drag is
+    /// live -- the boundary is what a drag-to-pin is aiming at. The swap
+    /// is deliberate rather than a color animation: the vertical edition
+    /// ships the same swap, refreshed by passes that already run, so the
+    /// state never waits on an animation (the 167ms BoundaryStroke token
+    /// governs a transition neither strip draws).
+    /// </summary>
+    private void ApplyPinZoneChrome()
+    {
+        var boundary = _manager.PinCount > 0
+            ? _manager.Tabs[_manager.PinCount - 1]
+            : null;
+        foreach (var (model, item) in _itemByModel)
+        {
+            if (ReferenceEquals(model, boundary))
+            {
+                item.BorderThickness = new Thickness(0, 0, 1, 0);
+                item.BorderBrush = PinBoundaryBrush();
+            }
+            else
+            {
+                item.BorderThickness = default;
+                item.BorderBrush = null;
+            }
+        }
+    }
+
+    /// <summary>
+    /// The boundary stroke's ink: the accent, resolved from the theme
+    /// resources on every call the way the bell glyph's is, so High
+    /// Contrast re-themes it and a runtime theme change is picked up by
+    /// the next pass (RefreshTabColors re-runs this). A fresh brush per
+    /// call because mutating one shared brush's alpha would retint every
+    /// other reader of the resource.
+    /// </summary>
+    private Brush PinBoundaryBrush()
+    {
+        // Bright only while a drag is LIVE: an armed-but-not-dragging
+        // strip keeps the idle stroke, or the boundary would flash on
+        // every session the strip opens.
+        byte alpha = _stripDragActive ? (byte)0xE6 : (byte)0x59;
+        if (Application.Current.Resources.TryGetValue("SystemAccentColor", out var v)
+            && v is Windows.UI.Color accent)
+            return new SolidColorBrush(Windows.UI.Color.FromArgb(alpha, accent.R, accent.G, accent.B));
+        return new SolidColorBrush(Windows.UI.Color.FromArgb(alpha, 0x60, 0xCD, 0xFF));
     }
 
     private static void ApplyTabViewItemHeaderBrushes(
@@ -1276,6 +1610,15 @@ internal sealed partial class TabHost : UserControl, ITabHost
     {
         _stripDragActive = true;
         _dropPositionValid = false;
+        // The label hides HERE, in the drag start's own dispatch pass, as
+        // a cut: an 83ms fade would overlap the drag ghost, which is the
+        // one overlap the label rule exists to forbid. No timer stands
+        // between this event and the hide.
+        ApplyLabelPhase(_labelRules.DragStarting());
+        // The boundary stroke brightens for the length of the drag: the
+        // zone edge is what a drag-to-pin is aiming at, and the flag this
+        // reads is live from the line above.
+        ApplyPinZoneChrome();
         // Hidden synchronously: the drag is live from this call onward,
         // and anything the strip does from here moves slots the manager
         // has not agreed to yet.
@@ -1286,6 +1629,14 @@ internal sealed partial class TabHost : UserControl, ITabHost
     {
         _stripDragActive = false;
         _dropPositionValid = false;
+        // The drag is over: the cut demand lifts, and hover may show the
+        // label again. The label is already hidden (the start hid it), so
+        // this is bookkeeping, not a second hide.
+        ApplyLabelPhase(_labelRules.DragEnded());
+        // The boundary stroke dims back -- and because this handler is the
+        // one pass every completed drag runs, the dim is the cleanup: a
+        // bright stroke cannot outlive the drag that brightened it.
+        ApplyPinZoneChrome();
         if (args.Item is TabViewItem item)
         {
             if (item.Tag is TabGroup draggedGroup)

--- a/windows/Ghostty/Tabs/TabRunLabel.cs
+++ b/windows/Ghostty/Tabs/TabRunLabel.cs
@@ -1,0 +1,185 @@
+using System;
+using Ghostty.Controls;
+using Ghostty.Core.Tabs;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Media.Animation;
+using Windows.Foundation;
+
+namespace Ghostty.Tabs;
+
+/// <summary>
+/// The horizontal strip's group run label: color dot, group title,
+/// member count, floating above an expanded run. Code-built and hosted on
+/// the morph layer's canvas by MainWindow -- the TabSwitcherPopup fit, not
+/// the ToolTip fit: a ToolTip attaches to one element and cannot span a
+/// run, and Flyout/TeachingTip take focus. This element is
+/// IsHitTestVisible=false, so it cannot take focus, never joins the focus
+/// chain, and clicks pass through to the strip beneath; it carries no
+/// AutomationProperties on purpose -- screen readers get the group title
+/// from the member items, never from hover. It hides by rule (the strip
+/// and the window call Hide), never by light-dismiss plumbing.
+/// </summary>
+internal sealed partial class TabRunLabel : Grid
+{
+    private readonly Border _dot;
+    private readonly TextBlock _title;
+    private readonly TextBlock _count;
+    private readonly Border _card;
+    private readonly Storyboard _fade = new();
+    private bool _shown;
+
+    /// <summary>
+    /// The motion gate, supplied by the window: TabStripMotion.Enabled
+    /// over the OS animation read and the composed High Contrast state.
+    /// Null means motion on -- the label is chrome, not state, and a gate
+    /// that cannot be read must not block it.
+    /// </summary>
+    internal Func<bool>? MotionEnabled { get; set; }
+
+    public TabRunLabel()
+    {
+        IsHitTestVisible = false;
+        Visibility = Visibility.Collapsed;
+        Height = TabRunLabelShape.HeightPx;
+        HorizontalAlignment = HorizontalAlignment.Left;
+        VerticalAlignment = VerticalAlignment.Top;
+
+        _dot = new Border
+        {
+            Width = 8,
+            Height = 8,
+            CornerRadius = new CornerRadius(2),
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(8, 0, 6, 0),
+        };
+        _title = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            TextTrimming = TextTrimming.CharacterEllipsis,
+        };
+        _count = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(4, 0, 8, 0),
+            Opacity = 0.7,
+        };
+        var row = new StackPanel { Orientation = Orientation.Horizontal };
+        row.Children.Add(_dot);
+        row.Children.Add(_title);
+        row.Children.Add(_count);
+
+        var card = new Border
+        {
+            CornerRadius = new CornerRadius(4),
+            Padding = new Thickness(0),
+            Child = row,
+        };
+        _card = card;
+        Children.Add(card);
+
+        var animation = new DoubleAnimation
+        {
+            From = 0,
+            To = 1,
+            Duration = new Duration(TimeSpan.Zero),
+        };
+        Storyboard.SetTarget(animation, this);
+        Storyboard.SetTargetProperty(animation, "Opacity");
+        _fade.Children.Add(animation);
+        _fade.Completed += (_, _) =>
+        {
+            if (!_shown) Visibility = Visibility.Collapsed;
+        };
+        Opacity = 0;
+    }
+
+    /// <summary>
+    /// Show the label for <paramref name="group"/> above the run whose
+    /// first and last member elements are given. The run's rect is read
+    /// in this element's own space -- the morph canvas, the one
+    /// coordinate space both strips are already measured in -- so the
+    /// label and the run cannot disagree about where anything is. A run
+    /// with no arranged bounds is refused rather than placed from a
+    /// stale offset, the same rule the seam cover keeps.
+    /// </summary>
+    internal void ShowFor(TabGroup group, int members,
+        FrameworkElement runHead, FrameworkElement runTail)
+    {
+        if (runHead.ActualWidth <= 0 || runTail.ActualWidth <= 0) return;
+
+        var head = runHead.TransformToVisual(this).TransformBounds(
+            new Rect(0, 0, runHead.ActualWidth, runHead.ActualHeight));
+        var tail = runTail.TransformToVisual(this).TransformBounds(
+            new Rect(0, 0, runTail.ActualWidth, runTail.ActualHeight));
+        var (left, top, width) = TabRunLabelShape.Place(
+            Math.Min(head.Left, tail.Left),
+            Math.Min(head.Top, tail.Top),
+            Math.Max(head.Right, tail.Right) - Math.Min(head.Left, tail.Left));
+        if (width <= 0) return;
+
+        Canvas.SetLeft(this, left);
+        Canvas.SetTop(this, top);
+        Width = width;
+
+        // The dot paints unconditionally: a group has no "no color" state,
+        // the same rule the chip's swatch keeps. The card's ink re-resolves
+        // per show rather than per construction, so a theme switch between
+        // openings is honored -- the TabSwitcherPopup's rule.
+        _dot.Background = TabColorBrush.From(
+            TabColorPalette.Background(group.Color, selected: false));
+        _card.Background = ThemeResources.Get<Brush>(
+            "CardBackgroundFillColorDefaultBrush",
+            new SolidColorBrush(Windows.UI.Color.FromArgb(0xF2, 0x2B, 0x2B, 0x2B)));
+        _card.BorderBrush = ThemeResources.Get<Brush>(
+            "SurfaceStrokeColorDefaultBrush",
+            new SolidColorBrush(Windows.UI.Color.FromArgb(0x0F, 0xFF, 0xFF, 0xFF)));
+        _card.BorderThickness = new Thickness(1);
+        var ink = ThemeResources.Get<Brush>(
+            "TextFillColorPrimaryBrush",
+            new SolidColorBrush(Windows.UI.Color.FromArgb(0xFF, 0xFF, 0xFF, 0xFF)));
+        _title.Foreground = ink;
+        _count.Foreground = ink;
+        _title.Text = group.Title;
+        _title.MaxWidth = TabRunLabelShape.TitleMaxWidthPx;
+        _count.Text = members.ToString();
+
+        _shown = true;
+        Visibility = Visibility.Visible;
+        RunFade(TabRunLabelShape.FadeDuration(MotionEnabled?.Invoke() ?? true), toVisible: true);
+    }
+
+    /// <summary>
+    /// Hide by rule. A drag-start hide is a cut regardless of the motion
+    /// gate: the label must be gone in the same pass that lifts the drag
+    /// ghost, and an 83ms overlap is exactly the overlap the rule exists
+    /// to forbid.
+    /// </summary>
+    internal void Hide(bool cut)
+    {
+        if (!_shown) return;
+        _shown = false;
+        RunFade(cut ? TimeSpan.Zero
+            : TabRunLabelShape.FadeDuration(MotionEnabled?.Invoke() ?? true), toVisible: false);
+    }
+
+    private void RunFade(TimeSpan duration, bool toVisible)
+    {
+        _fade.Stop();
+        var animation = (DoubleAnimation)_fade.Children[0];
+        animation.From = toVisible ? 0 : 1;
+        animation.To = toVisible ? 1 : 0;
+        animation.Duration = new Duration(duration);
+        if (duration == TimeSpan.Zero)
+        {
+            // A cut: land the end state in the same pass. The storyboard
+            // would take a dispatcher tick to do it, and the cut exists
+            // because that tick is too late.
+            Opacity = toVisible ? 1 : 0;
+            if (!toVisible) Visibility = Visibility.Collapsed;
+            return;
+        }
+        _fade.Begin();
+    }
+}

--- a/windows/Ghostty/Tabs/VerticalTabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabHost.xaml.cs
@@ -71,6 +71,28 @@ internal sealed partial class VerticalTabHost : UserControl, ITabHost
 
     public event EventHandler<double>? StripWidthChangeRequested;
 
+    /// <summary>
+    /// The strip's drag-live moment, surfaced for the window: the
+    /// horizontal run label hides on it, in the same dispatch pass, so a
+    /// vertical drag can never overlap the label's fade.
+    /// </summary>
+    internal event Action? DragVisualStarted
+    {
+        add => _strip.DragVisualStarted += value;
+        remove => _strip.DragVisualStarted -= value;
+    }
+
+    /// <summary>
+    /// The strip's drag end, surfaced for the window: the horizontal run
+    /// label's machine lifts its drag refusal here, or one vertical drag
+    /// would silence the label for the rest of the session.
+    /// </summary>
+    internal event Action? DragVisualEnded
+    {
+        add => _strip.DragVisualEnded += value;
+        remove => _strip.DragVisualEnded -= value;
+    }
+
     internal double CurrentStripTarget =>
         _pinnedExpanded
             ? _expandedWidth

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -1756,6 +1756,23 @@ internal sealed partial class VerticalTabStrip : UserControl
     internal event EventHandler<(TabGroup Group, bool Collapsed)>? GroupToggleFromCommandRequested;
 
     /// <summary>
+    /// Raised the moment this strip's drag goes live -- the pass where the
+    /// row lifts and the follow expression starts. The horizontal strip's
+    /// run label listens through the window: a drag anywhere that shares
+    /// the drag surface must close the label in that same pass, so the
+    /// label can never overlap a drag ghost it does not belong to.
+    /// </summary>
+    internal event Action? DragVisualStarted;
+
+    /// <summary>
+    /// The live drag ended, raised once from EndDrag -- the funnel every
+    /// exit (drop, cancel, teardown) passes through. The counterpart of
+    /// DragVisualStarted: the window listens so the horizontal run label's
+    /// machine can stop refusing shows.
+    /// </summary>
+    internal event Action? DragVisualEnded;
+
+    /// <summary>
     /// The command entry for collapse/expand: the router lands here (via
     /// the host) after announcing is guaranteed. Same drag stand-down as
     /// the chevron, and the explicit target state means a same-state
@@ -2362,6 +2379,7 @@ internal sealed partial class VerticalTabStrip : UserControl
             : row;
         drag.Item = item;
         drag.MotionOn = TabStripMotion.Enabled(SystemAnimationsEnabled(), _highContrast);
+        DragVisualStarted?.Invoke();
         // The selection row is parked while a drag could paint over it; a
         // run drag parks it when the active member is INSIDE the run, not
         // merely when it is the grabbed row.
@@ -3599,6 +3617,13 @@ internal sealed partial class VerticalTabStrip : UserControl
         }
         DragTrace($"DRAG end ghosts={CountLeakedMotion()}");
         if (!settled) ResetDragVisual(drag);
+        // This method is the funnel every exit passes through -- drop,
+        // drop with nothing committed, cancel, and strip teardown all land
+        // here -- so the end of a live drag has exactly one home. The
+        // horizontal run label's machine lifts its drag refusal through
+        // the window on this raise; without it the refusal would outlive
+        // every vertical drag.
+        DragVisualEnded?.Invoke();
     }
 
     /// <summary>


### PR DESCRIPTION
6b of the tab-reorder ladder.

The expanded-group run label for the horizontal strip: a code-built popup on the morph layer whose show/hide rules (hover dwell, keyboard courtesy, drag start, collapse, layout switch, window deactivation) translate through a pure phase machine in Core. Vertical drags close and re-open it through a paired raise from the strip's drag-teardown funnel, so a vertical drag cannot strand the label's refusal for the session.

Also lands the horizontal pin rendering PR 4 deferred: the E718 pin glyph in the header icon slot and the boundary stroke on the last pinned tab (idle and live-drag alphas).

The label's facts and the pin chrome's wiring facts follow as their own rung.