### PR TITLE
tabs: the release-path pin flight, shelf hover, and the motion tokens

### DIFF
--- a/windows/Ghostty.Core/Tabs/TabStripMotion.cs
+++ b/windows/Ghostty.Core/Tabs/TabStripMotion.cs
@@ -55,6 +55,29 @@ internal static class TabStripMotion
     public const float LiftScale = 1.03f;
 
     /// <summary>
+    /// The pin flight: the ghost travels from the released row to the slot
+    /// it promised, on the neighbours' Existing Elements curve. The flight
+    /// is programmatic -- it starts at velocity 0, never the gesture's.
+    /// </summary>
+    public const double PinFlightMs = 250;
+
+    /// <summary>
+    /// The landing's one visible bounce: the bounciest tier in the strip,
+    /// spent on the ghost because a programmatic flourish is the one place
+    /// an overshoot reads as delight instead of slop. DampingRatio and
+    /// Period are written explicitly -- the WinRT spring classes document
+    /// no defaults.
+    /// </summary>
+    public const float PinSettleDampingRatio = 0.6f;
+    public const double PinSettlePeriodMs = 60;
+
+    /// <summary>The Fade token: ghost handoff and header crossfades.</summary>
+    public const double FadeMs = 83;
+
+    /// <summary>The drag visual handing back after a release.</summary>
+    public const double UnliftFadeMs = 83;
+
+    /// <summary>
     /// The motion gate: springs and glides run only when Windows
     /// animation effects are on and High Contrast is not. Disabled means
     /// every spring collapses to a cut; state correctness never waits on

--- a/windows/Ghostty.Core/Tabs/TabStripMotion.cs
+++ b/windows/Ghostty.Core/Tabs/TabStripMotion.cs
@@ -74,9 +74,6 @@ internal static class TabStripMotion
     /// <summary>The Fade token: ghost handoff and header crossfades.</summary>
     public const double FadeMs = 83;
 
-    /// <summary>The drag visual handing back after a release.</summary>
-    public const double UnliftFadeMs = 83;
-
     /// <summary>
     /// The motion gate: springs and glides run only when Windows
     /// animation effects are on and High Contrast is not. Disabled means

--- a/windows/Ghostty.Tests/Wiring/PinnedRowFocusWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/PinnedRowFocusWiringTests.cs
@@ -180,11 +180,17 @@ public class PinnedRowFocusWiringTests
 
         var pinned = strip.Method("AddPinnedRow");
         var pinnedWiring = pinned.DescendantNodes().OfType<AssignmentExpressionSyntax>()
-            .Where(a => a.Left.ToString() is "row.KeyDown" or "row.GotFocus" or "row.LostFocus")
+            .Where(a => a.Left.ToString() is "row.KeyDown" or "row.GotFocus"
+                or "row.LostFocus" or "row.PointerEntered" or "row.PointerExited")
             .Select(a => a.Left.ToString())
             .ToList();
         Assert.Equal(
-            new[] { "row.KeyDown", "row.GotFocus", "row.LostFocus" }, pinnedWiring);
+            new[]
+            {
+                "row.KeyDown", "row.GotFocus", "row.LostFocus",
+                "row.PointerEntered", "row.PointerExited",
+            },
+            pinnedWiring);
 
         var bodyItem = strip.Method("AddBodyRow");
         var bodyWiring = bodyItem.DescendantNodes().OfType<AssignmentExpressionSyntax>()
@@ -192,12 +198,13 @@ public class PinnedRowFocusWiringTests
             .ToList();
         Assert.Single(bodyWiring);
 
-        // The focus visual is the pane's hover-fill resource, resolved
-        // through the strip's theme resources -- not a second colour
-        // invented for focus. Pinned rows paint no hover state today, so
-        // this fill is focus's alone.
+        // The fill is the pane's hover resource, resolved through the
+        // strip's theme resources -- not a second colour invented for
+        // focus or for hover. Both states route through the one painter,
+        // so neither can erase the other.
         var visual = strip.Method("OnPinnedRowFocusVisual");
-        Assert.Single(visual.Calls("ResolveThemeBrush"));
+        Assert.Single(visual.Calls("PaintShelfRow"));
+        Assert.Single(strip.Method("PaintShelfRow").Calls("ResolveThemeBrush"));
     }
 
     /// <summary>

