### PR TITLE
tabs: the vertical reconcile's presence check counts what renders

### DIFF
--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -1870,9 +1870,19 @@ internal sealed partial class VerticalTabStrip : UserControl
         // A projection-named row the strip holds no element for is skew an
         // order pass cannot repair -- counts can agree while a row is
         // missing on both sides -- so the miss flag joins the counts.
+        //
+        // The body-row expectation is `shown.Count`, the projection's own
+        // rendered-item count, and NOT tabs-minus-pinned: a chip'd run
+        // hides members on purpose, and they render no row. Expecting
+        // tabs-minus-pinned here contradicted the rebuild's own output
+        // (it removes the hidden member, dropping the count below the
+        // formula), so every pass re-detected drift and re-ran
+        // RebuildAllItems -- a dispatcher-looped rebuild that spun the UI
+        // thread and ballooned the working set. The check must describe
+        // what the rebuild produces, or the rebuild can never converge.
         if (missing
             || _pinnedRows.Count != pinCount
-            || _items.Count != _manager.Tabs.Count - pinCount
+            || _items.Count != shown.Count
             || _pinnedPanel.Children.Count != pinCount
             || NavView.MenuItems.Count != desired.Count)
         {


### PR DESCRIPTION
Collapsing a group via the palette command wedged the terminal: one UI thread spinning at full tilt, working set climbing gigabytes, no crash, no recovery - three-for-three on reproduction.

The spinning thread's captured stack named a ghost: the VERTICAL strip, hidden in horizontal mode. Its reconcile drift check still demanded the tab count minus pins - a formula from the era when every tab rendered a row. A chip'd collapse correctly removes the hidden members' rows, the count dropped below the formula, and every dispatcher pass re-detected drift and rebuilt the strip forever: dispatcher-looped, allocation-growing, UI-thread-spinning.

The drift check now compares against the projection's own rendered-item count from the same walk that builds the desired order, so the check and the rebuild describe the same output and the pass converges - one rebuild, no loop. It sits in the shared collapse receiver, so both known crash doors (the drop and the collapse-then-activate) are immune by the same principle.

SendInput probe with per-injection foreground verification: palette collapse completes cleanly; the collapse-then-activate regression guard passes; chip drag, drop-on-chip join, and the collapse paths all green.