### PR TITLE
tabs: horizontal lift and settle, and the chip swap fade

### DIFF
--- a/windows/Ghostty.Core/Tabs/TabStripMotion.cs
+++ b/windows/Ghostty.Core/Tabs/TabStripMotion.cs
@@ -75,6 +75,23 @@ internal static class TabStripMotion
     public const double FadeMs = 83;
 
     /// <summary>
+    /// The horizontal drag's handback: the lifted tab's shadow fades out
+    /// on this clock while its scale springs down. The spring is the
+    /// landing; the fade is what keeps the shadow from popping off a tab
+    /// that is still visibly settling.
+    /// </summary>
+    public const double UnliftFadeMs = 83;
+
+    /// <summary>
+    /// The lifted tab's shadow: the one depth cue the horizontal drag
+    /// spends. BlurRadius, offset, and opacity are written explicitly at
+    /// the use site.
+    /// </summary>
+    public const double LiftShadowBlurRadiusPx = 16;
+    public const double LiftShadowOffsetYPx = 4;
+    public const float LiftShadowOpacity = 0.25f;
+
+    /// <summary>
     /// The motion gate: springs and glides run only when Windows
     /// animation effects are on and High Contrast is not. Disabled means
     /// every spring collapses to a cut; state correctness never waits on

--- a/windows/Ghostty.Tests/Tabs/TabPinMotionStateFuzzTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabPinMotionStateFuzzTests.cs
@@ -189,13 +189,17 @@ public class TabPinMotionStateFuzzTests
     [Fact]
     public void TheMotionTokens_AreTheSanctionedValues()
     {
-        // The flight and its landing, and the fade. Values live in
-        // Core next to the machine so both strips and the tests read
-        // one copy.
+        // The flight and its landing, the fade, and the horizontal
+        // lift's shadow. Values live in Core next to the machine so
+        // both strips and the tests read one copy.
         Assert.Equal(250, TabStripMotion.PinFlightMs);
         Assert.Equal(0.6f, TabStripMotion.PinSettleDampingRatio);
         Assert.Equal(60, TabStripMotion.PinSettlePeriodMs);
         Assert.Equal(83, TabStripMotion.FadeMs);
+        Assert.Equal(83, TabStripMotion.UnliftFadeMs);
+        Assert.Equal(16, TabStripMotion.LiftShadowBlurRadiusPx);
+        Assert.Equal(4, TabStripMotion.LiftShadowOffsetYPx);
+        Assert.Equal(0.25f, TabStripMotion.LiftShadowOpacity);
     }
 
     [Fact]

