### PR TITLE
tests: census the tab host and the group-color picker in MainWindow's teardown

### DIFF
--- a/windows/Ghostty.Tests/Wiring/WindowTeardownWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/WindowTeardownWiringTests.cs
@@ -115,6 +115,12 @@ public class WindowTeardownWiringTests
         ("_host", "this window's own GhosttyHost; its events are raised from surface input, "
                   + "which a closing window no longer receives"),
         ("_tabManager", "this window's own TabManager"),
+        ("_verticalTabHost", "this window's own vertical tab host, constructed and held only by "
+                             + "this window; its events are raised from strip drag and selection "
+                             + "input, which a closing window no longer receives"),
+        ("picker", "a TabColorPalettePicker this window builds into the group-color flyout; "
+                   + "it takes only input routed through that flyout, which a closing "
+                   + "window no longer receives"),
         ("_themeManager", "per-window; OnClosedAsync disposes it before the first await, "
                           + "and WindowThemeManager.Dispose nulls ThemeChanged"),
         ("seedHost.ActiveLeaf.Terminal()", "a leaf of this window's pane tree; "


### PR DESCRIPTION
The teardown census found two MainWindow receivers nobody had classified: _verticalTabHost (the #833/#834 run-label subscriptions - one vertical drag or deactivation would have kept firing at a closed window) and the group-color picker's local TabColorPalettePicker from #823. Both die with the window - the host is constructed and held only by it, and the picker takes only input routed through its flyout - so both get Owned entries with that reasoning, which is what the census asks a declaration to carry. Test-only change; removing either entry reds the theory naming its events.