--- a/windows/Ghostty.Tests/Wiring/TabPinFlightWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabPinFlightWiringTests.cs
@@ -1,0 +1,326 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// The release-path pin flight, and the asymmetry it lives on. A
+/// mid-drag boundary crossing commits through the tick loop: SetPinned,
+/// Move, and a follow rebind -- the row never detaches, the churn's
+/// own re-anchor is the motion, and there is nothing left to fly. A
+/// release on the preview is the other landing shape: the churn
+/// replaces the dragged element outright, so the flight carries a
+/// ghost from where the eye held the row to the slot the preview
+/// promised, and hands it to the real prefix-end row.
+///
+/// Three properties are pinned here. Both flight endpoints are read
+/// before the commit, because the commit is what destroys the elements
+/// the measurements ride. The flight is decoration -- gated on the
+/// drag's motion flag, programmatic (velocity zero, no inertia), and
+/// performing no manager calls -- so motion off keeps the release the
+/// cut it always was and state never waits on an animation. And every
+/// flight-ending callback is identity-guarded, because the batches and
+/// the guard timer all fire long after the release that started them.
+///
+/// Wiring guards, not behaviour tests: what the flight looks like on
+/// screen is only observable on a live strip. The motion constants'
+/// values are pinned Core-side, next to the machine.
+/// </summary>
+public class TabPinFlightWiringTests
+{
+    private static ShellSource Strip() => ShellSource.Load("Tabs.VerticalTabStrip.xaml.cs");
+
+    private static AssignmentExpressionSyntax Assign(SyntaxNode node, string left) =>
+        node.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Single(a => a.Left.ToString() == left);
+
+    private static IEnumerable<AssignmentExpressionSyntax> Assignments(
+        SyntaxNode node, string left) =>
+        node.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.Left.ToString() == left);
+
+    /// <summary>
+    /// The start is the arranged row plus the follow offset, and the
+    /// destination is the preview itself -- the element that has been
+    /// sitting on the slot the drop is about to fill. Both reads live
+    /// inside the drag's motion gate and both precede SetPinned: after
+    /// it, the churn has replaced every element involved and a freshly
+    /// inserted row has no arranged truth to measure. Reading late is
+    /// how a flight departs from a ghost town.
+    /// </summary>
+    [Fact]
+    public void BothFlightEndpoints_AreRead_BeforeTheCommit()
+    {
+        var released = Strip().Method("OnDragPointerReleased");
+        var gate = released.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "_pinPreview is not null");
+        var setPinned = gate.Calls("_manager.SetPinned").Single();
+
+        var motionGate = gate.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "drag.MotionOn");
+        Assert.Contains(motionGate.Statement.DescendantNodesAndSelf()
+                .OfType<InvocationExpressionSyntax>(),
+            c => c.CalleeText() == "DraggedRowRect");
+        Assert.Contains(motionGate.Statement.DescendantNodesAndSelf()
+                .OfType<InvocationExpressionSyntax>(),
+            c => c.CalleeText() == "Canvas.GetLeft");
+        Assert.Contains(motionGate.Statement.DescendantNodesAndSelf()
+                .OfType<InvocationExpressionSyntax>(),
+            c => c.CalleeText() == "Canvas.GetTop");
+        Assert.True(motionGate.Span.End < setPinned.Span.Start,
+            "the flight endpoints must be measured before the commit churns the rows");
+
+        // The destination is the preview's own geometry: the flight aims
+        // at the promise, not at a re-derivation that could disagree
+        // with what the user was shown.
+        var dest = motionGate.Statement.DescendantNodesAndSelf()
+            .OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString()
+                == "_pinPreview is { } preview && preview.ActualWidth > 0");
+        Assert.Contains("preview.Width", dest.Statement.ToString());
+        Assert.Contains("VerticalTabPinnedRow.RowHeight", dest.Statement.ToString());
+    }
+
+    /// <summary>
+    /// Motion off keeps the release byte-identical to the cut it was
+    /// before the flight existed. The gate is the flight's first
+    /// statement -- not a branch deep in the build-out -- so a motion-off
+    /// release performs nothing past it; and the one caller sits after
+    /// EndDrag, so even a motion-on release lands its state before the
+    /// first frame of decoration. State first, decoration second, or
+    /// the flight becomes a dependency.
+    /// </summary>
+    [Fact]
+    public void MotionOff_KeepsTheReleaseTheCutItAlwaysWas()
+    {
+        var strip = Strip();
+        var start = strip.Method("StartPinFlight");
+
+        // The gate is the FIRST statement, and the cut is total: the
+        // motion-off arm returns without so much as a cleanup call.
+        var first = Assert.IsType<IfStatementSyntax>(start.Body!.Statements.First());
+        // The polarity IS the semantics: motion off is the cut, so the
+        // gate is the negation and the return sits in its arm.
+        Assert.Equal("!drag.MotionOn", first.Condition.ToString());
+        Assert.Contains(
+            first.Statement.DescendantNodesAndSelf().OfType<ReturnStatementSyntax>(),
+            r => true);
+        Assert.DoesNotContain(
+            first.Statement.DescendantNodesAndSelf().OfType<InvocationExpressionSyntax>(),
+            c => c.CalleeText().StartsWith("_manager."));
+
+        // The single caller runs after EndDrag: the row is already in
+        // the manager and the drag is already torn down when the ghost
+        // lifts off.
+        var released = strip.Method("OnDragPointerReleased");
+        var gate = released.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "_pinPreview is not null");
+        var call = gate.Calls("StartPinFlight").Single();
+        var end = gate.Calls("EndDrag").Single();
+        Assert.True(end.Span.Start < call.Span.Start,
+            "state lands through EndDrag before the flight decorates it");
+        Assert.Empty(strip.Method("EvaluateDrag").Calls("StartPinFlight"));
+        Assert.Empty(strip.Method("EvaluateRunDrag").Calls("StartPinFlight"));
+    }
+
+    /// <summary>
+    /// The asymmetry, pinned on both landing shapes. The hysteresis
+    /// commit IS motion: SetPinned, Move, RebindFollow -- the follow
+    /// expression carries the row through the churn, so the row never
+    /// detaches and a flight would paint a second copy of something
+    /// that never went anywhere. The release shape is the only caller.
+    /// Letting the tick loop fly too would stack a ghost on top of the
+    /// very re-anchor that already explains the movement.
+    /// </summary>
+    [Fact]
+    public void TheHysteresisCommit_IsItsOwnMotion_AndNeverFlights()
+    {
+        var strip = Strip();
+        var evaluate = strip.Method("EvaluateDrag");
+
+        // The churn path's own motion: the pin branch rebinds the follow
+        // on the fresh element, which is what the user watches instead
+        // of a flight.
+        Assert.NotEmpty(evaluate.Calls("_manager.SetPinned"));
+        Assert.NotEmpty(evaluate.Calls("_manager.Move"));
+        var rebind = evaluate.Calls("RebindFollow").Single();
+        var loop = rebind.Ancestors().OfType<WhileStatementSyntax>().First();
+        Assert.Contains(loop.Statement.DescendantNodesAndSelf()
+                .OfType<InvocationExpressionSyntax>(),
+            c => c.CalleeText() == "_manager.SetPinned");
+        Assert.Empty(evaluate.Calls("StartPinFlight"));
+        Assert.Empty(strip.Method("EvaluateRunDrag").Calls("StartPinFlight"));
+
+        Assert.Single(strip.Root.DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .Where(i => i.CalleeText() == "StartPinFlight"));
+    }
+
+    /// <summary>
+    /// The flight is programmatic: the release hands the drag back at
+    /// velocity zero, the travel itself is a keyframe on the tokens --
+    /// never a spring -- and the one spring in the pipeline is the
+    /// landing's deliberate bounce, on the settle tokens. Inheriting the
+    /// gesture's velocity would fling the ghost past the slot its
+    /// promise named, and the flight exists to keep that promise.
+    /// </summary>
+    [Fact]
+    public void TheFlight_IsProgrammatic_AtVelocityZero()
+    {
+        var strip = Strip();
+        var gate = strip.Method("OnDragPointerReleased")
+            .DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "_pinPreview is not null");
+        var end = gate.Calls("EndDrag").Single();
+        Assert.Equal("settle: false", end.Arg(1));
+        Assert.Equal("velocity: 0", end.Arg(2));
+
+        var flight = strip.Method("StartPinFlight");
+        Assert.Contains(flight.DescendantNodes().OfType<InvocationExpressionSyntax>(),
+            c => c.CalleeText().EndsWith("CreateVector3KeyFrameAnimation"));
+        Assert.DoesNotContain(
+            flight.DescendantNodes().OfType<InvocationExpressionSyntax>(),
+            c => c.CalleeText().EndsWith("CreateSpringVector3Animation"));
+        var duration = Assign(flight, "fly.Duration");
+        Assert.Contains("TabStripMotion.PinFlightMs", duration.Right.ToString());
+
+        // The landing's bounce is the only spring, and it names the
+        // settle tokens explicitly -- the WinRT spring classes document
+        // no defaults, so an implicit period would be a guess.
+        var settle = strip.Method("StartPinSettle");
+        Assert.Equal("TabStripMotion.PinSettleDampingRatio",
+            Assign(settle, "spring.DampingRatio").Right.ToString());
+        Assert.Contains("TabStripMotion.PinSettlePeriodMs",
+            Assign(settle, "spring.Period").Right.ToString());
+
+        // The handoff crossfades both sides on the fade token, one
+        // batch, one clock -- no frame where both are gone.
+        var handback = strip.Method("StartPinHandback");
+        foreach (var fade in new[] { "fadeOut.Duration", "fadeIn.Duration" })
+            Assert.Contains("TabStripMotion.FadeMs",
+                Assign(handback, fade).Right.ToString());
+    }
+
+    /// <summary>
+    /// Every callback that can end a flight checks that the flight it
+    /// was created for is still the one in the field. The batches and
+    /// the guard timer all complete long after the release: a
+    /// superseding flight, a new drag, or a teardown has replaced the
+    /// field by then, and a stale callback running its phase or its
+    /// landing would tear down a flight it does not own -- or fade out
+    /// a row the new flight just hid.
+    /// </summary>
+    [Fact]
+    public void EveryFlightEndingCallback_IsIdentityGuarded()
+    {
+        var methods = new[]
+        {
+            Strip().Method("StartPinFlight"),
+            Strip().Method("StartPinSettle"),
+            Strip().Method("StartPinHandback"),
+        };
+        var guarded = methods.SelectMany(m => m.DescendantNodes()
+                .OfType<AnonymousFunctionExpressionSyntax>())
+            .Where(f => f.Body is BlockSyntax block && block.Statements.Count > 0
+                        && block.DescendantNodes().OfType<InvocationExpressionSyntax>()
+                            .Any(c => c.CalleeText() is "StartPinSettle"
+                                or "StartPinHandback"
+                                or "FinishPinFlight"))
+            .ToList();
+
+        // fly-to-settle, settle-to-handback, handback-to-landing, and the
+        // guard timer's timeout: four handoffs, one guard shape.
+        Assert.Equal(4, guarded.Count);
+        foreach (var callback in guarded)
+        {
+            var block = (BlockSyntax)callback.Body!;
+            var first = Assert.IsType<IfStatementSyntax>(block.Statements.First());
+            Assert.Equal("!ReferenceEquals(_pinFlight, flight)",
+                first.Condition.ToString());
+        }
+    }
+
+    /// <summary>
+    /// The flight cannot outlive the strip or dodge the census. The
+    /// leak count folds the live flight in -- one field, zero or one --
+    /// so the trace oracle's any-N-above-zero rule covers it like every
+    /// other composition the strip believes it is driving. Teardown
+    /// finishes it, a fresh drag supersedes it, and landing restores the
+    /// row's opacity by writing it: stopping an animation reverts the
+    /// property to its set value, so an assumed end state would land
+    /// the row at whatever it was before the flight hid it.
+    /// </summary>
+    [Fact]
+    public void TheFlight_NeverOutlivesTheStrip_NorTheCensus()
+    {
+        var strip = Strip();
+
+        Assert.Contains("_pinFlight",
+            strip.Method("CountLeakedMotion").ExpressionBody!.ToString());
+
+        var unloaded = strip.Root.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Single(a => a.Left.ToString() == "Unloaded");
+        Assert.NotEmpty(unloaded.Right.Calls("FinishPinFlight"));
+        Assert.Single(strip.Method("StartDragVisual").Calls("FinishPinFlight"));
+
+        var finish = strip.Method("FinishPinFlight");
+        Assert.NotEmpty(finish.Calls("flight.Guard.Stop"));
+        var restored = Assign(finish, "flight.Row.Opacity");
+        Assert.Equal("1", restored.Right.ToString());
+        Assert.Contains(finish.DescendantNodes().OfType<InvocationExpressionSyntax>(),
+            c => c.CalleeText().EndsWith("PreviewHost.Children.Remove"));
+    }
+
+    /// <summary>
+    /// The shelf rows' two pointer-adjacent states share one painter,
+    /// and focus wins: the condition names focus first and the pointer
+    /// only as the second disjunct, so a keyboard user's indicator does
+    /// not flicker off because the pointer wandered across, and a row
+    /// that is neither stays transparent -- the lane it sits on. The
+    /// exit path repaints through the same painter rather than writing
+    /// a fill of its own, because a private restore is how the two
+    /// states drift apart.
+    /// </summary>
+    [Fact]
+    public void HoverAndFocus_ShareOnePainter_AndFocusWins()
+    {
+        var strip = Strip();
+        var paint = strip.Method("PaintShelfRow");
+        var fill = Assign(paint, "row.Background");
+        var ternary = Assert.IsType<ConditionalExpressionSyntax>(fill.Right);
+        // Whitespace-normalized: the condition spans two source lines,
+        // and the pin is the ORDER -- focus named first, pointer second.
+        Assert.Equal(
+            "row.FocusState != FocusState.Unfocused "
+            + "|| ReferenceEquals(_hoveredShelfRow, row)",
+            System.Text.RegularExpressions.Regex.Replace(
+                ternary.Condition.ToString(), @"\s+", " "));
+        Assert.Equal("TransparentBrush", ternary.WhenFalse.ToString());
+        Assert.DoesNotContain(
+            paint.DescendantNodes().OfType<InvocationExpressionSyntax>(),
+            c => c.CalleeText() == "Color.FromArgb");
+
+        // Enter records the pointer before painting -- the read and the
+        // paint must agree on the same row -- and exit repaints through
+        // the painter, writing no background of its own.
+        var exited = strip.Method("OnShelfRowPointerExited");
+        Assert.Single(exited.Calls("PaintShelfRow"));
+        Assert.Empty(Assignments(exited, "row.Background"));
+
+        var entered = strip.Method("OnShelfRowPointerEntered");
+        var record = entered.AssignsTo("_hoveredShelfRow").Single();
+        var repaint = entered.Calls("PaintShelfRow").Single();
+        Assert.True(record.Span.Start < repaint.Span.Start,
+            "hover is recorded before it is painted");
+
+        // Both focus transitions route through the painter too: one
+        // writer for the row's fill, or the states erase each other.
+        var focus = strip.Method("OnPinnedRowFocusVisual");
+        Assert.Single(focus.Calls("PaintShelfRow"));
+        Assert.Empty(Assignments(focus, "row.Background"));
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/TabPinFlightWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabPinFlightWiringTests.cs
@@ -248,7 +248,10 @@ public class TabPinFlightWiringTests
     /// The flight cannot outlive the strip or dodge the census. The
     /// leak count folds the live flight in -- one field, zero or one --
     /// so the trace oracle's any-N-above-zero rule covers it like every
-    /// other composition the strip believes it is driving. Teardown
+    /// other composition the strip believes it is driving. The
+    /// backstop is pinned armed, not merely configured: a guard that
+    /// never starts stops nothing, and the wedged batch it exists for
+    /// is exactly the case no batch callback reports. Teardown
     /// finishes it, a fresh drag supersedes it, and landing restores the
     /// row's opacity by writing it: stopping an animation reverts the
     /// property to its set value, so an assumed end state would land
@@ -266,6 +269,8 @@ public class TabPinFlightWiringTests
             .Single(a => a.Left.ToString() == "Unloaded");
         Assert.NotEmpty(unloaded.Right.Calls("FinishPinFlight"));
         Assert.Single(strip.Method("StartDragVisual").Calls("FinishPinFlight"));
+
+        Assert.Single(strip.Method("StartPinFlight").Calls("flight.Guard.Start"));
 
         var finish = strip.Method("FinishPinFlight");
         Assert.NotEmpty(finish.Calls("flight.Guard.Stop"));

--- a/windows/Ghostty.Tests/Wiring/TabRunLabelWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabRunLabelWiringTests.cs
@@ -127,6 +127,30 @@ public sealed class TabRunLabelWiringTests
             "_strip.DragVisualEnded -= value", remove.ToString());
     }
 