--- a/windows/Ghostty.Tests/Wiring/TabHorizontalMotionWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabHorizontalMotionWiringTests.cs
@@ -1,0 +1,274 @@
+using System;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// The horizontal strip's motion: the drag lift and the collapse swap's
+/// appear-hand. TabView owns the drag itself -- the reorder preview, the
+/// drop, the OS ghost -- so what is pinned here is the polish the host
+/// adds around it: the pressed tab's own visual lifts on the grab and
+/// settles back on the release, a shadow carries the depth, and the
+/// chip &lt;-&gt; members swap fades what appears while removals stay
+/// immediate.
+///
+/// Two properties are pinned. The motion gate is the first statement of
+/// everything that animates, and its cut is total: motion off means no
+/// composition work at all, not different composition work -- state
+/// correctness never waits on an animation. And every animation is
+/// programmatic: TabView exposes no machine velocity, so both springs
+/// start at rest, the policy the vertical's pin flight runs on.
+///
+/// Wiring guards, not behaviour tests: what a lift looks like on screen
+/// is only observable on a live strip.
+/// </summary>
+public class TabHorizontalMotionWiringTests
+{
+    private const string HostSource = "Tabs.TabHost.xaml.cs";
+
+    private static ShellSource Host() => ShellSource.Load(HostSource);
+
+    private static AssignmentExpressionSyntax Assign(SyntaxNode node, string left) =>
+        node.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Single(a => a.Left.ToString() == left);
+
+    /// <summary>
+    /// The gate is the first statement of everything that animates, and
+    /// the cut is total: the motion-off arm returns without so much as a
+    /// cleanup call, so a gated strip performs zero animation work. The
+    /// settle is held to the same bar from the other side: it runs only
+    /// when a lift is live in the field, so a gate that cut the grab
+    /// also cut the handback. And decoration stands last in both drag
+    /// handlers: the commit's state has landed before anything visual
+    /// runs, never the reverse.
+    /// </summary>
+    [Fact]
+    public void TheGate_IsTheFirstStatement_AndTheCutIsTotal()
+    {
+        var host = Host();
+        foreach (var name in new[] { "StartLift", "FadeInAppearing" })
+        {
+            var first = Assert.IsType<IfStatementSyntax>(
+                host.Method(name).Body!.Statements.First());
+            Assert.Equal(
+                "!TabStripMotion.Enabled(SystemAnimationsEnabled(), _highContrast)",
+                first.Condition.ToString());
+            Assert.Contains(
+                first.Statement.DescendantNodesAndSelf().OfType<ReturnStatementSyntax>(),
+                r => true);
+            Assert.DoesNotContain(
+                first.Statement.DescendantNodesAndSelf().OfType<InvocationExpressionSyntax>(),
+                c => true);
+        }
+
+        // No lift in the field, no settle work: the guard is the settle's
+        // first statement, not a branch deep in its build-out.
+        var settle = Assert.IsType<IfStatementSyntax>(
+            host.Method("SettleLift").Body!.Statements.First());
+        Assert.Equal("_lift is not { } lift", settle.Condition.ToString());
+
+        // Decoration stands last in the drag handlers: the lift runs
+        // after the seam cover is suppressed, and the settle runs after
+        // the reconcile and the bridge update have spoken.
+        var starting = host.Method("OnTabDragStarting");
+        var seam = starting.Calls("SelectedTabSeamChanged?.Invoke").Single();
+        var lift = starting.Calls("StartLift").Single();
+        Assert.True(seam.Span.Start < lift.Span.Start,
+            "the lift is decoration and stands last in the drag start");
+
+        var completed = host.Method("OnTabDragCompleted");
+        var bridge = completed.Calls("QueueBridgeUpdate").Single();
+        var settleCall = completed.Calls("SettleLift").Single();
+        Assert.True(bridge.Span.Start < settleCall.Span.Start,
+            "the settle is decoration and stands last in the drag completion");
+    }
+
+    /// <summary>
+    /// The lift is programmatic at rest. TabView exposes no machine
+    /// velocity, so nothing in the gesture reads one: the grab springs
+    /// the scale up on the lift tokens, the release springs it down to
+    /// exactly rest on the drop-settle tokens, and no keyframe carries a
+    /// scale the hand did not earn. The dragged element is named by the
+    /// drag start's own args.Item -- the container TabView hands the
+    /// event -- and nothing else.
+    /// </summary>
+    [Fact]
+    public void TheLift_IsProgrammatic_AtRest()
+    {
+        var host = Host();
+
+        // The dragged tab is the event's own item pattern: the container
+        // TabView names, not a container lookup that can answer for a
+        // different slot.
+        var starting = host.Method("OnTabDragStarting");
+        var liftCall = starting.Calls("StartLift").Single();
+        var pattern = Assert.IsType<IfStatementSyntax>(
+            liftCall.Ancestors().OfType<IfStatementSyntax>().First());
+        Assert.Equal("args.Item is TabViewItem lifted", pattern.Condition.ToString());
+
+        // Springs only, and every parameter named: the WinRT spring
+        // classes document no defaults, so an implicit period would be a
+        // guess.
+        var start = host.Method("StartLift");
+        Assert.Contains(start.DescendantNodes().OfType<InvocationExpressionSyntax>(),
+            c => c.CalleeText() == "compositor.CreateSpringVector3Animation");
+        Assert.Contains(start.DescendantNodes().OfType<InvocationExpressionSyntax>(),
+            c => c.CalleeText() == "compositor.CreateSpringScalarAnimation");
+        Assert.DoesNotContain(
+            start.DescendantNodes().OfType<InvocationExpressionSyntax>(),
+            c => c.CalleeText().EndsWith("KeyFrameAnimation", StringComparison.Ordinal));
+        Assert.Equal("TabStripMotion.LiftDampingRatio",
+            Assign(start, "scale.DampingRatio").Right.ToString());
+        Assert.Contains("TabStripMotion.LiftPeriodMs",
+            Assign(start, "scale.Period").Right.ToString());
+        Assert.Contains("TabStripMotion.LiftScale",
+            Assign(start, "scale.FinalValue").Right.ToString());
+        Assert.Equal("TabStripMotion.LiftDampingRatio",
+            Assign(start, "shadowIn.DampingRatio").Right.ToString());
+        Assert.Equal("TabStripMotion.LiftShadowOpacity",
+            Assign(start, "shadowIn.FinalValue").Right.ToString());
+
+        // The handback lands at rest: the full identity, on the settle
+        // tokens the vertical's drop uses.
+        var settle = host.Method("SettleLift");
+        Assert.Equal("TabStripMotion.SettleDampingRatio",
+            Assign(settle, "settle.DampingRatio").Right.ToString());
+        Assert.Contains("TabStripMotion.SettlePeriodMs",
+            Assign(settle, "settle.Period").Right.ToString());
+        Assert.Equal("new Vector3(1f, 1f, 1f)",
+            Assign(settle, "settle.FinalValue").Right.ToString());
+
+        // No machine velocity exists to read, and none may be invented:
+        // the whole gesture is at rest, the flight's policy.
+        foreach (var name in new[]
+                 {
+                     "OnTabDragStarting", "OnTabDragCompleted", "StartLift", "SettleLift"
+                 })
+        {
+            Assert.DoesNotContain(
+                host.Method(name).DescendantNodes().OfType<MemberAccessExpressionSyntax>(),
+                m => m.Name.Identifier.ValueText == "Velocity");
+        }
+    }
+
+    /// <summary>
+    /// The shadow is born and dies with the lift. It is attached as the
+    /// tab's child visual -- the one place that composes behind the
+    /// tab's own content -- and FinishLift detaches it there, anchored
+    /// to the element so the undo reaches the tab whatever the strip did
+    /// to its slots in between. Its parameters are the shadow tokens,
+    /// and the handback's shadow rides the unlift fade: the spring is
+    /// the landing, and the fade is what keeps the shadow from popping
+    /// off a tab that is still visibly settling.
+    /// </summary>
+    [Fact]
+    public void TheShadow_IsBornAndDiesWithTheLift_AndTheHandbackIsAFade()
+    {
+        var host = Host();
+        var start = host.Method("StartLift");
+        var attach = start.Call("ElementCompositionPreview.SetElementChildVisual");
+        Assert.Equal("item", attach.Arg(0));
+        Assert.Equal("shadow", attach.Arg(1));
+        Assert.Contains("TabStripMotion.LiftShadowBlurRadiusPx",
+            Assign(start, "drop.BlurRadius").Right.ToString());
+        Assert.Contains("TabStripMotion.LiftShadowOffsetYPx",
+            Assign(start, "drop.Offset").Right.ToString());
+
+        var finish = host.Method("FinishLift");
+        Assert.NotEmpty(finish.Calls("lift.Guard.Stop"));
+        var detach = finish.Call("ElementCompositionPreview.SetElementChildVisual");
+        Assert.Equal("lift.Item", detach.Arg(0));
+        Assert.Equal("null", detach.Arg(1));
+
+        var fadeOut = Assign(host.Method("SettleLift"), "fadeOut.Duration");
+        Assert.Contains("TabStripMotion.UnliftFadeMs", fadeOut.Right.ToString());
+    }
+
+    /// <summary>
+    /// The collapse swap fades what appears and lingers over nothing.
+    /// The chip fades in where it mints; a retiring chip arms the swap
+    /// flag and the rebuild that re-enters its members fades exactly
+    /// those -- rows the strip did not hold -- and never its own repair
+    /// re-adds. The flag is cleared by the pass that consumed it, so a
+    /// retirement with nothing to re-enter cannot fade some later pass.
+    /// Removals are immediate: TabView has no item exit, and neither the
+    /// chip's nor a tab's removal fades.
+    /// </summary>
+    [Fact]
+    public void TheSwapFadesWhatAppears_AndItsClearIsPassOwned()
+    {
+        var host = Host();
+
+        var mint = host.Method("AddGroupChip");
+        Assert.Equal("chip", mint.Call("FadeInAppearing").Arg(0));
+
+        var retire = host.Method("RemoveGroupChip");
+        Assert.Single(retire.AssignsTo("_swapFadePending"));
+        Assert.Empty(retire.Calls("FadeInAppearing"));
+        Assert.Empty(host.Method("RemoveItem").Calls("FadeInAppearing"));
+
+        var rebuild = host.Method("RebuildStripFromManager");
+        var fade = rebuild.Calls("FadeInAppearing").Single();
+        var guard = Assert.IsType<IfStatementSyntax>(
+            fade.Ancestors().OfType<IfStatementSyntax>().First());
+        Assert.Equal("_swapFadePending && !held.Contains(item)",
+            guard.Condition.ToString());
+
+        var clear = host.Method("ReconcileStripOrder").AssignsTo("_swapFadePending")
+            .Single();
+        Assert.Equal("false", clear.Right.ToString());
+
+        // What appears arrives on the fade token -- the crossfade the
+        // pin flight's handoff uses -- not on a duration of its own.
+        var fadeIn = Assign(host.Method("FadeInAppearing"), "fadeIn.Duration");
+        Assert.Contains("TabStripMotion.FadeMs", fadeIn.Right.ToString());
+    }
+
+    /// <summary>
+    /// The lift cannot outlive its supersede or its teardown. One lift
+    /// lives in the field; a fresh grab finishes the one still handing
+    /// back, the strip's Unloaded finishes it, and both callbacks that
+    /// can end it -- the settle batch and the guard timer -- check the
+    /// field before they run, because they fire long after the grab
+    /// that armed them. FinishLift itself is the one door: it clears the
+    /// field first, so a re-entrant ending cannot tear down a lift it
+    /// does not own.
+    /// </summary>
+    [Fact]
+    public void TheLift_CannotOutliveItsSupersedeOrItsTeardown()
+    {
+        var host = Host();
+
+        var start = host.Method("StartLift");
+        Assert.Contains(start.DescendantNodes().OfType<InvocationExpressionSyntax>(),
+            c => c.CalleeText() == "FinishLift" && c.Arg(0) == "\"superseded\"");
+
+        var unloaded = host.Root.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Single(a => a.Left.ToString() == "Unloaded");
+        Assert.NotEmpty(unloaded.Right.Calls("FinishLift"));
+
+        // settle-to-landing and the guard timer's timeout: two endings,
+        // one guard shape, the pin flight's rule.
+        var guarded = new[] { host.Method("StartLift"), host.Method("SettleLift") }
+            .SelectMany(m => m.DescendantNodes().OfType<AnonymousFunctionExpressionSyntax>())
+            .Where(f => f.Body is BlockSyntax block
+                        && block.DescendantNodes().OfType<InvocationExpressionSyntax>()
+                            .Any(c => c.CalleeText() == "FinishLift"))
+            .ToList();
+        Assert.Equal(2, guarded.Count);
+        foreach (var callback in guarded)
+        {
+            var block = (BlockSyntax)callback.Body!;
+            var first = Assert.IsType<IfStatementSyntax>(block.Statements.First());
+            Assert.Equal("!ReferenceEquals(_lift, lift)", first.Condition.ToString());
+        }
+
+        var finish = host.Method("FinishLift");
+        var field = Assert.IsType<IfStatementSyntax>(finish.Body!.Statements.First());
+        Assert.Equal("_lift is not { } lift", field.Condition.ToString());
+        Assert.Single(finish.AssignsTo("_lift"));
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/TabHorizontalMotionWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabHorizontalMotionWiringTests.cs
@@ -235,7 +235,10 @@ public class TabHorizontalMotionWiringTests
     /// field before they run, because they fire long after the grab
     /// that armed them. FinishLift itself is the one door: it clears the
     /// field first, so a re-entrant ending cannot tear down a lift it
-    /// does not own.
+    /// does not own. The backstop is pinned armed, not merely
+    /// configured: a guard that never starts stops nothing, and the
+    /// wedged settle batch it exists for is exactly the case no batch
+    /// callback reports.
     /// </summary>
     [Fact]
     public void TheLift_CannotOutliveItsSupersedeOrItsTeardown()
@@ -245,6 +248,7 @@ public class TabHorizontalMotionWiringTests
         var start = host.Method("StartLift");
         Assert.Contains(start.DescendantNodes().OfType<InvocationExpressionSyntax>(),
             c => c.CalleeText() == "FinishLift" && c.Arg(0) == "\"superseded\"");
+        Assert.Single(start.Calls("lift.Guard.Start"));
 
         var unloaded = host.Root.DescendantNodes().OfType<AssignmentExpressionSyntax>()
             .Single(a => a.Left.ToString() == "Unloaded");

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -2810,7 +2810,9 @@ public sealed partial class MainWindow : Window
         // scores its own titles against it. One read feeds both, so the two
         // layouts cannot come out calibrated against different surfaces for
         // one config, which only shows up mid-switch with both on screen.
-        _horizontalTabHost.SetChromeGround(ground);
+        // High Contrast rides along: it is the horizontal strip's motion
+        // gate, composed from the same window chrome truth.
+        _horizontalTabHost.SetChromeGround(ground, HighContrastChromeActive);
     }
 
     /// <summary>

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Numerics;
 using System.Threading.Tasks;
 using Ghostty.Core.Tabs;
 using Ghostty.Dialogs;
@@ -10,10 +11,12 @@ using Ghostty.Panes;
 using Ghostty.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.UI.Composition;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Hosting;
 using Microsoft.UI.Xaml.Input;
 using Ghostty.Core.Windows;
 using Microsoft.UI.Xaml.Media;
@@ -131,6 +134,10 @@ internal sealed partial class TabHost : UserControl, ITabHost
         // under Equal sizing, so the strip resizing moves it too.
         Loaded += (_, _) => QueueBridgeUpdate();
         TabViewControl.SizeChanged += (_, _) => UpdateSelectedTabBridge();
+
+        // A lift cannot outlive the strip: teardown finishes it, the same
+        // door the vertical's drag and its pin flight go out through.
+        Unloaded += (_, _) => FinishLift("teardown");
 
         // The drag lifecycle gates the seam cover below: mid-drag the
         // strip's slots are TabView's reorder preview, not the manager's
@@ -579,12 +586,21 @@ internal sealed partial class TabHost : UserControl, ITabHost
         group.PropertyChanged += OnGroupPropertyChanged;
         TabViewControl.TabItems.Add(chip);
         RefreshChip(group);
+        // The mint is the swap's appear-hand: the chip takes the slots
+        // its members just left, so it arrives on the fade token rather
+        // than snapping into a strip the eye was reading a moment ago.
+        FadeInAppearing(chip);
     }
 
     private void RemoveGroupChip(TabGroup group)
     {
         if (!_chipByGroup.Remove(group, out var chip)) return;
         group.PropertyChanged -= OnGroupPropertyChanged;
+        // The retirement is the swap's other half: the run's members
+        // re-enter through the rebuild that follows, and that pass fades
+        // them in. The removal itself stays immediate -- TabView has no
+        // item exit, and a retiring chip must not linger.
+        _swapFadePending = true;
         TabViewControl.TabItems.Remove(chip.Item);
     }
 
