### PR TITLE
tabs: the chip swap owns presence, so the collapse never rebuilds

### DIFF
--- a/windows/Ghostty.Tests/Wiring/TabStripSyncWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabStripSyncWiringTests.cs
@@ -408,6 +408,86 @@ public sealed class TabStripSyncWiringTests
     }
 
     [Fact]
+    public void The_chip_swap_hides_and_restores_the_run_under_a_saved_fence()
+    {
+        var src = ShellSource.Load(TabHostSource);
+        var chips = src.Method("ReconcileChips");
+
+        // The swap owns BOTH halves of presence. A mint replaces the run's
+        // rendered members -- whose items must LEAVE TabItems -- and a
+        // retirement brings them back. Missing the hide half is the
+        // collapse-activate crash: the strip holds one more row than the
+        // projection names, the order pass refuses, and the rebuild's
+        // Clear runs re-entrantly from inside the raising
+        // SelectionChanged -- 0x8000FFFF, the family that killed three
+        // owner sessions.
+        var retire = chips.Calls("RemoveGroupChip").Single();
+        var restore = chips.Call("RestoreRunMembers");
+        var mint = chips.Calls("AddGroupChip").Single();
+        var hide = chips.Call("HideRunMembers");
+        Assert.True(
+            retire.SpanStart < restore.SpanStart
+                && mint.SpanStart < hide.SpanStart
+                && hide.SpanStart > mint.Span.End,
+            "Each swap half must carry its presence work: the retirement "
+            + "restores the run's members, the mint hides them -- a mint "
+            + "without the hide is the presence skew that forces the "
+            + "rebuild.");
+
+        // The swap runs under the selection fence, saved and restored --
+        // not disarmed. This pass runs inside RebuildStripFromManager's
+        // own fence window on the rebuild path, and a naive disarm would
+        // cut the outer window short, the RemoveGroupChip fence lesson
+        // at the pass that owns the swap.
+        var writes = chips.AssignsTo("_suppressSelectionEvent").ToList();
+        Assert.True(
+            writes.Count == 2
+                && writes[0].Right.ToString() == "true"
+                && writes[1].Right.ToString() == "outerSuppress"
+                && writes[1].Ancestors().OfType<FinallyClauseSyntax>().Any()
+                && writes[0].SpanStart < hide.SpanStart
+                && writes[1].SpanStart > hide.Span.End,
+            "The fence must arm before the swap and restore from the saved "
+            + "outer state in the finally: a naive disarm would cut "
+            + "RebuildStripFromManager's window short mid-rebuild.");
+
+        // And the halves themselves: the hide removes exactly the run's
+        // members, the restore re-adds exactly what is missing.
+        var hideBody = src.Method("HideRunMembers");
+        Assert.True(
+            hideBody.Calls("TabViewControl.TabItems.Remove").Count == 1
+                && hideBody.DescendantNodes()
+                    .OfType<InvocationExpressionSyntax>()
+                    .Any(c => c.CalleeText() == "_itemByModel.TryGetValue"),
+            "The hide removes the run's member items and nothing else.");
+        var restoreBody = src.Method("RestoreRunMembers");
+        var add = restoreBody.Call("TabViewControl.TabItems.Add");
+        Assert.True(
+            add.Ancestors().OfType<IfStatementSyntax>()
+                .Any(i => i.Condition.ToString().Contains(
+                    "!TabViewControl.TabItems.Contains(item)", StringComparison.Ordinal)),
+            "The restore re-adds a member only when the strip does not hold "
+            + "it: re-adding a rendered row duplicates it.");
+
+        // And the fade is real, not prose: the Add is followed by the
+        // swap flag's guarded FadeInAppearing -- the appear-hand the
+        // retirement armed, spent on exactly these rows. Deleted, the
+        // members snap in past the appear-hand and nothing else in the
+        // suite would know.
+        var guardedFade = restoreBody.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "_swapFadePending");
+        Assert.True(
+            guardedFade.SpanStart > add.Span.End
+                && guardedFade.Statement.DescendantNodes()
+                    .OfType<InvocationExpressionSyntax>()
+                    .Any(c => c.CalleeText() == "FadeInAppearing"),
+            "The restore's Add must be followed by the swap flag's guarded "
+            + "FadeInAppearing: the retirement armed the flag for exactly "
+            + "these rows, and a restore without the fade snaps the run in "
+            + "past the swap's appear-hand.");
+    }
+
+    [Fact]
     public void The_chip_selection_fork_expands_through_the_command_and_never_activates()
     {
         var chipArm = ChipSelectionArm(

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -618,14 +618,76 @@ internal sealed partial class TabHost : UserControl, ITabHost
             if (row is TabStripProjection.HorizontalRow.Chip { Group: { } group })
                 desired.Add(group);
 
-        foreach (var group in _chipByGroup.Keys.ToArray())
-            if (!desired.Contains(group))
-                RemoveGroupChip(group);
-        foreach (var group in desired)
-            if (!_chipByGroup.ContainsKey(group))
-                AddGroupChip(group);
+        // The swap's mutations raise SelectionChanged -- hiding the
+        // previously-active member removes the SELECTED item, and TabView
+        // re-targets its selection synchronously. Suppressed here, the
+        // raise cannot re-enter Activate and chain a second reconcile
+        // onto a strip this pass is still mid-swap on. Saved and
+        // restored, not disarmed: this pass runs inside
+        // RebuildStripFromManager's own fence window on the rebuild path,
+        // and a naive disarm there would cut the outer window short (the
+        // RemoveGroupChip fence lesson, at the pass that owns the swap).
+        var outerSuppress = _suppressSelectionEvent;
+        _suppressSelectionEvent = true;
+        try
+        {
+            foreach (var group in _chipByGroup.Keys.ToArray())
+                if (!desired.Contains(group))
+                {
+                    RemoveGroupChip(group);
+                    RestoreRunMembers(group);
+                }
+            foreach (var group in desired)
+                if (!_chipByGroup.ContainsKey(group))
+                {
+                    AddGroupChip(group);
+                    HideRunMembers(group);
+                }
+        }
+        finally
+        {
+            _suppressSelectionEvent = outerSuppress;
+        }
         foreach (var group in desired)
             RefreshChip(group);
+    }
+
+    /// <summary>
+    /// The hide half of the chip swap: a minted chip replaces the run's
+    /// rendered members, whose items leave TabItems here. Left in, the
+    /// strip holds one more row than the projection names -- presence
+    /// skew the order pass must refuse, and its rebuild runs
+    /// TabItems.Clear re-entrantly from inside the raising
+    /// SelectionChanged, the 0x8000FFFF family. The order pass owns the
+    /// last word; this pass owes it consistent presence.
+    /// </summary>
+    private void HideRunMembers(TabGroup group)
+    {
+        foreach (var member in _manager.MembersOf(group))
+        {
+            if (_itemByModel.TryGetValue(member, out var item))
+                TabViewControl.TabItems.Remove(item);
+        }
+    }
+
+    /// <summary>
+    /// The restore half: a retiring chip's members re-enter TabItems, in
+    /// manager order for now -- the order pass re-seats them. The
+    /// retirement armed the swap flag for exactly these rows, and the
+    /// restore spends it: each re-entering row fades in, the swap's
+    /// appear-hand.
+    /// </summary>
+    private void RestoreRunMembers(TabGroup group)
+    {
+        foreach (var member in _manager.MembersOf(group))
+        {
+            if (_itemByModel.TryGetValue(member, out var item)
+                && !TabViewControl.TabItems.Contains(item))
+            {
+                TabViewControl.TabItems.Add(item);
+                if (_swapFadePending) FadeInAppearing(item);
+            }
+        }
     }
 
     private void OnGroupPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -859,7 +921,20 @@ internal sealed partial class TabHost : UserControl, ITabHost
             // its refusal as the contract; here a terminal's strip must
             // not die, so rebuild from the manager.
             _log.LogReconcileFailed(ex);
-            RebuildStripFromManager();
+            // The skew is named in the log; this line is the trace half
+            // of the same fact -- the rebuild is the last resort, and a
+            // rung that lands one must be able to see it fire.
+            TabDragTrace.Line($"DIAG reconcile failed items={TabViewControl.TabItems.Count} " +
+                $"ex={ex.Message}");
+            try
+            {
+                RebuildStripFromManager();
+            }
+            catch (Exception rex)
+            {
+                TabDragTrace.Line($"DIAG rebuild threw {rex.GetType().Name}: {rex.Message}");
+                throw;
+            }
             rebuilt = true;
             TabDragTrace.Line("COMMIT reconcile rebuilt from manager");
         }


### PR DESCRIPTION
Clicking a tab to switch activation away from a collapsed group's active member killed the process - the same fatal chain as the drop crash, through a second door that needs no drag.

Root cause, from instrumented evidence: the active-member-to-chip swap never completed. ReconcileChips minted the chip but nothing removed the hidden member's item, so every activation-away from a collapsed run left a ghost row behind - presence skew by construction. The resulting refusal rebuilt the strip synchronously inside the click's own MUXC selection operation, where the items vector is locked; SelectionChanged re-entered mid-rebuild and the Clear landed the 0x8000FFFF family. (The app's crash handler deliberately leaves Handled=false - the teardown is designed.)

ReconcileChips now owns both halves of the swap: a mint hides the run's member items, a retirement restores them (re-adds only rows the strip doesn't hold). The order pass sees consistent presence, so the rebuild is structurally unreachable from the swap. The swap runs under the selection fence saved and restored, never disarmed. No swallow: a genuine skew still refuses, logs, and rebuilds.

SendInput probe: collapse then switch leaves the strip intact with the correct chip-only shape; the drag probes confirm no regression.