### PR TITLE
tabs: trace what the horizontal drop actually lands

### DIFF
--- a/windows/Ghostty.Tests/Wiring/TabStripSyncWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabStripSyncWiringTests.cs
@@ -216,13 +216,15 @@ public sealed class TabStripSyncWiringTests
         var standDown = handler.DescendantNodes().OfType<IfStatementSyntax>()
             .Where(i => i.Condition is IdentifierNameSyntax flag
                         && flag.Identifier.ValueText == "_stripDragActive"
-                        && i.Statement is ReturnStatementSyntax { Expression: null })
+                        && StandDownIsInert(i))
             .ToList();
         Assert.True(
             standDown.Count == 1,
-            "OnSelectionChanged needs exactly one bare `if (_stripDragActive) return;` " +
-            "stand-down: every selection raise a live drag produces is TabView's " +
-            "mid-batch churn, not an intent.");
+            "OnSelectionChanged needs exactly one `if (_stripDragActive)` " +
+            "stand-down, and it must stay inert: a bare return, or at most " +
+            "the trace's count-and-line before the return. Every selection " +
+            "raise a live drag produces is TabView's mid-batch churn, not " +
+            "an intent.");
         Assert.True(
             standDown.Count == 1 && standDown[0].SpanStart > opener!.Span.End,
             "The stand-down must follow the suppress guard, which must stay first.");
@@ -949,6 +951,29 @@ public sealed class TabStripSyncWiringTests
         => handler.DescendantNodes().OfType<IfStatementSyntax>()
             .First(i => i.Condition.ToString().Contains(
                 "item.Tag is TabGroup", StringComparison.Ordinal));
+
+    // The stand-down may count and trace, and nothing else. A bare return
+    // is the original inert shape; the block form is inert exactly when it
+    // holds only the counter bump, the trace line, and the return -- any
+    // other statement in there would be the drag acting on its own churn.
+    private static bool StandDownIsInert(IfStatementSyntax standDown) => standDown.Statement switch
+    {
+        ReturnStatementSyntax { Expression: null } => true,
+        BlockSyntax block => block.Statements.Count == 3
+            && block.Statements[0] is ExpressionStatementSyntax bump
+            && bump.Expression is PostfixUnaryExpressionSyntax
+            {
+                OperatorToken.ValueText: "++"
+            } counted
+            && counted.Operand is IdentifierNameSyntax
+            {
+                Identifier.ValueText: "_stoodDownSelectionRaises"
+            }
+            && block.Statements[1] is ExpressionStatementSyntax trace
+            && trace.Expression.AssertCallTo("TabDragTrace.Line") is not null
+            && block.Statements[2] is ReturnStatementSyntax { Expression: null },
+        _ => false,
+    };
 
     private static bool SetsFlag(MethodDeclarationSyntax method, string field, SyntaxKind literal)
         => method.DescendantNodes()

--- a/windows/Ghostty/Tabs/TabDragTrace.cs
+++ b/windows/Ghostty/Tabs/TabDragTrace.cs
@@ -1,0 +1,36 @@
+using System;
+using System.IO;
+
+namespace Ghostty.Tabs;
+
+/// <summary>
+/// The drag oracle both tab directions write. The env var names one file
+/// per run, so concurrent instances never interleave one file, and the
+/// trace is inert (a null check) when the variable is unset. Lines pair
+/// DRAG start/completed per gesture, and COMMIT lines name what each
+/// drop actually landed -- a move, a join, a reconcile repair -- so a
+/// COMMIT with no gesture around it, or a completed gesture with no
+/// COMMIT under it, is the fact the next fix starts from.
+/// </summary>
+internal static class TabDragTrace
+{
+    private static readonly string? TracePath =
+        Environment.GetEnvironmentVariable("WINTTY_TABDRAG_TRACE");
+
+    /// <summary>Whether a Line would write, so callers can skip building
+    /// trace-only strings on hot paths.</summary>
+    internal static bool Enabled => TracePath is not null;
+
+    internal static void Line(string message)
+    {
+        if (TracePath is null) return;
+        try
+        {
+            File.AppendAllText(TracePath, message + Environment.NewLine);
+        }
+        catch
+        {
+            // A locked or unwritable log must never take the drag down.
+        }
+    }
+}

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -764,6 +764,16 @@ internal sealed partial class TabHost : UserControl, ITabHost
         ReconcileStripOrder();
     }
 
