### PR TITLE
tabs: the engine carries chips across runs and the pin boundary

### DIFF
--- a/windows/Ghostty.Tests/Tabs/TabEnginePinCrossingTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabEnginePinCrossingTests.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Ghostty.Core.Tabs;
+using Xunit;
+
+namespace Ghostty.Tests.Tabs;
+
+/// <summary>
+/// The engine's pin-boundary commit, executed against a real manager:
+/// Classify first, SetPinned to relocate the row to the boundary, Move
+/// to place it at the crossing's slot in the new zone, and the read-back
+/// that catches a clamp. Manager state only -- the visual is the
+/// engine's to rebind, and these are the states it must render.
+/// The sequences here ARE the engine's CommitTabCrossing, minus the
+/// host: if the manager sequence and the wiring ever drift apart, one
+/// of the two is lying.
+/// </summary>
+public class TabEnginePinCrossingTests
+{
+    /// <summary>A manager holding exactly <paramref name="tabs"/> tabs:
+    /// the constructor starts with one, so this adds the rest.</summary>
+    private static TabManager NewManager(int tabs)
+    {
+        var mgr = new TabManager((_) => new FakePaneHost());
+        for (var i = 1; i < tabs; i++) mgr.NewTab();
+        return mgr;
+    }
+
+    /// <summary>The engine's commit sequence for one machine crossing,
+    /// verbatim from CommitTabCrossing minus trace and visual.</summary>
+    private static (bool Committed, int ActualSlot) CommitCrossing(
+        TabManager mgr, TabModel dragged, int managerTo)
+    {
+        var from = mgr.IndexOf(dragged);
+        var zone = TabPinBoundary.Classify(
+            dragged.IsPinned, mgr.PinCount, mgr.Tabs.Count, managerTo);
+        if (zone.Op != TabPinZoneOp.None)
+        {
+            mgr.SetPinned(dragged, zone.Op == TabPinZoneOp.Pin);
+            from = mgr.IndexOf(dragged);
+            if (from < 0) return (false, -1);
+        }
+        mgr.Move(from, managerTo);
+
+        var (_, managerIndex) = TabStripProjection.DragSlots(mgr);
+        var actual = mgr.IndexOf(dragged);
+        var actualSlot = managerIndex.IndexOf(actual);
+        if (actual != managerTo || actualSlot < 0) return (false, actualSlot);
+        return (true, actualSlot);
+    }
+
+    [Fact]
+    public void An_unpinned_row_crossing_into_the_prefix_pins_and_lands()
+    {
+        var mgr = NewManager(3);
+        var head = mgr.Tabs[0];
+        var dragged = mgr.Tabs[2];
+        mgr.SetPinned(head, true);
+        // [pinned, A, B]; B crossing left past the boundary targets slot
+        // 0 -- on the pinned side of PinCount=1, so classify calls it a
+        // pin, SetPinned relocates B to the boundary, and the Move lands
+        // it at the crossing's slot.
+        var zone = TabPinBoundary.Classify(
+            dragged.IsPinned, mgr.PinCount, mgr.Tabs.Count, 0);
+        Assert.Equal(TabPinZoneOp.Pin, zone.Op);
+
+        var (committed, slot) = CommitCrossing(mgr, dragged, 0);
+
+        Assert.True(committed);
+        Assert.Equal(0, slot);
+        Assert.True(dragged.IsPinned);
+        Assert.Equal(2, mgr.PinCount);
+        Assert.Equal(new[] { dragged, head, mgr.Tabs[2] }, mgr.Tabs.ToArray());
+    }
+
+    [Fact]
+    public void A_pinned_row_crossing_out_of_the_prefix_unpins_and_lands()
+    {
+        var mgr = NewManager(3);
+        var dragged = mgr.Tabs[0];
+        mgr.SetPinned(dragged, true);
+        mgr.SetPinned(mgr.Tabs[1], true);
+        // [p0, p1, B]; p0 crossing right past the boundary targets slot 2,
+        // beyond PinCount=2 -- an unpin, the relocation to the body's
+        // first slot, and the Move carrying it the rest of the way.
+        var zone = TabPinBoundary.Classify(
+            dragged.IsPinned, mgr.PinCount, mgr.Tabs.Count, 2);
+        Assert.Equal(TabPinZoneOp.Unpin, zone.Op);
+
+        var (committed, slot) = CommitCrossing(mgr, dragged, 2);
+
+        Assert.True(committed);
+        Assert.Equal(2, slot);
+        Assert.False(dragged.IsPinned);
+        Assert.Equal(1, mgr.PinCount);
+        Assert.Equal(new[] { mgr.Tabs[0], mgr.Tabs[1], dragged }, mgr.Tabs.ToArray());
+    }
+
+    [Fact]
+    public void A_grouped_row_crossing_in_leaves_its_run_and_pins()
+    {
+        var mgr = NewManager(4);
+        var head = mgr.Tabs[0];
+        var dragged = mgr.Tabs[2];
+        mgr.SetPinned(head, true);
+        var group = new TabGroup();
+        mgr.GroupTabs(new[] { mgr.Tabs[2], mgr.Tabs[3] }, group);
+        // [pinned, A, B, C] with {B, C} grouped; B crossing into the
+        // prefix targets slot 0 -- the pinned side of PinCount=1 -- and
+        // the manager's own SetPinned contract ungroups it first: the
+        // commit lands it pinned and alone, its run left behind.
+        var zone = TabPinBoundary.Classify(
+            dragged.IsPinned, mgr.PinCount, mgr.Tabs.Count, 0);
+        Assert.Equal(TabPinZoneOp.Pin, zone.Op);
+
+        var (committed, _) = CommitCrossing(mgr, dragged, 0);
+
+        Assert.True(committed);
+        Assert.True(dragged.IsPinned);
+        Assert.Null(dragged.Group);
+        Assert.Equal(2, mgr.PinCount);
+        Assert.Equal(0, mgr.IndexOf(dragged));
+    }
+
+    [Fact]
+    public void A_same_zone_crossing_commits_as_a_plain_move()
+    {
+        var mgr = NewManager(3);
+        var head = mgr.Tabs[0];
+        var dragged = mgr.Tabs[1];
+        var other = mgr.Tabs[2];
+        mgr.SetPinned(head, true);
+        // [pinned, A, B]; A crossing right to the last slot stays inside
+        // the body zone -- a plain Move, no pin bit touched.
+        var zone = TabPinBoundary.Classify(
+            dragged.IsPinned, mgr.PinCount, mgr.Tabs.Count, 2);
+        Assert.Equal(TabPinZoneOp.None, zone.Op);
+
+        var (committed, slot) = CommitCrossing(mgr, dragged, 2);
+
+        Assert.True(committed);
+        Assert.Equal(2, slot);
+        Assert.False(dragged.IsPinned);
+        Assert.Equal(1, mgr.PinCount);
+        Assert.Equal(new[] { head, other, dragged }, mgr.Tabs.ToArray());
+    }
+
+    [Fact]
+    public void The_unit_space_never_offers_a_crossing_the_clamp_would_refuse()
+    {
+        // The chip drag's unit space is body-only: whatever the machine
+        // offers, MoveGroup's clamp window covers it, so a committed
+        // crossing lands. One crossing, executed: the lone tab crosses
+        // the chip'd run downward and the read-back agrees with the
+        // formula.
+        var mgr = NewManager(3);
+        var runHead = mgr.Tabs[0];
+        var runMate = mgr.Tabs[1];
+        var lone = mgr.Tabs[2];
+        var group = new TabGroup();
+        mgr.GroupTabs(new[] { runHead, runMate }, group);
+        mgr.Activate(runMate);
+
+        var units = TabGroupDragUnits.Build(mgr);
+        var dragged = units.Count - 1;
+        var pivot = 0;
+        var target = TabGroupDragUnits.TargetAfter(units, units[dragged], pivot);
+        mgr.MoveGroup(group, target);
+
+        var nowUnits = TabGroupDragUnits.Build(mgr);
+        var now = -1;
+        for (var i = 0; i < nowUnits.Count; i++)
+        {
+            if (ReferenceEquals(nowUnits[i].Group, group)) { now = i; break; }
+        }
+        Assert.True(now >= 0 && nowUnits[now].First == target,
+            "the read-back must agree with the formula on a body-space "
+            + "crossing: a mismatch here is the clamp the unit space promised "
+            + "never to provoke.");
+        Assert.Equal(new[] { lone, runHead, runMate }, mgr.Tabs.ToArray());
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/PinnedPanelWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/PinnedPanelWiringTests.cs
@@ -159,15 +159,19 @@ public class PinnedPanelWiringTests
         // Skew is checked against BOTH registries, plus the rows the
         // projection named but the strip holds no element for -- counts can
         // agree while a row is missing on both sides, and only the walk's
-        // miss flag sees that. Dropping any of these passes a drifted
-        // container straight into an indexer miss or a wrong order.
+        // miss flag sees that. The body-row expectation is the
+        // projection's rendered count (shown.Count), NOT tabs-minus-pinned:
+        // a chip'd run hides members on purpose, and a formula that counts
+        // them would disagree with the rebuild's own output every pass
+        // forever. Dropping any of these passes a drifted container
+        // straight into an indexer miss or a wrong order.
         var skew = reconcile.DescendantNodes().OfType<IfStatementSyntax>()
             .Single(i => i.DescendantNodes().OfType<InvocationExpressionSyntax>()
                              .Any(c => c.CalleeText() == "RebuildAllItems"));
         var condition = skew.Condition.ToString();
         Assert.Contains("missing", condition);
         Assert.Contains("_pinnedRows.Count != pinCount", condition);
-        Assert.Contains("_items.Count != _manager.Tabs.Count - pinCount", condition);
+        Assert.Contains("_items.Count != shown.Count", condition);
         Assert.Contains("_pinnedPanel.Children.Count != pinCount", condition);
         Assert.Contains("NavView.MenuItems.Count != desired.Count", condition);
 

--- a/windows/Ghostty.Tests/Wiring/TabHorizontalMotionWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabHorizontalMotionWiringTests.cs
@@ -240,7 +240,7 @@ public class TabHorizontalMotionWiringTests
     public void A_crossing_rebinds_the_lift_set_not_respringed()
     {
         var host = Host();
-        var commit = host.Method("CommitHorizontalCrossing");
+        var commit = host.Method("CommitTabCrossing");
         var move = commit.Call("_manager.Move");
         var rebind = commit.Call("RebindLift");
         Assert.True(

--- a/windows/Ghostty.Tests/Wiring/TabStripSyncWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabStripSyncWiringTests.cs
@@ -503,27 +503,70 @@ public sealed class TabStripSyncWiringTests
     }
 
     [Fact]
-    public void A_chip_press_never_arms_the_engine()
+    public void A_chip_press_arms_the_unit_space_machine()
     {
         var pressed = ShellSource.Load(TabHostSource).Method("OnStripPointerPressed");
+        var armChip = ShellSource.Load(TabHostSource).Method("ArmChipDrag");
 
-        // A chip drags its whole run, and the run's commit is the group
-        // rung's grammar -- not a Move this engine may guess at. The chip
-        // refusal sits before the identity walk and before any session
-        // is built, so a press on a chip stays exactly what it was: a
-        // click that may expand, and nothing else.
-        var chipGate = pressed.DescendantNodes().OfType<IfStatementSyntax>()
-            .First(i => i.Condition.ToString() == "item.Tag is TabGroup");
-        Assert.True(
-            chipGate.Statement is ReturnStatementSyntax { Expression: null },
-            "A chip press must fall through without arming: the engine's plain "
-            + "reorder must never relocate a run it does not understand.");
+        // A chip drags its whole run, and the arm routes the press to the
+        // unit-space machine: one slot per body run, the run the atom, so
+        // a crossing can offer a landing inside a neighbouring run that
+        // the projector could not render.
+        // The arm routes on the tag, in one expression: a chip's press
+        // goes to the unit-space arm, anything else to the plain one.
+        var route = pressed.DescendantNodes().OfType<ConditionalExpressionSyntax>()
+            .Single(c => c.Condition.ToString() == "item.Tag is TabGroup group");
+        var arm = Assert.IsType<InvocationExpressionSyntax>(route.WhenTrue);
+        Assert.Equal("ArmChipDrag", arm.CalleeText());
+        Assert.Equal("(group, item, pressX)", arm.ArgumentList.ToString());
+        Assert.Equal("ArmTabDrag",
+            Assert.IsType<InvocationExpressionSyntax>(route.WhenFalse).CalleeText());
 
-        // And nothing in the arm path builds a session for one: no chip
-        // drag may reach the machine through any other door.
-        Assert.Empty(pressed.DescendantNodes()
+        // The unit machine is TabGroupDragUnits' build, and the dragged
+        // unit is found by GROUP IDENTITY -- index arithmetic here is how
+        // a wrong-run drag hides.
+        Assert.Single(armChip.Calls("TabGroupDragUnits.Build"));
+        var identity = armChip.DescendantNodes()
             .OfType<InvocationExpressionSyntax>()
-            .Where(c => c.CalleeText() == "_manager.MoveGroup"));
+            .Single(c => c.CalleeText() == "ReferenceEquals");
+        Assert.True(
+            identity.ArgumentList.ToString() == "(units[i].Group, group)",
+            "The dragged unit must be found by group identity: positioning the "
+            + "machine on any other run drags a run the user never grabbed.");
+
+        // The pinned prefix contributes no units and MoveGroup clamps as
+        // the backstop, but the arm itself still refuses a strip it
+        // cannot measure: BuildSession answers null, the press stays a
+        // click.
+        Assert.Single(armChip.Calls("BuildSession"));
+
+        // And WHICH element a unit's center comes from: the minted chip
+        // first -- a chip'd collapse renders no member at all, so the
+        // chip is the run's visible atom and the honest center -- else
+        // the first member the strip ACTUALLY renders. Collapse does not
+        // prune the item map, so first-in-map can answer the run's
+        // detached head, whose geometry is a refusal: that is exactly
+        // the trap that dead-drove every chip drag once, and its old
+        // bytes must stay red here.
+        var rep = ShellSource.Load(TabHostSource).Method("UnitRepresentative");
+        var chipTry = rep.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Single(c => c.CalleeText() == "_chipByGroup.TryGetValue");
+        var chipGate = chipTry.Ancestors().OfType<IfStatementSyntax>()
+            .First(i => i.Condition.ToString().StartsWith(
+                "_chipByGroup.TryGetValue", StringComparison.Ordinal));
+        var memberLoop = rep.DescendantNodes().OfType<ForEachStatementSyntax>()
+            .Single(f => f.Expression.ToString() == "_manager.MembersOf(group)");
+        var rendered = memberLoop.Statement.DescendantNodes()
+            .OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString().Contains(
+                "TabViewControl.TabItems.IndexOf(item) >= 0", StringComparison.Ordinal));
+        Assert.True(
+            chipGate.SpanStart < memberLoop.SpanStart,
+            "The chip must speak before the member walk: under a chip'd "
+            + "collapse the first map entry is a detached head, and measuring "
+            + "it refuses every chip drag at the arm.");
+        Assert.Contains("TabViewControl.TabItems.IndexOf(item) >= 0",
+            rendered.Condition.ToString(), StringComparison.Ordinal);
     }
 
     [Fact]
@@ -575,37 +618,148 @@ public sealed class TabStripSyncWiringTests
     }
 
     [Fact]
-    public void A_crossing_commits_through_the_projection_and_rewinds_at_chip_slots()
+    public void A_crossing_dispatches_and_refusals_stop_the_tick()
     {
         var commit = ShellSource.Load(TabHostSource).Method("CommitHorizontalCrossing");
+        var moved = ShellSource.Load(TabHostSource).Method("OnStripPointerMoved");
 
-        // The machine speaks slots; the manager speaks model indices.
-        // The translation is the projection's, taken fresh per crossing
-        // because every prior commit reordered the manager the machine
-        // cannot see.
-        Assert.Single(commit.Calls("TabStripProjection.DragSlots"));
+        // The dispatcher is identity-only: a session carries exactly one
+        // of tab or group, and each kind owns its own commit. Both arms
+        // answer a bool, and the moved loop stops on false -- a refused
+        // crossing rewound the machine, so the same center would re-earn
+        // the same refusal forever if the tick kept asking.
+        Assert.Contains("CommitTabCrossing(drag, crossing)",
+            commit.ExpressionBody?.Expression.ToString(), StringComparison.Ordinal);
+        Assert.Contains("CommitGroupCrossing(drag, group, crossing)",
+            commit.ExpressionBody?.Expression.ToString(), StringComparison.Ordinal);
+        var loop = moved.DescendantNodes().OfType<WhileStatementSyntax>().Single();
+        Assert.Contains("if (!CommitHorizontalCrossing(drag, crossing)) break;",
+            loop.Statement.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_tab_crossing_classifies_the_pin_boundary_before_the_move()
+    {
+        var commit = ShellSource.Load(TabHostSource).Method("CommitTabCrossing");
+
+        // The boundary is classified FIRST, against the projection's
+        // manager target: a crossing over the pinned prefix is a zone
+        // change Move alone would clamp away, so SetPinned relocates the
+        // row to the boundary and the Move then places it at the
+        // crossing's slot in the new zone.
+        var classify = commit.Call("TabPinBoundary.Classify");
+        Assert.True(
+            classify.Arg(0) == "drag.Tab!.IsPinned"
+                && classify.Arg(1) == "_manager.PinCount"
+                && classify.Arg(2) == "_manager.Tabs.Count"
+                && classify.Arg(3) == "managerTo",
+            "The boundary must be classified from the machine's manager target: "
+            + "classifying from the strip slot, or after the move, pins the "
+            + "wrong row or pins nothing.");
+        var setPinned = commit.Call("_manager.SetPinned");
         var move = commit.Call("_manager.Move");
-        var refusal = commit.DescendantNodes().OfType<IfStatementSyntax>()
-            .Single(i => i.Condition.ToString() == "target < 0 || old < 0 || old == target");
         Assert.True(
-            refusal.Statement is BlockSyntax arm
-                && arm.Statements.Last() is ReturnStatementSyntax { Expression: null }
-                && move.SpanStart > refusal.Span.End,
-            "The crossing's move must sit behind the projection's translation: an "
-            + "unmapped target, a lost tab, and the no-op are all refusals that "
-            + "return, not moves the strip guesses at.");
+            setPinned.SpanStart < move.SpanStart,
+            "SetPinned must precede the Move: the pin relocates the row to the "
+            + "boundary, and the move's `from` is read fresh from it.");
 
-        // A slot the projection cannot map is a chip's, and the machine's
-        // index is rewound to the crossing's origin: the next Evaluate
-        // measures from the slot the strip actually shows.
-        var rewinds = commit.Calls("drag.Machine.UpdateIndex").ToList();
+        // The truth is read back after the commit, and the two failures
+        // have two ends. A clamp -- Move no-ops at the boundary -- rewinds
+        // the machine to the slot the strip actually shows and refuses
+        // the tick. A vanished row -- the pairing no longer names it, a
+        // chord-collapse of its run, say -- CANCELS: refusing without
+        // rewinding or cancelling leaves a zombie session committing for
+        // a row the strip does not show.
+        var vanish = commit.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "actualSlot < 0");
         Assert.True(
-            rewinds.Count == 2
-                && rewinds.All(r => r.Arg(0) == "crossing.From")
-                && rewinds.All(r => r.SpanStart < move.SpanStart),
-            "Every refused crossing must rewind the machine to the crossing's "
-            + "origin before the commit returns: a stranded index would let the "
-            + "next Evaluate commit from a slot the strip never showed.");
+            vanish.Statement.DescendantNodes()
+                .OfType<InvocationExpressionSyntax>()
+                .Any(c => c.CalleeText() == "CancelHorizontalDrag")
+                && vanish.Statement.DescendantNodes().OfType<ReturnStatementSyntax>().Any(),
+            "A vanished row must cancel the drag: a refuse-without-rewind arm "
+            + "zombies the session on, committing for a row the strip does "
+            + "not show.");
+        var clamp = commit.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "actual != managerTo");
+        Assert.True(
+            clamp.Statement.DescendantNodes()
+                .OfType<InvocationExpressionSyntax>()
+                .Any(c => c.CalleeText() == "drag.Machine.UpdateIndex"),
+            "A crossing that did not land must rewind the machine to the actual "
+            + "slot and refuse: the engine owns the visual now, and a silent "
+            + "clamp would strand the row on a slot it never reached.");
+
+        // The read-back comes after the Move: it reads the post-commit
+        // pairing, the pre-commit one being stale past the displaced rows.
+        Assert.True(clamp.SpanStart > move.Span.End,
+            "The read-back must follow the move; before it, the pairing is the "
+            + "pre-commit state and the read lies.");
+    }
+
+    [Fact]
+    public void A_chip_crossing_maps_through_the_unit_formulas_and_reads_the_truth_back()
+    {
+        var commit = ShellSource.Load(TabHostSource).Method("CommitGroupCrossing");
+
+        // The crossing maps through the unit formulas and nothing else:
+        // down swaps past the pivot's whole span (After, with the dragged
+        // run's own departure subtracted), up lands before the pivot's
+        // head (Before). Slot arithmetic here is the transposition trap
+        // 5a flagged -- a strip-slot read past a chip names a member, not
+        // a run, and would split the run the projector draws as one.
+        var down = commit.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Single(c => c.CalleeText() == "TabGroupDragUnits.TargetAfter");
+        Assert.True(
+            down.ArgumentList.ToString() == "(units, units[dragged], pivot)",
+            "The downward target must come from TargetAfter with the dragged "
+            + "unit and the pivot: any other index math splits a run the "
+            + "projector renders as one.");
+        var up = commit.Call("TabGroupDragUnits.TargetBefore");
+        Assert.Equal("(units, pivot)", up.ArgumentList.ToString());
+        var direction = commit.Body!.DescendantNodes()
+            .OfType<VariableDeclaratorSyntax>()
+            .Single(v => v.Identifier.ValueText == "down");
+        Assert.Equal("pivot > dragged", direction.Initializer!.Value.ToString());
+        var chosen = commit.DescendantNodes().OfType<ConditionalExpressionSyntax>()
+            .Single(c => c.Condition.ToString() == "down");
+        Assert.True(
+            chosen.WhenTrue.ToString().EndsWith("TargetAfter(units, units[dragged], pivot)",
+                StringComparison.Ordinal)
+            && chosen.WhenFalse.ToString().EndsWith("TargetBefore(units, pivot)",
+                StringComparison.Ordinal),
+            "Direction decides the formula: After for a downward crossing, "
+            + "Before for an upward one -- swapped, every drag lands one run "
+            + "short.");
+
+        // MoveGroup clamps, so the truth is read back against a fresh
+        // unit build: a crossing that did not land rewinds the machine to
+        // the run's actual unit and refuses the tick.
+        var groupCommit = commit.Call("_manager.MoveGroup");
+        var groupVanish = commit.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "now < 0");
+        Assert.True(
+            groupVanish.SpanStart > groupCommit.Span.End
+                && groupVanish.Statement.DescendantNodes()
+                    .OfType<InvocationExpressionSyntax>()
+                    .Any(c => c.CalleeText() == "CancelHorizontalDrag"),
+            "A run that left the unit space mid-drag must cancel the drag, the "
+            + "same zombie rule the tab path follows.");
+        var readBack = commit.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "nowUnits[now].First != target");
+        Assert.True(
+            readBack.SpanStart > groupCommit.Span.End
+                && readBack.Statement.DescendantNodes()
+                    .OfType<InvocationExpressionSyntax>()
+                    .Any(c => c.CalleeText() == "drag.Machine.UpdateIndex"),
+            "The read-back must follow MoveGroup and rewind on a clamp: the "
+            + "formula's promise is checked against the manager's answer, "
+            + "never assumed.");
+
+        // The commit is MoveGroup's, never a member Move: a Move here
+        // would relocate one member out of the run the chip is carrying.
+        Assert.Empty(commit.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(c => c.CalleeText() == "_manager.Move"));
     }
 
     [Fact]

