### PR TITLE
tabs: the horizontal strip's drag is the capture-less engine

### DIFF
--- a/windows/Ghostty.Core/Tabs/TabDragReorder.cs
+++ b/windows/Ghostty.Core/Tabs/TabDragReorder.cs
@@ -20,16 +20,18 @@ public enum TabDragPhase
 public readonly record struct TabDragCrossing(int From, int To);
 
 /// <summary>
-/// State machine for the vertical strip's drag-to-reorder gesture: the
-/// press threshold, commit-on-center-crossing with hysteresis, the
+/// State machine for a strip's drag-to-reorder gesture, either axis:
+/// the press threshold, commit-on-center-crossing with hysteresis, the
 /// autoscroll ramp, release velocity, and the terminal drop/cancel
 /// transitions. Pure data in, decisions out, so the whole gesture
 /// grammar is unit-testable without a WinUI host.
 ///
 /// The strip owns every measurement and all composition, and feeds
-/// results in here. Row centers are ARRANGED positions in strip space
-/// (never raw pointer positions, so scroll cannot corrupt a crossing),
-/// and a crossing is reported, not applied -- the strip turns it into
+/// results in here. Every position is a scalar ALONG THE AXIS -- the
+/// vertical strip feeds Y, the horizontal strip feeds X -- and row
+/// centers are ARRANGED positions in strip space (never raw pointer
+/// positions, so scroll cannot corrupt a crossing), and a crossing is
+/// reported, not applied -- the strip turns it into
 /// <see cref="TabManager.Move"/>, keeping the manager the truth
 /// mid-drag.
 /// </summary>
@@ -48,9 +50,9 @@ public sealed class TabDragReorder
     private double[] _centers;
     private int _index;
     private TabDragPhase _phase;
-    private double _pressY;
+    private double _pressPosition;
     // Trailing window of pointer samples release velocity reads from.
-    private readonly List<(double Ms, double Y)> _samples = new();
+    private readonly List<(double Ms, double Position)> _samples = new();
 
     public TabDragReorder(int rowCount, int grabIndex)
         : this(rowCount, grabIndex,
@@ -75,22 +77,22 @@ public sealed class TabDragReorder
     public int Index => _index;
 
     /// <summary>Arm the gesture on a pointer press over row <c>grabIndex</c>.</summary>
-    public void Press(double pointerY)
+    public void Press(double position)
     {
         if (_phase != TabDragPhase.Idle) return;
-        _pressY = pointerY;
+        _pressPosition = position;
         _phase = TabDragPhase.Pressed;
     }
 
     /// <summary>
-    /// Lift to <see cref="TabDragPhase.Dragging"/> once vertical travel
-    /// passes the start threshold. Horizontal movement never starts the
-    /// drag, so a jittering grab stays a click.
+    /// Lift to <see cref="TabDragPhase.Dragging"/> once travel along the
+    /// axis passes the start threshold. Movement along the OTHER axis
+    /// never starts the drag, so a jittering grab stays a click.
     /// </summary>
-    public bool Begin(double pointerY)
+    public bool Begin(double position)
     {
         if (_phase != TabDragPhase.Pressed) return false;
-        if (Math.Abs(pointerY - _pressY) < _startThresholdPx) return false;
+        if (Math.Abs(position - _pressPosition) < _startThresholdPx) return false;
         _phase = TabDragPhase.Dragging;
         return true;
     }
@@ -160,18 +162,18 @@ public sealed class TabDragReorder
     /// measures against the neighbour's new slot, and undoing a swap
     /// costs a full row of travel, not the 8px that committed it.
     /// </summary>
-    public TabDragCrossing? Evaluate(double draggedCenterY)
+    public TabDragCrossing? Evaluate(double draggedCenter)
     {
         if (_phase != TabDragPhase.Dragging) return null;
 
         if (_index + 1 < _centers.Length
-            && draggedCenterY > _centers[_index + 1] + _hysteresisPx)
+            && draggedCenter > _centers[_index + 1] + _hysteresisPx)
         {
             _index++;
             return new TabDragCrossing(_index - 1, _index);
         }
 
-        if (_index > 0 && draggedCenterY < _centers[_index - 1] - _hysteresisPx)
+        if (_index > 0 && draggedCenter < _centers[_index - 1] - _hysteresisPx)
         {
             _index--;
             return new TabDragCrossing(_index + 1, _index);
@@ -181,16 +183,17 @@ public sealed class TabDragReorder
     }
 
     /// <summary>
-    /// Signed autoscroll speed in px/s at <paramref name="pointerY"/>
-    /// against the scrolling viewport's bounds: negative scrolls up,
-    /// positive down, zero outside the edge band. Ramps with distance so
-    /// the ramp-up is proportional to how far into the band the drag is.
+    /// Signed autoscroll speed in px/s at <paramref name="position"/>
+    /// against the scrolling viewport's bounds along the axis: negative
+    /// scrolls toward the start, positive toward the end, zero outside
+    /// the edge band. Ramps with distance so the ramp-up is proportional
+    /// to how far into the band the drag is.
     /// </summary>
-    public double AutoscrollSpeed(double pointerY, double viewportTop, double viewportBottom)
+    public double AutoscrollSpeed(double position, double viewportStart, double viewportEnd)
     {
-        double fromTop = pointerY - viewportTop;
-        double fromBottom = viewportBottom - pointerY;
-        double d = Math.Min(fromTop, fromBottom);
+        double fromStart = position - viewportStart;
+        double fromEnd = viewportEnd - position;
+        double d = Math.Min(fromStart, fromEnd);
         if (d > TabStripMotion.AutoscrollBandPx) return 0;
 
         double speed = d <= TabStripMotion.AutoscrollInnerBandPx
@@ -200,11 +203,11 @@ public sealed class TabDragReorder
               * (TabStripMotion.AutoscrollBandPx - d)
               / (TabStripMotion.AutoscrollBandPx - TabStripMotion.AutoscrollInnerBandPx);
 
-        return fromTop <= fromBottom ? -speed : speed;
+        return fromStart <= fromEnd ? -speed : speed;
     }
 
     /// <summary>Feed the velocity window. <paramref name="ms"/> is monotonic.</summary>
-    public void SampleVelocity(double y, double ms)
+    public void SampleVelocity(double position, double ms)
     {
         // Front-prune rather than RemoveAll: this runs per pointer move,
         // and a lambda there allocates a closure on every call.
@@ -212,7 +215,7 @@ public sealed class TabDragReorder
         int stale = 0;
         while (stale < _samples.Count && _samples[stale].Ms < cutoff) stale++;
         if (stale > 0) _samples.RemoveRange(0, stale);
-        _samples.Add((ms, y));
+        _samples.Add((ms, position));
     }
 
     /// <summary>
@@ -223,10 +226,10 @@ public sealed class TabDragReorder
     /// spring owns the direction, and handing it a fling against the
     /// travel would throw the row the wrong way before reeling it back.
     ///
-    /// <paramref name="remainingDistancePx"/> is signed on the same axis
-    /// as <see cref="SampleVelocity"/>, positive = down; passing a bare
-    /// magnitude makes every velocity read as running away from the slot
-    /// and this guard kills legitimate upward settles.
+    /// <paramref name="remainingDistancePx"/> is signed on the machine's
+    /// axis, positive = toward the axis end; passing a bare magnitude
+    /// makes every velocity read as running away from the slot and this
+    /// guard kills legitimate settles against the travel.
     ///
     /// Read BEFORE <see cref="Drop"/> or <see cref="Cancel"/>: both clear
     /// the sample window, so the natural call order reports 0 forever

--- a/windows/Ghostty.Core/Tabs/TabStripProjection.cs
+++ b/windows/Ghostty.Core/Tabs/TabStripProjection.cs
@@ -262,4 +262,45 @@ internal static class TabStripProjection
         }
         return -1;
     }
+
+    /// <summary>
+    /// The slot space a drag speaks: the manager's tabs in order, minus
+    /// the members a collapsed run hides. A hidden member has no slot at
+    /// all -- no row renders for it, so no crossing can name it -- and
+    /// the pairing list preserves each row's manager index so a slot can
+    /// be turned back into the manager position a commit needs. The
+    /// vertical strip builds its machine on these rows; the horizontal
+    /// engine reads the same shape, with chips layered on top of the
+    /// slot order through <see cref="HorizontalRows"/>.
+    /// </summary>
+    public static (List<TabModel> Rows, List<int> ManagerIndex) DragSlots(TabManager manager)
+    {
+        var rows = new List<TabModel>(manager.Tabs.Count);
+        var managerIndex = new List<int>(manager.Tabs.Count);
+        var tabs = manager.Tabs;
+        for (int i = 0; i < tabs.Count; i++)
+        {
+            var tab = tabs[i];
+            if (tab.Group is { } group && group.IsCollapsed
+                && !ReferenceEquals(tab, manager.ActiveTab))
+                continue; // hidden under a collapsed header: no slot at all
+            rows.Add(tab);
+            managerIndex.Add(i);
+        }
+        return (rows, managerIndex);
+    }
+
+    /// <summary>
+    /// SLOT -> MANAGER lookup is <see cref="DragSlots"/>' pairing list
+    /// itself; this is the inverse: which slot the tab at manager index
+    /// <c>IndexOf(tab)</c> occupies. Indexing the pairing list BY the
+    /// manager index answers a different row's slot -- the first row past
+    /// a hidden run is out of range or a stranger. -1 when the tab holds
+    /// no slot.
+    /// </summary>
+    public static int SlotIndexOf(TabManager manager, List<int> managerIndex, TabModel tab)
+    {
+        var at = manager.IndexOf(tab);
+        return at >= 0 ? managerIndex.IndexOf(at) : -1;
+    }
 }

--- a/windows/Ghostty.Tests/Tabs/TabDragReorderTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabDragReorderTests.cs
@@ -6,11 +6,11 @@ using Xunit;
 namespace Ghostty.Tests.Tabs;
 
 /// <summary>
-/// The drag state machine behind the vertical strip's drag-to-reorder:
-/// press threshold, commit-on-center-crossing with hysteresis,
+/// The drag state machine behind a strip's drag-to-reorder, either
+/// axis: press threshold, commit-on-center-crossing with hysteresis,
 /// autoscroll ramp, release velocity, and the terminal transitions.
 /// Pure class, so the gesture grammar is pinned without a WinUI host;
