### PR TITLE
tabs: the run label's facts, and the pin chrome's wiring facts

### DIFF
--- a/windows/Ghostty.Tests/Tabs/TabRunLabelShapeTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabRunLabelShapeTests.cs
@@ -1,0 +1,176 @@
+using System;
+using Ghostty.Core.Tabs;
+using Xunit;
+
+namespace Ghostty.Tests.Tabs;
+
+/// <summary>
+/// The run label's geometry and rule machine, without a strip. The shell
+/// renders what this answers; every regression that would show up as a
+/// misplaced popup, a stuck label, or an 83ms fade over a drag ghost is a
+/// wrong answer HERE first.
+/// </summary>
+public sealed class TabRunLabelShapeTests
+{
+    [Fact]
+    public void The_spec_numbers_are_the_label_numbers()
+    {
+        // The label contract: 24px tall, 4px above the rail, title ellipsized at
+        // 240, the classic TTDT_INIT hover delay, the anti-flicker grace,
+        // the keyboard courtesy, and the Fade token. A number drifting
+        // here drifts on screen; pin them as the contract they are.
+        Assert.Equal(24, TabRunLabelShape.HeightPx);
+        Assert.Equal(4, TabRunLabelShape.RailGapPx);
+        Assert.Equal(240, TabRunLabelShape.TitleMaxWidthPx);
+        Assert.Equal(500, TabRunLabelShape.HoverShowMs);
+        Assert.Equal(150, TabRunLabelShape.LeaveGraceMs);
+        Assert.Equal(1200, TabRunLabelShape.KeyboardShowMs);
+        Assert.Equal(83, TabRunLabelShape.FadeMs);
+    }
+
+    [Fact]
+    public void The_label_floats_four_above_the_rail_left_aligned_to_the_run()
+    {
+        // A run whose head sits at (120, 100), 300 wide: the label's
+        // bottom edge clears the rail line by exactly the gap, and its
+        // left edge is the run's first member -- never the strip's.
+        var (left, top, width) = TabRunLabelShape.Place(120, 100, 300);
+        Assert.Equal(120, left);
+        Assert.Equal(100 - TabRunLabelShape.RailGapPx - TabRunLabelShape.HeightPx, top);
+        Assert.Equal(300, width);
+    }
+
+    [Fact]
+    public void The_label_is_never_wider_than_the_run_names()
+    {
+        // A run with no arranged bounds places a zero-width label: the
+        // host refuses to show, it does not fall back to a guess.
+        var (_, _, width) = TabRunLabelShape.Place(0, 50, -5);
+        Assert.Equal(0, width);
+    }
+
+    [Fact]
+    public void Motion_off_renders_the_cut_motion_on_the_fade()
+    {
+        Assert.Equal(TimeSpan.FromMilliseconds(83), TabRunLabelShape.FadeDuration(true));
+        // Zero, not a short fade: under the motion gate the label lands
+        // in the same pass, the same path a cut takes.
+        Assert.Equal(TimeSpan.Zero, TabRunLabelShape.FadeDuration(false));
+    }
+
+    // --- The rule machine ---
+
+    [Fact]
+    public void Hover_shows_after_the_delay_and_hides_after_the_grace()
+    {
+        var rules = new TabRunLabelRules();
+        Assert.Equal(TabRunLabelRules.Phase.Idle, rules.Current);
+
+        Assert.Equal(TabRunLabelRules.Phase.HoverPending, rules.HoverEnter());
+        Assert.Equal(TabRunLabelRules.Phase.Shown, rules.HoverTimerFired());
+
+        // Out of the run: the grace is the phase between shown and gone.
+        Assert.Equal(TabRunLabelRules.Phase.GracePending, rules.HoverExit());
+        Assert.Equal(TabRunLabelRules.Phase.Idle, rules.GraceTimerFired());
+    }
+
+    [Fact]
+    public void Crossing_between_members_of_one_run_never_passes_through_idle()
+    {
+        var rules = new TabRunLabelRules();
+        rules.HoverEnter();
+        rules.HoverTimerFired();
+
+        // Head to neighbour: out of one member, into the next. Neither
+        // transition may land on Idle -- Idle hides the label, and the
+        // gap between two members of the run the label is naming is not
+        // a leave. The grace absorbs the exit; the re-entry supersedes it.
+        var afterExit = rules.HoverExit();
+        Assert.Equal(TabRunLabelRules.Phase.GracePending, afterExit);
+        var afterEnter = rules.HoverEnter();
+        Assert.NotEqual(TabRunLabelRules.Phase.Idle, afterEnter);
+        Assert.NotEqual(TabRunLabelRules.Phase.Idle, afterExit);
+    }
+
+    [Fact]
+    public void A_drag_start_is_a_cut_in_the_same_pass_from_any_phase()
+    {
+        // Pending, shown, or mid-grace: the drag start ends the label
+        // outright, no grace, no delay -- the hide rides the same dispatch
+        // pass that lifts the ghost, which is the rule's whole point.
+        foreach (var warmup in new Func<TabRunLabelRules, TabRunLabelRules.Phase>[] {
+            r => { r.HoverEnter(); return r.Current; },
+            r => { r.HoverEnter(); r.HoverTimerFired(); return r.Current; },
+            r => { r.HoverEnter(); r.HoverTimerFired(); r.HoverExit(); return r.Current; },
+        })
+        {
+            var rules = new TabRunLabelRules();
+            warmup(rules);
+            Assert.NotEqual(TabRunLabelRules.Phase.Idle, rules.Current);
+
+            Assert.Equal(TabRunLabelRules.Phase.Idle, rules.DragStarting());
+            Assert.True(rules.CutOnHide, "the drag-start hide must be a cut");
+            Assert.True(rules.DragLive);
+        }
+
+        // The cut demand and the drag live past the drag; an ordinary
+        // later hide must be a fade, not the drag's cut leaking.
+        var after = new TabRunLabelRules();
+        after.DragStarting();
+        after.DragEnded();
+        Assert.False(after.DragLive);
+        Assert.False(after.CutOnHide);
+    }
+
+    [Fact]
+    public void Under_a_drag_no_rule_shows_the_label()
+    {
+        var rules = new TabRunLabelRules();
+        rules.DragStarting();
+
+        // Hover and keyboard alike are refused while a drag is live: the
+        // strip is being reordered under the pointer, and a run's
+        // position is exactly what is not settled.
+        Assert.Equal(TabRunLabelRules.Phase.Idle, rules.HoverEnter());
+        Assert.Equal(TabRunLabelRules.Phase.Idle, rules.KeyboardRequested());
+        Assert.Equal(TabRunLabelRules.Phase.Idle, rules.HoverTimerFired());
+    }
+
+    [Fact]
+    public void A_keyboard_show_auto_expires_and_hover_replaces_it()
+    {
+        var rules = new TabRunLabelRules();
+        Assert.Equal(TabRunLabelRules.Phase.Shown, rules.KeyboardRequested());
+        Assert.True(rules.KeyboardShown);
+        Assert.Equal(TabRunLabelRules.Phase.Idle, rules.KeyboardTimerFired());
+
+        // The next hover is the hover rule, not a keyboard encore: the
+        // host arms its 500ms delay, not another 1200ms courtesy.
+        rules.KeyboardRequested();
+        rules.HoverEnter();
+        Assert.False(rules.KeyboardShown);
+    }
+
+    [Fact]
+    public void The_hide_rules_all_land_on_idle_without_a_cut()
+    {
+        // Collapse, selection, a layout switch request, deactivation:
+        // each ends the label as a plain fade -- the cut is the drag
+        // start's alone, and none of these may leave it set.
+        Func<TabRunLabelRules, TabRunLabelRules.Phase>[] hides =
+        [
+            r => r.Collapsed(),
+            r => r.SelectionChanged(),
+            r => r.LayoutSwitchRequested(),
+            r => r.Deactivated(),
+        ];
+        foreach (var hide in hides)
+        {
+            var rules = new TabRunLabelRules();
+            rules.HoverEnter();
+            rules.HoverTimerFired();
+            Assert.Equal(TabRunLabelRules.Phase.Idle, hide(rules));
+            Assert.False(rules.CutOnHide);
+        }
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/TabPinZoneChromeWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabPinZoneChromeWiringTests.cs
@@ -1,0 +1,176 @@
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// The horizontal pin zone's chrome: the glyph rides the header's
+/// existing chrome build, and the boundary stroke has one writer, one
+/// predicate, and the vertical stroke's brighten-only-while-live polarity
+/// (4b-1). The vertical stroke's drag-machine facts live in
+/// TabPinZoneWiringTests; this is the horizontal edition's paint, which
+/// the shell cannot load into this test host to check -- so these parse
+/// it.
+/// </summary>
+public sealed class TabPinZoneChromeWiringTests
+{
+    private const string TabHostSource = "Tabs.TabHost.xaml.cs";
+
+    [Fact]
+    public void The_pin_glyph_rides_the_chrome_build_not_a_parallel_path()
+    {
+        var tabHost = ShellSource.Load(TabHostSource);
+        var addItem = tabHost.Method("AddItem");
+
+        // Built in the header's build loop, exactly once: a glyph minted
+        // by a second path (a refresh method, a template) drifts from the
+        // chrome the rest of the header rides. The rail's twin lesson.
+        var pinIcons = addItem.DescendantNodes()
+            .OfType<ObjectCreationExpressionSyntax>()
+            .Where(o => o.Type.ToString().Contains("FontIcon"))
+            .Where(o => o.Initializer.ToString().Contains("\\uE718"))
+            .ToList();
+        Assert.True(
+            pinIcons.Count == 1,
+            $"AddItem builds the pin glyph exactly once; found {pinIcons.Count}.");
+
+        // Leading slot of the icon row: the pin is read before the
+        // profile icon and the title, which is what makes it a zone mark
+        // rather than an attachment.
+        var adds = addItem.Calls("iconRow.Children.Add");
+        var glyphAdd = adds.FirstOrDefault(a => a.Arg(0) == "pinGlyph");
+        var iconAdd = adds.FirstOrDefault(a => a.Arg(0) == "iconHost");
+        Assert.True(
+            glyphAdd is not null && iconAdd is not null
+                && glyphAdd.SpanStart < iconAdd.SpanStart,
+            "the pin glyph takes the icon row's leading slot.");
+
+        // The IsPinned INPC branch is the only thing that shows it:
+        // SetPinned can skip TabMoved (the boundary tab pinning up, the
+        // last pinned tab unpinning both relocate without one), so the
+        // flag change itself must carry the toggle.
+        var toggle = addItem.DescendantNodes().OfType<IfStatementSyntax>()
+            .FirstOrDefault(i => i.Condition.ToString().Contains("IsPinned")
+                && i.Statement.ToString().Contains("pinGlyph.Visibility"));
+        Assert.True(
+            toggle is not null,
+            "the IsPinned INPC branch must toggle the glyph.");
+
+        // And nothing else in the shell writes it: one writer, or two
+        // pin states that can disagree.
+        var stray = tabHost.Root.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.Left.ToString() == "pinGlyph.Visibility"
+                && !addItem.FullSpan.Contains(a.Span))
+            .ToList();
+        Assert.Empty(stray);
+    }
+
+    [Fact]
+    public void The_boundary_stroke_cleans_up_on_every_drag_exit()
+    {
+        var tabHost = ShellSource.Load(TabHostSource);
+        var dragEnd = tabHost.Method("OnTabDragCompleted");
+
+        // The drop is the one pass every completed drag runs, so it is
+        // where the dim has to live -- a cleanup on any narrower event is
+        // a stroke a cancelled or off-strip release can outlive. The leak
+        // census is the shape: ApplyPinZoneChrome is the border's ONLY
+        // writer in the shell, so any assignment outside it is a stroke
+        // this handler does not own.
+        var apply = tabHost.Method("ApplyPinZoneChrome");
+        Assert.True(
+            dragEnd.Calls("ApplyPinZoneChrome").Count == 1,
+            "OnTabDragCompleted must run the boundary pass: the dim is " +
+            "the cleanup, and the drop is the pass every drag exits by.");
+        // What a parse cannot see: the Escape or capture-loss terminal.
+        // Mux completes the drag either way, so the drop pass is the exit
+        // every observed release takes; whether a capture loss can arrive
+        // here un-completed is not decidable from source -- settling that
+        // would take a live-strip probe, not a stronger assertion.
+        var stray = tabHost.Root.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Where(a => (a.Left.ToString().EndsWith(".BorderBrush")
+                    || a.Left.ToString().EndsWith(".BorderThickness"))
+                && !apply.FullSpan.Contains(a.Span))
+            .ToList();
+        Assert.Empty(stray);
+
+        // After the flag drops, not before: the pass reads the flag, so a
+        // cleanup ordered ahead of the drop would repaint the bright
+        // stroke it exists to remove.
+        var flagDrop = dragEnd.AssignsTo("_stripDragActive")
+            .First(a => a.Right.ToString() == "false");
+        var cleanup = dragEnd.Call("ApplyPinZoneChrome");
+        Assert.True(
+            flagDrop.SpanStart < cleanup.SpanStart,
+            "the boundary cleanup must follow the drag flag dropping.");
+    }
+
+    [Fact]
+    public void The_stroke_brightens_only_while_a_drag_is_live()
+    {
+        var tabHost = ShellSource.Load(TabHostSource);
+        var brush = tabHost.Method("PinBoundaryBrush");
+
+        // Polarity, by arm and not by substring: bright 0xE6 under the
+        // live flag, dim 0x59 otherwise. A hover, an armed-but-undragged
+        // session, and an idle strip all read the dim branch -- the exact
+        // match on the condition is what a `!` or a `!=` fails.
+        var branch = brush.DescendantNodes().OfType<ConditionalExpressionSyntax>()
+            .ToList();
+        Assert.True(
+            branch.Count == 1,
+            $"PinBoundaryBrush branches once on drag liveness; found {branch.Count}.");
+        Assert.Equal("_stripDragActive", branch[0].Condition.ToString());
+        Assert.Contains("0xE6", branch[0].WhenTrue.ToString());
+        Assert.Contains("0x59", branch[0].WhenFalse.ToString());
+
+        // And the brighten pass itself reads the flag already live: the
+        // raise precedes the pass in the drag-start handler, so the first
+        // boundary brush of a drag is the bright one, not a frame late.
+        var dragStart = tabHost.Method("OnTabDragStarting");
+        var flagRaise = dragStart.AssignsTo("_stripDragActive")
+            .First(a => a.Right.ToString() == "true");
+        var brighten = dragStart.Call("ApplyPinZoneChrome");
+        Assert.True(
+            flagRaise.SpanStart < brighten.SpanStart,
+            "the drag start must raise the flag before its boundary pass.");
+    }
+
+    [Fact]
+    public void The_stroke_marks_the_last_pinned_tab_and_nothing_else()
+    {
+        var tabHost = ShellSource.Load(TabHostSource);
+        var apply = tabHost.Method("ApplyPinZoneChrome");
+
+        // The predicate is the manager's prefix length minus one: the zone
+        // edge is manager truth, and during a drag the strip's order is
+        // TabView's preview -- no TabItems read here, ever.
+        var edge = apply.DescendantNodes().OfType<ElementAccessExpressionSyntax>()
+            .FirstOrDefault(e => e.Expression.ToString() == "_manager.Tabs");
+        Assert.True(
+            edge is not null,
+            "the zone edge reads the manager's tab list.");
+        Assert.Contains("PinCount - 1", edge.ArgumentList.ToString());
+        var guard = apply.DescendantNodes().OfType<ConditionalExpressionSyntax>()
+            .ToList();
+        Assert.True(
+            guard.Count == 1 && guard[0].WhenFalse.ToString() == "null",
+            "an empty pin zone draws nothing: the edge is null, not tab 0.");
+        Assert.DoesNotContain("TabItems", apply.Body!.ToString());
+
+        // And the neighbour carries nothing: every non-boundary item gets
+        // the default thickness and no brush, which is what keeps the
+        // stroke an edge instead of a fence around the zone.
+        var fork = apply.DescendantNodes().OfType<IfStatementSyntax>()
+            .FirstOrDefault(i => i.Condition.ToString()
+                .Contains("ReferenceEquals(model, boundary)"));
+        Assert.True(
+            fork is not null,
+            "the stroke forks on the boundary identity.");
+        Assert.Contains(
+            "BorderThickness = default", fork.Else?.Statement.ToString() ?? string.Empty);
+        Assert.Contains(
+            "BorderBrush = null", fork.Else?.Statement.ToString() ?? string.Empty);
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/TabRunLabelWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabRunLabelWiringTests.cs
@@ -1,0 +1,351 @@
+using System;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// The group run label's wiring: the drag-start cut, the sugar-only
+/// surface, the rail's chrome path, and the motion gate. The shell cannot
+/// load into this test host, so these parse it; the rules themselves are
+/// tested outright in TabRunLabelShapeTests.
+/// </summary>
+public sealed class TabRunLabelWiringTests
+{
+    private const string TabHostSource = "Tabs.TabHost.xaml.cs";
+    private const string LabelSource = "Tabs.TabRunLabel.cs";
+    private const string VerticalSource = "Tabs.VerticalTabStrip.xaml.cs";
+    private const string VerticalHostSource = "Tabs.VerticalTabHost.xaml.cs";
+    private const string MainWindowSource = "MainWindow.xaml.cs";
+
+    [Fact]
+    public void The_drag_start_hides_the_label_in_its_own_dispatch_pass()
+    {
+        var dragStart = ShellSource.Load(TabHostSource).Method("OnTabDragStarting");
+
+        // The hide is the machine's drag rule applied in this handler's
+        // own body: not a timer arm, not a deferred close. A timer between
+        // the drag start and the hide is the exact overlap the rule
+        // forbids, so its absence is asserted, not assumed.
+        var cut = dragStart.InvocationWithArgument("_labelRules.DragStarting");
+        Assert.True(
+            cut is not null,
+            "OnTabDragStarting must apply the label rule machine's drag start.");
+        var seamRaise = dragStart.Calls("SelectedTabSeamChanged?.Invoke")
+            .Select(c => c.SpanStart)
+            .DefaultIfEmpty(-1)
+            .Min();
+        Assert.True(
+            cut.SpanStart < seamRaise,
+            "the label hide must precede the drag's own teardown raise: " +
+            "the drag is live from that call onward.");
+        Assert.Empty(dragStart.Calls("_labelShowTimer.Start"));
+        Assert.Empty(dragStart.Calls("_labelGraceTimer.Start"));
+
+        // The drag's end lifts the cut demand; the label stays hidden and
+        // hover may show it again. Without this the next ordinary hide
+        // would still read the drag's cut.
+        var dragEnd = ShellSource.Load(TabHostSource).Method("OnTabDragCompleted");
+        Assert.True(
+            dragEnd.InvocationWithArgument("_labelRules.DragEnded") is not null,
+            "OnTabDragCompleted must end the label's drag state.");
+
+        // The cross-host half: the vertical strip raises its drag-live
+        // moment, and the window closes the horizontal label with it --
+        // one dispatch pass, a different strip.
+        var vertical = ShellSource.Load(VerticalSource).Method("StartDragVisual");
+        Assert.True(
+            vertical.Calls("DragVisualStarted?.Invoke").Count == 1,
+            "StartDragVisual must raise DragVisualStarted in the pass that " +
+            "goes live.");
+        var window = ShellSource.Load(MainWindowSource).Root;
+        Assert.Contains(window.DescendantNodes().OfType<AssignmentExpressionSyntax>(),
+            a => a.Left.ToString() == "_verticalTabHost.DragVisualStarted"
+                && a.Right.ToString().Contains("CloseRunLabelForDrag"));
+    }
+
+    [Fact]
+    public void The_drag_end_lifts_the_refusal_through_the_same_pair()
+    {
+        // The drag-start fact pins the start pair; this is the end pair,
+        // and a suite that pins a start raise but not its end is exactly
+        // how a missing off-switch ships: DragLive with no way down means
+        // ONE vertical drag silences the label for the session -- hover,
+        // keyboard, all refused, the cut demand stuck on.
+        var vertical = ShellSource.Load(VerticalSource);
+        var endDrag = vertical.Method("EndDrag");
+
+        // Raised once, from the funnel. Every exit -- drop, drop with
+        // nothing committed, cancel, strip teardown -- passes through
+        // EndDrag, so one raise inside it covers them all; a raise
+        // anywhere else is a second door a narrower exit can skip.
+        Assert.True(
+            endDrag.Calls("DragVisualEnded?.Invoke").Count == 1,
+            "EndDrag must raise the drag's end for the horizontal label.");
+        var stray = vertical.Root.Calls("DragVisualEnded?.Invoke")
+            .Where(i => !endDrag.FullSpan.Contains(i.Span))
+            .ToList();
+        Assert.Empty(stray);
+
+        // The cancel exit explicitly rides the funnel, so a cancelled or
+        // torn-down drag lifts the refusal too.
+        Assert.True(
+            vertical.Method("CancelDrag").Calls("EndDrag").Count == 1,
+            "the cancel path must end the drag through the funnel.");
+
+        // And the window forwards the raise to the horizontal strip's
+        // seam, whose body is the machine's DragEnded -- the refusal
+        // lifts and hover may show again.
+        var window = ShellSource.Load(MainWindowSource).Root;
+        Assert.Contains(window.DescendantNodes().OfType<AssignmentExpressionSyntax>(),
+            a => a.Left.ToString() == "_verticalTabHost.DragVisualEnded"
+                && a.Right.ToString().Contains("EndRunLabelDrag"));
+        var seam = ShellSource.Load(TabHostSource).Method("EndRunLabelDrag");
+        Assert.True(
+            seam.InvocationWithArgument("_labelRules.DragEnded") is not null,
+            "the end seam must apply the machine's drag-ended rule.");
+
+        // The chain's middle link is the host's passthrough, and it is
+        // the one link every other assertion here skips over: the
+        // window's subscription compiles against the event's NAME, so an
+        // accessor that swallows its value -- `add => { }` -- compiles,
+        // parses, and leaves the raise and the seam green while the
+        // chain carries nothing. The bodies are pinned, not the shape:
+        // both accessors must actually reach the strip's event.
+        var passthrough = ShellSource.Load(VerticalHostSource).Root
+            .DescendantNodes().OfType<EventDeclarationSyntax>()
+            .First(e => e.Identifier.ValueText == "DragVisualEnded");
+        var add = passthrough.AccessorList!.Accessors
+            .First(a => a.Keyword.ValueText == "add");
+        var remove = passthrough.AccessorList!.Accessors
+            .First(a => a.Keyword.ValueText == "remove");
+        Assert.Contains(
+            "_strip.DragVisualEnded += value", add.ToString());
+        Assert.Contains(
+            "_strip.DragVisualEnded -= value", remove.ToString());
+    }
+
+    [Fact]
+    public void The_label_is_hit_test_sugar_only()
+    {
+        var label = ShellSource.Load(LabelSource).Root;
+        var ctor = label.DescendantNodes().OfType<ConstructorDeclarationSyntax>()
+            .First(c => c.Identifier.ValueText == "TabRunLabel");
+
+        // Non-focusable by construction: clicks pass through to the strip
+        // beneath, the element never joins the focus chain, and every
+        // click that lands on it therefore fires a hide rule -- the
+        // light-dismiss behavior without any focus-holding surface.
+        Assert.Contains(ctor.DescendantNodes().OfType<AssignmentExpressionSyntax>(),
+            a => a.Left.ToString() == "IsHitTestVisible"
+                && a.Right.ToString() == "false");
+
+        // No automation surface and no focus calls anywhere in the file:
+        // screen readers get the group title from the member items, never
+        // from hover; that contract deliberately keeps the label out.
+        Assert.Empty(label.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(c => c.CalleeText().Contains("AutomationProperties")));
+        Assert.Empty(label.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(c => c.CalleeText().EndsWith(".Focus")
+                || c.CalleeText() == "Focus"));
+    }
+
+    [Fact]
+    public void The_rail_is_member_chrome_painted_by_the_chrome_pass()
+    {
+        var tabHost = ShellSource.Load(TabHostSource);
+        var chrome = tabHost.Method("ApplyTabChrome");
+
+        // The rail is not a parallel paint path: it lives inside the same
+        // per-item pass every header brush rides, so a join, a leave, or
+        // a theme pass re-derives it for free. A paint outside this pass
+        // is a second door that will be forgotten.
+        var railRead = chrome.Calls("_railByModel.TryGetValue");
+        Assert.True(
+            railRead.Count == 1,
+            $"ApplyTabChrome must read the rail exactly once; found {railRead.Count}.");
+        // Nearest if first: the read is the gate itself. Grouped paints,
+        // ungrouped collapses -- the fork sits inside the gate.
+        var gate = railRead[0].Ancestors().OfType<IfStatementSyntax>().First();
+        Assert.Contains(
+            "_railByModel.TryGetValue", gate.Condition.ToString());
+        var fork = gate.Statement.DescendantNodes().OfType<IfStatementSyntax>()
+            .FirstOrDefault(i => i.Condition.ToString().Contains("tab.Group is"));
+        Assert.True(fork is not null, "the rail's paint must fork on membership.");
+        Assert.True(
+            fork.Statement.ToString().Contains("TabColorPalette.Background")
+                && fork.Statement.ToString().Contains("Visibility.Visible"),
+            "a grouped tab paints the rail in the group's palette color.");
+        Assert.Contains(
+            "Visibility.Collapsed", fork.Else?.Statement.ToString() ?? string.Empty);
+
+        // The rail element is built in the header's build loop and takes
+        // the TOP slot: above the icon row, which is what puts it at the
+        // top edge the label anchors four pixels above.
+        var addItem = tabHost.Method("AddItem");
+        var railBuild = addItem.DescendantNodes()
+            .OfType<ObjectCreationExpressionSyntax>()
+            .Where(o => o.Type.ToString().Contains("Rectangle"))
+            .ToList();
+        Assert.True(
+            railBuild.Count == 1,
+            $"AddItem builds exactly one rail rectangle; found {railBuild.Count}.");
+        var adds = addItem.Calls("headerPanel.Children.Add");
+        var railAdd = adds.FirstOrDefault(a => a.Arg(0) == "rail");
+        var iconRowAdd = adds.FirstOrDefault(a => a.Arg(0) == "iconRow");
+        Assert.True(
+            railAdd is not null && iconRowAdd is not null
+                && railAdd.SpanStart < iconRowAdd.SpanStart,
+            "the rail must be added before the icon row: it owns the top slot.");
+    }
+
+    [Fact]
+    public void A_group_color_change_repaints_the_run_through_one_door()
+    {
+        var tabHost = ShellSource.Load(TabHostSource);
+        var groupChanged = tabHost.Method("OnGroupPropertyChanged");
+
+        // Color and title fall through the collapse branch to the one
+        // refresh; the members' chrome rides the same door the chip's
+        // swatch rides. Deleting the run refresh here is how a run ends
+        // up two-tone after a recolor.
+        Assert.True(
+            groupChanged.Calls("RefreshRunRails").Count == 1,
+            "OnGroupPropertyChanged must refresh the run's member chrome.");
+
+        // The collapse arm is also a label hide rule, from the machine.
+        var collapse = groupChanged.InvocationWithArgument("_labelRules.Collapsed");
+        Assert.True(
+            collapse is not null,
+            "a collapse must close the label through the rule machine.");
+
+        var refresh = tabHost.Method("RefreshRunRails");
+        Assert.True(
+            refresh.Calls("_manager.MembersOf").Count == 1
+                && refresh.Calls("ApplyTabChrome").Count == 1,
+            "RefreshRunRails re-runs the per-item chrome pass over the run's members.");
+    }
+
+    [Fact]
+    public void The_label_show_reads_the_run_from_identity_maps()
+    {
+        var show = ShellSource.Load(TabHostSource).Method("ShowRunLabel");
+
+        // The run comes from the manager and the elements from the strip's
+        // model map -- never from TabItems order, which hides members
+        // behind chips and cannot say where a run starts.
+        Assert.True(
+            show.Calls("_manager.MembersOf").Count == 1,
+            "the run's members come from the manager.");
+        Assert.Equal(2, show.Calls("_itemByModel.TryGetValue").Count);
+        Assert.True(
+            show.Calls("_runLabel.ShowFor").Count == 1,
+            "the show lands on the label element.");
+        Assert.Empty(show.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(c => c.CalleeText().EndsWith("TabItems.IndexOf")));
+    }
+
+    [Fact]
+    public void The_label_fades_by_the_motion_gate_and_cuts_for_a_drag()
+    {
+        var label = ShellSource.Load(LabelSource);
+        var hide = label.Method("Hide");
+
+        // A drag-start hide is zero duration -- a cut -- regardless of the
+        // gate; every other hide reads the gate. Reading the gate for the
+        // cut is the bug: an 83ms fade over a lifting ghost is precisely
+        // the overlap the rule exists to forbid.
+        var cut = hide.DescendantNodes().OfType<ConditionalExpressionSyntax>()
+            .Where(c => c.Condition.ToString() == "cut")
+            .ToList();
+        Assert.True(
+            cut.Count == 1,
+            $"Hide must branch on the cut flag exactly once; found {cut.Count}.");
+        Assert.Equal("TimeSpan.Zero", cut[0].WhenTrue.ToString());
+        Assert.Contains("TabRunLabelShape.FadeDuration", cut[0].WhenFalse.ToString());
+
+        // The show reads the gate too, through the machine's shape -- not
+        // its own constant.
+        var showFor = label.Method("ShowFor");
+        Assert.True(
+            showFor.Calls("TabRunLabelShape.FadeDuration").Count == 1,
+            "the show's duration comes from the shared shape.");
+
+        // The cut is landed in the same pass: a zero duration writes the
+        // end state directly instead of waiting for a storyboard tick.
+        var runFade = label.Method("RunFade");
+        var zero = runFade.DescendantNodes().OfType<IfStatementSyntax>()
+            .FirstOrDefault(i => i.Condition.ToString() == "duration == TimeSpan.Zero");
+        Assert.True(
+            zero is not null && zero.Statement.AssignsTo("Opacity").Any(),
+            "a zero-duration fade must write the end state in the same pass.");
+    }
+
+    [Fact]
+    public void The_window_supplies_the_motion_gate_and_hosts_the_label()
+    {
+        var window = ShellSource.Load(MainWindowSource).Root;
+
+        // The label is hosted on the morph layer's canvas -- the surface
+        // both strips are measured in -- and its gate is the strips' gate:
+        // TabStripMotion.Enabled over the OS animation read and the
+        // composed High Contrast state, not raw IsActive.
+        Assert.Contains(window.DescendantNodes().OfType<AssignmentExpressionSyntax>(),
+            a => a.Left.ToString() == "_runLabel.MotionEnabled"
+                && a.Right.ToString().Contains("TabStripMotion.Enabled")
+                && a.Right.ToString().Contains("HighContrastChromeActive"));
+        Assert.Contains(window.DescendantNodes().OfType<InvocationExpressionSyntax>(),
+            c => c.CalleeText() == "TabMorphLayer.Children.Add");
+        Assert.Contains(window.DescendantNodes().OfType<InvocationExpressionSyntax>(),
+            c => c.CalleeText() == "_horizontalTabHost.AttachRunLabel");
+
+        // Deactivation is a window-side hide rule, and it goes through the
+        // strip's machine door: a bare element hide would leave the phase
+        // pending and its timers armed, and the label would surface again
+        // on a window nobody is looking at. Both ends pinned -- the
+        // window subscribes, and the seam applies the machine's rule,
+        // which lands Idle and cancels whatever was pending.
+        var deactivate = window.DescendantNodes()
+            .Where(n => n is InvocationExpressionSyntax i
+                && i.CalleeText() == "_horizontalTabHost.CloseRunLabelForDeactivation")
+            .ToList();
+        Assert.True(
+            deactivate.Count == 1,
+            "the window hides the label exactly once: on deactivation, " +
+            "through the strip's machine door.");
+        var deactivationSeam = ShellSource.Load(TabHostSource)
+            .Method("CloseRunLabelForDeactivation");
+        Assert.True(
+            deactivationSeam.InvocationWithArgument("_labelRules.Deactivated")
+                is not null,
+            "the deactivation seam must apply the machine's rule, not a " +
+            "bare element hide.");
+
+        // So is a layout switch request: ToggleTabLayout is where every
+        // chord, menu item, and settings toggle lands, and the label is
+        // anchored to the strip the switch is about to replace.
+        var toggle = ShellSource.Load(MainWindowSource).Method("ToggleTabLayout");
+        Assert.True(
+            toggle.Calls("_horizontalTabHost.CloseRunLabelForLayoutSwitch").Count == 1,
+            "a layout switch request must close the label through the strip seam.");
+    }
+}
+
+internal static class TabRunLabelWiringQueries
+{
+    /// <summary>
+    /// The one invocation in <paramref name="method"/> whose argument list
+    /// contains a call to <paramref name="callee"/>, or null. For the
+    /// ApplyLabelPhase translations: the rule call is the argument, and
+    /// the argument is the polarity the wiring fact names.
+    /// </summary>
+    public static InvocationExpressionSyntax? InvocationWithArgument(
+        this MethodDeclarationSyntax method, string callee)
+        => method.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .FirstOrDefault(i => i.ArgumentList.Arguments.Any(
+                a => a.Expression.DescendantNodesAndSelf()
+                    .OfType<InvocationExpressionSyntax>()
+                    .Any(inner => inner.CalleeText() == callee)));
+}


### PR DESCRIPTION
Facts rung for #833.

TabRunLabelShapeTests pins the pure phase machine (DragLive set only in DragStarting, cleared only in DragEnded, every terminal rule total). TabRunLabelWiringTests pins the label's wiring including both ends of the cross-host drag pair: the vertical strip's teardown funnel raises DragVisualEnded exactly once and nowhere else, CancelDrag rides the funnel, the window forwards it to EndRunLabelDrag, and the host's passthrough accessors actually reach the strip's event -- an accessor that swallows its value compiles and runs green while the chain carries nothing. TabPinZoneChromeWiringTests pins the pin glyph's INPC toggle and the boundary stroke's idle/live-drag alphas.

Every fact is red-proven under exactly its regression.