@@ -829,6 +845,12 @@ internal sealed partial class TabHost : UserControl, ITabHost
         {
             _suppressSelectionEvent = false;
         }
+        // The swap pass ends here, whatever it did: a chip that retired
+        // without a rebuild (a run's last member closed; nothing
+        // re-entered) must not fade some later pass's re-adds. One
+        // clear, owned by the pass, so the flag can never outlive the
+        // retirement that set it.
+        _swapFadePending = false;
         if (repaired) SelectActive();
     }
 
@@ -843,6 +865,11 @@ internal sealed partial class TabHost : UserControl, ITabHost
     {
         // Presence first: the walk below reads chips this host must hold.
         ReconcileChips();
+        // The swap's appear-hand is measured against the slots this pass
+        // started with: a row the strip did not hold is one the chip <->
+        // members swap just revealed, and it fades in. Every other
+        // re-add is the rebuild's own repair, and a repair is not motion.
+        var held = new HashSet<object>(TabViewControl.TabItems);
         TabViewControl.TabItems.Clear();
         foreach (var row in TabStripProjection.HorizontalRows(_manager))
         {
@@ -855,6 +882,8 @@ internal sealed partial class TabHost : UserControl, ITabHost
                 case TabStripProjection.HorizontalRow.Item { Tab: { } tab }
                     when _itemByModel.TryGetValue(tab, out var item):
                     TabViewControl.TabItems.Add(item);
+                    if (_swapFadePending && !held.Contains(item))
+                        FadeInAppearing(item);
                     break;
             }
         }
