### PR TITLE
tabs: the vertical pin returns by release, and the crossing arm pins only

### DIFF
--- a/windows/Ghostty.Tests/Tabs/TabEnginePinCrossingTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabEnginePinCrossingTests.cs
@@ -180,4 +180,44 @@ public class TabEnginePinCrossingTests
             + "never to provoke.");
         Assert.Equal(new[] { lone, runHead, runMate }, mgr.Tabs.ToArray());
     }
+
+    /// <summary>
+    /// The vertical engine's pin-boundary ROUND TRIP, release-classified:
+    /// the mid-drag crossing into the zone pins (the classify fires Pin,
+    /// the row relocates to the prefix, the commit places it at the zone
+    /// head); the RELEASE then decides by position -- out of the zone
+    /// unpins and places at the body slot under the release point; in the
+    /// zone keeps the pin. The boundary-out leg's contract: the drag ends
+    /// UNPINNED at the row's pre-leg home, never stranded in the prefix.
+    /// </summary>
+    [Fact]
+    public void The_pin_round_trip_unpins_when_the_release_leaves_the_zone()
+    {
+        var mgr = NewManager(4);
+        mgr.SetPinned(mgr.Tabs[0], true);
+        var dragged = mgr.Tabs[2];
+
+        // The mid-drag pin crossing: SetPinned relocates the row into the
+        // prefix; the commit places it at the zone head.
+        mgr.SetPinned(dragged, true);
+        mgr.Move(mgr.IndexOf(dragged), 0);
+        Assert.True(dragged.IsPinned);
+        Assert.Equal(0, mgr.IndexOf(dragged));
+
+        // RELEASE-OUT: the release point left the zone. Unpin relocates
+        // the row to the first body slot; the placement Move carries it
+        // home (the slot it occupied before the leg).
+        mgr.SetPinned(dragged, false);
+        var home = mgr.IndexOf(dragged);
+        mgr.Move(home, 2);
+
+        Assert.False(dragged.IsPinned);
+        Assert.Equal(2, mgr.IndexOf(dragged));
+        Assert.Equal(new[] { mgr.Tabs[0], mgr.Tabs[1], dragged, mgr.Tabs[3] }, mgr.Tabs.ToArray());
+
+        // RELEASE-IN: the release point stays over the shelf/zone -- the
+        // row keeps the pin (the in-zone landing needs no relocation).
+        mgr.SetPinned(dragged, true);
+        Assert.True(dragged.IsPinned);
+    }
 }

--- a/windows/Ghostty.Tests/Wiring/TabPinZoneWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabPinZoneWiringTests.cs
@@ -25,12 +25,15 @@ public class TabPinZoneWiringTests
     private static ShellSource Strip() => ShellSource.Load("Tabs.VerticalTabStrip.xaml.cs");
 
     /// <summary>
-    /// The commit classifies the crossing first, pins (or unpins) before
-    /// it moves, and re-reads the row's index in between: SetPinned
-    /// relocates the row, so a Move fired with the pre-pin index would
-    /// land the row a slot off -- or get clamped into the zone it just
-    /// left, which the refused-crossing break then turns into a dropped
-    /// crossing for the rest of the gesture.
+    /// The commit classifies the crossing first, pins before it moves,
+    /// and re-reads the row's index in between: SetPinned relocates the
+    /// row, so a Move fired with the pre-pin index would land the row a
+    /// slot off -- or get clamped into the zone it just left, which the
+    /// refused-crossing break then turns into a dropped crossing for the
+    /// rest of the gesture. The arm PINS only: an Unpin classification
+    /// mid-drag rewinds and refuses (the drag wiring fact pins that
+    /// refusal), so the only flag this commit can pass is the literal
+    /// true.
     /// </summary>
     [Fact]
     public void ZoneCrossing_CommitsAsSetPinnedThenMove_WithTheIndexReRead()
@@ -52,16 +55,11 @@ public class TabPinZoneWiringTests
                         && call.Span.End < move.Span.Start),
             "the row's index must be re-read between SetPinned and Move");
 