+    /// <summary>
+    /// The start half of the pair carries the same swallowed-accessor
+    /// hole as the end half: the window's subscription compiles against
+    /// the event's name, so a no-op add accessor compiles clean, keeps
+    /// every other link here green, and decapitates the chain -- the
+    /// label would stay up across every vertical drag. Same pin as the
+    /// end pair, same reason: the bodies, not the shape.
+    /// </summary>
+    [Fact]
+    public void The_drag_start_passthrough_IsPairedLikeItsEnd()
+    {
+        var passthrough = ShellSource.Load(VerticalHostSource).Root
+            .DescendantNodes().OfType<EventDeclarationSyntax>()
+            .First(e => e.Identifier.ValueText == "DragVisualStarted");
+        var add = passthrough.AccessorList!.Accessors
+            .First(a => a.Keyword.ValueText == "add");
+        var remove = passthrough.AccessorList!.Accessors
+            .First(a => a.Keyword.ValueText == "remove");
+        Assert.Contains(
+            "_strip.DragVisualStarted += value", add.ToString());
+        Assert.Contains(
+            "_strip.DragVisualStarted -= value", remove.ToString());
+    }
+
     [Fact]
     public void The_label_is_hit_test_sugar_only()
     {

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -3640,10 +3640,6 @@ internal sealed partial class VerticalTabStrip : UserControl
             return;
         }
 