@@ -1623,6 +1652,10 @@ internal sealed partial class TabHost : UserControl, ITabHost
         // and anything the strip does from here moves slots the manager
         // has not agreed to yet.
         SelectedTabSeamChanged?.Invoke(0, 0, null);
+        // The lift is decoration and stands last: everything above lands
+        // the state the drag's truth needs, and the visual must never be
+        // a dependency of it.
+        if (args.Item is TabViewItem lifted) StartLift(lifted);
     }
 
     private void OnTabDragCompleted(TabView sender, TabViewTabDragCompletedEventArgs args)
@@ -1725,6 +1758,10 @@ internal sealed partial class TabHost : UserControl, ITabHost
         // scan.
         ReconcileStripOrder();
         QueueBridgeUpdate();
+        // The settle is decoration and stands last: the commit above has
+        // landed, the reconcile has spoken, and the handback runs on
+        // whatever element the tab has now.
+        SettleLift();
     }
 
     /// <summary>
@@ -1821,6 +1858,232 @@ internal sealed partial class TabHost : UserControl, ITabHost
         if (!_stripDragActive) return;
         _lastDropPosition = e.GetPosition(TabViewControl);
         _dropPositionValid = true;
+    }
+
+    // -----------------------------------------------------------------
+    // The horizontal lift, and the collapse swap's appear-hand. TabView
+    // owns the drag itself -- the reorder preview, the drop, the ghost
+    // it hands the OS -- so what lands here is polish on the slot it
+    // already animates: the pressed tab's own visual lifts on the grab
+    // and settles back on the release, and a shadow carries the depth a
+    // scale alone does not. There is no machine velocity to inherit:
+    // TabView exposes none, so both springs start at rest -- the
+    // programmatic policy the vertical's pin flight runs on.
+    // -----------------------------------------------------------------
+
+    // The one live lift, zero or one. A fresh grab supersedes a settle
+    // that is still handing back, and every callback that can end the
+    // lift checks the field before it runs -- the batch and the guard
+    // fire long after the grab that armed them.
+    private HorizontalLift? _lift;
+
+    /// <summary>
+    /// The renderable parts of one lift, kept so every ending can undo
+    /// exactly what the grab did. The visual is the tab's at grab time;
+    /// the shadow is the child sprite, anchored to the element, so it
+    /// stays reachable no matter what the strip does to slots in
+    /// between.
+    /// </summary>
+    private sealed record HorizontalLift(
+        TabViewItem Item,
+        Visual Visual,
+        SpriteVisual Shadow,
+        Microsoft.UI.Dispatching.DispatcherQueueTimer Guard);
+
+    // The chip <-> members swap's appear-hand, armed when a chip retires
+    // and consumed by the rebuild that re-enters its members. Cleared at
+    // the end of every reconcile pass: a retirement with nothing to
+    // re-enter (a run's last member closed) must not fade some later
+    // pass's re-adds.
+    private bool _swapFadePending;
+
+    private void StartLift(TabViewItem item)
+    {
+        // The gate is first, and the cut is total: with motion off the
+        // grab performs no composition work at all -- no spring, no
+        // shadow, no guard -- and the release finds no lift to settle.
+        if (!TabStripMotion.Enabled(SystemAnimationsEnabled(), _highContrast)) return;
+        // One lift at a time: a fresh grab yields the settle still
+        // handing back.
+        FinishLift("superseded");
+
+        Visual visual;
+        try
+        {
+            visual = ElementCompositionPreview.GetElementVisual(item);
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException
+            or System.Runtime.InteropServices.COMException or NullReferenceException)
+        {
+            // Composition refusing here is a cut, the same refusal
+            // family every geometry read in the drag guards.
+            return;
+        }
+        var compositor = visual.Compositor;
+
+        // The shadow rides a child sprite: it composes behind the item's
+        // own content, so only the blur's halo extends past the tab. It
+        // is sized once, at the grab -- TabView resizes slots mid-drag
+        // under Equal width, and a stale halo for the length of one drag
+        // beats re-anchoring the element tree mid-gesture.
+        var shadow = compositor.CreateSpriteVisual();
+        shadow.Size = new Vector2((float)item.ActualWidth, (float)item.ActualHeight);
+        var drop = compositor.CreateDropShadow();
+        drop.BlurRadius = (float)TabStripMotion.LiftShadowBlurRadiusPx;
+        drop.Offset = new Vector3(0f, (float)TabStripMotion.LiftShadowOffsetYPx, 0f);
+        shadow.Shadow = drop;
+
+        var lift = new HorizontalLift(
+            item, visual, shadow, DispatcherQueue.CreateTimer());
+        _lift = lift;
+
+        // State first, decoration second: the field and the child visual
+        // land before any animation starts, so every later ending can
+        // reach the things it must undo.
+        ElementCompositionPreview.SetElementChildVisual(item, shadow);
+
+        // The lift is the grab's own spring, on the vertical's lift
+        // tokens: the same growth the rows use, pivoting from the tab's
+        // center so it grows where the pointer holds it.
+        visual.CenterPoint = new Vector3(
+            (float)item.ActualWidth / 2f, (float)item.ActualHeight / 2f, 0f);
+        var scale = compositor.CreateSpringVector3Animation();
+        scale.DampingRatio = TabStripMotion.LiftDampingRatio;
+        scale.Period = TimeSpan.FromMilliseconds(TabStripMotion.LiftPeriodMs);
+        scale.FinalValue = new Vector3(
+            TabStripMotion.LiftScale, TabStripMotion.LiftScale, 1f);
+        visual.StartAnimation("Scale", scale);
+
+        // The shadow breathes with the grab: the same spring family,
+        // scalar, so the depth arrives on the clock the height does.
+        var shadowIn = compositor.CreateSpringScalarAnimation();
+        shadowIn.DampingRatio = TabStripMotion.LiftDampingRatio;
+        shadowIn.Period = TimeSpan.FromMilliseconds(TabStripMotion.LiftPeriodMs);
+        shadowIn.FinalValue = TabStripMotion.LiftShadowOpacity;
+        shadow.StartAnimation("Opacity", shadowIn);
+
+        // The guard is the completion path's backstop, the pin flight's
+        // rule: a batch that never fires must not leave the tab lifted
+        // under a shadow. One shot, longer than the lift and the
+        // handback together; landing through it is identical to landing
+        // through a batch.
+        lift.Guard.IsRepeating = false;
+        lift.Guard.Interval = TimeSpan.FromMilliseconds(
+            3 * (TabStripMotion.LiftPeriodMs + TabStripMotion.SettlePeriodMs)
+            + TabStripMotion.UnliftFadeMs + 250);
+        lift.Guard.Tick += (_, _) =>
+        {
+            if (!ReferenceEquals(_lift, lift)) return;
+            FinishLift("timeout");
+        };
+        lift.Guard.Start();
+    }
+
+    /// <summary>
+    /// The release handback. The scale springs down on the drop-settle
+    /// tokens -- at rest, since TabView exposes no machine velocity --
+    /// and the shadow fades out alongside: the spring is the landing,
+    /// and the fade is what keeps the shadow from popping off a tab
+    /// that is still visibly settling.
+    /// </summary>
+    private void SettleLift()
+    {
+        if (_lift is not { } lift) return;
+        // The element is read fresh: a refused or repaired commit can
+        // churn the strip, and the settle must drive the visual the tab
+        // has now, not the one the grab lifted.
+        Visual visual;
+        try
+        {
+            visual = ElementCompositionPreview.GetElementVisual(lift.Item);
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException
+            or System.Runtime.InteropServices.COMException or NullReferenceException)
+        {
+            FinishLift("churned");
+            return;
+        }
+        var compositor = visual.Compositor;
+        var settle = compositor.CreateSpringVector3Animation();
+        settle.DampingRatio = TabStripMotion.SettleDampingRatio;
+        settle.Period = TimeSpan.FromMilliseconds(TabStripMotion.SettlePeriodMs);
+        settle.FinalValue = new Vector3(1f, 1f, 1f);
+        var settling = compositor.CreateScopedBatch(CompositionBatchTypes.Animation);
+        settling.Completed += (_, _) =>
+        {
+            if (!ReferenceEquals(_lift, lift)) return;
+            FinishLift("landed");
+        };
+        var fadeOut = compositor.CreateScalarKeyFrameAnimation();
+        fadeOut.Duration = TimeSpan.FromMilliseconds(TabStripMotion.UnliftFadeMs);
+        fadeOut.InsertKeyFrame(1f, 0f);
+        lift.Shadow.StartAnimation("Opacity", fadeOut);
+        visual.StartAnimation("Scale", settle);
+        settling.End();
+    }
+
+    /// <summary>
+    /// The lift's every ending: landing, timeout, a superseding grab, a
+    /// churned commit, and the strip's teardown. Stopping the
+    /// animations is bookkeeping; the real undo is detaching the child
+    /// sprite, which is anchored to the element and so reaches the tab
+    /// whatever the strip did to its slots in between.
+    /// </summary>
+    private void FinishLift(string reason)
+    {
+        if (_lift is not { } lift) return;
+        _lift = null;
+        lift.Guard.Stop();
+        lift.Visual.StopAnimation("Scale");
+        lift.Shadow.StopAnimation("Opacity");
+        ElementCompositionPreview.SetElementChildVisual(lift.Item, null);
+    }
+
+    /// <summary>
+    /// The collapse swap's appear-hand: what the chip &lt;-&gt; members
+    /// swap just revealed fades in on the fade token. What the swap
+    /// removed does not linger -- TabView has no item exit, and the
+    /// removals stay immediate. Gate off is a cut: the element simply
+    /// appears, and no animation is built at all.
+    /// </summary>
+    private void FadeInAppearing(FrameworkElement appearing)
+    {
+        if (!TabStripMotion.Enabled(SystemAnimationsEnabled(), _highContrast)) return;
+        Visual visual;
+        try
+        {
+            visual = ElementCompositionPreview.GetElementVisual(appearing);
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException
+            or System.Runtime.InteropServices.COMException or NullReferenceException)
+        {
+            return;
+        }
+        var fadeIn = visual.Compositor.CreateScalarKeyFrameAnimation();
+        fadeIn.Duration = TimeSpan.FromMilliseconds(TabStripMotion.FadeMs);
+        fadeIn.InsertKeyFrame(0f, 0f);
+        fadeIn.InsertKeyFrame(1f, 1f);
+        var batch = visual.Compositor.CreateScopedBatch(CompositionBatchTypes.Animation);
+        batch.Completed += (_, _) => visual.StopAnimation("Opacity");
+        visual.StartAnimation("Opacity", fadeIn);
+        batch.End();
+    }
+
+    /// <summary>
+    /// The window animations preference, read at the gesture, never
+    /// cached: reading can throw in packaged/sandboxed contexts
+    /// (App.xaml.cs notes the same); unreadable is not "off", so the
+    /// gate fails open and High Contrast still collapses the motion
+    /// through its own pushed flag.
+    /// </summary>
+    private static bool SystemAnimationsEnabled()
+    {
+        try { return new Windows.UI.ViewManagement.UISettings().AnimationsEnabled; }
+        catch (Exception ex) when (ex is InvalidOperationException
+            or System.Runtime.InteropServices.COMException or NullReferenceException)
+        {
+            return true;
+        }
     }
 
     /// <summary>