-        // The flag's polarity is the crossing's direction. The argument
-        // alone is only a variable name, so the initializer is what
-        // actually goes red when the comparison inverts -- SetPinned(false)
-        // on a crossing up would unpin the row mid-gesture.
-        Assert.Equal("pin", setPinned.Arg(1));
-        var flag = commit.DescendantNodes().OfType<LocalDeclarationStatementSyntax>()
-            .Single(l => l.Declaration.Variables.Any(v => v.Identifier.ValueText == "pin"));
-        Assert.Equal(
-            "zone.Op == TabPinZoneOp.Pin",
-            flag.Declaration.Variables.Single().Initializer!.Value.ToString());
+        // The arm pins, literally. An argument that still names a computed
+        // pin boolean would mean the gate widened back to "any zone
+        // change" -- the shape that obeyed a mid-drag Unpin off stale
+        // centers. The gate text itself is the drag wiring fact's pin.
+        Assert.Equal("true", setPinned.Arg(1));
 
         // The zone commit repaints the boundary in the same tick: the
         // stroke is the gesture's aiming feedback and it just moved.

--- a/windows/Ghostty.Tests/Wiring/VerticalTabGroupDragWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/VerticalTabGroupDragWiringTests.cs
@@ -595,5 +595,16 @@ public class VerticalTabGroupDragWiringTests
             polarityGate.SpanStart < unpin.SpanStart,
             "the unpin must sit inside the !inZone gate: the polarity is the "
             + "fix -- hoisted out it always unpins, inverted it never does.");
+
+        // The inZone initializer is the second prong: the ancestors-pin
+        // cannot catch a VALUE-level flip (swapping >=/<= inside inZone's
+        // initializer still passes everything). The initializer must
+        // compare releaseY against BOTH shelf bounds.
+        Assert.Contains("releaseY >= shelfTop && releaseY <= shelfBottom",
+            arm.DescendantNodes()
+               .OfType<VariableDeclaratorSyntax>()
+               .Single(v => v.Identifier.ValueText == "inZone")
+               .Initializer!.Value.ToFullString(),
+            StringComparison.Ordinal);
     }
 }

--- a/windows/Ghostty.Tests/Wiring/VerticalTabGroupDragWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/VerticalTabGroupDragWiringTests.cs
@@ -552,8 +552,10 @@ public class VerticalTabGroupDragWiringTests
     /// pinned (the in-zone landing). Released outside: unpin and place
     /// at the body slot under the release point. The position is fresh
     /// pointer truth -- never machine centers, whose staleness after a
-    /// pin is the trap this replaces. No mid-drag unpin crossing exists:
-    /// there is no center threshold to fall short of.
+    /// pin is the trap this replaces. The mid-drag crossing arm PINS only:
+    /// an Unpin classification there rewinds and refuses, so the one-
+    /// grammar contract (pin-in by crossing, out by release) is true in
+    /// bytes.
     /// </summary>
     [Fact]
     public void Pin_out_is_release_classified()
@@ -578,5 +580,20 @@ public class VerticalTabGroupDragWiringTests
         // The out-of-zone arm unpins and places -- never a bare keep.
         Assert.Contains("SetPinned(drag.Tab, false);", arm.ToFullString(),
             StringComparison.Ordinal);
+
+        // POLARITY: the SetPinned(false) invocation sits INSIDE the
+        // !inZone gate -- the unpin fires only when the release point is
+        // provably outside the shelf bounds. Hoisted out (always-unpin)
+        // or inverted (unpin only when in-zone), both go red here. The
+        // mutation record must be verified in the same run as the claim.
+        var unpin = arm.DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .Single(c => c.CalleeText() == "_manager.SetPinned");
+        var polarityGate = unpin.Ancestors().OfType<IfStatementSyntax>()
+            .First(a => a.Condition.ToString() == "!inZone");
+        Assert.True(
+            polarityGate.SpanStart < unpin.SpanStart,
+            "the unpin must sit inside the !inZone gate: the polarity is the "
+            + "fix -- hoisted out it always unpins, inverted it never does.");
     }
 }

--- a/windows/Ghostty.Tests/Wiring/VerticalTabGroupDragWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/VerticalTabGroupDragWiringTests.cs
@@ -545,4 +545,38 @@ public class VerticalTabGroupDragWiringTests
             + "frame can be MUXC's own container realization.");
         Assert.Equal("RebuildAllItems", retry.Arg(1));
     }