-/// the composition wiring it feeds is in VerticalTabStrip and the
+/// the composition wiring it feeds is in the strips and the
 /// SendInput-level harness is the noted follow-up.
 /// </summary>
 public class TabDragReorderTests
@@ -31,6 +31,38 @@ public class TabDragReorderTests
 
         Assert.False(machine.Begin(23));
         Assert.Equal(TabDragPhase.Pressed, machine.Phase);
+    }
+
+    // The machine's positions are scalars along whichever axis the strip
+    // feeds. The facts above are written in the vertical's vocabulary;
+    // this one speaks the horizontal's -- X centers left to right, travel
+    // toward the strip's end -- and pins that nothing in the grammar
+    // cares which axis it is.
+    [Fact]
+    public void The_grammar_is_axis_neutral()
+    {
+        // Four equal-width slots of 90px: arranged centers 50, 140, 230, 320.
+        var machine = new TabDragReorder(4, 1);
+        machine.UpdateCenters(new double[] { 50, 140, 230, 320 });
+
+        machine.Press(140);
+        Assert.False(machine.Begin(143));
+        Assert.True(machine.Begin(148));
+
+        // Right past slot 2's center plus hysteresis commits 1 -> 2.
+        Assert.Equal(new TabDragCrossing(1, 2), machine.Evaluate(240));
+        // Left back past slot 1 costs the full row, not the 8px.
+        Assert.Equal(new TabDragCrossing(2, 1), machine.Evaluate(100));
+        Assert.Equal(1, machine.Index);
+
+        machine.SampleVelocity(300, 1_000);
+        machine.SampleVelocity(180, 1_050);
+        // Remaining distance signed toward the axis start; the fling ran
+        // the same way, so the velocity survives the direction guard.
+        Assert.True(machine.ReleaseVelocity(-90) < 0);
+
+        machine.Drop();
+        Assert.Equal(TabDragPhase.Idle, machine.Phase);
     }
 
     [Fact]

--- a/windows/Ghostty.Tests/Tabs/TabStripProjectionTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabStripProjectionTests.cs
@@ -54,8 +54,9 @@ public class TabStripProjectionTests
     }
 
     /// <summary>
-    /// OnTabDragCompleted's shape, driven against a live mirror: read the
-    /// strip index, Move in manager space, reconcile via the projector.
+    /// The engine's crossing-commit shape, driven against a live mirror:
+    /// read the strip index, Move in manager space, reconcile via the
+    /// projector.
     /// </summary>
     private static void CompleteDrag(TabManager mgr, Strip strip, TabModel dragged)
     {

--- a/windows/Ghostty.Tests/Tabs/TabStripProjectionTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabStripProjectionTests.cs
@@ -711,4 +711,41 @@ public class TabStripProjectionTests
             }
         }
     }
+
+    [Fact]
+    public void DragSlots_pairs_every_visible_row_with_its_manager_index()
+    {
+        var mgr = NewManager(3); // [A, B, C, D]
+        mgr.SetPinned(mgr.Tabs[0], true);
+        var group = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[1], mgr.Tabs[2] }, group);
+        mgr.Activate(mgr.Tabs[1]);
+        mgr.CollapseGroup(group, true);
+
+        var (rows, managerIndex) = TabStripProjection.DragSlots(mgr);
+
+        // The chip'd run hides its inactive member, so the slot space is
+        // the pinned lead, the active member, and the ungrouped tail --
+        // each paired with the manager index it commits through.
+        Assert.Equal(new[] { mgr.Tabs[0], mgr.Tabs[1], mgr.Tabs[3] }, rows);
+        Assert.Equal(new[] { 0, 1, 3 }, managerIndex);
+    }
+
+    [Fact]
+    public void SlotIndexOf_answers_the_pairing_not_the_forward_list()
+    {
+        var mgr = NewManager(3); // [A, B, C, D]
+        var group = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[1], mgr.Tabs[2] }, group);
+        mgr.Activate(mgr.Tabs[1]);
+        mgr.CollapseGroup(group, true);
+
+        var (_, managerIndex) = TabStripProjection.DragSlots(mgr);
+
+        // Tab D sits at manager index 3 but slot 2: indexing the pairing
+        // list BY the manager index would answer 3, a slot the strip
+        // does not render. The hidden member holds no slot at all.
+        Assert.Equal(2, TabStripProjection.SlotIndexOf(mgr, managerIndex, mgr.Tabs[3]));
+        Assert.Equal(-1, TabStripProjection.SlotIndexOf(mgr, managerIndex, mgr.Tabs[2]));
+    }
 }

--- a/windows/Ghostty.Tests/Wiring/TabHorizontalMotionWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabHorizontalMotionWiringTests.cs
@@ -8,19 +8,20 @@ namespace Ghostty.Tests.Wiring;
 
 /// <summary>
 /// The horizontal strip's motion: the drag lift and the collapse swap's
-/// appear-hand. TabView owns the drag itself -- the reorder preview, the
-/// drop, the OS ghost -- so what is pinned here is the polish the host
-/// adds around it: the pressed tab's own visual lifts on the grab and
-/// settles back on the release, a shadow carries the depth, and the
-/// chip &lt;-&gt; members swap fades what appears while removals stay
-/// immediate.
+/// appear-hand. The capture-less engine owns the drag itself -- the arm,
+/// the crossings, the release -- so what is pinned here is the polish
+/// the host adds around it: the pressed tab's own visual lifts at the
+/// threshold and settles back on the release, a shadow carries the
+/// depth, and the chip &lt;-&gt; members swap fades what appears while
+/// removals stay immediate.
 ///
 /// Two properties are pinned. The motion gate is the first statement of
 /// everything that animates, and its cut is total: motion off means no
 /// composition work at all, not different composition work -- state
 /// correctness never waits on an animation. And every animation is
-/// programmatic: TabView exposes no machine velocity, so both springs
-/// start at rest, the policy the vertical's pin flight runs on.
+/// programmatic: the machine's velocity is not spent on any settle yet,
+/// so both springs start at rest, the policy the vertical's pin flight
+/// runs on.
 ///
 /// Wiring guards, not behaviour tests: what a lift looks like on screen
 /// is only observable on a live strip.
@@ -70,20 +71,20 @@ public class TabHorizontalMotionWiringTests
             host.Method("SettleLift").Body!.Statements.First());
         Assert.Equal("_lift is not { } lift", settle.Condition.ToString());
 
-        // Decoration stands last in the drag handlers: the lift runs
+        // Decoration stands last in the engine's passes: the lift runs
         // after the seam cover is suppressed, and the settle runs after
         // the reconcile and the bridge update have spoken.
-        var starting = host.Method("OnTabDragStarting");
-        var seam = starting.Calls("SelectedTabSeamChanged?.Invoke").Single();
-        var lift = starting.Calls("StartLift").Single();
+        var begin = host.Method("BeginHorizontalDragVisual");
+        var seam = begin.Calls("SelectedTabSeamChanged?.Invoke").Single();
+        var lift = begin.Calls("StartLift").Single();
         Assert.True(seam.Span.Start < lift.Span.Start,
-            "the lift is decoration and stands last in the drag start");
+            "the lift is decoration and stands last in the drag begin");
 
-        var completed = host.Method("OnTabDragCompleted");
-        var bridge = completed.Calls("QueueBridgeUpdate").Single();
-        var settleCall = completed.Calls("SettleLift").Single();
+        var finish = host.Method("FinishHorizontalDrag");
+        var bridge = finish.Calls("QueueBridgeUpdate").Single();
+        var settleCall = finish.Calls("SettleLift").Single();
         Assert.True(bridge.Span.Start < settleCall.Span.Start,
-            "the settle is decoration and stands last in the drag completion");
+            "the settle is decoration and stands last in the drag finish");
     }
 
     /// <summary>