@@ -1920,14 +2183,24 @@ internal sealed partial class TabHost : UserControl, ITabHost
     /// change on different inputs, and folding them into one call would drop
     /// an OS light/dark flip that never moved the fill.
     /// </summary>
-    internal void SetChromeGround(uint groundRgb)
+    internal void SetChromeGround(uint groundRgb, bool highContrast)
     {
-        if (_chromeGroundPacked == groundRgb) return;
+        var groundChanged = _chromeGroundPacked != groundRgb;
         _chromeGroundPacked = groundRgb;
-        RefreshShellInactiveInk();
+        // The motion gate's High Contrast half rides the same push: it is
+        // a window chrome truth composed from the same inputs the
+        // separators read, and the strip must not re-derive it.
+        _highContrast = highContrast;
+        if (groundChanged) RefreshShellInactiveInk();
     }
 
     private uint _chromeGroundPacked = 0x0C0C0C;
+
+    // High Contrast as the window composed it (detector composed through
+    // the opt-out, the one read the vertical's gate uses too). Motion
+    // input, not ink input: it gates the lift and the swap fade and
+    // touches no brush.
+    private bool _highContrast;
 
     private SolidColorBrush? _shellActiveTextBrush;
     private SolidColorBrush? _shellInactiveTextBrush;