--- a/windows/Ghostty.Tests/Wiring/TabStripSyncWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabStripSyncWiringTests.cs
@@ -1213,4 +1213,34 @@ public sealed class TabStripSyncWiringTests
             .Any(a => a.Left is IdentifierNameSyntax id
                       && id.Identifier.ValueText == field
                       && a.Right.IsKind(literal));
+
+    [Fact]
+    public void The_body_session_carries_its_tab_and_the_fork_resolves_the_chips_slot()
+    {
+        var src = ShellSource.Load(TabHostSource);
+
+        // The body session must CARRY the dragged tab: a null tab survives
+        // the arm, then the first crossing dies on
+        // _manager.IndexOf(null) -- a NullReferenceException mid-gesture,
+        // mid-strip, with the pointer still down.
+        var armTab = src.Method("ArmTabDrag");
+        var build = armTab.Call("BuildSession");
+        Assert.Equal("dragged", build.Arg(0));
+
+        // And a release that lands on a chip resolves THAT chip's slot
+        // for the join fork: the dragged tab's own slot is an item slot by
+        // definition, so feeding it to the projector refuses every join
+        // before geometry is ever asked.
+        var finish = src.Method("FinishHorizontalDrag");
+        var chipSlot = finish.Body!.DescendantNodes()
+            .OfType<VariableDeclaratorSyntax>()
+            .Single(v => v.Identifier.ValueText == "chipSlot");
+        var fork = finish.Calls("ResolveDropAtChip").Single();
+        Assert.True(
+            chipSlot.SpanStart < fork.SpanStart
+                && fork.Arg(1) == "chipSlot",
+            "The join fork must resolve the released-on chip's slot: the "
+            + "dragged tab's own slot never names a group, so the fork "
+            + "refused every join before geometry was asked.");
+    }
 }