+
+    /// <summary>
+    /// PIN-OUT is RELEASE-CLASSIFIED: a row the drag pinned mid-gesture
+    /// ends where the user let go. Released over the shelf/zone: stay
+    /// pinned (the in-zone landing). Released outside: unpin and place
+    /// at the body slot under the release point. The position is fresh
+    /// pointer truth -- never machine centers, whose staleness after a
+    /// pin is the trap this replaces. No mid-drag unpin crossing exists:
+    /// there is no center threshold to fall short of.
+    /// </summary>
+    [Fact]
+    public void Pin_out_is_release_classified()
+    {
+        var released = Strip().Method("OnDragPointerReleased");
+        var gate = released.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "drag.Tab.IsPinned");
+        var arm = Assert.IsType<BlockSyntax>(gate.Statement);
+
+        // The branch reads fresh pointer truth and the shelf bounds: the
+        // release Y against the pinned panel, the body slot under the
+        // point from the strip's own pairing.
+        Assert.Contains(arm.DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .Where(c => c.CalleeText().EndsWith("GetCurrentPoint", StringComparison.Ordinal)).ToList(),
+            c => true);
+        Assert.Contains(arm.DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .Where(c => c.CalleeText() == "BodySlotAtY").ToList(),
+            c => true);
+
+        // The out-of-zone arm unpins and places -- never a bare keep.
+        Assert.Contains("SetPinned(drag.Tab, false);", arm.ToFullString(),
+            StringComparison.Ordinal);
+    }
 }

--- a/windows/Ghostty.Tests/Wiring/VerticalTabGroupDragWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/VerticalTabGroupDragWiringTests.cs
@@ -606,5 +606,22 @@ public class VerticalTabGroupDragWiringTests
                .Single(v => v.Identifier.ValueText == "inZone")
                .Initializer!.Value.ToFullString(),
             StringComparison.Ordinal);
+
+        // The mid-drag crossing arm PINS only: the gate is the Pin
+        // classification, and the Unpin classification hangs off it as an
+        // else that rewinds the machine to the row's still-true slot and
+        // refuses the crossing. Release classification owns the out, so
+        // no unpin may fire mid-drag.
+        var evaluated = Strip().Method("EvaluateDrag");
+        var crossingGate = evaluated.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "zone.Op == TabPinZoneOp.Pin");
+        var refuse = Assert.IsType<IfStatementSyntax>(crossingGate.Else!.Statement);
+        Assert.Equal("zone.Op == TabPinZoneOp.Unpin", refuse.Condition.ToString());
+        Assert.Contains(refuse.Statement.DescendantNodes().OfType<BreakStatementSyntax>().ToList(),
+            b => true);
+        Assert.Contains("drag.Machine.UpdateIndex(crossing.From);",
+            refuse.Statement.ToFullString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("SetPinned(drag.Tab, false)", crossingGate.ToFullString(),
+            StringComparison.Ordinal);
     }
 }

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -2387,6 +2387,50 @@ internal sealed partial class VerticalTabStrip : UserControl
                 ActivateFromShelf(drag.Tab);
             return;
         }
+        // PIN-OUT (release-classified): a row the drag pinned mid-gesture
+        // ends where the user LET GO -- the same signal the horizontal
+        // engine honors. Released over the shelf/zone: stay pinned (the
+        // 4b-2 in-zone landing; the mid-drag crossings already placed the
+        // row). Released out in the body: unpin and place at the body
+        // slot under the release point. The position is fresh pointer
+        // truth -- never machine centers, whose staleness after a pin is
+        // the trap this replaces.
+        if (drag.Tab.IsPinned)
+        {
+            var releaseY = e.GetCurrentPoint(this).Position.Y;
+            double shelfTop = double.NaN, shelfBottom = double.NaN;
+            try
+            {
+                var origin = _pinnedPanel.TransformToVisual(this)
+                    .TransformPoint(new Windows.Foundation.Point(0, 0));
+                shelfTop = origin.Y;
+                shelfBottom = origin.Y + _pinnedPanel.ActualHeight;
+            }
+            catch (Exception ex) when (IsLayoutReadFailure(ex))
+            {
+                // No honest shelf bounds: keep the mid-drag state (the row
+                // stays pinned) rather than guess at the pointer.
+            }
+            var inZone = !double.IsNaN(shelfTop)
+                && releaseY >= shelfTop && releaseY <= shelfBottom;
+            if (!inZone)
+            {
+                _commitChurn = true;
+                try
+                {
+                    _manager.SetPinned(drag.Tab, false);
+                    var bodySlot = BodySlotAtY(releaseY);
+                    var from = _manager.IndexOf(drag.Tab);
+                    if (bodySlot >= 0 && from >= 0 && from != bodySlot)
+                        _manager.Move(from, bodySlot);
+                    DragTrace($"DRAG unpin drop body={bodySlot} from={from}");
+                }
+                finally { _commitChurn = false; }
+            }
+            DragTrace("DRAG pin release kept" + (inZone ? " in zone" : " -> unpinned"));
+            EndDrag(drag, settle: drag.MotionOn, velocity: 0);
+            return;
+        }
         // Drop inside the pinned zone pins (5.5). The preview is the
         // promise -- it shows only while the row is still unpinned and its
         // center is over the shelf -- so honouring it at release is the