-        // State first: the real row waits hidden for the crossfade, and
-        // only the flight's completion restores it -- never the reverse.
-        row.Opacity = 0;
-
         var visual = ElementCompositionPreview.GetElementVisual(ghost);
         var compositor = visual.Compositor;
         var flight = new PinFlight
@@ -3654,6 +3650,13 @@ internal sealed partial class VerticalTabStrip : UserControl
             Guard = DispatcherQueue.CreateTimer(),
         };
         _pinFlight = flight;
+
+        // State first, then the hide: the field write above is the
+        // flight's birth, and anything that throws before it must leave
+        // the row untouched -- nothing would exist to restore it. From
+        // here the real row waits hidden for the crossfade, and only
+        // the flight's completion restores it -- never the reverse.
+        row.Opacity = 0;
 
         // The guard is the completion path's backstop: a batch that never
         // fires (composition wedged, window minimized through the flight)

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -163,7 +163,11 @@ internal sealed partial class VerticalTabStrip : UserControl
         NavView.ItemInvoked += OnNavItemInvoked;
 
         HookDragInput();
-        Unloaded += (_, _) => CancelDrag("teardown");
+        Unloaded += (_, _) =>
+        {
+            CancelDrag("teardown");
+            FinishPinFlight("teardown");
+        };
     }
 
     internal SolidColorBrush AccentBrush =>