@@ -100,14 +101,12 @@ public class TabHorizontalMotionWiringTests
     {
         var host = Host();
 
-        // The dragged tab is the event's own item pattern: the container
-        // TabView names, not a container lookup that can answer for a
-        // different slot.
-        var starting = host.Method("OnTabDragStarting");
-        var liftCall = starting.Calls("StartLift").Single();
-        var pattern = Assert.IsType<IfStatementSyntax>(
-            liftCall.Ancestors().OfType<IfStatementSyntax>().First());
-        Assert.Equal("args.Item is TabViewItem lifted", pattern.Condition.ToString());
+        // The dragged tab is the session's own item: the element the arm
+        // resolved the press through by identity, not a container lookup
+        // that can answer for a different slot.
+        var begin = host.Method("BeginHorizontalDragVisual");
+        var liftCall = begin.Calls("StartLift").Single();
+        Assert.Equal("drag.Item", liftCall.Arg(0));
 
         // Springs only, and every parameter named: the WinRT spring
         // classes document no defaults, so an implicit period would be a
@@ -145,7 +144,8 @@ public class TabHorizontalMotionWiringTests
         // the whole gesture is at rest, the flight's policy.
         foreach (var name in new[]
                  {
-                     "OnTabDragStarting", "OnTabDragCompleted", "StartLift", "SettleLift"
+                     "BeginHorizontalDragVisual", "FinishHorizontalDrag",
+                     "StartLift", "SettleLift"
                  })
         {
             Assert.DoesNotContain(
@@ -225,6 +225,58 @@ public class TabHorizontalMotionWiringTests
         // pin flight's handoff uses -- not on a duration of its own.
         var fadeIn = Assign(host.Method("FadeInAppearing"), "fadeIn.Duration");
         Assert.Contains("TabStripMotion.FadeMs", fadeIn.Right.ToString());
+    }
+
+    /// <summary>
+    /// A mid-drag commit churns the dragged tab's slot, and the rebind
+    /// refuses to let the lift depend on whether composition carries a
+    /// visual's scale, center, and child sprite across that: every
+    /// crossing re-asserts all three from the element's fresh visual,
+    /// set rather than re-springed -- the vertical's RebindFollow
+    /// precedent, and the reason the lift neither drops to rest nor
+    /// re-bounces at the first commit.
+    /// </summary>
+    [Fact]
+    public void A_crossing_rebinds_the_lift_set_not_respringed()
+    {
+        var host = Host();
+        var commit = host.Method("CommitHorizontalCrossing");
+        var move = commit.Call("_manager.Move");
+        var rebind = commit.Call("RebindLift");
+        Assert.True(
+            move.SpanStart < rebind.SpanStart,
+            "the rebind must follow the move: it re-asserts the lift on the "
+            + "element the churn just re-slotted, so it cannot run first.");
+
+        var rebindBody = host.Method("RebindLift");
+        // The guard is first and names the one live lift on the dragged
+        // element: nothing else's churn may rebind, and a no-lift strip
+        // does no composition work.
+        var first = Assert.IsType<IfStatementSyntax>(
+            rebindBody.Body!.Statements.First());
+        Assert.Equal(
+            "_lift is not { } lift || !ReferenceEquals(lift.Item, item)",
+            first.Condition.ToString());
+
+        // Center from the element's own size, scale to the lift tokens as
+        // a SET -- no spring in the rebind, or every crossing re-bounces
+        // the tab the way a fresh grab does.
+        Assert.Contains("item.ActualWidth", rebindBody
+            .DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Single(a => a.Left.ToString() == "visual.CenterPoint").Right.ToString());
+        Assert.Equal(
+            "newVector3(TabStripMotion.LiftScale,TabStripMotion.LiftScale,1f)",
+            Assign(rebindBody, "visual.Scale").Right.ToString()
+                .Replace(" ", "").Replace("\n", "").Replace("\r", ""));
+        Assert.Empty(rebindBody.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(c => c.CalleeText().EndsWith("CreateSpring", StringComparison.Ordinal)));
+
+        // And the shadow rides the element again: the sprite is the one
+        // part that anchors to the element tree, and the churn's answer
+        // is to re-attach it, not to rebuild it.
+        var attach = rebindBody.Call("ElementCompositionPreview.SetElementChildVisual");
+        Assert.Equal("item", attach.Arg(0));
+        Assert.Equal("lift.Shadow", attach.Arg(1));
     }
 
     /// <summary>

--- a/windows/Ghostty.Tests/Wiring/TabPinZoneChromeWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabPinZoneChromeWiringTests.cs
@@ -70,24 +70,22 @@ public sealed class TabPinZoneChromeWiringTests
     public void The_boundary_stroke_cleans_up_on_every_drag_exit()
     {
         var tabHost = ShellSource.Load(TabHostSource);
-        var dragEnd = tabHost.Method("OnTabDragCompleted");
+        var dragEnd = tabHost.Method("FinishHorizontalDrag");
 
-        // The drop is the one pass every completed drag runs, so it is
+        // The release is the one pass every completed drag runs, so it is
         // where the dim has to live -- a cleanup on any narrower event is
         // a stroke a cancelled or off-strip release can outlive. The leak
         // census is the shape: ApplyPinZoneChrome is the border's ONLY
         // writer in the shell, so any assignment outside it is a stroke
-        // this handler does not own.
+        // this pass does not own.
         var apply = tabHost.Method("ApplyPinZoneChrome");
         Assert.True(
             dragEnd.Calls("ApplyPinZoneChrome").Count == 1,
-            "OnTabDragCompleted must run the boundary pass: the dim is " +
-            "the cleanup, and the drop is the pass every drag exits by.");
-        // What a parse cannot see: the Escape or capture-loss terminal.
-        // Mux completes the drag either way, so the drop pass is the exit
-        // every observed release takes; whether a capture loss can arrive
-        // here un-completed is not decidable from source -- settling that
-        // would take a live-strip probe, not a stronger assertion.
+            "FinishHorizontalDrag must run the boundary pass: the dim is " +
+            "the cleanup, and the release is the pass every drag exits by.");
+        // The other exit: CancelHorizontalDrag runs the same pass for a
+        // canceled, captured-away, or stale session, so those ends dim
+        // the stroke too.
         var stray = tabHost.Root.DescendantNodes().OfType<AssignmentExpressionSyntax>()
             .Where(a => (a.Left.ToString().EndsWith(".BorderBrush")
                     || a.Left.ToString().EndsWith(".BorderThickness"))
@@ -126,15 +124,16 @@ public sealed class TabPinZoneChromeWiringTests
         Assert.Contains("0x59", branch[0].WhenFalse.ToString());
 
         // And the brighten pass itself reads the flag already live: the
-        // raise precedes the pass in the drag-start handler, so the first
-        // boundary brush of a drag is the bright one, not a frame late.
-        var dragStart = tabHost.Method("OnTabDragStarting");
+        // raise precedes the pass in the engine's begin pass, so the
+        // first boundary brush of a drag is the bright one, not a frame
+        // late.
+        var dragStart = tabHost.Method("BeginHorizontalDragVisual");
         var flagRaise = dragStart.AssignsTo("_stripDragActive")
             .First(a => a.Right.ToString() == "true");
         var brighten = dragStart.Call("ApplyPinZoneChrome");
         Assert.True(
             flagRaise.SpanStart < brighten.SpanStart,
-            "the drag start must raise the flag before its boundary pass.");
+            "the drag begin must raise the flag before its boundary pass.");
     }
 
     [Fact]

--- a/windows/Ghostty.Tests/Wiring/TabRunLabelWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabRunLabelWiringTests.cs
@@ -23,16 +23,16 @@ public sealed class TabRunLabelWiringTests
     [Fact]
     public void The_drag_start_hides_the_label_in_its_own_dispatch_pass()
     {
-        var dragStart = ShellSource.Load(TabHostSource).Method("OnTabDragStarting");
+        var dragStart = ShellSource.Load(TabHostSource).Method("BeginHorizontalDragVisual");
 
-        // The hide is the machine's drag rule applied in this handler's
+        // The hide is the machine's drag rule applied in the begin pass's
         // own body: not a timer arm, not a deferred close. A timer between
-        // the drag start and the hide is the exact overlap the rule
+        // the threshold and the hide is the exact overlap the rule
         // forbids, so its absence is asserted, not assumed.
         var cut = dragStart.InvocationWithArgument("_labelRules.DragStarting");
         Assert.True(
             cut is not null,
-            "OnTabDragStarting must apply the label rule machine's drag start.");
+            "BeginHorizontalDragVisual must apply the label rule machine's drag start.");
         var seamRaise = dragStart.Calls("SelectedTabSeamChanged?.Invoke")
             .Select(c => c.SpanStart)
             .DefaultIfEmpty(-1)
@@ -47,10 +47,10 @@ public sealed class TabRunLabelWiringTests
         // The drag's end lifts the cut demand; the label stays hidden and
         // hover may show it again. Without this the next ordinary hide
         // would still read the drag's cut.
-        var dragEnd = ShellSource.Load(TabHostSource).Method("OnTabDragCompleted");
+        var dragEnd = ShellSource.Load(TabHostSource).Method("FinishHorizontalDrag");
         Assert.True(
             dragEnd.InvocationWithArgument("_labelRules.DragEnded") is not null,
-            "OnTabDragCompleted must end the label's drag state.");
+            "FinishHorizontalDrag must end the label's drag state.");
 
         // The cross-host half: the vertical strip raises its drag-live
         // moment, and the window closes the horizontal label with it --

--- a/windows/Ghostty.Tests/Wiring/TabStripSyncWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabStripSyncWiringTests.cs
@@ -107,15 +107,15 @@ public sealed class TabStripSyncWiringTests
     public void Drag_start_hides_the_seam_cover_and_the_drop_replaces_it()
     {
         var src = ShellSource.Load(TabHostSource);
-        var starting = src.Method("OnTabDragStarting");
-        var completed = src.Method("OnTabDragCompleted");
+        var starting = src.Method("BeginHorizontalDragVisual");
+        var completed = src.Method("FinishHorizontalDrag");
 
         Assert.True(
             SetsFlag(starting, "_stripDragActive", SyntaxKind.TrueLiteralExpression),
-            "OnTabDragStarting must raise _stripDragActive (audit 3.2, item 1).");
+            "BeginHorizontalDragVisual must raise _stripDragActive (audit 3.2, item 1).");
         Assert.True(
             SetsFlag(completed, "_stripDragActive", SyntaxKind.FalseLiteralExpression),
-            "OnTabDragCompleted must lower _stripDragActive so the cover is placed again.");
+            "FinishHorizontalDrag must lower _stripDragActive so the cover is placed again.");
 
         // Synchronous, not queued: a dispatcher hop paints one frame
         // against the stale slot. Nothing else runs between the flag
@@ -124,21 +124,21 @@ public sealed class TabStripSyncWiringTests
         Assert.True(
             hide.Count == 1
                 && hide[0].Arg(0) == "0" && hide[0].Arg(1) == "0" && hide[0].Arg(2) == "null",
-            "OnTabDragStarting must hide the cover synchronously with (0, 0, null).");
+            "BeginHorizontalDragVisual must hide the cover synchronously with (0, 0, null).");
 
-        // Wired even though TabHost.xaml predates it: the drag start is
-        // where the stale-slot window opens.
+        // Wired in the constructor: the pointer hooks are where the
+        // stale-slot window opens.
         var ctor = src.Root.DescendantNodes()
             .OfType<ConstructorDeclarationSyntax>()
             .Single(c => c.Identifier.ValueText == "TabHost");
         var hooked = ctor.DescendantNodes()
-            .OfType<AssignmentExpressionSyntax>()
-            .Where(a => a.OperatorToken.IsKind(SyntaxKind.PlusEqualsToken)
-                        && a.Left.ToString().EndsWith("TabDragStarting", StringComparison.Ordinal))
+            .OfType<ExpressionStatementSyntax>()
+            .Where(s => s.Expression.ToString().StartsWith("HookStripDragInput()", StringComparison.Ordinal))
             .ToList();
         Assert.True(
             hooked.Count == 1,
-            "The constructor must subscribe OnTabDragStarting on TabViewControl.TabDragStarting.");
+            "The constructor must call HookStripDragInput: the engine's pointer " +
+            "hooks are the drag lifecycle's front door.");
     }
 
     [Fact]
@@ -176,17 +176,17 @@ public sealed class TabStripSyncWiringTests
     [Fact]
     public void The_drop_reconciles_even_when_the_manager_refused_the_move()
     {
-        var completed = ShellSource.Load(TabHostSource).Method("OnTabDragCompleted");
+        var finish = ShellSource.Load(TabHostSource).Method("FinishHorizontalDrag");
 
-        var reconcile = completed.Calls("ReconcileStripOrder").ToList();
+        var reconcile = finish.Calls("ReconcileStripOrder").ToList();
         Assert.True(
             reconcile.Count == 1,
-            "OnTabDragCompleted must reconcile the strip to the manager's order.");
+            "FinishHorizontalDrag must reconcile the strip to the manager's order.");
         Assert.Empty(reconcile[0].Ancestors().OfType<IfStatementSyntax>());
 