--- a/windows/Ghostty.Tests/Wiring/VerticalTabGroupDragWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/VerticalTabGroupDragWiringTests.cs
@@ -425,4 +425,23 @@ public class VerticalTabGroupDragWiringTests
             .Single(a => a.Left.ToString() == "_gapMotionHeaders[group]");
         Assert.Equal("(item, batch)", parked.Right.ToString());
     }
+
+    /// <summary>
+    /// The order pass's drift check must expect what the projection
+    /// RENDERS. The old formula (tabs minus pinned) predates chip'd
+    /// collapses: the rebuild correctly removes a hidden member's row,
+    /// dropping the count below the formula, so every pass re-detected
+    /// drift and re-ran RebuildAllItems -- a dispatcher-looped rebuild
+    /// that spun the UI thread and ballooned the working set.
+    /// </summary>
+    [Fact]
+    public void The_order_drift_check_counts_what_the_projection_renders()
+    {
+        var strip = Strip();
+        var order = strip.Method("ReconcileRowOrder");
+        var gate = order.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString().Contains("_items.Count !=", StringComparison.Ordinal));
+        Assert.Contains("_items.Count != shown.Count", gate.Condition.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("_manager.Tabs.Count - pinCount", gate.Condition.ToString(), StringComparison.Ordinal);
+    }
 }

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -1765,7 +1765,14 @@ internal sealed partial class TabHost : UserControl, ITabHost
     private sealed class HorizontalDragSession
     {
         public required TabDragReorder Machine;
-        public required TabModel Tab;
+
+        // Exactly one of the two names what the drag carries: a tab for
+        // a plain drag, a group for a chip drag. The chip's machine
+        // speaks unit space (one slot per run, TabGroupDragUnits'), the
+        // plain tab's speaks DragSlots row space.
+        public TabModel? Tab;
+        public TabGroup? Group;
+
         public required TabViewItem Item;
 
         // Press position and the dragged item's arranged center at the
@@ -1817,43 +1824,133 @@ internal sealed partial class TabHost : UserControl, ITabHost
         // never the drag's.
         if (VisualTreeHelperEx.FindAncestor<ButtonBase>(source) is not null) return;
         if (VisualTreeHelperEx.FindAncestor<TabViewItem>(source) is not { } item) return;
-        // A chip press never arms: a chip drags its whole run, and the
-        // run's commit is the group rung's, not this one's.
-        if (item.Tag is TabGroup) return;
 
+        var pressX = e.GetCurrentPoint(TabViewControl).Position.X;
+        var drag = item.Tag is TabGroup group
+            ? ArmChipDrag(group, item, pressX)
+            : ArmTabDrag(item, pressX);
+        if (drag is null) return;
+        _horizontalDrag = drag;
+    }
+
+    /// <summary>
+    /// Arm a plain tab drag: row space, the machine seeded at the tab's
+    /// slot. Centers are measured once, at the arm, and survive commits
+    /// on the machine's own invariant: rows occupy slots in manager
+    /// order, so a committed crossing leaves them describing the layout
+    /// the strip is arranging toward. They are exact only while slots
+    /// stay equal-width -- TabWidthMode="Equal" in TabHost.xaml is a
+    /// dependency of this gesture, not a styling choice. A variable-
+    /// width mode would need UpdateCenters re-fed per commit, which the
+    /// machine already supports.
+    /// </summary>
+    private HorizontalDragSession? ArmTabDrag(TabViewItem item, double pressX)
+    {
         TabModel? dragged = null;
         foreach (var (model, vi) in _itemByModel)
         {
             if (ReferenceEquals(vi, item)) { dragged = model; break; }
         }
-        if (dragged is null) return;
+        if (dragged is null) return null;
 
         var (rows, managerIndex) = TabStripProjection.DragSlots(_manager);
         var slot = TabStripProjection.SlotIndexOf(_manager, managerIndex, dragged);
-        if (slot < 0 || rows.Count < 2) return;
-        var (grabbed, centers) = MeasureSlots(rows, dragged);
-        if (double.IsNaN(grabbed)) return;
+        if (slot < 0 || rows.Count < 2) return null;
 
-        var pressX = e.GetCurrentPoint(TabViewControl).Position.X;
-        var drag = new HorizontalDragSession
+        var reps = new FrameworkElement[rows.Count];
+        for (var i = 0; i < rows.Count; i++)
         {
-            Machine = new TabDragReorder(rows.Count, slot),
-            Tab = dragged,
+            if (!_itemByModel.TryGetValue(rows[i], out var rowItem)) return null;
+            reps[i] = rowItem;
+        }
+        return BuildSession(null, null, item, pressX, reps, slot);
+    }
+
+    /// <summary>
+    /// Arm a chip drag: unit space, one machine slot per body run. The
+    /// run is the atom -- the chip can swap past a whole neighbouring
+    /// run and never land inside one, because a run landed between
+    /// another group's head and its members would split a run the
+    /// projector cannot render. The pinned prefix contributes no units
+    /// (groups cannot be pinned, and MoveGroup would clamp the crossing
+    // right back), so the unit space never offers a crossing the
+    /// commit would refuse; the clamp stays as the backstop.
+    /// </summary>
+    private HorizontalDragSession? ArmChipDrag(TabGroup group, TabViewItem chip, double pressX)
+    {
+        var units = TabGroupDragUnits.Build(_manager);
+        var dragged = -1;
+        for (var i = 0; i < units.Count; i++)
+        {
+            if (ReferenceEquals(units[i].Group, group)) { dragged = i; break; }
+        }
+        if (dragged < 0 || units.Count < 2) return null;
+
+        var reps = new FrameworkElement[units.Count];
+        for (var i = 0; i < units.Count; i++)
+        {
+            var rep = UnitRepresentative(units[i]);
+            if (rep is null) return null;
+            reps[i] = rep;
+        }
+        return BuildSession(null, group, chip, pressX, reps, dragged);
+    }
+
+    /// <summary>
+    /// The element a unit's center is measured from. The minted chip
+    /// first: a chip'd collapse renders no member at all -- collapse
+    /// does not prune the item map, so the first entry can be the
+    /// run's DETACHED head, whose geometry is a refusal, not a center
+    /// -- and the chip is the run's visible atom, the honest center.
+    /// Else the first member the strip actually renders: an expanded
+    /// run, or a collapsed one still holding the active member.
+    /// </summary>
+    private FrameworkElement? UnitRepresentative(GroupDragUnit unit)
+    {
+        if (unit.Group is { } group)
+        {
+            if (_chipByGroup.TryGetValue(group, out var chip)) return chip.Item;
+            foreach (var member in _manager.MembersOf(group))
+            {
+                if (_itemByModel.TryGetValue(member, out var item)
+                    && TabViewControl.TabItems.IndexOf(item) >= 0)
+                    return item;
+            }
+            return null;
+        }
+        return _itemByModel.TryGetValue(unit.Rep, out var lone) ? lone : null;
+    }
+
+    /// <summary>
+    /// The shared arm tail: measure the representative centers, seed the
+    /// machine, and build the session -- or answer null when the strip
+    /// cannot measure what the gesture needs. Measurement is the arm's
+    /// contract: a NaN center would swallow every crossing past that
+    /// slot, so an unmeasurable arm refuses the gesture and the press
+    /// stays a click.
+    /// </summary>
+    private HorizontalDragSession? BuildSession(
+        TabModel? tab, TabGroup? group, TabViewItem item, double pressX,
+        IReadOnlyList<FrameworkElement> reps, int grabSlot)
+    {
+        var centers = new double[reps.Count];
+        for (var i = 0; i < reps.Count; i++)
+        {
+            centers[i] = MeasuredCenterX(reps[i]);
+            if (double.IsNaN(centers[i])) return null;
+        }
+        var machine = new TabDragReorder(reps.Count, grabSlot);
+        machine.Press(pressX);
+        machine.UpdateCenters(centers);
+        return new HorizontalDragSession
+        {
+            Machine = machine,
+            Tab = tab,
+            Group = group,
             Item = item,
             PressX = pressX,
-            GrabCenterX = grabbed,
+            GrabCenterX = centers[grabSlot],
         };
-        drag.Machine.Press(pressX);
-        drag.Machine.UpdateCenters(centers);
-        // Centers are measured once, at the arm, and survive commits on
-        // the machine's own invariant: rows occupy slots in manager
-        // order, so a committed crossing leaves them describing the
-        // layout the strip is arranging toward. They are exact only
-        // while slots stay equal-width -- TabWidthMode="Equal" in
-        // TabHost.xaml is a dependency of this gesture, not a styling
-        // choice. A variable-width mode would need UpdateCenters re-fed
-        // per commit, which the machine already supports.
-        _horizontalDrag = drag;
     }
 
     private void OnStripPointerMoved(object sender, PointerRoutedEventArgs e)