@@ -466,6 +470,22 @@ internal sealed partial class VerticalTabStrip : UserControl
     // honours it still commits through the zone grammar (Classify /
     // SetPinned / read-back), never through the ghost.
     private VerticalTabPinnedRow? _pinPreview;
+
+    // The release-path flight at most one of: the ghost flying the pinned
+    // row from its released slot to the prefix end. One field is the whole
+    // identity guard -- a superseding flight, a teardown, or a completed
+    // phase checks it before touching anything, so no stale callback can
+    // reach into a flight that is no longer this one.
+    private PinFlight? _pinFlight;
+
+    /// <summary>One flight's live parts, released together on landing.</summary>
+    private sealed class PinFlight
+    {
+        public required Ghostty.Shell.TabMorphGhost Ghost;
+        public required Visual Visual;
+        public required FrameworkElement Row;
+        public required DispatcherQueueTimer Guard;
+    }
 
     // The tab whose row held focus when a churn removed it, so the rebuilt
     // row can take the focus with it (AddItem). Focus is unique, so at
@@ -1511,13 +1531,14 @@ internal sealed partial class VerticalTabStrip : UserControl
 
         // Outside MUXC, the row owns its own keyboard story: Enter/Space
         // activate through the same fenced path a shelf click uses, and
-        // Up/Down walk within the shelf and across the boundary. The focus
-        // indicator is the pane's hover-fill resource -- pinned rows paint
-        // no hover state today, so the fill is focus's alone -- because
-        // the row has no focus rect of its own to lean on.
+        // Up/Down walk within the shelf and across the boundary. Focus
+        // and pointer hover share one painter, so neither state can erase
+        // the other and the row has no focus rect of its own to lean on.
         row.KeyDown += OnPinnedRowKeyDown;
         row.GotFocus += OnPinnedRowFocusVisual;
         row.LostFocus += OnPinnedRowFocusVisual;
+        row.PointerEntered += OnShelfRowPointerEntered;
+        row.PointerExited += OnShelfRowPointerExited;
     }
 
     /// <summary>
@@ -2027,16 +2048,46 @@ internal sealed partial class VerticalTabStrip : UserControl
         e.Handled = true;
     }
 