-        // The refused drop raises no TabMoved, so nothing else would run
-        // the reconcile: a clamp against the pin boundary (PR 4's grammar)
-        // leaves TabView's own reorder standing unless the reconcile is
+        // A crossing the manager refused or clamped raises no TabMoved,
+        // so nothing else would run the reconcile: the refusal leaves
+        // the machine's slot belief standing unless the sweep is
         // unconditional.
     }
 
@@ -247,25 +247,24 @@ public sealed class TabStripSyncWiringTests
     [Fact]
     public void The_drop_lands_the_selection_once_after_the_batch_has_closed()
     {
-        var completed = ShellSource.Load(TabHostSource).Method("OnTabDragCompleted");
+        var finish = ShellSource.Load(TabHostSource).Method("FinishHorizontalDrag");
 
         // The stand-down swallows every selection raise the drag produced,
         // so this landing is the only thing that can end a drop with the
-        // strip and the manager agreeing: after the commit and the
-        // reconcile, outside TabView's batch, exactly once.
-        var reconcile = completed.Calls("ReconcileStripOrder").ToList();
-        var landing = completed.Calls("SelectActive").ToList();
+        // strip and the manager agreeing: after the last commit and the
+        // reconcile, exactly once.
+        var reconcile = finish.Calls("ReconcileStripOrder").ToList();
+        var landing = finish.Calls("SelectActive").ToList();
         Assert.True(
             landing.Count == 1 && reconcile.Count == 1
                 && landing[0].SpanStart > reconcile[0].Span.End,
-            "OnTabDragCompleted must land the selection exactly once, after the " +
+            "FinishHorizontalDrag must land the selection exactly once, after the " +
             "commit's reconcile: the order has to be settled before the selection " +
             "is re-asserted against it.");
 
         // Unconditional. A refused commit and a repaired one must end the
-        // same way, and the off-strip release (TabView re-applies the inner
-        // ListView's possibly cleared selection just before this handler
-        // runs) is the drift a guarded landing would leave standing.
+        // same way -- the strip resting on the manager's active tab is the
+        // only end state a reorder may leave.
         Assert.Empty(landing[0].Ancestors().OfType<IfStatementSyntax>());
     }
 
@@ -424,105 +423,109 @@ public sealed class TabStripSyncWiringTests
     }
 
     [Fact]
-    public void A_chip_drag_commits_MoveGroup_through_the_drop_map_and_never_Move()
+    public void A_chip_press_never_arms_the_engine()
     {
-        var completed = ShellSource.Load(TabHostSource).Method("OnTabDragCompleted");
+        var pressed = ShellSource.Load(TabHostSource).Method("OnStripPointerPressed");
 
-        // A chip drags its whole run, and the commit is MoveGroup even for
-        // a single-member run -- a Move here would relocate one member out
-        // of the run it is carrying and let Normalize re-gather the rest
-        // somewhere else. The strip's rest slot is not a manager index
-        // (chips occupy slots; hidden members occupy none), so the target
-        // comes from the drop map, never from the slot arithmetic.
-        var chipGate = completed.DescendantNodes().OfType<IfStatementSyntax>()
-            .First(i => i.Condition.ToString().Contains("item.Tag is TabGroup", StringComparison.Ordinal));
-        // Scope to the gate's own statement: the if node's descendants
-        // include its else arm, and the tab path's Move lives there.
-        var chipArm = chipGate.Statement;
-        var map = chipArm.Call("TabChipDrop.GroupTarget");
-        var commit = chipArm.Call("_manager.MoveGroup");
+        // A chip drags its whole run, and the run's commit is the group
+        // rung's grammar -- not a Move this engine may guess at. The chip
+        // refusal sits before the identity walk and before any session
+        // is built, so a press on a chip stays exactly what it was: a
+        // click that may expand, and nothing else.
+        var chipGate = pressed.DescendantNodes().OfType<IfStatementSyntax>()
+            .First(i => i.Condition.ToString() == "item.Tag is TabGroup");
         Assert.True(
-            commit.Arg(1) == "target" && map.SpanStart < commit.SpanStart,
-            "The chip drag must commit MoveGroup with the drop map's target, not a "
-            + "slot the strip happened to land on.");
-        Assert.True(
-            map.Arg(2) == "leftTab" && map.Arg(3) == "leftChip",
-            "The drop map must be fed the neighbour's IDENTITY, not a slot: on a "
-            + "downward move TabView shifts the strip slots left, and a slot "
-            + "re-read through the pre-drag projection names the dragged chip "
-            + "itself.");
+            chipGate.Statement is ReturnStatementSyntax { Expression: null },
+            "A chip press must fall through without arming: the engine's plain "
+            + "reorder must never relocate a run it does not understand.");
 
-        // The neighbour's identity is read off the strip's own final
-        // arrangement, from the slot LEFT of the rest. The transposed
-        // read (slot + 1) is the boundary flip this rung exists to make
-        // impossible, so the argument is pinned verbatim.
-        var neighbour = chipArm.DescendantNodes().OfType<InvocationExpressionSyntax>()
-            .Single(c => c.CalleeText().EndsWith("ContainerFromIndex", StringComparison.Ordinal));
-        Assert.True(
-            neighbour.ArgumentList.ToString() == "(slot - 1)",
-            "The left neighbour must be read from slot - 1, the strip's own "
-            + "arrangement: slot + 1 is the transposed boundary, and a projector "
-            + "slot read is the pre-drag order the drag just overruled.");
-
-        // A rest the strip cannot name a neighbour for is skew: the whole
-        // commit sits behind that refusal rather than guessing at the
-        // strip head, and behind the map's own -1, since MoveGroup clamps
-        // a guess into a landing.
-        Assert.True(
-            map.Ancestors().OfType<IfStatementSyntax>()
-                .Any(a => a.Condition.ToString() == "known"),
-            "The commit must be refused when the left neighbour is unresolvable: "
-            + "a guessed head target yanks the run to the front of the strip.");
-        Assert.True(
-            commit.Ancestors().OfType<IfStatementSyntax>()
-                .Any(a => a.Condition.ToString() == "target >= 0"),
-            "The MoveGroup commit must sit behind the map's refusal (target >= 0): "
-            + "a strip the projection cannot describe is the reconcile's, not the "
-            + "drop map's to guess at.");
-
-        Assert.Empty(chipArm.DescendantNodes().OfType<InvocationExpressionSyntax>()
-            .Where(c => c.CalleeText().EndsWith(".Move", StringComparison.Ordinal)));
+        // And nothing in the arm path builds a session for one: no chip
+        // drag may reach the machine through any other door.
+        Assert.Empty(pressed.DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .Where(c => c.CalleeText() == "_manager.MoveGroup"));
     }
 
     [Fact]
-    public void A_tab_drop_moves_through_the_projection_and_forks_at_chip_slots()
+    public void A_sub_threshold_release_is_a_click_the_engine_leaves_alone()
     {
-        var completed = ShellSource.Load(TabHostSource).Method("OnTabDragCompleted");
+        var released = ShellSource.Load(TabHostSource).Method("OnStripPointerReleased");
 
-        // The tab path is exactly the chip gate's else arm: one of the two
-        // owns every drop. The translation is still the projection's (a
-        // raw IndexOf is a slot, not a manager index -- chips occupy
-        // slots), and the move is still gated on the mapped index.
-        var chipGate = completed.DescendantNodes().OfType<IfStatementSyntax>()
-            .First(i => i.Condition.ToString().Contains("item.Tag is TabGroup", StringComparison.Ordinal));
-        var tabArm = chipGate.Else?.Statement;
+        // The begin bundle never ran for a press still under the
+        // threshold: the flag is down, the seam is placed, the lift does
+        // not exist. The release must answer that press with nothing but
+        // the machine's own cancel -- finishing it as a drag would run
+        // the landing, reconcile against a pointer the strip never
+        // showed, and steal the click the item's own pipeline is
+        // answering on the same event.
+        var gate = Assert.IsType<IfStatementSyntax>(
+            released.Body!.Statements.ElementAt(2));
+        Assert.Equal("drag.Machine.Phase != TabDragPhase.Dragging",
+            gate.Condition.ToString());
+        var arm = Assert.IsType<BlockSyntax>(gate.Statement);
+        Assert.Equal(2, arm.Statements.Count);
+        Assert.Contains(arm.DescendantNodes().OfType<InvocationExpressionSyntax>(),
+            c => c.CalleeText() == "drag.Machine.Cancel");
         Assert.True(
-            tabArm is not null,
-            "The chip gate must carry the tab path as its else arm: neither drop "
-            + "shape may fall through both arms or between them.");
-        Assert.Single(
-            tabArm!.DescendantNodes().OfType<InvocationExpressionSyntax>()
-                .Where(c => c.CalleeText().EndsWith(
-                    "TabStripProjection.VisibleIndexToModelIndex", StringComparison.Ordinal)));
+            arm.Statements.Last() is ReturnStatementSyntax { Expression: null },
+            "the sub-threshold arm must return: the finish pass is for drags "
+            + "that began, never for clicks.");
 
-        var move = tabArm.DescendantNodes().OfType<InvocationExpressionSyntax>()
-            .Single(c => c.CalleeText().EndsWith(".Move", StringComparison.Ordinal));
+        // And the disarm stands before everything else: the guard is the
+        // handler's first statement, and the field is down at the second,
+        // so a re-entrant release finds no session to finish a second
+        // time.
+        var statements = released.Body!.Statements.ToList();
+        var guard = Assert.IsType<IfStatementSyntax>(statements[0]);
+        Assert.Equal("_horizontalDrag is not { } drag", guard.Condition.ToString());
         Assert.True(
-            move.Ancestors().OfType<IfStatementSyntax>()
-                .Any(a => a.Condition.ToString() == "newIndex >= 0"),
-            "The tab drop's move must be gated on the mapped index (newIndex >= 0).");
+            guard.Statement is ReturnStatementSyntax { Expression: null },
+            "a release with no session of ours belongs to whoever owns it.");
+        Assert.True(
+            statements[1] is ExpressionStatementSyntax
+            {
+                Expression: AssignmentExpressionSyntax
+                {
+                    Left: IdentifierNameSyntax { Identifier.ValueText: "_horizontalDrag" },
+                    Right: LiteralExpressionSyntax { Token.ValueText: "null" }
+                }
+            },
+            "the handler must disarm before any pass runs: a re-entrant release "
+            + "must not finish the same drag twice.");
+    }
 