+    /// <summary>A row's trace name: which kind, and whose. A chip and a
+    /// tab can carry the same title, so the kind prefix is the identity.
+    /// </summary>
+    private static string RowName(object? row) => row switch
+    {
+        TabViewItem { Tag: TabGroup group } => "chip:" + group.Title,
+        TabViewItem { Tag: TabModel tab } => "tab:" + tab.EffectiveTitle,
+        _ => row?.GetType().Name ?? "null",
+    };
+
     /// <summary>
     /// Bring TabItems back into the order the projection holds, chips
     /// included -- a chip occupies a slot, so the flat tab list stopped
@@ -776,7 +786,9 @@ internal sealed partial class TabHost : UserControl, ITabHost
     /// </summary>
     private void ReconcileStripOrder()
     {
-        var repaired = false;
+        var repairedRows = 0;
+        var rebuilt = false;
+        var actualOrder = new List<string>();
         // ListView drops its selection when the selected item is removed
         // and does not restore it on re-insert; live, that drop surfaces
         // as an activation of whatever TabView picked instead. A repair
@@ -815,6 +827,11 @@ internal sealed partial class TabHost : UserControl, ITabHost
                     "TabHost reconcile: the strip and the projection hold " +
                     "different rows. Order is repairable; presence skew " +
                     "is a wiring bug, not a projection.");
+            // The strip's order as the pass found it, taken before any
+            // repair: the repair trace's "actual" half must describe what
+            // was wrong, not the already-fixed strip.
+            if (TabDragTrace.Enabled)
+                actualOrder.AddRange(TabViewControl.TabItems.Select(RowName));
             for (var i = 0; i < desired.Count; i++)
             {
                 if (ReferenceEquals(TabViewControl.TabItems[i], desired[i])) continue;
@@ -828,8 +845,12 @@ internal sealed partial class TabHost : UserControl, ITabHost
                         "projection does not name. Order is repairable; " +
                         "presence skew is a wiring bug, not a projection.");
                 TabViewControl.TabItems.Insert(i, desired[i]);
-                repaired = true;
+                repairedRows++;
             }
+            if (repairedRows > 0)
+                TabDragTrace.Line($"COMMIT reconcile repaired={repairedRows} " +
+                    $"desired=[{string.Join(",", desired.Select(RowName))}] " +
+                    $"actual=[{string.Join(",", actualOrder)}]");
         }
         catch (Exception ex) when (ex is InvalidOperationException or KeyNotFoundException)
         {
@@ -839,7 +860,8 @@ internal sealed partial class TabHost : UserControl, ITabHost
             // not die, so rebuild from the manager.
             _log.LogReconcileFailed(ex);
             RebuildStripFromManager();
-            repaired = true;
+            rebuilt = true;
+            TabDragTrace.Line("COMMIT reconcile rebuilt from manager");
         }
         finally
         {
@@ -851,7 +873,7 @@ internal sealed partial class TabHost : UserControl, ITabHost
         // clear, owned by the pass, so the flag can never outlive the
         // retirement that set it.
         _swapFadePending = false;
-        if (repaired) SelectActive();
+        if (repairedRows > 0 || rebuilt) SelectActive();
     }
 
     /// <summary>
@@ -1565,7 +1587,13 @@ internal sealed partial class TabHost : UserControl, ITabHost
         // where the selection truth lands instead: OnTabDragCompleted
         // re-asserts the manager's active tab after the commit, once the
         // batch has closed.