@@ -3837,6 +3881,27 @@ internal sealed partial class VerticalTabStrip : UserControl
     /// while the row has no layout to read (the same failure family the
     /// separator and selection-row reads guard).
     /// </summary>
+    /// <summary>
+    /// The body slot whose row band contains <paramref name="y"/> -- the
+    /// row the release point is over. Above the first row: the first
+    /// slot; below the last: the last. -1 when the body has no rendered
+    /// rows (the caller keeps the mid-drag state rather than guess).
+    /// </summary>
+    private int BodySlotAtY(double y)
+    {
+        var (rows, managerIndex) = DragSlots();
+        var best = -1;
+        var bestDist = double.MaxValue;
+        for (var i = 0; i < rows.Count; i++)
+        {
+            var center = RowCenterY(rows[i]);
+            if (double.IsNaN(center)) continue;
+            var d = Math.Abs(center - y);
+            if (d < bestDist) { bestDist = d; best = managerIndex[i]; }
+        }
+        return best;
+    }
+
     private double RowCenterY(TabModel tab)
     {
         if (RowElementOf(tab) is not { } item || item.ActualHeight <= 0)

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -2408,8 +2408,12 @@ internal sealed partial class VerticalTabStrip : UserControl
             }
             catch (Exception ex) when (IsLayoutReadFailure(ex))
             {
-                // No honest shelf bounds: keep the mid-drag state (the row
-                // stays pinned) rather than guess at the pointer.
+                // No honest shelf bounds: NaN fails the IsNaN gate below,
+                // so the release is treated as OUT of the zone and the
+                // unpin arm runs. That polarity is deliberate -- unpin
+                // unless provably in-zone -- and safe to act on without
+                // the bounds, because BodySlotAtY reads the body pairing
+                // and never the shelf's layout.
             }
             var inZone = !double.IsNaN(shelfTop)
                 && releaseY >= shelfTop && releaseY <= shelfBottom;
@@ -3437,19 +3441,31 @@ internal sealed partial class VerticalTabStrip : UserControl
             // A crossing over the pin boundary is a zone change Move alone
             // would clamp away: SetPinned first relocates the row to the
             // boundary, then the Move places it at the crossing's slot in
-            // the new zone -- the drop position, not append-last.
+            // the new zone -- the drop position, not append-last. The arm
+            // PINS only: pin-out is release-classified, so a mid-drag
+            // Unpin classification is stale centers speaking, and it is
+            // refused below rather than obeyed.
             var zone = TabPinBoundary.Classify(
                 drag.Tab.IsPinned, _manager.PinCount, _manager.Tabs.Count, managerTo);
             _commitChurn = true;
             try
             {
-                if (zone.Op != TabPinZoneOp.None)
+                if (zone.Op == TabPinZoneOp.Pin)
                 {
-                    bool pin = zone.Op == TabPinZoneOp.Pin;
-                    _manager.SetPinned(drag.Tab, pin);
-                    DragTrace($"DRAG {(pin ? "pin" : "unpin")} {crossing.From}->{crossing.To}");
+                    _manager.SetPinned(drag.Tab, true);
+                    DragTrace($"DRAG pin {crossing.From}->{crossing.To}");
                     from = _manager.IndexOf(drag.Tab);
                     if (from < 0) { CancelDrag("closed"); return; }
+                }
+                else if (zone.Op == TabPinZoneOp.Unpin)
+                {
+                    // Mid-drag unpin is noise, never intent: nothing was
+                    // committed, so the row still sits at crossing.From.
+                    // Rewind the machine to it and refuse the crossing --
+                    // no SetPinned, no Move; the release arm owns the out.
+                    drag.Machine.UpdateIndex(crossing.From);
+                    DragTrace($"DRAG refused {crossing.From}->{crossing.To}");
+                    break;
                 }
                 _manager.Move(from, managerTo);
             }