@@ -1873,7 +1970,13 @@ internal sealed partial class TabHost : UserControl, ITabHost
         // following the machine rather than waiting for a release.
         var draggedCenter = drag.GrabCenterX + (x - drag.PressX);
         while (drag.Machine.Evaluate(draggedCenter) is { } crossing)
-            CommitHorizontalCrossing(drag, crossing);
+        {
+            // A refused crossing rewinds the machine to where the strip
+            // really shows the dragged row; the same center would re-earn
+            // the same refusal forever, so the tick stops there -- the
+            // next pointer move retries with fresh geometry.
+            if (!CommitHorizontalCrossing(drag, crossing)) break;
+        }
     }
 
     private void OnStripPointerReleased(object sender, PointerRoutedEventArgs e)
@@ -1907,7 +2010,7 @@ internal sealed partial class TabHost : UserControl, ITabHost
     private void BeginHorizontalDragVisual(HorizontalDragSession drag)
     {
         TabDragTrace.Line($"DRAG begin index={drag.Machine.Index} " +
-            $"rows={drag.Machine.RowCount} run=no motion=" +
+            $"rows={drag.Machine.RowCount} run={(drag.Group is null ? "no" : "yes")} motion=" +
             (TabStripMotion.Enabled(SystemAnimationsEnabled(), _highContrast) ? "on" : "off"));
         _stripDragActive = true;
         _stoodDownSelectionRaises = 0;
@@ -1933,26 +2036,142 @@ internal sealed partial class TabHost : UserControl, ITabHost
     /// index is rewound: crossing a chip is the group rung's grammar,
     /// not a move this rung may guess at.
     /// </summary>
-    private void CommitHorizontalCrossing(HorizontalDragSession drag, TabDragCrossing crossing)
+    /// <summary>
+    /// One committed crossing. Answers false when the crossing refused --
+    /// the manager would not take it, or the read-back caught a clamp --
+    /// so the tick stops instead of re-earning the same refusal.
+    /// </summary>
+    private bool CommitHorizontalCrossing(HorizontalDragSession drag, TabDragCrossing crossing)
+        => drag.Group is { } group
+            ? CommitGroupCrossing(drag, group, crossing)
+            : CommitTabCrossing(drag, crossing);
+
+    /// <summary>
+    /// A plain tab's crossing: the machine's row slot translated through
+    /// the projection, the pin boundary classified FIRST -- a crossing
+    /// over the prefix is a zone change Move alone would clamp away, so
+    /// SetPinned relocates the row to the boundary and the Move then
+    /// places it at the crossing's slot in the new zone -- and the truth
+    /// read back, because Move clamps at the boundary and no-ops on
+    /// collapse. A crossing that did not land rewinds the machine to the
+    /// slot the strip actually shows the row in and refuses the tick.
+    /// </summary>
+    private bool CommitTabCrossing(HorizontalDragSession drag, TabDragCrossing crossing)
     {
-        var (rows, _) = TabStripProjection.DragSlots(_manager);
-        if (crossing.To < 0 || crossing.To >= rows.Count)
+        var (rows, managerIndex) = TabStripProjection.DragSlots(_manager);
+        if (crossing.To < 0 || crossing.To >= managerIndex.Count)
         {
             drag.Machine.UpdateIndex(crossing.From);
-            return;
+            return false;
         }
-        var target = _manager.IndexOf(rows[crossing.To]);
-        var old = _manager.IndexOf(drag.Tab);
-        if (target < 0 || old < 0 || old == target)
+        var managerTo = managerIndex[crossing.To];
+        var from = _manager.IndexOf(drag.Tab!);
+        var zone = TabPinBoundary.Classify(
+            drag.Tab!.IsPinned, _manager.PinCount, _manager.Tabs.Count, managerTo);
+        if (zone.Op != TabPinZoneOp.None)
         {
-            drag.Machine.UpdateIndex(crossing.From);
-            TabDragTrace.Line($"DRAG refused {crossing.From}->{crossing.To}");
-            return;
+            bool pin = zone.Op == TabPinZoneOp.Pin;
+            // Groups cannot be pinned: a grouped row crossing the
+            // boundary leaves its run, the manager's own SetPinned
+            // contract. The commit speaks the truth the projection will
+            // render, never a tab dragged through the boundary still
+            // pretending to belong to a run.
+            _manager.SetPinned(drag.Tab, pin);
+            TabDragTrace.Line($"DRAG {(pin ? "pin" : "unpin")} {crossing.From}->{crossing.To}");
+            from = _manager.IndexOf(drag.Tab);
+            if (from < 0) { CancelHorizontalDrag("closed"); return false; }
         }
         TabDragTrace.Line($"DRAG commit {crossing.From}->{crossing.To}");
-        TabDragTrace.Line($"COMMIT move old={old} new={target}");
-        _manager.Move(old, target);
+        TabDragTrace.Line($"COMMIT move old={from} new={managerTo}");
+        _manager.Move(from, managerTo);
+
+        // Read the truth back: the pairing is re-walked post-commit, the
+        // move having displaced other rows.
+        var (_, nowIndex) = TabStripProjection.DragSlots(_manager);
+        var actual = _manager.IndexOf(drag.Tab);
+        var actualSlot = nowIndex.IndexOf(actual);
+        if (actualSlot < 0)
+        {
+            // The row left the pairing mid-drag -- a chord-collapse of
+            // its run, say. The drag's subject is gone; committing
+            // further crossings for a row the strip does not show would
+            // zombie the gesture on.
+            CancelHorizontalDrag("closed");
+            return false;
+        }
+        if (actual != managerTo)
+        {
+            // Clamped, not vanished: rewind to the slot the strip
+            // actually shows and refuse the tick.
+            drag.Machine.UpdateIndex(actualSlot);
+            TabDragTrace.Line($"DRAG refused {crossing.From}->{crossing.To}");
+            return false;
+        }
+        drag.Machine.UpdateIndex(actualSlot);
         RebindLift(drag.Item);
+        return true;
+    }
+
+    /// <summary>
+    /// A chip's crossing in unit space: the crossing's pivot run maps
+    /// through the unit formulas -- the only crossing-to-index mapping
+    /// this commit accepts, because a run landed by slot arithmetic
+    /// would split the pivot run across its own head. MoveGroup clamps,
+    /// so the truth is read back against a fresh unit build: a crossing
+    /// that did not land rewinds the machine to the run's actual unit
+    /// and refuses the tick. The group stays collapsed through the drag
+    /// -- MoveGroup relocates a run and touches no collapse bit -- which
+    /// is the contract: a chip drag is a relocation, never an
+    /// expansion.
+    /// </summary>
+    private bool CommitGroupCrossing(
+        HorizontalDragSession drag, TabGroup group, TabDragCrossing crossing)
+    {
+        var units = TabGroupDragUnits.Build(_manager);
+        var dragged = -1;
+        for (var i = 0; i < units.Count; i++)
+        {
+            if (ReferenceEquals(units[i].Group, group)) { dragged = i; break; }
+        }
+        var pivot = crossing.To;
+        if (dragged < 0 || pivot < 0 || pivot >= units.Count || pivot == dragged)
+        {
+            drag.Machine.UpdateIndex(crossing.From);
+            return false;
+        }
+        bool down = pivot > dragged;
+        var target = down
+            ? TabGroupDragUnits.TargetAfter(units, units[dragged], pivot)
+            : TabGroupDragUnits.TargetBefore(units, pivot);
+        TabDragTrace.Line($"DRAG commit {crossing.From}->{crossing.To}");
+        TabDragTrace.Line($"COMMIT movegroup target={target}");
+        _manager.MoveGroup(group, target);
+
+        var nowUnits = TabGroupDragUnits.Build(_manager);
+        var now = -1;
+        for (var i = 0; i < nowUnits.Count; i++)
+        {
+            if (ReferenceEquals(nowUnits[i].Group, group)) { now = i; break; }
+        }
+        if (now < 0)
+        {
+            // The run left the unit space mid-drag -- dissolved or
+            // regrouped by another actor. Same zombie rule as the tab
+            // path: the subject is gone, so the gesture ends.
+            CancelHorizontalDrag("closed");
+            return false;
+        }
+        if (nowUnits[now].First != target)
+        {
+            // Clamped, not vanished: rewind to the run's actual unit and
+            // refuse the tick.
+            drag.Machine.UpdateIndex(now);
+            TabDragTrace.Line($"DRAG refused {crossing.From}->{crossing.To}");
+            return false;
+        }
+        drag.Machine.UpdateIndex(now);
+        RebindLift(drag.Item);
+        return true;
     }
 
     /// <summary>
@@ -2055,29 +2274,24 @@ internal sealed partial class TabHost : UserControl, ITabHost
     /// arm rather than feeding the machine a NaN that would swallow every
     /// crossing past that slot.
     /// </summary>
-    private (double Grabbed, double[] Centers) MeasureSlots(
-        IReadOnlyList<TabModel> rows, TabModel dragged)
+    /// <summary>
+    /// A row's arranged center in TabViewControl space, or NaN when there
+    /// is no arranged truth: the item is not in the tree yet, or is
+    /// leaving it. The arm refuses on NaN -- an unmeasured slot would
+    /// swallow every crossing past it.
+    /// </summary>
+    private double MeasuredCenterX(FrameworkElement item)
     {
-        var centers = new double[rows.Count];
-        double grabbed = double.NaN;
-        for (var i = 0; i < rows.Count; i++)
+        try
         {
-            if (!_itemByModel.TryGetValue(rows[i], out var item)) return (double.NaN, centers);
-            double x;
-            try
-            {
-                x = item.TransformToVisual(TabViewControl)
-                    .TransformPoint(new Point(0, 0)).X + item.ActualWidth / 2;
-            }
-            catch (Exception ex) when (ex is ArgumentException or InvalidOperationException
-                or System.Runtime.InteropServices.COMException or NullReferenceException)
-            {
-                return (double.NaN, centers);
-            }
-            centers[i] = x;
-            if (ReferenceEquals(rows[i], dragged)) grabbed = x;
+            return item.TransformToVisual(TabViewControl)
+                .TransformPoint(new Point(0, 0)).X + item.ActualWidth / 2;
         }
-        return (grabbed, centers);
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException
+            or System.Runtime.InteropServices.COMException or NullReferenceException)
+        {
+            return double.NaN;
+        }
     }
 
     /// <summary>

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -1863,7 +1863,7 @@ internal sealed partial class TabHost : UserControl, ITabHost
             if (!_itemByModel.TryGetValue(rows[i], out var rowItem)) return null;
             reps[i] = rowItem;
         }