-        if (_stripDragActive) return;
+        if (_stripDragActive)
+        {
+            _stoodDownSelectionRaises++;
+            TabDragTrace.Line($"COMMIT selection stood-down " +
+                $"count={_stoodDownSelectionRaises} item={RowName(TabViewControl.SelectedItem)}");
+            return;
+        }
         if (TabViewControl.SelectedItem is TabViewItem item)
         {
             // A chip's selection is not an activation. Selecting the chip
@@ -1639,6 +1667,11 @@ internal sealed partial class TabHost : UserControl, ITabHost
     /// </summary>
     private bool _stripDragActive;
 
+    // The selection raises a live drag's stand-down has swallowed, since
+    // the last drag began. Every one is TabView's mid-batch churn, and
+    // the count says how much churn a single drop actually produces.
+    private int _stoodDownSelectionRaises;
+
     // The drop point, and whether it is this drag's. Recorded by
     // OnTabStripDrop for the drop-at-a-run fork in OnTabDragCompleted,
     // which carries no position of its own; the flag is the guard that
@@ -1650,7 +1683,9 @@ internal sealed partial class TabHost : UserControl, ITabHost
 
     private void OnTabDragStarting(TabView sender, TabViewTabDragStartingEventArgs args)
     {
+        TabDragTrace.Line($"DRAG start item={args.Item?.GetType().Name ?? "null"}");
         _stripDragActive = true;
+        _stoodDownSelectionRaises = 0;
         _dropPositionValid = false;
         // The label hides HERE, in the drag start's own dispatch pass, as
         // a cut: an 83ms fade would overlap the drag ghost, which is the
@@ -1673,6 +1708,10 @@ internal sealed partial class TabHost : UserControl, ITabHost
 
     private void OnTabDragCompleted(TabView sender, TabViewTabDragCompletedEventArgs args)
     {
+        // First, before the point is invalidated below: whether the drop
+        // landed on the strip is exactly what the recorded point answers.
+        TabDragTrace.Line($"DRAG completed item={args.Item?.GetType().Name ?? "null"} " +
+            $"point={(_dropPositionValid ? "live" : "stale")}");
         _stripDragActive = false;
         _dropPositionValid = false;
         // The drag is over: the cut demand lifts, and hover may show the
@@ -1730,7 +1769,19 @@ internal sealed partial class TabHost : UserControl, ITabHost
                 {
                     var target =
                         TabChipDrop.GroupTarget(_manager, draggedGroup, leftTab, leftChip);
-                    if (target >= 0) _manager.MoveGroup(draggedGroup, target);
+                    if (target >= 0)
+                    {
+                        TabDragTrace.Line($"COMMIT movegroup slot={slot} target={target}");
+                        _manager.MoveGroup(draggedGroup, target);
+                    }
+                    else
+                    {
+                        TabDragTrace.Line($"COMMIT movegroup refused reason=target-negative slot={slot}");
+                    }
+                }
+                else
+                {
+                    TabDragTrace.Line($"COMMIT movegroup refused reason=unknown-neighbour slot={slot}");
                 }
             }
             else
@@ -1750,6 +1801,9 @@ internal sealed partial class TabHost : UserControl, ITabHost
                         if (vi == item)
                         {
                             var oldIndex = _manager.IndexOf(model);
+                            TabDragTrace.Line(oldIndex == newIndex
+                                ? $"COMMIT move skipped in-place old={oldIndex} new={newIndex}"
+                                : $"COMMIT move old={oldIndex} new={newIndex}");
                             if (oldIndex != newIndex && oldIndex >= 0)
                                 _manager.Move(oldIndex, newIndex);
                             break;
@@ -1758,6 +1812,7 @@ internal sealed partial class TabHost : UserControl, ITabHost
                 }
                 else
                 {
+                    TabDragTrace.Line($"COMMIT drop at chip slot={slot}");
                     ResolveDropAtChip(item, slot);
                 }
             }
@@ -1817,10 +1872,15 @@ internal sealed partial class TabHost : UserControl, ITabHost
         if (dropped is null) return;
 
         var bounds = DropPointIn(chip.Item);
-        if (bounds is null) return;
+        if (bounds is null)
+        {
+            TabDragTrace.Line("COMMIT drop at chip refused reason=no-geometry");
+            return;
+        }
 
         if (bounds.Value.Contains(_lastDropPosition))
         {
+            TabDragTrace.Line($"COMMIT join group={chipGroup.Title}");
             _manager.JoinGroup(dropped, chipGroup);
             return;
         }
@@ -1831,7 +1891,14 @@ internal sealed partial class TabHost : UserControl, ITabHost
             : TabChipDrop.MemberTargetAfter(_manager, chipGroup);
         var oldIndex = _manager.IndexOf(dropped);
         if (beside >= 0 && oldIndex >= 0 && oldIndex != beside)
+        {
+            TabDragTrace.Line($"COMMIT move beside old={oldIndex} new={beside}");
             _manager.Move(oldIndex, beside);
+        }
+        else
+        {
+            TabDragTrace.Line($"COMMIT move beside refused old={oldIndex} target={beside}");
+        }
     }
 
     /// <summary>