-    private void OnPinnedRowFocusVisual(object sender, RoutedEventArgs e)
+    // The shelf row under the pointer, if any. Enter/exit pairs are
+    // trusted: a drag holds capture and suppresses them, so nothing has
+    // to re-derive hover from drag state.
+    private VerticalTabPinnedRow? _hoveredShelfRow;
+
+    private void OnShelfRowPointerEntered(object sender, PointerRoutedEventArgs e)
     {
         if (sender is not VerticalTabPinnedRow row) return;
-        // The pane's hover-fill resource, reused as the focus indicator:
-        // pinned rows paint no hover state today, so this fill is focus's
-        // alone, and the row's FocusState is what picks it over the
-        // transparent rest state.
-        row.Background = row.FocusState == FocusState.Unfocused
-            ? TransparentBrush
-            : ResolveThemeBrush("SubtleFillColorSecondaryBrush");
+        _hoveredShelfRow = row;
+        PaintShelfRow(row);
+    }
+
+    private void OnShelfRowPointerExited(object sender, PointerRoutedEventArgs e)
+    {
+        if (sender is not VerticalTabPinnedRow row) return;
+        if (!ReferenceEquals(_hoveredShelfRow, row)) return;
+        _hoveredShelfRow = null;
+        PaintShelfRow(row);
+    }
+
+    private void OnPinnedRowFocusVisual(object sender, RoutedEventArgs e)
+    {
+        if (sender is VerticalTabPinnedRow row) PaintShelfRow(row);
+    }
+
+    /// <summary>
+    /// One painter for the shelf row's two pointer-adjacent states, focus
+    /// and hover, on the pane's own hover-fill resource -- the same fill a
+    /// body row's hover carries. Focus wins when both apply, so a
+    /// keyboard user's indicator never flickers off because the pointer
+    /// wandered across; the rest state is transparent, the lane the rows
+    /// sit on.
+    /// </summary>
+    private void PaintShelfRow(VerticalTabPinnedRow row)
+    {
+        row.Background =
+            row.FocusState != FocusState.Unfocused
+            || ReferenceEquals(_hoveredShelfRow, row)
+                ? ResolveThemeBrush("SubtleFillColorSecondaryBrush")
+                : TransparentBrush;
     }
 
     /// <summary>The row rendering <paramref name="tab"/>, if built.</summary>
@@ -2321,9 +2372,26 @@ internal sealed partial class VerticalTabStrip : UserControl
         // op, SetPinned relocates to the prefix's last slot (exactly where
         // the ghost sat), and the read-back traces what landed. The churn
         // has replaced the dragged row's element, so there is no live
-        // visual to settle: the row lands as a cut, in the ghost's slot.
+        // visual to settle: the row lands as a cut, in the ghost's slot --
+        // or, with motion on, as the flight below.
         if (_pinPreview is not null)
         {
+            // Both flight endpoints are read BEFORE the commit: the start
+            // from the arranged row plus the follow offset the eye holds,
+            // the destination from the preview itself, which has been
+            // sitting on the exact slot the drop is about to fill. After
+            // SetPinned the churn has replaced both elements, and a
+            // freshly inserted row has no arranged truth to measure.
+            Rect? start = null, dest = null;
+            if (drag.MotionOn)
+            {
+                start = DraggedRowRect(drag);
+                if (_pinPreview is { } preview && preview.ActualWidth > 0)
+                    dest = new Rect(
+                        Canvas.GetLeft(preview), Canvas.GetTop(preview),
+                        preview.Width, VerticalTabPinnedRow.RowHeight);
+            }
+
             var zone = TabPinBoundary.Classify(
                 drag.Tab.IsPinned, _manager.PinCount, _manager.Tabs.Count,
                 _manager.PinCount - 1);
@@ -2337,6 +2405,8 @@ internal sealed partial class VerticalTabStrip : UserControl
                     $"to={zone.To}");
             }
             EndDrag(drag, settle: false, velocity: 0);
+            if (start is { } from && dest is { } to)
+                StartPinFlight(drag, from, to);
             return;
         }
         // Capture is not released here: a synchronous PointerCaptureLost
@@ -2369,6 +2439,10 @@ internal sealed partial class VerticalTabStrip : UserControl
 
     private void StartDragVisual(DragSession drag, PointerRoutedEventArgs e)
     {
+        // A fresh gesture outranks a flight still in the air: one flight
+        // at a time, and the new drag's churn must not share the shelf
+        // with a ghost from the old one.
+        FinishPinFlight("superseded");
         // Existence is the rep row's answer for both kinds; the anchor --
         // the element the follow rides -- is the header for a run.
         if (RowElementOf(drag.Tab) is not { } row) { CancelDrag("closed"); return; }
@@ -3478,6 +3552,230 @@ internal sealed partial class VerticalTabStrip : UserControl
         PreviewHost.Visibility = Visibility.Collapsed;
     }
 