--- a/windows/scripts/dump-uia-state.ps1
+++ b/windows/scripts/dump-uia-state.ps1
@@ -100,9 +100,43 @@ if ($null -ne $nav) {
     Note ("(b) root children=" + $kids.Count)
 }
 
-# Flush the window/CPU answers BEFORE the UIA walk: a hang in that walk
-# must not swallow the evidence the earlier probes already collected.
+# Flush incrementally: the (a)/(c)/(c2) answers go to disk BEFORE the UIA
+# walk, so a hang there cannot swallow them. The walk's results are
+# appended after.
 $out = if ($OutFile) { $OutFile } else { '' }
-if ($out) { [System.IO.File]::WriteAllLines($out, $lines) } else { $lines | ForEach-Object { Write-Host $_ } }
+if ($out) { [System.IO.File]::WriteAllLines($out, $lines) }
+$lines.Clear()
+
+# (b) FRESH-PROCESS UIA query: this process IS the fresh client (spawned
+# separately by the harness). Walk the window for NavView by AutomationId.
+Add-Type -AssemblyName UIAutomationClient
+Add-Type -AssemblyName UIAutomationTypes
+$root = [System.Windows.Automation.AutomationElement]::FromHandle($h)
+$cond = New-Object System.Windows.Automation.PropertyCondition(
+    [System.Windows.Automation.AutomationElement]::AutomationIdProperty, 'NavView')
+$sw2 = [System.Diagnostics.Stopwatch]::StartNew()
+$nav = $root.FindFirst([System.Windows.Automation.TreeScope]::Descendants, $cond)
+$sw2.Stop()
+if ($null -ne $nav) {
+    $r = $nav.Current.BoundingRectangle
+    $lines.Add("(b) FRESH NavView FOUND rect=" + $r.Width + "x" + $r.Height +
+        " walk=" + $sw2.ElapsedMilliseconds + "ms")
+    $items = $nav.FindAll([System.Windows.Automation.TreeScope]::Descendants,
+        (New-Object System.Windows.Automation.PropertyCondition(
+            [System.Windows.Automation.AutomationElement]::ControlTypeProperty,
+            [System.Windows.Automation.ControlType]::ListItem)))
+    $lines.Add("(b) FRESH NavView ListItems=" + $items.Count)
+} else {
+    $lines.Add("(b) FRESH NavView NOT FOUND walk=" + $sw2.ElapsedMilliseconds + "ms")
+    $kids = $root.FindAll([System.Windows.Automation.TreeScope]::Children,
+        [System.Windows.Automation.Condition]::TrueCondition)
+    $lines.Add("(b) root children=" + $kids.Count)
+}
+
+# Flush the walk's answers too.
+if ($out) {
+    $all = [System.IO.File]::ReadAllLines($out)
+    [System.IO.File]::WriteAllLines($out, $all + $lines)
+} else { $lines | ForEach-Object { Write-Host $_ } }
 
 Note "=== END BATTERY ==="