@@ -1881,6 +1948,7 @@ internal sealed partial class TabHost : UserControl, ITabHost
         if (!_stripDragActive) return;
         _lastDropPosition = e.GetPosition(TabViewControl);
         _dropPositionValid = true;
+        TabDragTrace.Line($"DRAG drop point x={_lastDropPosition.X:0} y={_lastDropPosition.Y:0}");
     }
 
     // -----------------------------------------------------------------

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -2114,30 +2114,13 @@ internal sealed partial class VerticalTabStrip : UserControl
     // -----------------------------------------------------------------
 
     /// <summary>
-    /// Oracle for the drag harness, the same shape as
-    /// LayoutCoordinator's morph trace: the env var is the per-run log
-    /// path, so concurrent instances never interleave one file, and the
-    /// trace is inert (a null check) when it is unset. Lines pair
-    /// DRAG begin/end, one per commit, and the ghosts counts report
+    /// The strip's half of the shared drag oracle. Lines pair DRAG
+    /// begin/end, one per commit, and the ghosts counts report
     /// composition the strip still believes it is driving -- the oracle
     /// reads any N above zero as a leak, and a `drop` line without a
     /// later `DRAG settle` as a settle that never completed.
     /// </summary>
-    private static readonly string? DragTracePath =
-        Environment.GetEnvironmentVariable("WINTTY_TABDRAG_TRACE");
-
-    private static void DragTrace(string message)
-    {
-        if (DragTracePath is null) return;
-        try
-        {
-            System.IO.File.AppendAllText(DragTracePath, message + Environment.NewLine);
-        }
-        catch
-        {
-            // A locked or unwritable log must never take the drag down.
-        }
-    }
+    private static void DragTrace(string message) => TabDragTrace.Line(message);
 
     private DragSession? _drag;
     private bool _evalPending;


### PR DESCRIPTION
The horizontal drop has a second bug behind the crash fix: the choreography plays but the order never commits. Root cause, from this rung's own first live capture: TabViewTabDragStarting/Completed carry args.Item = null for every real in-strip reorder, so the Item-gated commit has never run; TabStripDrop never fires for internal reorders; and the silent reconcile repair then snaps the strip back to the manager's order.

This rung is pure diagnostics and is deliberately landable on its own: the WINTTY_TABDRAG_TRACE oracle lifts into a shared TabDragTrace, TabHost gains trace points across the whole drop path (start, drop point, completion, commit forks, reconcile repaired/rebuilt, selection stand-down count), all inert when the env var is unset. The reconcile's repaired bool becomes a row count feeding the same SelectActive gate; the stand-down block counts what it swallows. Two wiring facts pin the refactor points.