-        // A slot that maps to a chip is the join fork's, and the fork
-        // lives in its own method so its pins read one story below.
-        var newIndexGate = move.Ancestors().OfType<IfStatementSyntax>()
-            .First(a => a.Condition.ToString() == "newIndex >= 0");
+    [Fact]
+    public void A_crossing_commits_through_the_projection_and_rewinds_at_chip_slots()
+    {
+        var commit = ShellSource.Load(TabHostSource).Method("CommitHorizontalCrossing");
+
+        // The machine speaks slots; the manager speaks model indices.
+        // The translation is the projection's, taken fresh per crossing
+        // because every prior commit reordered the manager the machine
+        // cannot see.
+        Assert.Single(commit.Calls("TabStripProjection.DragSlots"));
+        var move = commit.Call("_manager.Move");
+        var refusal = commit.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "target < 0 || old < 0 || old == target");
         Assert.True(
-            newIndexGate.Else?.Statement.DescendantNodes()
-                .OfType<InvocationExpressionSyntax>()
-                .Any(c => c.CalleeText().EndsWith("ResolveDropAtChip", StringComparison.Ordinal))
-            == true,
-            "The unmapped arm (-1, a chip's slot) must route to the drop-at-a-run "
-            + "fork; refusing outright would bounce every drop a chip borders.");
+            refusal.Statement is BlockSyntax arm
+                && arm.Statements.Last() is ReturnStatementSyntax { Expression: null }
+                && move.SpanStart > refusal.Span.End,
+            "The crossing's move must sit behind the projection's translation: an "
+            + "unmapped target, a lost tab, and the no-op are all refusals that "
+            + "return, not moves the strip guesses at.");
+
+        // A slot the projection cannot map is a chip's, and the machine's
+        // index is rewound to the crossing's origin: the next Evaluate
+        // measures from the slot the strip actually shows.
+        var rewinds = commit.Calls("drag.Machine.UpdateIndex").ToList();
+        Assert.True(
+            rewinds.Count == 2
+                && rewinds.All(r => r.Arg(0) == "crossing.From")
+                && rewinds.All(r => r.SpanStart < move.SpanStart),
+            "Every refused crossing must rewind the machine to the crossing's "
+            + "origin before the commit returns: a stranded index would let the "
+            + "next Evaluate commit from a slot the strip never showed.");
     }
 
     [Fact]
@@ -561,58 +564,53 @@ public sealed class TabStripSyncWiringTests
     }
 
     [Fact]
-    public void The_strip_accepts_only_its_own_drags_and_records_the_drop_point()
+    public void The_engine_hooks_the_pointer_without_capture_and_owns_the_drop_point()
     {
         var src = ShellSource.Load(TabHostSource);
-        var over = src.Method("OnTabStripDragOver");
-        var drop = src.Method("OnTabStripDrop");
+        var hook = src.Method("HookStripDragInput");
+        var finish = src.Method("FinishHorizontalDrag");
 
-        // Both handlers open with the live-drag guard: an external drag
-        // must stay declined, which an untouched accepted operation does.
-        foreach (var handler in new[] { over, drop })
-        {
-            var guard = handler.Body!.Statements.First() as IfStatementSyntax;
-            Assert.True(
-                guard?.Condition is PrefixUnaryExpressionSyntax not
-                    && not.Operand is IdentifierNameSyntax id
-                    && id.Identifier.ValueText == "_stripDragActive"
-                    && guard.Statement is ReturnStatementSyntax { Expression: null },
-                handler.Identifier.ValueText + " must open with `if (!_stripDragActive) "
-                + "return;`: accepting a foreign drag lets a drop the strip never "
-                + "started write state.");
-        }
+        // The five pointer handlers are wired on the host's own root with
+        // handledEventsToo, the vertical's proven shape -- and nowhere in
+        // the hook or the handlers does a capture appear: presses route
+        // by hit-testing, which is why a sub-threshold press is still the
+        // click it started as.
+        Assert.Equal(5, hook.Calls("HostRoot.AddHandler").Count());
+        Assert.All(
+            hook.Calls("HostRoot.AddHandler"),
+            c => Assert.True(
+                c.Arg(1).StartsWith("new PointerEventHandler", StringComparison.Ordinal)
+                && c.Arg(2) == "true",
+                "every pointer hook must carry its handler with handledEventsToo: "
+                + "true -- a press over any part of an item arms."));
+        // CalleeText keeps the receiver, so the no-capture pin must match
+        // by suffix: a bare-name match can never go red, because
+        // CapturePointer is only ever spelled with something before the
+        // dot.
+        Assert.Empty(src.Root.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(c => c.CalleeText().EndsWith("CapturePointer", StringComparison.Ordinal)));
 
-        var accept = over.DescendantNodes().OfType<AssignmentExpressionSyntax>()
-            .First(a => a.Left.ToString().EndsWith("AcceptedOperation", StringComparison.Ordinal));
-        Assert.True(
-            accept.Right.ToString().Contains("DataPackageOperation.Move", StringComparison.Ordinal),
-            "The strip accepts Move only: the accept exists so TabStripDrop fires "
-            + "with the pointer position the join fork reads.");
-
-        // The drop records and stops there -- the commit is OnTabDrag-
-        // Completed's, and neither handler may move anything itself.
-        var record = drop.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+        // The drop point is the engine's own release event now, recorded
+        // in the finish pass: TabView no longer supplies one (no OLE
+        // drag), and the join fork's geometry reads what the pointer
+        // actually did.
+        var record = finish.DescendantNodes().OfType<AssignmentExpressionSyntax>()
             .First(a => a.Left is IdentifierNameSyntax lid
                         && lid.Identifier.ValueText == "_lastDropPosition");
         Assert.True(
             record.DescendantNodes().OfType<InvocationExpressionSyntax>()
-                .Any(c => c.CalleeText().EndsWith("GetPosition", StringComparison.Ordinal)),
-            "The recorded point must come from the drop event's position.");
-        Assert.Empty(drop.DescendantNodes().OfType<InvocationExpressionSyntax>()
-            .Where(c => c.CalleeText().EndsWith(".Move", StringComparison.Ordinal)
-                        || c.CalleeText().EndsWith("JoinGroup", StringComparison.Ordinal)));
-        Assert.Empty(over.DescendantNodes().OfType<InvocationExpressionSyntax>()
-            .Where(c => c.CalleeText().EndsWith(".Move", StringComparison.Ordinal)
-                        || c.CalleeText().EndsWith("JoinGroup", StringComparison.Ordinal)));
+                .Any(c => c.CalleeText().EndsWith("GetCurrentPoint", StringComparison.Ordinal)),
+            "The recorded point must come from the release event's position.");
 
-        // The handlers are wired in markup, where the code-behind sweep
-        // cannot see them (the TabDroppedOutside pin's lesson).
+        // The switch-off is total: no OLE drag handshake in the markup,
+        // and the reorder engine it used to feed is off with it.
         var xaml = ReadEmbedded(TabHostXaml);