-        return BuildSession(null, null, item, pressX, reps, slot);
+        return BuildSession(dragged, null, item, pressX, reps, slot);
     }
 
     /// <summary>
@@ -2229,9 +2229,13 @@ internal sealed partial class TabHost : UserControl, ITabHost
         if (VisualTreeHelperEx.FindAncestor<TabViewItem>(e.OriginalSource as DependencyObject)
             is { } releasedOn && releasedOn.Tag is TabGroup)
         {
-            var slot = TabViewControl.TabItems.IndexOf(drag.Item);
-            TabDragTrace.Line($"COMMIT drop at chip slot={slot}");
-            ResolveDropAtChip(drag.Item, slot);
+            // The fork resolves the run whose CHIP the release landed on:
+            // the dragged tab's own slot is an item slot by definition, so
+            // feeding it to the projector names no group and refuses every
+            // join before geometry is ever asked.
+            var chipSlot = TabViewControl.TabItems.IndexOf(releasedOn);
+            TabDragTrace.Line($"COMMIT drop at chip slot={chipSlot}");
+            ResolveDropAtChip(drag.Item, chipSlot);
         }
         _stripDragActive = false;
         // The drag is over: the cut demand lifts, and hover may show the
@@ -2337,6 +2341,12 @@ internal sealed partial class TabHost : UserControl, ITabHost
         }
 
         var before = _lastDropPosition.X < bounds.Value.X + bounds.Value.Width / 2;
