### PR TITLE
test(bench): give each scripted-response stage its own budget

### DIFF
--- a/windows/Ghostty.Tests/Bench/FakeTransportTests.cs
+++ b/windows/Ghostty.Tests/Bench/FakeTransportTests.cs
@@ -5,7 +5,14 @@ namespace Ghostty.Tests.Bench;
 
 public class FakeTransportTests
 {
-    private static readonly TimeSpan BoundedWait = TimeSpan.FromSeconds(5);
+    // Generous on purpose. The deadlock this suite once hit blocked forever,
+    // so any bound catches it; the bound exists to keep a broken suite
+    // failing fast, not to measure latency. Each stage gets its OWN budget
+    // and stopwatch: a shared one converts slow-but-innocent latency
+    // anywhere in front of the second gate into a false "write never
+    // completed" verdict, and the failure messages below carry each stage's
+    // timing so the next flake says where the budget went.
+    private static readonly TimeSpan BoundedWait = TimeSpan.FromSeconds(20);
 
     // Regression for a proven suite-wide deadlock. With the zero-size pipe
     // buffers the default NamedPipeServerStream constructor passes, a write
@@ -38,34 +45,60 @@ public class FakeTransportTests
         // BEFORE the response write, so at first call the IO thread holds no
         // reader on the output pipe: the write-under-test is already in
         // flight, which is the state this test exists to pin.
-        var sw = Stopwatch.StartNew();
-        while (Volatile.Read(ref responderCalls) < 1 && sw.Elapsed < BoundedWait)
+        var firstCall = Stopwatch.StartNew();
+        while (Volatile.Read(ref responderCalls) < 1 && firstCall.Elapsed < BoundedWait)
             Thread.Sleep(10);
+        var firstCallMs = firstCall.ElapsedMilliseconds;
 
         Assert.True(Volatile.Read(ref responderCalls) >= 1,
             $"scripted responder never ran within {BoundedWait.TotalSeconds:F0}s");
 
-        // Second input chunk from a background task: pre-fix the IO thread
-        // never comes back for it (stuck in the first response write), so
-        // this write blocks. Keeping it off the test thread lets the poll
-        // below fail the test inside the bound instead of hanging the suite.
-        var secondWrite = Task.Run(() =>
+        // Second input chunk on its own dedicated thread, deliberately not
+        // Task.Run: with the pool saturated by blocked workers (the shape a
+        // full-suite run can approach), a single pool item has measured
+        // 14.5s to dispatch where a dedicated thread started in 7ms, and
+        // pool dispatch is the one latency here no test bound can cover.
+        // Pre-buffer-fix, the IO thread stuck in the first response write
+        // never came back for this byte, so the write below blocks forever
+        // and the poll after it fails inside the bound instead of hanging
+        // the suite.
+        Exception? writeError = null;
+        var secondWrite = new Thread(() =>
         {
-            t.Input.Write(new byte[] { 0x00 }, 0, 1);
-            t.Input.Flush();
-        });
+            try
+            {
+                t.Input.Write(new byte[] { 0x00 }, 0, 1);
+                t.Input.Flush();
+            }
+            catch (Exception e)
+            {
+                writeError = e;
+            }
+        })
+        {
+            IsBackground = true,
+            Name = "FakeTransportTests.SecondWrite",
+        };
+        secondWrite.Start();
 
         // The responder only runs its second call after the first response
-        // write completed with zero readers on the output pipe.
-        while (Volatile.Read(ref responderCalls) < 2 && sw.Elapsed < BoundedWait)
+        // write completed with zero readers on the output pipe. Timed from
+        // here with its own stopwatch: this stage's job is to prove the
+        // write-before-read completes, and it gets its own full budget.
+        var secondCall = Stopwatch.StartNew();
+        while (Volatile.Read(ref responderCalls) < 2 && secondCall.Elapsed < BoundedWait)
             Thread.Sleep(10);
 
         Assert.True(Volatile.Read(ref responderCalls) >= 2,
-            $"scripted response write never completed without a reader within {BoundedWait.TotalSeconds:F0}s");
+            $"scripted response write never completed without a reader within {BoundedWait.TotalSeconds:F0}s " +
+            $"(first responder call after {firstCallMs}ms; second write " +
+            $"{(writeError is null ? "still in flight" : $"threw: {writeError.Message}")})");
 
         // Drain both responses so the read side is proven too, not just the
-        // responder count. Both bytes are already in the kernel buffer, so
-        // the synchronous reads return without blocking.
+        // responder count. The responder counts its call before the matching
+        // response write, so the second byte may land a beat after the gate
+        // above opens; it is one byte into an empty 64KB buffer, so the
+        // reads below complete without waiting on any writer.
         byte[] received = new byte[2];
         int read = 0;
         while (read < received.Length)
@@ -76,5 +109,12 @@ public class FakeTransportTests
         }
         Assert.Equal((byte)0x01, received[0]);
         Assert.Equal((byte)0x01, received[1]);
+
+        // The gate above proves the second byte reached the pipe, so the
+        // writer has finished its work; observe its outcome so a faulted
+        // write fails here instead of vanishing into an unobserved thread.
+        Assert.True(secondWrite.Join(TimeSpan.FromSeconds(5)),
+            "second write thread never finished even though its byte was drained");
+        Assert.Null(writeError);
     }
 }


### PR DESCRIPTION
## What

`FakeTransportTests.ScriptedResponseWrite_CompletesWithoutAnyReader` ran both polls on one shared stopwatch. Slow-but-innocent latency in the first stage (loaded runner, post-build AV scans) exhausted the budget, and the second assert then reported a false "write never completed" verdict that pointed at the pipe. Each stage now gets its own stopwatch and a 20s bound, and the failure message carries the first stage's duration and the second write's completion state.

## Why

The deadlock this test guards against blocked forever, so the bound only has to fail fast, not measure latency. Observed locally: ~75% failure rate across a ~35 minute window during a release train's ladder run, back to ~100% pass either side, with the transport code exonerated by a standalone repro of the same logic that never flaked.

## Test plan

`dotnet test -c Release -p:Platform=x64 --filter FullyQualifiedName~FakeTransportTests` on Windows: 6/6 green (was flaky ~25% pass in the affected window).