--- a/windows/scripts/dump-uia-state.ps1
+++ b/windows/scripts/dump-uia-state.ps1
@@ -1,0 +1,106 @@
+#requires -Version 7
+# Task #32 Phase 1: the UIA-tree-loss discrimination battery. Run AT the
+# HARVEST_MISS moment as a FRESH PROCESS (its own UIA client, no shared
+# cache with the harness). Emits the (a)-(c) evidence block to stdout.
+param(
+    [Parameter(Mandatory)][int]$ProcId,
+    [Parameter(Mandatory)][long]$Hwnd,
+    [string]$OutFile = ''
+)
+$ErrorActionPreference = 'Continue'
+$lines = [System.Collections.Generic.List[string]]::new()
+function Note([string]$s) { $lines.Add($s) }
+
+Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+public static class Wnd {
+    [DllImport("user32.dll")] public static extern bool IsWindow(IntPtr h);
+    [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr h);
+    [DllImport("user32.dll")] public static extern bool IsIconic(IntPtr h);
+    [DllImport("user32.dll")] public static extern bool IsWindowEnabled(IntPtr h);
+    [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
+    [DllImport("user32.dll")] public static extern IntPtr GetFocus();
+    [DllImport("user32.dll")] public static extern IntPtr SetFocus(IntPtr h);
+    [DllImport("user32.dll", CharSet=CharSet.Unicode)] public static extern int GetWindowText(IntPtr h, StringBuilder s, int n);
+    [DllImport("user32.dll")] public static extern IntPtr SendMessageTimeout(IntPtr h, uint msg, IntPtr w, IntPtr l, uint flags, uint timeout, out IntPtr result);
+    [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h, out uint pid);
+    [DllImport("kernel32.dll")] public static extern bool GetThreadTimes(IntPtr h, out long created, out long exited, out long kernel, out long user);
+}
+'@
+
+$h = [IntPtr]$Hwnd
+Note "=== UIA-LOSS BATTERY pid=$ProcId hwnd=$Hwnd t=$(Get-Date -Format o) ==="
+
+# (a) window state
+Note ("(a) IsWindow=" + [Wnd]::IsWindow($h) +
+    " Visible=" + [Wnd]::IsWindowVisible($h) +
+    " Iconic=" + [Wnd]::IsIconic($h) +
+    " Enabled=" + [Wnd]::IsWindowEnabled($h))
+$fg = [Wnd]::GetForegroundWindow()
+$sb = [System.Text.StringBuilder]::new(256)
+[void][Wnd]::GetWindowText($fg, $sb, 256)
+Note ("(a) foreground=0x" + $fg.ToString('X') + " title='" + $sb.ToString() + "'" +
+    " fgIsTarget=" + ($fg -eq $h))
+
+# (a2) the process's window threads + CPU snapshot (twice, 400ms apart)
+$p = Get-Process -Id $ProcId -ErrorAction SilentlyContinue
+if ($p) {
+    $t1 = $p.TotalProcessorTime.TotalMilliseconds
+    Start-Sleep -Milliseconds 400
+    $p.Refresh()
+    $t2 = $p.TotalProcessorTime.TotalMilliseconds
+    Note ("(c) proc cpuDelta400ms=" + [math]::Round($t2 - $t1, 1) + "ms threads=" + $p.Threads.Count)
+    $hot = $p.Threads | Sort-Object TotalProcessorTime -Descending | Select-Object -First 3
+    foreach ($th in $hot) {
+        Note ("(c) hot tid=" + $th.Id + " cpu=" + [math]::Round($th.TotalProcessorTime.TotalMilliseconds, 0) +
+            "ms state=" + $th.ThreadState.WaitReason)
+    }
+} else {
+    Note "(c) PROCESS GONE"
+}
+
+# (c2) UI-thread responsiveness: SendMessageTimeout WM_GETTEXT with a 1s
+# cap -- a hung/busy UI thread lets this time out.
+$wmGetText = 0x000D
+$smtoAbortIfHung = 0x0002
+$timeoutMs = 1000
+$sw = [System.Diagnostics.Stopwatch]::StartNew()
+$result = [IntPtr]::Zero
+$ok = [Wnd]::SendMessageTimeout($h, $wmGetText, [IntPtr]::Zero, [IntPtr]::Zero,
+    $smtoAbortIfHung, $timeoutMs, [ref]$result)
+$sw.Stop()
+Note ("(c2) SendMessageTimeout ok=" + $ok + " ms=" + $sw.ElapsedMilliseconds +
+    " (0/timeout or 1/answered)")
+
+# (b) FRESH-PROCESS UIA query: this process IS the fresh client (spawned
+# separately by the harness). Walk the window for NavView by AutomationId.
+Add-Type -AssemblyName UIAutomationClient
+Add-Type -AssemblyName UIAutomationTypes
+$root = [System.Windows.Automation.AutomationElement]::FromHandle($h)
+$cond = New-Object System.Windows.Automation.PropertyCondition(
+    [System.Windows.Automation.AutomationElement]::AutomationIdProperty, 'NavView')
+$sw2 = [System.Diagnostics.Stopwatch]::StartNew()
+$nav = $root.FindFirst([System.Windows.Automation.TreeScope]::Descendants, $cond)
+$sw2.Stop()
+if ($null -ne $nav) {
+    $r = $nav.Current.BoundingRectangle
+    Note ("(b) FRESH NavView FOUND rect=" + $r.Width + "x" + $r.Height +
+        " walk=" + $sw2.ElapsedMilliseconds + "ms")
+    $items = $nav.FindAll([System.Windows.Automation.TreeScope]::Descendants,
+        (New-Object System.Windows.Automation.PropertyCondition(
+            [System.Windows.Automation.AutomationElement]::ControlTypeProperty,
+            [System.Windows.Automation.ControlType]::ListItem)))
+    Note ("(b) FRESH NavView ListItems=" + $items.Count)
+} else {
+    Note ("(b) FRESH NavView NOT FOUND walk=" + $sw2.ElapsedMilliseconds + "ms")
+    # The broader tree: what DOES the fresh walk see at the top?
+    $kids = $root.FindAll([System.Windows.Automation.TreeScope]::Children,
+        [System.Windows.Automation.Condition]::TrueCondition)
+    Note ("(b) root children=" + $kids.Count)
+}
+
+Note "=== END BATTERY ==="
+$out = if ($OutFile) { $OutFile } else { '' }
+if ($out) { [System.IO.File]::WriteAllLines($out, $lines) } else { $lines | ForEach-Object { Write-Host $_ } }

--- a/windows/scripts/dump-uia-state.ps1
+++ b/windows/scripts/dump-uia-state.ps1
@@ -22,7 +22,6 @@ public static class Wnd {
     [DllImport("user32.dll")] public static extern bool IsWindowEnabled(IntPtr h);
     [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
     [DllImport("user32.dll")] public static extern IntPtr GetFocus();
-    [DllImport("user32.dll")] public static extern IntPtr SetFocus(IntPtr h);
     [DllImport("user32.dll", CharSet=CharSet.Unicode)] public static extern int GetWindowText(IntPtr h, StringBuilder s, int n);
     [DllImport("user32.dll")] public static extern IntPtr SendMessageTimeout(IntPtr h, uint msg, IntPtr w, IntPtr l, uint flags, uint timeout, out IntPtr result);
     [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h, out uint pid);
@@ -101,6 +100,9 @@ if ($null -ne $nav) {
     Note ("(b) root children=" + $kids.Count)
 }
 
-Note "=== END BATTERY ==="
+# Flush the window/CPU answers BEFORE the UIA walk: a hang in that walk
+# must not swallow the evidence the earlier probes already collected.
 $out = if ($OutFile) { $OutFile } else { '' }
 if ($out) { [System.IO.File]::WriteAllLines($out, $lines) } else { $lines | ForEach-Object { Write-Host $_ } }
+
+Note "=== END BATTERY ==="


### PR DESCRIPTION
The vertical pin-boundary round trip stranded the dragged row pinned: cross into the pinned zone and return, and the row stayed pinned at the prefix. Two roots, fixed by a design change and a grammar restriction.

The design change: pin-out is release-classified, not crossing-classified. The mid-drag pin-in crossing keeps working (classify Pin, relocate, preview), but the unpin decision belongs to the release position - over the shelf stays pinned, out in the body unpins and places at the body slot under the pointer via the nearest-row read. That is the horizontal engine's exact grammar, one shape both modes, and it dissolves the failure entirely: there is no mid-drag unpin threshold for stale centers to bend. The crossing commit arm is restricted to pin-only - an Unpin classification mid-drag is stale centers speaking, so it rewinds the machine to the row's still-true slot and refuses the crossing rather than obeying it; the NaN shelf-bounds path's comment now states its deliberate polarity (unpin unless provably in-zone) instead of contradicting the code.

The rebuilt tab-drag harness caught this on its first run and its pin-boundary legs are green on the fixed build; ten guarded vertical drags pass with zero crash-log growth; a UIA-state battery script born of the diagnosis joins the scripts directory. Facts pin the release-classified polarity (including the initializer text - a structural pin alone provably misses value-level flips), the pin-only crossing arm, and the evolved zone-crossing contract.