### PR DESCRIPTION
PR 7b of the tab ladder (spec section 10, rung 7b).

- Lift on TabDragStarting: the dragged TabViewItem's composition visual (args.Item is the container -- TabItems holds TabViewItem instances, chips included) springs toward LiftScale 1.03 with a child-sprite DropShadow (16/4/0.25) fading in on the same lift tokens. TabDragCompleted settles scale to 1 and fades the shadow out over UnliftFadeMs, which returns here with a live consumer and rides the guard interval.
- DropShadow attaches via SpriteVisual.Shadow (rectangular by default per the composition shadows docs); the brushless sprite's core hides behind the tab's XAML content, leaving the blur fringe and offset visible.
- Collapse fade: what APPEARS (chip mint on expand, member rows on re-entry via RebuildStripFromManager) fades in on FadeMs; removals are immediate -- TabView has no item-exit animation. The retire-arm flag is single-site, consumed by the rebuild walk, and pass-owned at the ReconcileStripOrder tail.
- Gate polarity: the motion gate is the first statement of StartLift and FadeInAppearing with a bare-return cut arm; gate-off produces zero animation work and no handback work. Vertical collapse is MUXC's own and is untouched.
- Lifecycle: single _lift field, supersede on a fresh grab (old guard stopped before the new lift exists), identity-guarded endings, element-anchored sprite detach as the real undo, Unloaded teardown, guard-arming pinned like 7a's flight.

Verification: solution build 0 errors / 49 warnings; 14/14 implementer + 5 reviewer mutations red-exactly-one (rebuilt per mutation); scoped 102/102 and full project 3106 passed / 0 failed at the review head, 3131 passed / 0 failed at the fold-in head.

Signed-off-by: Alessandro De Blasis <alex@deblasis.net>