-        Assert.True(
-            xaml.Contains("TabStripDragOver", StringComparison.Ordinal)
-                && xaml.Contains("TabStripDrop", StringComparison.Ordinal),
-            "TabHost.xaml must wire TabStripDragOver and TabStripDrop: without the "
-            + "drop the fork never gets a pointer position and refuses every join.");
+        Assert.Contains("CanReorderTabs=\"False\"", xaml, StringComparison.Ordinal);
+        Assert.Contains("CanDragTabs=\"False\"", xaml, StringComparison.Ordinal);
+        Assert.DoesNotContain("TabStripDragOver", xaml, StringComparison.Ordinal);
+        Assert.DoesNotContain("TabStripDrop", xaml, StringComparison.Ordinal);
+        Assert.DoesNotContain("TabDragStarting", xaml, StringComparison.Ordinal);
+        Assert.DoesNotContain("TabDragCompleted", xaml, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/windows/Ghostty.Tests/Wiring/VerticalTabGroupHeaderWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/VerticalTabGroupHeaderWiringTests.cs
@@ -289,9 +289,16 @@ public class VerticalTabGroupHeaderWiringTests
     {
         var strip = Strip();
         var method = strip.Method("SlotIndexOf");
-        var ret = method.DescendantNodes().OfType<ReturnStatementSyntax>().Single();
-        Assert.Equal("manager >= 0 ? managerIndex.IndexOf(manager) : -1",
-            ret.Expression!.ToString());
+
+        // The inverse lives once, on the projection, where both strips
+        // read it and its guard is execution-tested; the strip's helper
+        // is the delegation, and nothing here may re-derive the pairing
+        // by indexing the forward list.
+        var delegated = method.ExpressionBody?.Expression?.ToString()
+            ?? method.DescendantNodes().OfType<ReturnStatementSyntax>()
+                .Single().Expression!.ToString();
+        Assert.Equal("TabStripProjection.SlotIndexOf(_manager, managerIndex, tab)",
+            delegated);
         Assert.DoesNotContain("managerIndex[_manager.IndexOf", method.ToString());
 
         // The three machine-index sites (press, zone churn, drag tick) all

--- a/windows/Ghostty/Tabs/TabHost.xaml
+++ b/windows/Ghostty/Tabs/TabHost.xaml
@@ -42,7 +42,7 @@
          both tab hosts can share a single container without ever
          reparenting the SwapChainPanels. This UserControl now renders
          only the tab strip chrome. -->
-    <Grid HorizontalAlignment="Stretch" VerticalAlignment="Top">
+    <Grid x:Name="HostRoot" HorizontalAlignment="Stretch" VerticalAlignment="Top">
         <!-- Trim the default 8px top gap above the tab strip
              (TabViewHeaderPadding) so the strip is not taller than it
              needs to be. The vertical-mode title bar height and the
@@ -53,16 +53,13 @@
             x:Name="TabViewControl"
             Padding="0,2,0,0"
             HorizontalAlignment="Stretch"
-            CanReorderTabs="True"
-            CanDragTabs="True"
+            CanReorderTabs="False"
+            CanDragTabs="False"
             TabWidthMode="Equal"
             IsAddTabButtonVisible="False"
             TabCloseRequested="OnTabCloseRequested"
             ContextRequested="OnTabViewContextRequested"
-            SelectionChanged="OnSelectionChanged"
-            TabStripDragOver="OnTabStripDragOver"
-            TabStripDrop="OnTabStripDrop"
-            TabDragCompleted="OnTabDragCompleted">
+            SelectionChanged="OnSelectionChanged">
             <controls:TabView.TabStripHeader>
                 <branding:AppIconBadge x:Name="IconBadgeHost" />
             </controls:TabView.TabStripHeader>

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -20,7 +20,6 @@ using Microsoft.UI.Xaml.Hosting;
 using Microsoft.UI.Xaml.Input;
 using Ghostty.Core.Windows;
 using Microsoft.UI.Xaml.Media;
-using Windows.ApplicationModel.DataTransfer;
 using Windows.Foundation;
 
 namespace Ghostty.Tabs;
@@ -140,10 +139,11 @@ internal sealed partial class TabHost : UserControl, ITabHost
         Unloaded += (_, _) => FinishLift("teardown");
 
         // The drag lifecycle gates the seam cover below: mid-drag the
-        // strip's slots are TabView's reorder preview, not the manager's
-        // order, so the cover (placed from the active item's slot) is
-        // suppressed for the drag and re-placed at the drop.
-        TabViewControl.TabDragStarting += OnTabDragStarting;
+        // strip's slots are the engine's crossing preview, not the
+        // manager's settled order, so the cover (placed from the active
+        // item's slot) is suppressed for the drag and re-placed at the
+        // drop.
+        HookStripDragInput();
 
         // The run label's timers. Each stops itself before translating, so
         // a timer that fires twice in a pass cannot double-apply.
@@ -161,7 +161,7 @@ internal sealed partial class TabHost : UserControl, ITabHost
         // this control's own writes as much as for TabView's, so a
         // validation handler on it would re-enter the reconcile that
         // mutates TabItems. The validation points are the reconciles in
-        // MoveItem and OnTabDragCompleted; both read the manager.
+        // MoveItem and the engine's finish pass; both read the manager.
     }
 
     private void AddItem(TabModel tab)
@@ -1576,17 +1576,16 @@ internal sealed partial class TabHost : UserControl, ITabHost
     {
         if (_suppressSelectionEvent) return;
         // A live drag holds the strip, and nothing raised while it does is
-        // an intent. TabView's reorder commits as a remove-then-insert on
-        // TabItems, and the selection model's reaction to the remove
-        // re-targets the selection -- raising this event while the dragged
-        // tab is still absent from the strip. Acting on that raise would
-        // reconcile, and the reconcile's refusal path would Clear()
-        // TabItems, inside TabView's still-open modification: the
-        // collection refuses a nested modification with 0x8000FFFF, and on
-        // the UI thread that refusal is process death. The drag's drop is
-        // where the selection truth lands instead: OnTabDragCompleted
-        // re-asserts the manager's active tab after the commit, once the
-        // batch has closed.
+        // an intent. The engine's crossings commit through the manager as
+        // they land, each a remove-then-insert on TabItems, and the
+        // selection model's reaction to the remove re-targets the
+        // selection -- raising this event while the dragged tab is still
+        // settling. Acting on that raise would reconcile mid-crossing.
+        // The drag's release is where the selection truth lands instead:
+        // the engine's finish re-asserts the manager's active tab after
+        // the last commit. No MUXC drag batch can be open under the
+        // engine, so the old batch-collision constraint is gone; what
+        // remains is that a crossing's churn is not an intent.
         if (_stripDragActive)
         {
             _stoodDownSelectionRaises++;
@@ -1661,185 +1660,349 @@ internal sealed partial class TabHost : UserControl, ITabHost
     }
 
     /// <summary>
-    /// True while a TabView drag has the strip. The seam cover derives
+    /// True while the drag engine has the strip. The seam cover derives
     /// from the active item's arranged slot, and during a drag that slot
-    /// is TabView's reorder preview rather than the manager's order.
+    /// is the engine's crossing preview rather than the manager's order.
     /// </summary>
     private bool _stripDragActive;
 
     // The selection raises a live drag's stand-down has swallowed, since
-    // the last drag began. Every one is TabView's mid-batch churn, and
+    // the last drag began. Every one is a commit's mid-drag churn, and
     // the count says how much churn a single drop actually produces.
     private int _stoodDownSelectionRaises;
 
-    // The drop point, and whether it is this drag's. Recorded by
-    // OnTabStripDrop for the drop-at-a-run fork in OnTabDragCompleted,
-    // which carries no position of its own; the flag is the guard that
-    // makes the record honest -- a release off the strip fires no
-    // TabStripDrop, so the last drag's stale point must not answer for
-    // this one. Invalidated at drag start and consumed at completion.
+    // The release point the drop-at-a-run fork reads, with the flag that
+    // says the point is this drag's own. The engine records a fresh
+    // point at every live release before the fork can run, so the flag
+    // is never seen false today; it stays as DropPointIn's shape guard,
+    // whose refusal (no honest point, no join, no side) is the contract
+    // any future caller of the fork inherits.
     private Windows.Foundation.Point _lastDropPosition;
     private bool _dropPositionValid;
 
-    private void OnTabDragStarting(TabView sender, TabViewTabDragStartingEventArgs args)
+    // The one live horizontal drag, zero or one. A press over the strip
+    // arms a session that stays a click until the pointer travels past
+    // the start threshold; the engine never captures the pointer, so a
+    // session is ended by its release, a cancel, or the next press after
+    // a release the window never saw.
+    private HorizontalDragSession? _horizontalDrag;
+
+    private sealed class HorizontalDragSession
     {
-        TabDragTrace.Line($"DRAG start item={args.Item?.GetType().Name ?? "null"}");
-        _stripDragActive = true;
-        _stoodDownSelectionRaises = 0;
-        _dropPositionValid = false;
-        // The label hides HERE, in the drag start's own dispatch pass, as
-        // a cut: an 83ms fade would overlap the drag ghost, which is the
-        // one overlap the label rule exists to forbid. No timer stands
-        // between this event and the hide.
-        ApplyLabelPhase(_labelRules.DragStarting());
-        // The boundary stroke brightens for the length of the drag: the
-        // zone edge is what a drag-to-pin is aiming at, and the flag this
-        // reads is live from the line above.
-        ApplyPinZoneChrome();
-        // Hidden synchronously: the drag is live from this call onward,
-        // and anything the strip does from here moves slots the manager
-        // has not agreed to yet.
-        SelectedTabSeamChanged?.Invoke(0, 0, null);
-        // The lift is decoration and stands last: everything above lands
-        // the state the drag's truth needs, and the visual must never be
-        // a dependency of it.
-        if (args.Item is TabViewItem lifted) StartLift(lifted);
+        public required TabDragReorder Machine;
+        public required TabModel Tab;
+        public required TabViewItem Item;
+
+        // Press position and the dragged item's arranged center at the
+        // press, both in TabViewControl space, so the machine's dragged
+        // center rides the pointer without a live follow: the row moves
+        // at crossings, and the pointer's travel supplies the intent.
+        public required double PressX;
+        public required double GrabCenterX;
     }
 
-    private void OnTabDragCompleted(TabView sender, TabViewTabDragCompletedEventArgs args)
+    /// <summary>
+    /// The horizontal strip's drag engine: the shared capture-less
+    /// machine fed by pointer handlers on the host's own root, with
+    /// handledEventsToo so a press over any part of an item still arms.
+    /// Nothing here sets Handled and nothing captures: presses route by
+    /// hit-testing exactly as they did before the engine existed, which
+    /// is why a click survives it untouched -- the item's own pipeline
+    /// answers a sub-threshold press-release, and the flag the selection
+    /// stand-down reads never goes up for one.
+    /// </summary>
+    private void HookStripDragInput()
     {
-        // First, before the point is invalidated below: whether the drop
-        // landed on the strip is exactly what the recorded point answers.
-        TabDragTrace.Line($"DRAG completed item={args.Item?.GetType().Name ?? "null"} " +
-            $"point={(_dropPositionValid ? "live" : "stale")}");
-        _stripDragActive = false;
-        _dropPositionValid = false;
-        // The drag is over: the cut demand lifts, and hover may show the
-        // label again. The label is already hidden (the start hid it), so
-        // this is bookkeeping, not a second hide.
-        ApplyLabelPhase(_labelRules.DragEnded());
-        // The boundary stroke dims back -- and because this handler is the
-        // one pass every completed drag runs, the dim is the cleanup: a
-        // bright stroke cannot outlive the drag that brightened it.
-        ApplyPinZoneChrome();
-        if (args.Item is TabViewItem item)
-        {
-            if (item.Tag is TabGroup draggedGroup)
-            {
-                // A chip drags its whole run. The strip's slot is not a
-                // manager index: chips occupy slots too, and the members
-                // a collapsed run hides occupy none. The commit is
-                // MoveGroup even for a single-member run, so a chip drag
-                // can never split the run it is carrying.
-                //
-                // The left neighbour is the element the strip arranged at
-                // slot - 1, read as an identity and never as a slot: on a
-                // downward move TabView shifts every strip slot left
-                // between the origin and the rest, so re-reading slot - 1
-                // through the pre-drag projection names the dragged chip
-                // itself.
-                var slot = TabViewControl.TabItems.IndexOf(item);
-                TabModel? leftTab = null;
-                TabGroup? leftChip = null;
-                var known = slot <= 0;
-                if (!known
-                    && TabViewControl.ContainerFromIndex(slot - 1) is TabViewItem neighbour)
-                {
-                    if (neighbour.Tag is TabGroup neighbourChip)
-                    {
-                        leftChip = neighbourChip;
-                        known = true;
-                    }
-                    else
-                    {
-                        foreach (var (model, vi) in _itemByModel)
-                        {
-                            if (vi != neighbour) continue;
-                            leftTab = model;
-                            known = true;
-                            break;
-                        }
-                    }
-                }
+        HostRoot.AddHandler(PointerPressedEvent,
+            new PointerEventHandler(OnStripPointerPressed), true);
+        HostRoot.AddHandler(PointerMovedEvent,
+            new PointerEventHandler(OnStripPointerMoved), true);
+        HostRoot.AddHandler(PointerReleasedEvent,
+            new PointerEventHandler(OnStripPointerReleased), true);
+        HostRoot.AddHandler(PointerCanceledEvent,
+            new PointerEventHandler(OnStripPointerCanceled), true);
+        HostRoot.AddHandler(PointerCaptureLostEvent,
+            new PointerEventHandler(OnStripPointerCaptureLost), true);
+    }
 
-                // A rest whose left neighbour the strip cannot name is
-                // skew the reconcile owns: refuse the commit rather than
-                // guess at the strip head.
-                if (known)
-                {
-                    var target =
-                        TabChipDrop.GroupTarget(_manager, draggedGroup, leftTab, leftChip);
-                    if (target >= 0)
-                    {
-                        TabDragTrace.Line($"COMMIT movegroup slot={slot} target={target}");
-                        _manager.MoveGroup(draggedGroup, target);
-                    }
-                    else
-                    {
-                        TabDragTrace.Line($"COMMIT movegroup refused reason=target-negative slot={slot}");
-                    }
-                }
-                else
-                {
-                    TabDragTrace.Line($"COMMIT movegroup refused reason=unknown-neighbour slot={slot}");
-                }
-            }
-            else
-            {
-                // The strip's slot is not a manager index: chips occupy
-                // slots too, so the raw IndexOf would land past every run
-                // left of the drop. The projection translates; a slot that
-                // maps back to a tab commits the move the strip previewed,
-                // and a slot that maps to a chip falls to the
-                // drop-at-a-run fork.
-                var slot = TabViewControl.TabItems.IndexOf(item);
-                var newIndex = TabStripProjection.VisibleIndexToModelIndex(_manager, slot);
-                if (newIndex >= 0)
-                {
-                    foreach (var (model, vi) in _itemByModel)
-                    {
-                        if (vi == item)
-                        {
-                            var oldIndex = _manager.IndexOf(model);
-                            TabDragTrace.Line(oldIndex == newIndex
-                                ? $"COMMIT move skipped in-place old={oldIndex} new={newIndex}"
-                                : $"COMMIT move old={oldIndex} new={newIndex}");
-                            if (oldIndex != newIndex && oldIndex >= 0)
-                                _manager.Move(oldIndex, newIndex);
-                            break;
-                        }
-                    }
-                }
-                else
-                {
-                    TabDragTrace.Line($"COMMIT drop at chip slot={slot}");
-                    ResolveDropAtChip(item, slot);
-                }
-            }
+    private void OnStripPointerPressed(object sender, PointerRoutedEventArgs e)
+    {
+        if (_horizontalDrag is not null)
+        {
+            // A button that came up off the window is a release the host
+            // never saw; the stale session ends here rather than blocking
+            // every drag after it.
+            CancelHorizontalDrag("stale");
         }
-        // The drop is where the two orders can end up disagreeing with
-        // nobody left to fix it: TabView has already applied whatever
-        // reorder it wanted, and the manager may have refused the move
-        // outright (an invariant clamp mutates nothing and raises
-        // nothing) or repaired further than the op asked. The strip
-        // yields to the manager; on an accepted drag this is a no-op
-        // scan.
+        if (!e.GetCurrentPoint(TabViewControl).Properties.IsLeftButtonPressed) return;
+
+        var source = e.OriginalSource as DependencyObject;
+        // The item's own controls keep their gestures: a press on the
+        // close button or any other button descendant is that button's,
+        // never the drag's.
+        if (VisualTreeHelperEx.FindAncestor<ButtonBase>(source) is not null) return;
+        if (VisualTreeHelperEx.FindAncestor<TabViewItem>(source) is not { } item) return;
+        // A chip press never arms: a chip drags its whole run, and the
+        // run's commit is the group rung's, not this one's.
+        if (item.Tag is TabGroup) return;
+
+        TabModel? dragged = null;
+        foreach (var (model, vi) in _itemByModel)
+        {
+            if (ReferenceEquals(vi, item)) { dragged = model; break; }
+        }
+        if (dragged is null) return;
+
+        var (rows, managerIndex) = TabStripProjection.DragSlots(_manager);
+        var slot = TabStripProjection.SlotIndexOf(_manager, managerIndex, dragged);
+        if (slot < 0 || rows.Count < 2) return;
+        var (grabbed, centers) = MeasureSlots(rows, dragged);
+        if (double.IsNaN(grabbed)) return;
+
+        var pressX = e.GetCurrentPoint(TabViewControl).Position.X;
+        var drag = new HorizontalDragSession
+        {
+            Machine = new TabDragReorder(rows.Count, slot),
+            Tab = dragged,
+            Item = item,
+            PressX = pressX,
+            GrabCenterX = grabbed,
+        };
+        drag.Machine.Press(pressX);
+        drag.Machine.UpdateCenters(centers);
+        // Centers are measured once, at the arm, and survive commits on
+        // the machine's own invariant: rows occupy slots in manager
+        // order, so a committed crossing leaves them describing the
+        // layout the strip is arranging toward. They are exact only
+        // while slots stay equal-width -- TabWidthMode="Equal" in
+        // TabHost.xaml is a dependency of this gesture, not a styling
+        // choice. A variable-width mode would need UpdateCenters re-fed
+        // per commit, which the machine already supports.
+        _horizontalDrag = drag;
+    }
+
+    private void OnStripPointerMoved(object sender, PointerRoutedEventArgs e)
+    {
+        if (_horizontalDrag is not { } drag) return;
+        var x = e.GetCurrentPoint(TabViewControl).Position.X;
+        if (drag.Machine.Phase == TabDragPhase.Pressed)
+        {
+            if (!drag.Machine.Begin(x)) return;
+            BeginHorizontalDragVisual(drag);
+        }
+        drag.Machine.SampleVelocity(x, Environment.TickCount64);
+        if (drag.Machine.Phase != TabDragPhase.Dragging) return;
+
+        // The dragged center travels with the pointer from its grab
+        // position; the crossings it earns commit live, the strip
+        // following the machine rather than waiting for a release.
+        var draggedCenter = drag.GrabCenterX + (x - drag.PressX);
+        while (drag.Machine.Evaluate(draggedCenter) is { } crossing)
+            CommitHorizontalCrossing(drag, crossing);
+    }
+
+    private void OnStripPointerReleased(object sender, PointerRoutedEventArgs e)
+    {
+        if (_horizontalDrag is not { } drag) return;
+        _horizontalDrag = null;
+        if (drag.Machine.Phase != TabDragPhase.Dragging)
+        {
+            // A press that never crossed the threshold was a click, and
+            // the item's own pipeline answers this release. The engine
+            // never held the pointer, so there is nothing to hand back
+            // and no side effect to undo.
+            drag.Machine.Cancel();
+            return;
+        }
+        FinishHorizontalDrag(drag, e);
+    }
+
+    private void OnStripPointerCanceled(object sender, PointerRoutedEventArgs e)
+        => CancelHorizontalDrag("canceled");
+
+    private void OnStripPointerCaptureLost(object sender, PointerRoutedEventArgs e)
+        => CancelHorizontalDrag("capture");
+
+    /// <summary>
+    /// The begin bundle, run once at the threshold, never at the press:
+    /// everything here changes what a click looks like or suppresses, so
+    /// a gesture that is still a click must not run it. The lift is
+    /// decoration and stands last, as it always did.
+    /// </summary>
+    private void BeginHorizontalDragVisual(HorizontalDragSession drag)
+    {
+        TabDragTrace.Line($"DRAG begin index={drag.Machine.Index} " +
+            $"rows={drag.Machine.RowCount} run=no motion=" +
+            (TabStripMotion.Enabled(SystemAnimationsEnabled(), _highContrast) ? "on" : "off"));
+        _stripDragActive = true;
+        _stoodDownSelectionRaises = 0;
+        // The label hides HERE, in the begin pass, as a cut: an 83ms fade
+        // would overlap the dragged tab's lift, which is the one overlap
+        // the label rule exists to forbid.
+        ApplyLabelPhase(_labelRules.DragStarting());
+        // The boundary stroke brightens for the length of the drag: the
+        // zone edge is what a drag-to-pin is aiming at.
+        ApplyPinZoneChrome();
+        // Hidden synchronously: the drag is live from this call onward,
+        // and the crossings below move slots the manager is asked to
+        // agree to as they land.
+        SelectedTabSeamChanged?.Invoke(0, 0, null);
+        StartLift(drag.Item);
+    }
+
+    /// <summary>
+    /// One committed crossing: the machine's slot space translated
+    /// through the projection into the manager move, the same seam the
+    /// old bridge committed through. A slot the projection cannot map is
+    /// a chip's -- a chip is a slot but not a model -- and the machine's
+    /// index is rewound: crossing a chip is the group rung's grammar,
+    /// not a move this rung may guess at.
+    /// </summary>
+    private void CommitHorizontalCrossing(HorizontalDragSession drag, TabDragCrossing crossing)
+    {
+        var (rows, _) = TabStripProjection.DragSlots(_manager);
+        if (crossing.To < 0 || crossing.To >= rows.Count)
+        {
+            drag.Machine.UpdateIndex(crossing.From);
+            return;
+        }
+        var target = _manager.IndexOf(rows[crossing.To]);
+        var old = _manager.IndexOf(drag.Tab);
+        if (target < 0 || old < 0 || old == target)
+        {
+            drag.Machine.UpdateIndex(crossing.From);
+            TabDragTrace.Line($"DRAG refused {crossing.From}->{crossing.To}");
+            return;
+        }
+        TabDragTrace.Line($"DRAG commit {crossing.From}->{crossing.To}");
+        TabDragTrace.Line($"COMMIT move old={old} new={target}");
+        _manager.Move(old, target);
+        RebindLift(drag.Item);
+    }
+
+    /// <summary>
+    /// The commit churned the dragged tab's slot -- MoveItem's remove and
+    /// insert keeps the same element, but whether the composition visual
+    /// carries its running scale, center, and shadow sprite across that
+    /// is a runtime question the rebind refuses to ask. Re-assert all
+    /// three, the way the vertical's RebindFollow does at every crossing.
+    /// Set, not re-spring: re-running the lift spring per crossing would
+    /// re-bounce the tab all the way across the strip.
+    /// </summary>
+    private void RebindLift(TabViewItem item)
+    {
+        if (_lift is not { } lift || !ReferenceEquals(lift.Item, item)) return;
+        Visual visual;
+        try
+        {
+            visual = ElementCompositionPreview.GetElementVisual(item);
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException
+            or System.Runtime.InteropServices.COMException or NullReferenceException)
+        {
+            return;
+        }
+        // The churned container scales from its own middle, the same
+        // center the grab set, or the lift pivots from the corner after
+        // the first mid-drag commit.
+        visual.CenterPoint = new Vector3(
+            (float)item.ActualWidth / 2f, (float)item.ActualHeight / 2f, 0f);
+        visual.Scale = new Vector3(
+            TabStripMotion.LiftScale, TabStripMotion.LiftScale, 1f);
+        ElementCompositionPreview.SetElementChildVisual(item, lift.Shadow);
+        if (!ReferenceEquals(lift.Visual, visual)) _lift = lift with { Visual = visual };
+    }
+
+    /// <summary>
+    /// The release bundle, run once per live drag. The commit is already
+    /// in the manager -- every crossing moved it -- so this pass is the
+    /// landing: the join fork for a release that came down on a chip,
+    /// the unconditional reconcile sweep, the selection landing the
+    /// stand-down owes, and the settle last.
+    /// </summary>
+    private void FinishHorizontalDrag(HorizontalDragSession drag, PointerRoutedEventArgs e)
+    {
+        var index = drag.Machine.Drop();
+        TabDragTrace.Line($"DRAG completed item=TabViewItem drop={index}");
+        // The release point the join fork reads, recorded now that it is
+        // this drag's own and none earlier's.
+        _lastDropPosition = e.GetCurrentPoint(TabViewControl).Position;
+        _dropPositionValid = true;
+        // A release that came down on a chip is the drop-at-a-run fork:
+        // ON the chip joins, beside it positions, by the same geometry
+        // the old bridge used -- now from a point the engine actually
+        // saw.
+        if (VisualTreeHelperEx.FindAncestor<TabViewItem>(e.OriginalSource as DependencyObject)
+            is { } releasedOn && releasedOn.Tag is TabGroup)
+        {
+            var slot = TabViewControl.TabItems.IndexOf(drag.Item);
+            TabDragTrace.Line($"COMMIT drop at chip slot={slot}");
+            ResolveDropAtChip(drag.Item, slot);
+        }
+        _stripDragActive = false;
+        // The drag is over: the cut demand lifts, and hover may show the
+        // label again; the boundary stroke dims back, the cleanup every
+        // completed drag runs.
+        ApplyLabelPhase(_labelRules.DragEnded());
+        ApplyPinZoneChrome();
+        // The sweep is unconditional: a crossing the manager refused or
+        // clamped raised no TabMoved, so nothing else would run it.
         ReconcileStripOrder();
         QueueBridgeUpdate();
-        // The drop's selection landing. OnSelectionChanged stands down for
-        // the whole drag, so the selection raises the drop produced --
-        // TabView's mid-batch churn, and the inner ListView's possibly
-        // cleared selection on an off-strip release, which TabView
-        // re-applies just before this handler runs -- meet the manager
-        // here instead: after the commit, outside the batch, once.
-        // Unconditional, because a refused commit and a repaired one must
-        // end the same way: the strip resting on the manager's active tab,
-        // a reorder never having switched one.
+        // The selection landing the stand-down owes: after the commit and
+        // the reconcile, once, the strip resting on the manager's active
+        // tab, a reorder never having switched one.
         SelectActive();
-        // The settle is decoration and stands last: the commit above has
-        // landed, the reconcile has spoken, and the handback runs on
-        // whatever element the tab has now.
+        // The settle is decoration and stands last.
         SettleLift();
+    }
+
+    private void CancelHorizontalDrag(string reason)
+    {
+        if (_horizontalDrag is not { } drag) return;
+        _horizontalDrag = null;
+        var wasDragging = drag.Machine.Phase == TabDragPhase.Dragging;
+        drag.Machine.Cancel();
+        if (!wasDragging) return;
+        TabDragTrace.Line($"DRAG cancel reason={reason}");
+        _stripDragActive = false;
+        ApplyLabelPhase(_labelRules.DragEnded());
+        ApplyPinZoneChrome();
+        ReconcileStripOrder();
+        SelectActive();
+        SettleLift();
+    }
+
+    /// <summary>
+    /// Arranged slot centers in TabViewControl space, one per row, with
+    /// the dragged row's center answered separately. FINAL arranged
+    /// positions only: a center the strip cannot measure yet refuses the
+    /// arm rather than feeding the machine a NaN that would swallow every
+    /// crossing past that slot.
+    /// </summary>
+    private (double Grabbed, double[] Centers) MeasureSlots(
+        IReadOnlyList<TabModel> rows, TabModel dragged)
+    {
+        var centers = new double[rows.Count];
+        double grabbed = double.NaN;
+        for (var i = 0; i < rows.Count; i++)
+        {
+            if (!_itemByModel.TryGetValue(rows[i], out var item)) return (double.NaN, centers);
+            double x;
+            try
+            {
+                x = item.TransformToVisual(TabViewControl)
+                    .TransformPoint(new Point(0, 0)).X + item.ActualWidth / 2;
+            }
+            catch (Exception ex) when (ex is ArgumentException or InvalidOperationException
+                or System.Runtime.InteropServices.COMException or NullReferenceException)
+            {
+                return (double.NaN, centers);
+            }
+            centers[i] = x;
+            if (ReferenceEquals(rows[i], dragged)) grabbed = x;
+        }
+        return (grabbed, centers);
     }
 
     /// <summary>
@@ -1854,9 +2017,8 @@ internal sealed partial class TabHost : UserControl, ITabHost
     /// The group comes from the projection, never from the strip's item
     /// order: the members are hidden at drop time, so no TabItems index
     /// can say which run took the drop. A slot the projection does not
-    /// name, or a drop with no usable point (released off the strip,
-    /// where TabStripDrop never fired), refuses outright and the
-    /// reconcile after the commit restores the strip.
+    /// name, or a drop whose point the engine did not record, refuses
+    /// outright and the reconcile after the commit restores the strip.
     /// </summary>
     private void ResolveDropAtChip(TabViewItem dragged, int slot)
     {
@@ -1925,30 +2087,6 @@ internal sealed partial class TabHost : UserControl, ITabHost
             // no honest answer without geometry.
             return null;
         }
-    }
-
-    private void OnTabStripDragOver(object sender, DragEventArgs e)
-    {
-        // Only this strip's own tab drags are drop material: an external
-        // drag has no reorder to land and must stay declined, which an
-        // untouched accepted-operation does. The accept exists so the
-        // drop has somewhere to land -- and so TabStripDrop fires with
-        // the pointer position the drop-at-a-run fork reads.
-        if (!_stripDragActive) return;
-        e.AcceptedOperation = DataPackageOperation.Move;
-        e.Handled = true;
-    }
-
-    private void OnTabStripDrop(object sender, DragEventArgs e)
-    {
-        // Record, nothing else. The commit belongs to OnTabDragCompleted
-        // -- TabView fires this first, then completes the drag -- and the
-        // strip's own reorder is already TabView's, applied in its live
-        // preview.
-        if (!_stripDragActive) return;
-        _lastDropPosition = e.GetPosition(TabViewControl);
-        _dropPositionValid = true;
-        TabDragTrace.Line($"DRAG drop point x={_lastDropPosition.X:0} y={_lastDropPosition.Y:0}");
     }
 
     // -----------------------------------------------------------------

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -3768,38 +3768,17 @@ internal sealed partial class VerticalTabStrip : UserControl
     /// Collapse-as-visibility is what creates the rows this list omits:
     /// a hidden member has no arranged center, and a NaN center would
     /// swallow every crossing past the group, so the machine speaks slots
-    /// and its crossing contract holds in their presence. The inverse
-    /// lookup is <see cref="SlotIndexOf"/>.
+    /// and its crossing contract holds in their presence. The shape and
+    /// its inverse live on the projection, which both strips read.
     /// </summary>
     private (List<TabModel> Rows, List<int> ManagerIndex) DragSlots()
-    {
-        var rows = new List<TabModel>(_manager.Tabs.Count);
-        var managerIndex = new List<int>(_manager.Tabs.Count);
-        var tabs = _manager.Tabs;
-        for (int i = 0; i < tabs.Count; i++)
-        {
-            var tab = tabs[i];
-            if (tab.Group is { } group && group.IsCollapsed
-                && !ReferenceEquals(tab, _manager.ActiveTab))
-                continue; // hidden under a collapsed header: no slot at all
-            rows.Add(tab);
-            managerIndex.Add(i);
-        }
-        return (rows, managerIndex);
-    }
+        => TabStripProjection.DragSlots(_manager);
 
     /// <summary>
     /// MANAGER -> SLOT: the inverse of DragSlots' SLOT -> MANAGER pairing.
-    /// A drag knows its row by manager position while the machine speaks
-    /// slots; indexing the list BY the manager index answers a different
-    /// row's slot -- the first row past a hidden run is out of range or a
-    /// stranger. -1 when the tab holds no slot.
     /// </summary>
     private int SlotIndexOf(List<int> managerIndex, TabModel tab)
-    {
-        var manager = _manager.IndexOf(tab);
-        return manager >= 0 ? managerIndex.IndexOf(manager) : -1;
-    }
+        => TabStripProjection.SlotIndexOf(_manager, managerIndex, tab);
 
     private (double Center, double[] Centers) MeasureRows(TabModel dragged)
     {


### PR DESCRIPTION
Horizontal drag-reorder never worked by hand: TabView's in-strip reorder raises its drag events with args.Item = null, so the Item-gated commit never ran, and the silent reconcile repair snapped every drop back. The trace oracle proved it live; this rung replaces the mechanism.

MUXC's drag machinery is switched off (CanReorderTabs/CanDragTabs false, the four OLE handlers deleted) and a capture-less engine owns the gesture: pointer hooks on the host root, 4px threshold arms, measured arranged centers feed the axis-neutral TabDragReorder machine, center-crossings commit live through _manager.Move, and the release lands selection once and settles the lift. Sub-threshold presses stay clicks; chip presses do not arm until the groups rung; stale sessions end at the next press, which still arms. Commit 1 renames the machine's Y-shaped API axis-neutral and lifts the slot translation into TabStripProjection.

SendInput probe: click survival, sub-threshold silence, and a full drag with UIA-verified order and no reconcile repair - the first automated drag-reorder in the app's history.

Size-override: 1005 countable vs the 900 gate - owner-approved; the review-mandated fix loop (real capture pin after the vacuous-pin finding, defensive lift rebind at crossings) pushed it 105 over, and the alternative split ships a two-live-drag-engines intermediate.