+    // -----------------------------------------------------------------
+    // The pin flight (release path only). The mid-drag hysteresis commit
+    // never flights: it lands the row through SetPinned + Move and the
+    // follow expression carries it through the churn -- the row never
+    // detaches, so there is nothing to fly. A release on the preview is
+    // different: the churn replaces the dragged element outright, so the
+    // settle spring has nothing left to move -- the ghost does instead.
+    // It departs from where the eye holds the row (arranged slot plus the
+    // follow offset), travels to the slot the preview promised, bounces
+    // once, and crossfades into the real prefix-end row. State has
+    // already landed before any of it runs; the flight is decoration,
+    // and with motion off the release stays the cut it always was.
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// Where the dragged row sits right now, in this control's coordinates:
+    /// the arranged slot plus the follow offset the row rides under the
+    /// pointer. Arranged truth plus the one offset the drag owns -- never a
+    /// neighbour's glide-in-flight position.
+    /// </summary>
+    private Rect? DraggedRowRect(DragSession drag)
+    {
+        if (RowElementOf(drag.Tab) is not { } row) return null;
+        try
+        {
+            var pos = row.TransformToVisual(this)
+                .TransformPoint(new Point(0, 0));
+            if (double.IsNaN(pos.X) || double.IsNaN(pos.Y)
+                || row.ActualWidth <= 0 || row.ActualHeight <= 0)
+                return null;
+            return new Rect(
+                pos.X, pos.Y + (drag.LastPointerY - drag.AnchorY),
+                row.ActualWidth, row.ActualHeight);
+        }
+        catch (Exception ex) when (IsLayoutReadFailure(ex))
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Fly the just-pinned row from <paramref name="start"/> to
+    /// <paramref name="dest"/>, the slot the preview showed. Unreadable
+    /// endpoints are a cut, the same honesty the preview's own NaN gate
+    /// keeps -- an unmeasurable flight is no flight.
+    /// </summary>
+    private void StartPinFlight(DragSession drag, Rect start, Rect dest)
+    {
+        // The gate is the drag's own, read at lift: OS animation sources
+        // are the wiring's business, never re-derived mid-gesture.
+        if (!drag.MotionOn) return;
+        // One flight at a time: a live one yields to the fresh release.
+        FinishPinFlight("superseded");
+        if (RowElementOf(drag.Tab) is not { } row) return;
+
+        var chrome = ActiveRowChrome(drag.Tab);
+        var ghost = new Ghostty.Shell.TabMorphGhost(
+            drag.Tab, chrome.Fill, chrome.Foreground, new CornerRadius(0))
+        {
+            Width = dest.Width,
+            Height = dest.Height,
+        };
+        // The destination is an icon-only shelf row, so the ghost travels
+        // as one: it arrives in the shape it hands over to.
+        ghost.Label.Visibility = Visibility.Collapsed;
+
+        // Placed at the destination and offset back to the start, the gap
+        // glides' pattern: the canvas slot stays the truth and the
+        // animation only ever travels to zero.
+        Canvas.SetLeft(ghost, dest.X);
+        Canvas.SetTop(ghost, dest.Y);
+        PreviewHost.Children.Add(ghost);
+        PreviewHost.Visibility = Visibility.Visible;
+
+        try
+        {
+            ElementCompositionPreview.SetIsTranslationEnabled(ghost, true);
+            // The row's visual is probed, not kept: composition refusing
+            // here is a cut, the same refusal family every layout read
+            // in the drag guards.
+            _ = ElementCompositionPreview.GetElementVisual(row);
+        }
+        catch (Exception ex) when (IsLayoutReadFailure(ex))
+        {
+            PreviewHost.Children.Remove(ghost);
+            return;
+        }
+
+        // State first: the real row waits hidden for the crossfade, and
+        // only the flight's completion restores it -- never the reverse.
+        row.Opacity = 0;
+
+        var visual = ElementCompositionPreview.GetElementVisual(ghost);
+        var compositor = visual.Compositor;
+        var flight = new PinFlight
+        {
+            Ghost = ghost,
+            Visual = visual,
+            Row = row,
+            Guard = DispatcherQueue.CreateTimer(),
+        };
+        _pinFlight = flight;
+
+        // The guard is the completion path's backstop: a batch that never
+        // fires (composition wedged, window minimized through the flight)
+        // must not leave the real row at opacity zero. One shot, longer
+        // than every phase together; landing through it is identical to
+        // landing through a batch.
+        flight.Guard.IsRepeating = false;
+        flight.Guard.Interval = TimeSpan.FromMilliseconds(
+            TabStripMotion.PinFlightMs + 3 * TabStripMotion.PinSettlePeriodMs
+            + TabStripMotion.FadeMs + 250);
+        flight.Guard.Tick += (_, _) =>
+        {
+            if (!ReferenceEquals(_pinFlight, flight)) return;
+            FinishPinFlight("timeout");
+        };
+        flight.Guard.Start();
+
+        // Phase 1: the flight itself, on the neighbours' curve. The ghost
+        // is programmatic -- it starts at velocity 0, never the gesture's.
+        var fly = compositor.CreateVector3KeyFrameAnimation();
+        fly.Duration = TimeSpan.FromMilliseconds(TabStripMotion.PinFlightMs);
+        fly.InsertKeyFrame(1f, Vector3.Zero,
+            compositor.CreateCubicBezierEasingFunction(
+                new Vector2(0.55f, 0.55f), new Vector2(0f, 1f)));
+        visual.Properties.InsertVector3("Translation", new Vector3(
+            (float)(start.X - dest.X), (float)(start.Y - dest.Y), 0f));
+        var flying = compositor.CreateScopedBatch(CompositionBatchTypes.Animation);
+        // Identity-guarded, the settle batch's rule: these callbacks fire
+        // long after the release, and only the flight still in the field
+        // may run its next phase or its landing.
+        flying.Completed += (_, _) =>
+        {
+            if (!ReferenceEquals(_pinFlight, flight)) return;
+            StartPinSettle(flight);
+        };
+        visual.StartAnimation("Translation", fly);
+        flying.End();
+        DragTrace($"DRAG flight start dy={start.Y - dest.Y:0}");
+    }
+
+    /// <summary>
+    /// Phase 2: the landing's one visible bounce, the bounciest tier in
+    /// the strip and the only overshoot the strip spends on purpose. The
+    /// ghost arrives slightly lifted and the spring settles it to rest.
+    /// </summary>
+    private void StartPinSettle(PinFlight flight)
+    {
+        flight.Visual.Scale = new Vector3(
+            TabStripMotion.LiftScale, TabStripMotion.LiftScale, 1f);
+        var spring = flight.Visual.Compositor.CreateSpringVector3Animation();
+        spring.DampingRatio = TabStripMotion.PinSettleDampingRatio;
+        spring.Period = TimeSpan.FromMilliseconds(TabStripMotion.PinSettlePeriodMs);
+        spring.FinalValue = new Vector3(1f, 1f, 1f);
+        var settling = flight.Visual.Compositor.CreateScopedBatch(
+            CompositionBatchTypes.Animation);
+        settling.Completed += (_, _) =>
+        {
+            if (!ReferenceEquals(_pinFlight, flight)) return;
+            StartPinHandback(flight);
+        };
+        flight.Visual.StartAnimation("Scale", spring);
+        settling.End();
+    }
+
+    /// <summary>
+    /// Phase 3: the handoff. Ghost and real row crossfade on one batch --
+    /// one clock, so there is no frame where both are gone.
+    /// </summary>
+    private void StartPinHandback(PinFlight flight)
+    {
+        var compositor = flight.Visual.Compositor;
+        var fadeOut = compositor.CreateScalarKeyFrameAnimation();
+        fadeOut.Duration = TimeSpan.FromMilliseconds(TabStripMotion.FadeMs);
+        fadeOut.InsertKeyFrame(1f, 0f);
+        var fadeIn = compositor.CreateScalarKeyFrameAnimation();
+        fadeIn.Duration = TimeSpan.FromMilliseconds(TabStripMotion.FadeMs);
+        fadeIn.InsertKeyFrame(1f, 1f);
+        var handing = compositor.CreateScopedBatch(CompositionBatchTypes.Animation);
+        handing.Completed += (_, _) =>
+        {
+            if (!ReferenceEquals(_pinFlight, flight)) return;
+            FinishPinFlight("landed");
+        };
+        flight.Visual.StartAnimation("Opacity", fadeOut);
+        ElementCompositionPreview.GetElementVisual(flight.Row)
+            .StartAnimation("Opacity", fadeIn);
+        handing.End();
+    }
+
+    /// <summary>
+    /// Take the flight down and hand the row back at full strength, on
+    /// every path that can reach here: landing, a superseding flight, a
+    /// new drag, strip teardown, or the guard's timeout. Idempotent by
+    /// the single-field identity: whoever runs first clears it.
+    /// </summary>
+    private void FinishPinFlight(string reason)
+    {
+        if (_pinFlight is not { } flight) return;
+        _pinFlight = null;
+        flight.Guard.Stop();
+        try
+        {
+            flight.Visual.StopAnimation("Translation");
+            flight.Visual.StopAnimation("Scale");
+            flight.Visual.StopAnimation("Opacity");
+            // Stopping an animation reverts the property to its set value,
+            // so the row's opacity is written, not assumed.
+            flight.Row.Opacity = 1;
+            ElementCompositionPreview.GetElementVisual(flight.Row)
+                .StopAnimation("Opacity");
+        }
+        catch (Exception ex) when (IsLayoutReadFailure(ex))
+        {
+            // The row's tree went away mid-flight; the ghost's removal
+            // below is the part that still matters.
+        }
+        PreviewHost.Children.Remove(flight.Ghost);
+        if (PreviewHost.Children.Count == 0)
+            PreviewHost.Visibility = Visibility.Collapsed;
+        DragTrace($"DRAG flight {reason} ghosts={CountLeakedMotion()}");
+    }
+
     /// <summary>
     /// The drag machine's slots: every row with a position on screen, in
     /// manager order, paired with its manager index (SLOT -> MANAGER).
@@ -3712,11 +4010,13 @@ internal sealed partial class VerticalTabStrip : UserControl
 
     /// <summary>
     /// Rows the strip still believes carry drag composition: gap glides
-    /// not yet handed back, plus any teardown step that had to be
-    /// abandoned. The oracle reads anything above zero as a leak.
+    /// not yet handed back, any teardown step that had to be abandoned,
+    /// and a pin flight still in the air. The oracle reads anything above
+    /// zero as a leak.
     /// </summary>
     private int CountLeakedMotion() =>
-        _gapMotion.Count + _gapMotionHeaders.Count + _teardownFailures;
+        _gapMotion.Count + _gapMotionHeaders.Count + _teardownFailures
+        + (_pinFlight is null ? 0 : 1);
 
     /// <summary>
     /// Windows' animation-effects setting. Constructing UISettings can


### PR DESCRIPTION
PR 7a of the tab reorder/groups/pins ladder (spec section 10, rung 7a).

- The pin flight plays ONLY on the release-on-ghost path, where SetPinned's churn has already killed the dragged element; the mid-drag hysteresis commit path keeps its existing motion (RebindFollow), pinned by a fact that fails if StartPinFlight is ever called from EvaluateDrag.
- Carrier is the existing TabMorphGhost on PreviewHost: no new canvas, no window involvement. Both endpoints are read pre-commit; FinishPinFlight is the single identity-guarded funnel, writes Opacity=1 itself, and folds into CountLeakedMotion. The guard backstop is pinned armed (deleting Guard.Start fails the census fact).
- Motion-off cut stays first-statement in StartPinFlight; the release remains today's cut plus two null reads.
- Shelf rows gain the hover affordance they never painted (one-writer hover, focus-first).
- Core motion-state-equality fuzz for the two pin landing shapes lands in the follow-up PR (7a-2).

Verification: full solution build 0 errors / 49 warnings; scoped wiring fact classes 21/21 green; reviewer mutation campaign (M-X1/M-X2 red-exactly-one, M-X3 red after the fix).

Signed-off-by: Alessandro De Blasis <alex@deblasis.net>