+        // Dead-today insurance: under TabWidthMode="Equal" the chip's arranged
+        // bounds span its entire slot, so a release that hit-tests to the chip
+        // is always inside bounds and the join above always wins. Beside is
+        // live only under a variable-width mode or a tighter bounds source;
+        // the fork stays because it is manager-state-tested and one XAML
+        // attribute away from reachable.
         var beside = before
             ? TabChipDrop.MemberTargetBefore(_manager, chipGroup)
             : TabChipDrop.MemberTargetAfter(_manager, chipGroup);


### PR DESCRIPTION
Third engine rung: groups, chips, and the pin boundary join the capture-less drag engine.

Chip presses arm the machine in run-unit space (one slot per body run via the group-drag units), the dragged unit is found by group identity rather than index arithmetic, and crossings commit MoveGroup with the collapse bit preserved - Chrome's contract, the group stays collapsed while dragged. Pin-boundary crossings classify before the move: SetPinned relocates to the boundary and the move places at the crossing's slot in the new zone, never append-last. Drop-on-chip join is live for the first time - under the old MUXC machinery the drop event never fired in-engine - with drop-beside kept as documented insurance (under Equal widths the chip's bounds span its slot, so a chip release always joins; beside is one mode change from reachable).

The probe legs that verified this rung also closed two of its own defects before review saw them: the drag session was carrying a null tab (every body-drag crossing died mid-gesture) and the join fork resolved the dragged tab's own slot, refusing every join. Both fixed with facts and mutations; the vanished-row read-backs now cancel instead of stranding a zombie drag.

SendInput probe with per-injection foreground verification: palette collapse, collapse-then-activate, chip drag, drop-on-chip join, and the pin crossings all green.