### PR TITLE
seam: an in-process test channel that drives the real drag handlers

### DIFF
--- a/windows/Ghostty.Tests/Wiring/PinnedPanelWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/PinnedPanelWiringTests.cs
@@ -201,7 +201,7 @@ public class PinnedPanelWiringTests
     [Fact]
     public void ClickingAShelfRow_ActivatesThroughTheSubThresholdRelease()
     {
-        var released = Strip().Method("OnDragPointerReleased");
+        var released = Strip().Method("DragRelease");
 
         // The guard names the press-time container. Dropping the conjunct
         // activates on every sub-threshold release -- body rows would then
@@ -274,7 +274,7 @@ public class PinnedPanelWiringTests
     [Fact]
     public void TheDrag_ArmsOnARowInEitherContainer()
     {
-        var pressed = Strip().Method("OnDragPointerPressed");
+        var pressed = Strip().Method("DragPress");
 
         // The pinned row ancestry is in the resolution chain.
         Assert.Contains(pressed.DescendantNodes().OfType<InvocationExpressionSyntax>(),

--- a/windows/Ghostty.Tests/Wiring/PinnedPreviewWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/PinnedPreviewWiringTests.cs
@@ -22,6 +22,20 @@ public class PinnedPreviewWiringTests
 {
     private static ShellSource Strip() => ShellSource.Load("Tabs.VerticalTabStrip.xaml.cs");
 
+    // The raw strip source, for absence pins over things that are not
+    // invocations -- an AddHandler hook is an argument, invisible to a
+    // call scan. Same shape as VerticalTabGroupDragWiringTests.ReadStrip.
+    private static string ReadStrip()
+    {
+        var asm = System.Reflection.Assembly.GetExecutingAssembly();
+        var name = asm.GetManifestResourceNames()
+            .Single(n => n.EndsWith("VerticalTabStrip.xaml.cs", StringComparison.OrdinalIgnoreCase));
+        using var stream = asm.GetManifestResourceStream(name);
+        Assert.NotNull(stream);
+        using var reader = new System.IO.StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+
     /// <summary>
     /// Show means "the drop would pin": the dragged row is still unpinned,
     /// pins exist, and its center is over the shelf. The pinned arm of the
@@ -170,10 +184,21 @@ public class PinnedPreviewWiringTests
     /// <summary>
     /// Every way a drag ends takes the ghost with it. EndDrag is the
     /// shared tail -- the release drops through it, and every cancel
-    /// family (escape, capture loss, row close, layout switch, teardown)
-    /// funnels through CancelDrag into it -- so one hide there covers the
-    /// exit paths, and the fact ties each family to the funnel so a new
-    /// exit path cannot quietly skip it.
+    /// family funnels through CancelDrag into it -- so one hide there
+    /// covers the exit paths, and the fact ties each family to the funnel
+    /// so a new exit path cannot quietly skip it.
+    ///
+    /// There is no capture-loss family, and the absence is pinned, not
+    /// just skipped: the engine holds no capture, so no CaptureLost is
+    /// ours -- the one the strip sees is MUXC's item layer releasing its
+    /// own press capture the moment a drag starts moving, and acting on
+    /// that murdered every real drag (the probe caught a cancel mid-drag,
+    /// then a zombie crossing landing the right order by luck). The
+    /// capture-less engine runs on hover-routed events; a PointerCapture
+    /// Lost hook or a CapturePointer call re-appearing anywhere in the
+    /// strip goes red here. The pointer-cancel family that DOES exist
+    /// reaches the funnel through the wrapper's DragCancel, the hop the
+    /// test-seam parameterization added.
     /// </summary>
     [Fact]
     public void EveryDragExit_ReachesTheHide()
@@ -185,19 +210,32 @@ public class PinnedPreviewWiringTests
         // The cancel funnel ends at EndDrag, which is where the hide sits.
         Assert.NotEmpty(strip.Method("CancelDrag").Calls("EndDrag"));
 
-        // Each exit family: escape, pointer cancel, capture loss, the
-        // mid-drag row close, the layout switch, and teardown. The cancel
-        // wrapper hops through DragCancel (the seam's parameterized core)
-        // before the funnel.
+        // Each exit family that exists: escape, pointer cancel (through
+        // the parameterized core), the stale press that ends a session the
+        // strip never saw the release of, the mid-drag row close, the
+        // layout switch, and teardown.
         Assert.NotEmpty(strip.Method("OnDragKeyDown").Calls("CancelDrag"));
         Assert.NotEmpty(strip.Method("OnDragPointerCanceled").Calls("DragCancel"));
         Assert.NotEmpty(strip.Method("DragCancel").Calls("CancelDrag"));
-        Assert.NotEmpty(strip.Method("OnDragPointerCaptureLost").Calls("CancelDrag"));
+        Assert.NotEmpty(strip.Method("DragPress").Calls("CancelDrag"));
         Assert.NotEmpty(strip.Method("RemoveItem").Calls("CancelDrag"));
         Assert.NotEmpty(strip.Method("SetSelectionRowSuppressed").Calls("CancelDrag"));
         var unloaded = strip.Root.DescendantNodes().OfType<AssignmentExpressionSyntax>()
             .Single(a => a.Left.ToString() == "Unloaded");
         Assert.NotEmpty(unloaded.Right.Calls("CancelDrag"));
+
+        // And no capture, in either spelling: no PointerCaptureLost hook
+        // for a family that must not come back, and no CapturePointer the
+        // engine could hold. Text-level for the event name -- a hook is an
+        // AddHandler argument, not an invocation -- and suffix-matched for
+        // the call, which is only ever spelled with a receiver.
+        Assert.DoesNotContain(
+            "PointerCaptureLostEvent", ReadStrip(), StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            strip.Root.DescendantNodes()
+                .OfType<Microsoft.CodeAnalysis.CSharp.Syntax.InvocationExpressionSyntax>()
+                .ToList(),
+            c => c.CalleeText().EndsWith("CapturePointer", StringComparison.Ordinal));
 
         // And the show runs only from the coalesced tick: a preview that
         // appeared from a raw pointer event would have no hide ordering

--- a/windows/Ghostty.Tests/Wiring/PinnedPreviewWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/PinnedPreviewWiringTests.cs
@@ -146,7 +146,7 @@ public class PinnedPreviewWiringTests
     [Fact]
     public void TheDrop_HonoursTheVisibleGhost_ThroughTheZoneGrammar()
     {
-        var released = Strip().Method("OnDragPointerReleased");
+        var released = Strip().Method("DragRelease");
 
         var gate = released.DescendantNodes().OfType<IfStatementSyntax>()
             .Single(i => i.Condition.ToString() == "_pinPreview is not null");
@@ -186,9 +186,12 @@ public class PinnedPreviewWiringTests
         Assert.NotEmpty(strip.Method("CancelDrag").Calls("EndDrag"));
 
         // Each exit family: escape, pointer cancel, capture loss, the
-        // mid-drag row close, the layout switch, and teardown.
+        // mid-drag row close, the layout switch, and teardown. The cancel
+        // wrapper hops through DragCancel (the seam's parameterized core)
+        // before the funnel.
         Assert.NotEmpty(strip.Method("OnDragKeyDown").Calls("CancelDrag"));
-        Assert.NotEmpty(strip.Method("OnDragPointerCanceled").Calls("CancelDrag"));
+        Assert.NotEmpty(strip.Method("OnDragPointerCanceled").Calls("DragCancel"));
+        Assert.NotEmpty(strip.Method("DragCancel").Calls("CancelDrag"));
         Assert.NotEmpty(strip.Method("OnDragPointerCaptureLost").Calls("CancelDrag"));
         Assert.NotEmpty(strip.Method("RemoveItem").Calls("CancelDrag"));
         Assert.NotEmpty(strip.Method("SetSelectionRowSuppressed").Calls("CancelDrag"));

--- a/windows/Ghostty.Tests/Wiring/PinnedRowFocusWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/PinnedRowFocusWiringTests.cs
@@ -101,8 +101,10 @@ public class PinnedRowFocusWiringTests
         Assert.True(fence[0].Span.Start < managerActivate.Span.Start,
             "the activation must be fenced, not just performed");
 
-        // And the click path shares it: one seam, two callers.
-        Assert.NotEmpty(Strip().Method("OnDragPointerReleased")
+        // And the click path shares it: one seam, two callers. (The
+        // release body lives in DragRelease since the test-seam
+        // parameterization; the pointer handler is its wrapper.)
+        Assert.NotEmpty(Strip().Method("DragRelease")
             .Calls("ActivateFromShelf"));
     }
 

--- a/windows/Ghostty.Tests/Wiring/TabPinFlightWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabPinFlightWiringTests.cs
@@ -55,7 +55,7 @@ public class TabPinFlightWiringTests
     [Fact]
     public void BothFlightEndpoints_AreRead_BeforeTheCommit()
     {
-        var released = Strip().Method("OnDragPointerReleased");
+        var released = Strip().Method("DragRelease");
         var gate = released.DescendantNodes().OfType<IfStatementSyntax>()
             .Single(i => i.Condition.ToString() == "_pinPreview is not null");
         var setPinned = gate.Calls("_manager.SetPinned").Single();
@@ -116,7 +116,7 @@ public class TabPinFlightWiringTests
         // The single caller runs after EndDrag: the row is already in
         // the manager and the drag is already torn down when the ghost
         // lifts off.
-        var released = strip.Method("OnDragPointerReleased");
+        var released = strip.Method("DragRelease");
         var gate = released.DescendantNodes().OfType<IfStatementSyntax>()
             .Single(i => i.Condition.ToString() == "_pinPreview is not null");
         var call = gate.Calls("StartPinFlight").Single();
@@ -172,7 +172,7 @@ public class TabPinFlightWiringTests
     public void TheFlight_IsProgrammatic_AtVelocityZero()
     {
         var strip = Strip();
-        var gate = strip.Method("OnDragPointerReleased")
+        var gate = strip.Method("DragRelease")
             .DescendantNodes().OfType<IfStatementSyntax>()
             .Single(i => i.Condition.ToString() == "_pinPreview is not null");
         var end = gate.Calls("EndDrag").Single();

--- a/windows/Ghostty.Tests/Wiring/TestSeamWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TestSeamWiringTests.cs
@@ -1,0 +1,130 @@
+using System.Linq;
+using Ghostty.Tests.Wiring;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// The test seam's opt-in is its only safety property, so the spike pins the
+/// two facts that keep it true: the gate reads before any pipe exists, and
+/// the pipe's life is bounded by the window that opened it. The full fact
+/// campaign waits for the seam to harden; these are the two that cannot be
+/// allowed to rot quietly.
+///
+/// What they can catch: the gate inverted or widened, the server started
+/// unconditionally, the window closing without the server dying, and a
+/// command bypassing the UI-thread marshal.
+///
+/// What they cannot catch: whether a command really drives the same handlers
+/// the pointer path does. That is what the seam acceptance script proves
+/// against the running app.
+/// </summary>
+public class TestSeamWiringTests
+{
+    private static void CtorCallsTestSeamStart()
+    {
+        var window = ShellSource.Load("MainWindow.xaml.cs");
+        var calls = window.Root.Calls("Testing.TestSeam.Start");
+        Assert.True(
+            calls.Count == 1,
+            $"expected exactly one TestSeam.Start call in MainWindow.xaml.cs, " +
+            $"found {calls.Count}");
+
+        var ctor = window.Root.DescendantNodes()
+            .OfType<Microsoft.CodeAnalysis.CSharp.Syntax.ConstructorDeclarationSyntax>()
+            .Where(c => c.Identifier.ValueText == "MainWindow"
+                        && c.Span.Contains(calls[0].Span))
+            .ToList();
+        Assert.True(
+            ctor.Count == 1,
+            "TestSeam.Start is not called from exactly one MainWindow constructor");
+    }
+
+    [Fact]
+    public void TheSeamIsGated_OnAnExplicitOptInEnvValue()
+    {
+        CtorCallsTestSeamStart();
+
+        var source = ShellSource.Load("Testing.TestSeam.cs");
+        var start = source.Method("Start");
+        var reads = start.Calls("Environment.GetEnvironmentVariable");
+        Assert.True(
+            reads.Count == 1,
+            $"expected exactly one env-var read in TestSeam.Start, found {reads.Count}");
+
+        // The name lives in one const; the gate reads that const, and the
+        // const is the opt-in literal. Pinning both halves keeps a rename
+        // of either side from splitting them apart.
+        var envVar = source.Field("EnvVar").Variable;
+        Assert.True(
+            envVar.Initializer is not null
+            && envVar.Initializer.Value.ToString().Contains(
+                "WINTTY_TEST_SEAM", StringComparison.Ordinal),
+            "the seam's env-var const no longer names WINTTY_TEST_SEAM");
+        Assert.Equal("EnvVar", reads[0].ArgumentList.Arguments[0].ToString());
+
+        // The polarity is the surface: "1" means on, anything else -- unset,
+        // empty, "0", "true" -- is off. A comparison whose text no longer
+        // demands the literal "1" has widened the gate.
+        var guard = start.Body!.Statements
+            .OfType<Microsoft.CodeAnalysis.CSharp.Syntax.IfStatementSyntax>()
+            .FirstOrDefault();
+        Assert.True(guard is not null, "TestSeam.Start has no gate guard");
+        Assert.Contains(
+            "\"1\"", guard!.Condition.ToString(), StringComparison.Ordinal);
+        Assert.Contains(
+            "!=", guard!.Condition.ToString(), StringComparison.Ordinal);
+
+        // And the gate has to run before the server does: nothing may spawn
+        // a pipe from Start ahead of it.
+        var guardEnd = guard.Span.End;
+        var server = start.Calls("ServeAsync");
+        Assert.True(
+            server.Count == 1 && server[0].Span.Start > guardEnd,
+            "TestSeam.Start reaches the pipe server before the opt-in gate");
+    }
+
+    [Fact]
+    public void ThePipeLifecycle_IsBoundedByTheWindow()
+    {
+        var source = ShellSource.Load("Testing.TestSeam.cs");
+
+        // One server loop, and it is the only place a pipe exists.
+        var serve = source.Method("ServeAsync");
+        Assert.True(
+            serve.DescendantNodes().OfType<Microsoft.CodeAnalysis.CSharp.Syntax
+                .ObjectCreationExpressionSyntax>().Count(c =>
+                    c.Type.ToString().Contains("NamedPipeServerStream")) == 1,
+            "expected exactly one NamedPipeServerStream creation, in ServeAsync");
+        Assert.True(
+            serve.Calls("pipe.WaitForConnectionAsync").Count == 1,
+            "the server loop no longer waits for exactly one connection per pipe");
+        Assert.True(
+            serve.Calls("pipe?.Dispose").Count >= 1,
+            "the server no longer disposes the pipe between connections");
+
+        // Start subscribes the window's close to the server's cancellation,
+        // so a closed window cannot leave a listening pipe behind.
+        var start = source.Method("Start");
+        Assert.True(
+            start.DescendantNodes().OfType<Microsoft.CodeAnalysis.CSharp.Syntax
+                .MemberAccessExpressionSyntax>().Count(m =>
+                    m.Name.Identifier.ValueText == "Closed") == 1,
+            "TestSeam.Start no longer subscribes exactly one window.Closed");
+        Assert.True(
+            start.Calls("Task.Run").Count == 1,
+            "TestSeam.Start no longer runs the server as exactly one background task");
+
+        // The marshal is the whole fidelity story: every command funnels
+        // through the one dispatcher hop, and the drag handoff runs below
+        // the drag tick's priority.
+        var marshal = source.Method("RunOnUiThreadAsync");
+        Assert.True(
+            marshal.Calls("window.DispatcherQueue.TryEnqueue").Count == 1,
+            "the UI marshal is no longer exactly one TryEnqueue");
+        var execute = source.Method("ExecuteAsync");
+        Assert.True(
+            execute.Calls("RunOnUiThreadAsync").Count == 1,
+            "commands no longer funnel through the single UI marshal");
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/TestSeamWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TestSeamWiringTests.cs
@@ -100,8 +100,35 @@ public class TestSeamWiringTests
             serve.Calls("pipe.WaitForConnectionAsync").Count == 1,
             "the server loop no longer waits for exactly one connection per pipe");
         Assert.True(
-            serve.Calls("pipe?.Dispose").Count >= 1,
+            serve.Calls("pipe.Dispose").Count == 1,
             "the server no longer disposes the pipe between connections");
+
+        // A name owned by another opted-in instance STOPS the server: one
+        // seam per machine. The creation-failure catch must return -- a
+        // continue here recreates the same refused pipe as fast as the
+        // loop can spin -- and the connection-level catch must NOT return,
+        // because a client hanging up is not the server's death. Both
+        // catches declare Exception and discriminate in the filter.
+        var catches = serve.DescendantNodes()
+            .OfType<Microsoft.CodeAnalysis.CSharp.Syntax.CatchClauseSyntax>()
+            .Where(c => c.Filter is not null
+                        && c.Filter!.FilterExpression.ToString().Contains("IOException"))
+            .ToList();
+        var creation = catches.Single(c => c.Filter!.FilterExpression.ToString()
+            .Contains("UnauthorizedAccessException"));
+        Assert.Contains(
+            creation.Block.Statements,
+            s => s is Microsoft.CodeAnalysis.CSharp.Syntax.ReturnStatementSyntax);
+        var wait = serve.Calls("pipe.WaitForConnectionAsync").Single();
+        Assert.True(
+            creation.Span.End <= wait.Span.Start,
+            "the name-taken refusal must guard the pipe creation, before the "
+            + "connection wait it must never reach");
+        var serving = catches.Single(c => c.Filter!.FilterExpression.ToString()
+            .Contains("ObjectDisposedException"));
+        Assert.DoesNotContain(
+            serving.Block.Statements,
+            s => s is Microsoft.CodeAnalysis.CSharp.Syntax.ReturnStatementSyntax);
 
         // Start subscribes the window's close to the server's cancellation,
         // so a closed window cannot leave a listening pipe behind.

--- a/windows/Ghostty.Tests/Wiring/VerticalTabGroupDragWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/VerticalTabGroupDragWiringTests.cs
@@ -35,7 +35,10 @@ public class VerticalTabGroupDragWiringTests
     [Fact]
     public void AHeaderPress_ArmsTheRunDrag_ThroughTheSameMachine()
     {
-        var pressed = Strip().Method("OnDragPointerPressed");
+        // The parameterized press: the pointer handler and the test seam
+        // both resolve values OUTSIDE this method; everything from the row
+        // resolution down -- the header arm included -- lives in DragPress.
+        var pressed = Strip().Method("DragPress");
         var arm = pressed.DescendantNodes().OfType<IfStatementSyntax>()
             .Single(i => i.Condition.ToString()
                 == "item is VerticalTabGroupHeaderItem { Tag: TabGroup group }");
@@ -481,7 +484,7 @@ public class VerticalTabGroupDragWiringTests
     [Fact]
     public void A_stale_session_ends_at_the_next_press()
     {
-        var pressed = Strip().Method("OnDragPointerPressed");
+        var pressed = Strip().Method("DragPress");
         var gate = Assert.IsType<IfStatementSyntax>(pressed.Body!.Statements.First());
         Assert.Equal("_drag is not null", gate.Condition.ToString());
         var arm = gate.Statement;
@@ -501,7 +504,7 @@ public class VerticalTabGroupDragWiringTests
     [Fact]
     public void Button_presses_and_sub_threshold_releases_never_arm()
     {
-        var pressed = Strip().Method("OnDragPointerPressed");
+        var pressed = Strip().Method("DragPress");
         var buttonGate = pressed.DescendantNodes().OfType<IfStatementSyntax>()
             .Single(i => i.Condition.ToString().Contains(
                 "FindAncestor<Button>", StringComparison.Ordinal));
@@ -560,18 +563,24 @@ public class VerticalTabGroupDragWiringTests
     [Fact]
     public void Pin_out_is_release_classified()
     {
-        var released = Strip().Method("OnDragPointerReleased");
+        // The parameterization moved the release body into DragRelease;
+        // the fresh pointer truth is the Y the pointer handler resolved,
+        // so the chain is pinned at both ends: the wrapper reads the
+        // event's position, and the pin branch takes that Y as its own.
+        var wrapper = Strip().Method("OnDragPointerReleased");
+        Assert.Single(wrapper.Calls("e.GetCurrentPoint"));
+        var released = Strip().Method("DragRelease");
         var gate = released.DescendantNodes().OfType<IfStatementSyntax>()
             .Single(i => i.Condition.ToString() == "drag.Tab.IsPinned");
         var arm = Assert.IsType<BlockSyntax>(gate.Statement);
 
         // The branch reads fresh pointer truth and the shelf bounds: the
-        // release Y against the pinned panel, the body slot under the
-        // point from the strip's own pairing.
-        Assert.Contains(arm.DescendantNodes()
-            .OfType<InvocationExpressionSyntax>()
-            .Where(c => c.CalleeText().EndsWith("GetCurrentPoint", StringComparison.Ordinal)).ToList(),
-            c => true);
+        // release Y the wrapper resolved, the body slot under the point
+        // from the strip's own pairing.
+        var releaseY = arm.DescendantNodes()
+            .OfType<VariableDeclaratorSyntax>()
+            .Single(v => v.Identifier.ValueText == "releaseY");
+        Assert.Equal("y", releaseY.Initializer!.Value.ToString());
         Assert.Contains(arm.DescendantNodes()
             .OfType<InvocationExpressionSyntax>()
             .Where(c => c.CalleeText() == "BodySlotAtY").ToList(),

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -102,6 +102,28 @@ public sealed partial class MainWindow : Window
     /// <summary>This window's tab manager, exposed for session capture.</summary>
     internal TabManager TabManager => _tabManager;
 
+    // ---- test seam accessors (WINTTY_TEST_SEAM=1) --------------------
+    // Internal surface, reachable only in-process: the pipe is the gate.
+    // Named TestSeam* so the seam's footprint on this class is greppable
+    // and removable as one shape.
+    internal Input.PaneActionRouter TestSeamRouter => _router;
+    internal bool TestSeamVerticalTabs => _verticalTabsVisible;
+    internal bool TestSeamLayoutSwitching => _layout.IsSwitching;
+
+    /// <summary>
+    /// The vertical strip when it is this window's active host, else null:
+    /// the seam's drag driver speaks the vertical engine only.
+    /// </summary>
+    internal Tabs.VerticalTabStrip? TestSeamVerticalStrip
+        => _tabHost is Tabs.VerticalTabHost vertical ? vertical.StripForTestSeam : null;
+
+    /// <summary>
+    /// A synchronous layout pass before a seam ack: the command's C# state
+    /// AND the XAML layout it caused are both settled when the driver hears
+    /// back, so the next command can never run mid-arrange.
+    /// </summary>
+    internal void TestSeamSettleLayout() => (Content as UIElement)?.UpdateLayout();
+
     /// <summary>
     /// The closed-tab store this window feeds. The quake window is excluded so
     /// its drop-down tabs never leak into the regular reopen-closed-tab history
@@ -1163,6 +1185,11 @@ public sealed partial class MainWindow : Window
         // retries until the input site exists, then unsubscribes).
         _beepSuppressor = new SysCharBeepSuppressor();
         Activated += OnActivatedInstallBeepSuppressor;
+
+        // The opt-in test seam: zero surface unless WINTTY_TEST_SEAM=1,
+        // and then one named pipe whose commands drive the real handlers
+        // on this UI thread. See Testing.TestSeam.
+        Testing.TestSeam.Start(this);
 
         Closed += OnClosedAsync;
     }

--- a/windows/Ghostty/Tabs/VerticalTabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabHost.xaml.cs
@@ -60,6 +60,9 @@ internal sealed partial class VerticalTabHost : UserControl, ITabHost
 
     public FrameworkElement HostElement => this;
 
+    /// <summary>The strip, for the test seam's drag driver.</summary>
+    internal VerticalTabStrip StripForTestSeam => _strip;
+
     public FrameworkElement? TabElement(TabModel tab) => _strip.TabElement(tab);
 
     internal void SetSelectionRowSuppressed(bool suppressed)

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -2236,6 +2236,20 @@ internal sealed partial class VerticalTabStrip : UserControl
 
     private void OnDragPointerPressed(object sender, PointerRoutedEventArgs e)
     {
+        DragPress(e.OriginalSource as DependencyObject, e.Pointer.PointerId,
+            e.GetCurrentPoint(this).Position.Y);
+    }
+
+    /// <summary>
+    /// The press, parameterized on where the values come from. The pointer
+    /// handler resolves the press origin, the pointer id, and the strip-space
+    /// Y out of <see cref="PointerRoutedEventArgs"/> -- which is
+    /// non-constructible, so the test seam cannot synthesize one; the seam
+    /// passes the same three values itself and lands here anyway. Everything
+    /// from the row resolution down is the one gesture body either way.
+    /// </summary>
+    private void DragPress(DependencyObject? source, uint pointerId, double y)
+    {
         if (_drag is not null)
         {
             // Without capture a release the strip never saw -- the button
@@ -2248,7 +2262,6 @@ internal sealed partial class VerticalTabStrip : UserControl
         // drag never starts under one.
         if (_selectionRowSuppressed) return;
 
-        var source = e.OriginalSource as DependencyObject;
         // A row is either a NavigationViewItem in the list or a pinned row
         // in the shelf; both carry the tab on Tag.
         var item = (FrameworkElement?)VisualTreeHelperEx.FindAncestor<NavigationViewItem>(source)
@@ -2264,7 +2277,7 @@ internal sealed partial class VerticalTabStrip : UserControl
         // exactly as before.
         if (item is VerticalTabGroupHeaderItem { Tag: TabGroup group })
         {
-            ArmGroupDrag(group, item, e);
+            ArmGroupDrag(group, item, pointerId, y);
             return;
         }
 
@@ -2272,10 +2285,9 @@ internal sealed partial class VerticalTabStrip : UserControl
         if (RowElementOf(tab) is not { } owned || !ReferenceEquals(owned, item)) return;
         if (_manager.Tabs.Count < 2) return;
 
-        var point = e.GetCurrentPoint(this);
         var (_, managerIndex) = DragSlots();
         var machine = new TabDragReorder(managerIndex.Count, SlotIndexOf(managerIndex, tab));
-        machine.Press(point.Position.Y);
+        machine.Press(y);
         // Each begin..settle pair owns its census: a teardown failure in
         // one drag must not inflate the ghost count of the next.
         _teardownFailures = 0;
@@ -2286,10 +2298,10 @@ internal sealed partial class VerticalTabStrip : UserControl
             PreDragOrder = TabStripProjection.Rows(_manager),
             PreDragPinned = new HashSet<TabModel>(
                 _manager.Tabs.Where(t => t.IsPinned)),
-            PointerId = e.Pointer.PointerId,
+            PointerId = pointerId,
             PressRow = owned,
-            LastPointerY = point.Position.Y,
-            PressY = point.Position.Y,
+            LastPointerY = y,
+            PressY = y,
         };
     }
 
@@ -2302,7 +2314,7 @@ internal sealed partial class VerticalTabStrip : UserControl
     /// prefix contributes no units, so the drag never even offers a
     /// crossing into the zone MoveGroup's clamp would refuse.
     /// </summary>
-    private void ArmGroupDrag(TabGroup group, FrameworkElement header, PointerRoutedEventArgs e)
+    private void ArmGroupDrag(TabGroup group, FrameworkElement header, uint pointerId, double y)
     {
         var run = _manager.MembersOf(group);
         if (run.Count == 0) return;
@@ -2311,9 +2323,8 @@ internal sealed partial class VerticalTabStrip : UserControl
         int grabbed = RunUnitIndex(units, group);
         if (grabbed < 0) return;
 
-        var point = e.GetCurrentPoint(this);
         var machine = new TabDragReorder(units.Count, grabbed);
-        machine.Press(point.Position.Y);
+        machine.Press(y);
         // Each begin..settle pair owns its census: a teardown failure in
         // one drag must not inflate the ghost count of the next.
         _teardownFailures = 0;
@@ -2325,10 +2336,10 @@ internal sealed partial class VerticalTabStrip : UserControl
             PreDragOrder = TabStripProjection.Rows(_manager),
             PreDragPinned = new HashSet<TabModel>(
                 _manager.Tabs.Where(t => t.IsPinned)),
-            PointerId = e.Pointer.PointerId,
+            PointerId = pointerId,
             PressRow = header,
-            LastPointerY = point.Position.Y,
-            PressY = point.Position.Y,
+            LastPointerY = y,
+            PressY = y,
         };
     }
 
@@ -2347,13 +2358,18 @@ internal sealed partial class VerticalTabStrip : UserControl
 
     private void OnDragPointerMoved(object sender, PointerRoutedEventArgs e)
     {
-        if (_drag is not { } drag || e.Pointer.PointerId != drag.PointerId) return;
-        var y = e.GetCurrentPoint(this).Position.Y;
+        DragMove(e.Pointer.PointerId, e.GetCurrentPoint(this).Position.Y);
+    }
+
+    /// <summary>The move, parameterized the same way as the press.</summary>
+    private void DragMove(uint pointerId, double y)
+    {
+        if (_drag is not { } drag || pointerId != drag.PointerId) return;
 
         if (drag.Machine.Phase == TabDragPhase.Pressed)
         {
             if (!drag.Machine.Begin(y)) return;
-            StartDragVisual(drag, e);
+            StartDragVisual(drag);
             if (_drag is null) return; // start refused; the click falls through
         }
 
@@ -2365,7 +2381,13 @@ internal sealed partial class VerticalTabStrip : UserControl
 
     private void OnDragPointerReleased(object sender, PointerRoutedEventArgs e)
     {
-        if (_drag is not { } drag || e.Pointer.PointerId != drag.PointerId) return;
+        DragRelease(e.Pointer.PointerId, e.GetCurrentPoint(this).Position.Y);
+    }
+
+    /// <summary>The release, parameterized the same way as the press.</summary>
+    private void DragRelease(uint pointerId, double y)
+    {
+        if (_drag is not { } drag || pointerId != drag.PointerId) return;
         // Velocity first, and signed: Drop clears the sample window, and
         // the remaining travel is slot minus release (AnchorY is the slot
         // the anchor holds), positive = down -- the same axis
@@ -2397,7 +2419,7 @@ internal sealed partial class VerticalTabStrip : UserControl
         // the trap this replaces.
         if (drag.Tab.IsPinned)
         {
-            var releaseY = e.GetCurrentPoint(this).Position.Y;
+            var releaseY = y;
             double shelfTop = double.NaN, shelfBottom = double.NaN;
             try
             {
@@ -2487,8 +2509,11 @@ internal sealed partial class VerticalTabStrip : UserControl
     }
 
     private void OnDragPointerCanceled(object sender, PointerRoutedEventArgs e)
+        => DragCancel(e.Pointer.PointerId);
+
+    private void DragCancel(uint pointerId)
     {
-        if (_drag is not { } drag || e.Pointer.PointerId != drag.PointerId) return;
+        if (_drag is not { } drag || pointerId != drag.PointerId) return;
         CancelDrag("canceled");
     }
 
@@ -2500,7 +2525,7 @@ internal sealed partial class VerticalTabStrip : UserControl
         CancelDrag("escape");
     }
 
-    private void StartDragVisual(DragSession drag, PointerRoutedEventArgs e)
+    private void StartDragVisual(DragSession drag)
     {
         // A fresh gesture outranks a flight still in the air: one flight
         // at a time, and the new drag's churn must not share the shelf
@@ -4119,4 +4144,106 @@ internal sealed partial class VerticalTabStrip : UserControl
     private static bool IsLayoutReadFailure(Exception ex)
         => ex is ArgumentException or InvalidOperationException
             or System.Runtime.InteropServices.COMException or NullReferenceException;
+
+    // -----------------------------------------------------------------
+    // The test seam's drag driver (WINTTY_TEST_SEAM=1). The gesture is
+    // the pointer path's own: DragPress/DragMove/DragRelease above, fed
+    // positions read out of arranged layout and stepped through a
+    // Low-priority dispatcher handoff per tick, so every synthetic move
+    // is evaluated -- crossings committed -- before the next one is fed.
+    // No OS input, no focus, no second implementation of the grammar.
+    // -----------------------------------------------------------------
+
+    /// <summary>True while a gesture (seam-driven or real) holds the strip.</summary>
+    internal bool TestSeamDragLive => _drag is not null;
+
+    /// <summary>
+    /// One seam drag: press the row of manager index <paramref name="from"/>,
+    /// walk the pointer to the slot of manager index <paramref name="to"/>,
+    /// release. The outcome carries the manager order after the settle so the
+    /// driver can assert in one round trip. A gesture that cannot run reports
+    /// ok=false with the reason instead of throwing: the seam reports, it
+    /// does not crash the app under test.
+    /// </summary>
+    internal async Task<Testing.TestSeamDragOutcome> TestSeamDragAsync(int from, int to)
+    {
+        var outcome = new Testing.TestSeamDragOutcome();
+        var tabs = _manager.Tabs;
+        if (from < 0 || from >= tabs.Count || to < 0 || to >= tabs.Count)
+            return outcome.Fail($"drag {from}->{to} out of range (tabs={tabs.Count})");
+        if (from == to)
+            return outcome.Fail("drag from == to; nothing to reorder");
+        if (_drag is not null)
+            return outcome.Fail("another drag is live");
+
+        var tab = tabs[from];
+        if (RowElementOf(tab) is not { } row)
+            return outcome.Fail("drag row has no element; the strip is not realized");
+        double y = RowCenterY(tab);
+        if (double.IsNaN(y))
+            return outcome.Fail("drag row has no arranged center; layout has not run");
+
+        const uint seamPointer = 0x5749_4E54; // 'WINT'; no real pointer carries it
+        DragPress(row, seamPointer, y);
+
+        // Steps of 12px: past the 4px start threshold on the first move,
+        // under the row pitch, so each tick is one honest crossing decision
+        // -- the pacing of a slow human finger, at seam speed.
+        const double stepPx = 12;
+        var reached = false;
+        for (int tick = 0; tick < TestSeamDragTickBudget; tick++)
+        {
+            if (_drag is null) break; // the gesture died under us (layout, close)
+
+            var (rows, managerIndex) = DragSlots();
+            int slot = managerIndex.IndexOf(to);
+            double target = slot >= 0 && slot < rows.Count
+                ? RowCenterY(rows[slot])
+                : double.NaN;
+            // An unreadable target means the strip is mid-arrange (a commit
+            // churned the containers); stand still this tick and re-read
+            // the next, exactly as a hovering pointer would.
+            if (!double.IsNaN(target))
+            {
+                if (Math.Abs(target - y) <= 1)
+                {
+                    reached = true;
+                    break;
+                }
+                y += Math.Clamp(target - y, -stepPx, stepPx);
+                DragMove(seamPointer, y);
+            }
+
+            // One handoff below the drag tick's Normal priority: the
+            // evaluate this move scheduled has run -- crossings included --
+            // by the time control is back.
+            await Testing.TestSeam.WaitForLowPriorityAsync(DispatcherQueue);
+        }
+
+        if (_drag is not { } drag)
+            return outcome.Fail("the gesture ended before the release");
+        if (!reached)
+        {
+            DragCancel(seamPointer);
+            return outcome.Fail(
+                $"drag did not reach its slot within {TestSeamDragTickBudget} ticks " +
+                $"(machine index {drag.Machine.Index}, wanted {to})");
+        }
+
+        DragRelease(seamPointer, y);
+        outcome.Landed = _manager.IndexOf(tab);
+        outcome.Order = TabStripProjection.Rows(_manager)
+            .Select(t => t.EffectiveTitle).ToList();
+        if (outcome.Landed != to)
+            return outcome.Fail($"landed at {outcome.Landed}, wanted {to}");
+        return outcome;
+    }
+
+    /// <summary>
+    /// Generous, because each tick is a dispatcher pass and the strip may
+    /// spend several of them mid-arrange after a commit; a healthy drag
+    /// lands in a handful. Bounded so a wedged layout reports a failure
+    /// instead of hanging the seam.
+    /// </summary>
+    private const int TestSeamDragTickBudget = 600;
 }

--- a/windows/Ghostty/Testing/TestSeam.cs
+++ b/windows/Ghostty/Testing/TestSeam.cs
@@ -21,7 +21,16 @@ namespace Ghostty.Testing;
 /// The gate is the whole surface: without WINTTY_TEST_SEAM=1 in the app's
 /// environment this class never creates a pipe and costs one env-var read
 /// per window. With it, the pipe is session-local and serves one client at
-/// a time; a second command connection waits for the first to hang up.
+/// a time; a second command connection waits for the first to hang up. A
+/// second opted-in process does not spin: the fixed name belongs to
+/// whoever took it first, and the loser goes quiet (one seam per machine).
+///
+/// Trust model, spike-honest: the pipe carries no ACL of its own, so any
+/// process running as the same local user can connect to an opted-in
+/// instance and drive its UI -- the same-user bar every dev tool on the
+/// box already clears. A user-scoped ACL (or a per-start nonce in the
+/// pipe name) is the hardening step for when the seam ships beyond this
+/// opt-in.
 ///
 /// Protocol: each request is one line of JSON, {"op": "...", ...args}; each
 /// response is one line, {"ok": true, ...} or {"ok": false, "error": "..."}.
@@ -69,12 +78,22 @@ internal static class TestSeam
     {
         while (!token.IsCancellationRequested)
         {
-            NamedPipeServerStream? pipe = null;
+            NamedPipeServerStream pipe;
             try
             {
                 pipe = new NamedPipeServerStream(
                     PipeName, PipeDirection.InOut, maxNumberOfServerInstances: 1,
                     PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                // The name belongs to another opted-in instance. One seam
+                // per machine is the honest semantics, so this process goes
+                // quiet instead of hot-spinning on a name it can never take.
+                return;
+            }
+            try
+            {
                 await pipe.WaitForConnectionAsync(token);
                 await ServeConnectionAsync(pipe, window, token);
             }
@@ -88,7 +107,7 @@ internal static class TestSeam
             {
                 try { if (pipe is { IsConnected: true }) pipe.Disconnect(); }
                 catch { /* the name must free up either way */ }
-                pipe?.Dispose();
+                pipe.Dispose();
             }
         }
     }

--- a/windows/Ghostty/Testing/TestSeam.cs
+++ b/windows/Ghostty/Testing/TestSeam.cs
@@ -1,0 +1,494 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Pipes;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Ghostty.Core.Tabs;
+using Microsoft.UI.Dispatching;
+
+namespace Ghostty.Testing;
+
+/// <summary>
+/// The opt-in in-process test seam: one named pipe inside Wintty whose
+/// newline-delimited JSON commands drive the REAL input handlers -- the tab
+/// manager ops and the vertical strip's drag engine -- on the UI thread.
+/// No OS input is synthesized, nothing is focused, and the user can be using
+/// the machine while a script drives the app.
+///
+/// The gate is the whole surface: without WINTTY_TEST_SEAM=1 in the app's
+/// environment this class never creates a pipe and costs one env-var read
+/// per window. With it, the pipe is session-local and serves one client at
+/// a time; a second command connection waits for the first to hang up.
+///
+/// Protocol: each request is one line of JSON, {"op": "...", ...args}; each
+/// response is one line, {"ok": true, ...} or {"ok": false, "error": "..."}.
+/// Commands marshal to the UI thread and every ack answers after the work
+/// settled, so a driver never races the app.
+///
+/// One window is served (the first): the spike scenario is a single window.
+/// Multi-window routing is hardening, not architecture.
+/// </summary>
+internal static class TestSeam
+{
+    private const string EnvVar = "WINTTY_TEST_SEAM";
+
+    /// <summary>The pipe the driver connects to, when the seam is on.</summary>
+    internal const string PipeName = "wintty-test-seam";
+
+    private static CancellationTokenSource? _lifetime;
+    private static int _started;
+
+    /// <summary>
+    /// Called once per window from the MainWindow constructor. The first
+    /// window in a seam-enabled process wins; later windows are no-ops. The
+    /// server dies with that window (the app closes with it).
+    /// </summary>
+    internal static void Start(MainWindow window)
+    {
+        if (Environment.GetEnvironmentVariable(EnvVar) != "1") return;
+        if (Interlocked.Exchange(ref _started, 1) == 1) return;
+
+        _lifetime = new CancellationTokenSource();
+        var token = _lifetime.Token;
+        window.Closed += (_, _) =>
+        {
+            try { _lifetime.Cancel(); } catch (ObjectDisposedException) { }
+        };
+        _ = Task.Run(() => ServeAsync(window, token));
+    }
+
+    /// <summary>
+    /// One connection at a time; a client that hangs up (or dies) frees the
+    /// name for the next. Transport-level failures are not findings: the
+    /// loop keeps serving.
+    /// </summary>
+    private static async Task ServeAsync(MainWindow window, CancellationToken token)
+    {
+        while (!token.IsCancellationRequested)
+        {
+            NamedPipeServerStream? pipe = null;
+            try
+            {
+                pipe = new NamedPipeServerStream(
+                    PipeName, PipeDirection.InOut, maxNumberOfServerInstances: 1,
+                    PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+                await pipe.WaitForConnectionAsync(token);
+                await ServeConnectionAsync(pipe, window, token);
+            }
+            catch (OperationCanceledException) { break; }
+            catch (Exception ex) when (ex is IOException or ObjectDisposedException)
+            {
+                // The client hung up mid-conversation. Fall through to the
+                // finally, then accept the next connection.
+            }
+            finally
+            {
+                try { if (pipe is { IsConnected: true }) pipe.Disconnect(); }
+                catch { /* the name must free up either way */ }
+                pipe?.Dispose();
+            }
+        }
+    }
+
+    private static async Task ServeConnectionAsync(
+        NamedPipeServerStream pipe, MainWindow window, CancellationToken token)
+    {
+        var reader = new StreamReader(pipe, Encoding.UTF8);
+        var writer = new StreamWriter(pipe, new UTF8Encoding(false))
+        {
+            AutoFlush = true,
+            NewLine = "\n",
+        };
+        while (!token.IsCancellationRequested && pipe.IsConnected)
+        {
+            var line = await reader.ReadLineAsync(token);
+            if (line is null) return; // client hung up
+            if (string.IsNullOrWhiteSpace(line)) continue;
+            var response = await ExecuteAsync(window, line);
+            await writer.WriteLineAsync(response);
+        }
+    }
+
+    private static async Task<string> ExecuteAsync(MainWindow window, string line)
+    {
+        JsonDocument doc;
+        try
+        {
+            doc = JsonDocument.Parse(line);
+        }
+        catch (JsonException ex)
+        {
+            return Error("parse", $"request is not JSON: {ex.Message}");
+        }
+
+        using (doc)
+        {
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object
+                || !root.TryGetProperty("op", out var op)
+                || op.ValueKind != JsonValueKind.String)
+            {
+                return Error("parse", "request needs a string 'op'");
+            }
+
+            var opName = op.GetString()!;
+            try
+            {
+                return await RunOnUiThreadAsync(
+                    window, () => ExecuteOnUiThreadAsync(window, opName, root));
+            }
+            catch (Exception ex)
+            {
+                // A command that throws IS a finding: the response carries
+                // it and the app keeps running.
+                return Error(opName, ex.Message);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The one marshal: every command, whatever it touches, runs on the
+    /// window's UI thread and the response awaits the work.
+    /// </summary>
+    private static Task<string> RunOnUiThreadAsync(
+        MainWindow window, Func<Task<string>> action)
+    {
+        var done = new TaskCompletionSource<string>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        if (!window.DispatcherQueue.TryEnqueue(async () =>
+            {
+                try
+                {
+                    var result = await action();
+                    // Settled means settled: layout, not just the manager.
+                    window.TestSeamSettleLayout();
+                    done.SetResult(result);
+                }
+                catch (Exception ex) { done.SetResult(Error("ui", ex.Message)); }
+            }))
+        {
+            done.SetResult(Error("ui", "dispatcher unavailable"));
+        }
+        return done.Task;
+    }
+
+    /// <summary>
+    /// A handoff one priority below the strip's Normal-priority drag tick:
+    /// when the awaited task completes, everything the last synthetic move
+    /// scheduled -- crossings included -- has already run. This is what
+    /// makes a seam drag deterministic without sleeps.
+    /// </summary>
+    internal static Task WaitForLowPriorityAsync(DispatcherQueue queue)
+    {
+        var done = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        if (!queue.TryEnqueue(DispatcherQueuePriority.Low, () => done.SetResult()))
+            done.SetException(new InvalidOperationException("dispatcher unavailable"));
+        return done.Task;
+    }
+
+    private static async Task<string> ExecuteOnUiThreadAsync(
+        MainWindow window, string op, JsonElement args)
+    {
+        var manager = window.TabManager;
+        switch (op)
+        {
+            case "get-state":
+                return OkWithState(window, manager, op);
+
+            case "seed-tabs":
+            {
+                var count = ArgInt(args, "count", -1);
+                if (count < 1 || count > 32)
+                    return Error(op, "count must be 1..32");
+                var titles = ArgStrings(args, "titles");
+
+                // Deterministic start: seed means a clean slate, so leftover
+                // groups and the pinned prefix from a previous scenario go
+                // first -- through the manager's own dissolvers. Then close
+                // down to one tab (closing the last would close the window),
+                // retitle it, and grow the rest. Real tabs through the
+                // manager: NewTab runs the pane factory and spawns real
+                // shells, exactly the state a human builds.
+                while (manager.Groups.Count > 0)
+                    manager.DissolveGroup(manager.Groups[0]);
+                foreach (var tab in manager.Tabs.ToArray())
+                {
+                    if (tab.IsPinned) manager.SetPinned(tab, false);
+                }
+                while (manager.Tabs.Count > 1)
+                {
+                    manager.CloseTab(manager.Tabs[^1]);
+                    // One teardown per dispatcher pass: a synchronous
+                    // four-surface close is denser than any human produces,
+                    // and native surface teardown racing the next churn is
+                    // exactly the interleaving a seam should not invent.
+                    if (manager.Tabs.Count > 1)
+                        await WaitForLowPriorityAsync(window.DispatcherQueue);
+                }
+                for (int i = 0; i < count; i++)
+                {
+                    var tab = i == 0 ? manager.Tabs[0] : manager.NewTab();
+                    tab.UserOverrideTitle = i < titles.Count ? titles[i] : $"tab-{i + 1}";
+                }
+                return OkWithState(window, manager, op);
+            }
+
+            case "pin":
+            case "unpin":
+            {
+                var index = ArgInt(args, "index", -1);
+                var tab = TabAt(manager, index);
+                if (tab is null) return Error(op, $"no tab at index {index}");
+                // "via":"router" sends it the way the context menu does --
+                // through the router command, which announces the change
+                // -- otherwise straight through the manager op the drag
+                // engine commits through.
+                var viaRouter = ArgString(args, "via") == "router";
+                if (viaRouter) window.TestSeamRouter.RequestPin(tab, op == "pin");
+                else manager.SetPinned(tab, op == "pin");
+                return OkWithState(window, manager, op);
+            }
+
+            case "group":
+            {
+                var indices = ArgInts(args, "indices");
+                if (indices.Count == 0) return Error(op, "group needs indices");
+                var members = new List<TabModel>();
+                foreach (var index in indices)
+                {
+                    var tab = TabAt(manager, index);
+                    if (tab is null) return Error(op, $"no tab at index {index}");
+                    members.Add(tab);
+                }
+                // The manager's own ops: one fresh group, then the joins.
+                // Refusals (pinned, unowned) come back from the manager as
+                // a null group, never as broken state.
+                var group = manager.CreateGroup(members[0]);
+                if (group is null)
+                    return Error(op, "the manager refused the group (pinned or unowned)");
+                group.Title = $"group-{manager.Groups.Count}";
+                for (int i = 1; i < members.Count; i++)
+                    manager.JoinGroup(members[i], group);
+                return OkWithState(window, manager, op);
+            }
+
+            case "collapse":
+            {
+                var index = ArgInt(args, "index", -1);
+                var tab = TabAt(manager, index);
+                if (tab is null) return Error(op, $"no tab at index {index}");
+                if (tab.Group is null) return Error(op, $"tab {index} is not in a group");
+                var collapsed = ArgBool(args, "collapsed", true);
+                // "via":"router" sends it the way the header's chevron does:
+                // the router's collapse command stages through the strip
+                // (focus re-home, drag stand-down) before the manager flips
+                // the bit. The default is the bare manager op.
+                if (ArgString(args, "via") == "router")
+                    window.TestSeamRouter.RequestCollapseGroup(tab.Group, collapsed);
+                else
+                    manager.CollapseGroup(tab.Group, collapsed);
+                return OkWithState(window, manager, op);
+            }
+
+            case "toggle-layout":
+            {
+                // The keyboard path's own dispatch: the router event the
+                // chord raises, so the seam cannot drift from the real
+                // action.
+                window.TestSeamRouter.RequestToggleTabLayout();
+
+                // The ack waits out the morph. ToggleTabLayout no-ops while
+                // LayoutCoordinator is mid-switch, so a driver that did not
+                // wait would silently skip every other toggle.
+                var deadline = Environment.TickCount64 + 10_000;
+                while (window.TestSeamLayoutSwitching
+                       && Environment.TickCount64 < deadline)
+                {
+                    await Task.Delay(15);
+                }
+                return window.TestSeamLayoutSwitching
+                    ? Error(op, "layout switch did not settle within 10s")
+                    : OkWithState(window, manager, op);
+            }
+
+            case "drag":
+            {
+                var strip = window.TestSeamVerticalStrip;
+                if (strip is null)
+                    return Error(op, "the vertical strip is not the active host");
+                var outcome = await strip.TestSeamDragAsync(
+                    ArgInt(args, "from", -1), ArgInt(args, "to", -1));
+                return Json(json =>
+                {
+                    json.WriteStartObject();
+                    json.WriteBoolean("ok", outcome.Ok);
+                    json.WriteString("op", op);
+                    if (outcome.Error is { } error) json.WriteString("error", error);
+                    json.WriteNumber("landed", outcome.Landed);
+                    json.WriteStartArray("order");
+                    foreach (var title in outcome.Order)
+                        json.WriteStringValue(title);
+                    json.WriteEndArray();
+                    json.WriteEndObject();
+                });
+            }
+
+            default:
+                return Error(op, $"unknown op '{op}'");
+        }
+    }
+
+    // ---- responses ---------------------------------------------------
+
+    private static string OkWithState(MainWindow window, TabManager manager, string op)
+        => Json(json =>
+        {
+            json.WriteStartObject();
+            json.WriteBoolean("ok", true);
+            json.WriteString("op", op);
+            WriteState(json, window, manager);
+            json.WriteEndObject();
+        });
+
+    /// <summary>The one response builder: AOT-safe, reflection-free.</summary>
+    private static string Json(Action<Utf8JsonWriter> write)
+    {
+        using var stream = new MemoryStream();
+        using var json = new Utf8JsonWriter(stream);
+        write(json);
+        // The writer buffers internally; nothing reaches the stream until
+        // this flush. The dispose-time flush is too late for a read.
+        json.Flush();
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    private static string Error(string op, string message)
+        => Json(json =>
+        {
+            json.WriteStartObject();
+            json.WriteBoolean("ok", false);
+            json.WriteString("op", op);
+            json.WriteString("error", message);
+            json.WriteEndObject();
+        });
+
+    /// <summary>
+    /// The assert surface: manager truth -- order, pin flags, groups and
+    /// their collapse bits -- plus the two layout bits the driver needs to
+    /// know where the window stands.
+    /// </summary>
+    private static void WriteState(
+        Utf8JsonWriter json, MainWindow window, TabManager manager)
+    {
+        json.WriteStartObject("state");
+        json.WriteBoolean("vertical", window.TestSeamVerticalTabs);
+        json.WriteBoolean("switching", window.TestSeamLayoutSwitching);
+        json.WriteStartArray("tabs");
+        for (int i = 0; i < manager.Tabs.Count; i++)
+        {
+            var tab = manager.Tabs[i];
+            json.WriteStartObject();
+            json.WriteNumber("index", i);
+            json.WriteString("title", tab.EffectiveTitle);
+            json.WriteBoolean("pinned", tab.IsPinned);
+            if (tab.Group is { } group)
+            {
+                json.WriteString("group", group.Title);
+                json.WriteBoolean("collapsedGroup", group.IsCollapsed);
+            }
+            json.WriteEndObject();
+        }
+        json.WriteEndArray();
+        json.WriteStartArray("groups");
+        foreach (var group in manager.Groups)
+        {
+            json.WriteStartObject();
+            json.WriteString("title", group.Title);
+            json.WriteBoolean("collapsed", group.IsCollapsed);
+            json.WriteStartArray("members");
+            foreach (var member in manager.MembersOf(group))
+                json.WriteStringValue(member.EffectiveTitle);
+            json.WriteEndArray();
+            json.WriteEndObject();
+        }
+        json.WriteEndArray();
+        json.WriteEndObject();
+    }
+
+    // ---- argument readers --------------------------------------------
+
+    private static string? ArgString(JsonElement args, string name)
+        => args.ValueKind == JsonValueKind.Object
+           && args.TryGetProperty(name, out var value)
+           && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    private static int ArgInt(JsonElement args, string name, int fallback)
+        => args.ValueKind == JsonValueKind.Object
+           && args.TryGetProperty(name, out var value)
+           && value.ValueKind == JsonValueKind.Number
+            ? value.GetInt32()
+            : fallback;
+
+    private static bool ArgBool(JsonElement args, string name, bool fallback)
+        => args.ValueKind == JsonValueKind.Object
+           && args.TryGetProperty(name, out var value)
+           && value.ValueKind is JsonValueKind.True or JsonValueKind.False
+            ? value.GetBoolean()
+            : fallback;
+
+    private static List<string> ArgStrings(JsonElement args, string name)
+    {
+        var result = new List<string>();
+        if (args.ValueKind == JsonValueKind.Object
+            && args.TryGetProperty(name, out var value)
+            && value.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in value.EnumerateArray())
+                if (item.ValueKind == JsonValueKind.String)
+                    result.Add(item.GetString()!);
+        }
+        return result;
+    }
+
+    private static List<int> ArgInts(JsonElement args, string name)
+    {
+        var result = new List<int>();
+        if (args.ValueKind == JsonValueKind.Object
+            && args.TryGetProperty(name, out var value)
+            && value.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in value.EnumerateArray())
+                if (item.ValueKind == JsonValueKind.Number)
+                    result.Add(item.GetInt32());
+        }
+        return result;
+    }
+
+    private static TabModel? TabAt(TabManager manager, int index)
+        => index >= 0 && index < manager.Tabs.Count ? manager.Tabs[index] : null;
+}
+
+/// <summary>
+/// What one seam drag reports back: whether the engine landed the row where
+/// the driver aimed, and the manager order it left behind.
+/// </summary>
+internal sealed class TestSeamDragOutcome
+{
+    public bool Ok = true;
+    public string? Error;
+    public int Landed = -1;
+    public List<string> Order = new();
+
+    public TestSeamDragOutcome Fail(string reason)
+    {
+        Ok = false;
+        Error = reason;
+        return this;
+    }
+}

--- a/windows/scripts/seam-acceptance.ps1
+++ b/windows/scripts/seam-acceptance.ps1
@@ -1,0 +1,258 @@
+#requires -Version 7
+<#
+    The in-process test seam's acceptance run: one Wintty with
+    WINTTY_TEST_SEAM=1, driven over the named pipe with zero OS input, zero
+    focus steals, and the driver asserting manager truth after every step.
+
+    The scenario is the crash investigation's repro, made deterministic.
+    Per iteration, all over the pipe:
+
+      seed-tabs 5 -> pin 1 -> group 2,3 -> collapse 2 -> toggle-layout x2
+      -> assert order, pin flag, group membership and collapse bit, and
+      that the process is still alive.
+
+    The toggle is run twice so every iteration contains one switch INTO the
+    vertical layout with pins, groups and collapsed chips already in the
+    strip -- the compound crash.log 2026-08-31T04:58:03Z died in
+    (COMException 0x800F1000, NavigationViewItem style onto a ContentControl,
+    VerticalTabStrip.ApplyPaneLayout -> set_PaneDisplayMode -> MeasureOverride).
+    A final leg drives the drag engine itself: seed, unpin, then
+    drag(1 -> 3) through the strip's real press/threshold/crossing/release
+    sequence, asserting the landed order.
+
+    Exits 0 on pass, 2 on a product finding (the app died, refused a
+    command, or landed in a state the assertions reject), 1 when the harness
+    could not run and nothing is known about the product (the exe is
+    missing, a Wintty is already running, the seam pipe never appeared).
+#>
+param(
+    [Parameter(Mandatory)][string]$ExePath,
+    [Parameter(Mandatory)][string]$OutDir,
+    [ValidateRange(1, 100)][int]$Iterations = 5
+)
+. (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
+$ErrorActionPreference = 'Stop'
+
+$titles = @('tab-1', 'tab-2', 'tab-3', 'tab-4', 'tab-5')
+
+# ---- process and environment staging ------------------------------------
+
+if (-not (Test-Path $ExePath)) {
+    Write-Host "HARNESS: missing exe: $ExePath"
+    exit 1
+}
+Assert-NoWintty -Context 'The seam acceptance run'
+
+$crashPath = Join-Path $env:LOCALAPPDATA 'Wintty\crash.log'
+$crashStamp = if (Test-Path $crashPath) {
+    (Get-Item $crashPath).LastWriteTimeUtc
+} else {
+    [datetime]::MinValue
+}
+
+$tempXdg = Join-Path $env:TEMP "wintty-seam-accept-$([guid]::NewGuid().ToString('N'))"
+New-Item -ItemType Directory -Force -Path (Join-Path $tempXdg 'wintty') | Out-Null
+@'
+windows-single-instance = true
+window-save-state = never
+vertical-tabs = true
+'@ | Set-Content (Join-Path $tempXdg 'wintty\config.wintty') -Encoding utf8
+
+$origXdgSet = Test-Path Env:XDG_CONFIG_HOME
+$origXdg = if ($origXdgSet) { $env:XDG_CONFIG_HOME } else { $null }
+$origSeamSet = Test-Path Env:WINTTY_TEST_SEAM
+$origSeam = if ($origSeamSet) { $env:WINTTY_TEST_SEAM } else { $null }
+
+$script:Proc = $null
+$script:Reader = $null
+$script:Writer = $null
+$script:Pipe = $null
+$stamp = Get-WinttyLaunchStamp
+
+function Invoke-Seam {
+    param([Parameter(Mandatory)][hashtable]$Command)
+    if ($script:Proc.HasExited) {
+        throw ("PRODUCT_EXIT: the app exited (code {0}) before '{1}'" -f
+            $script:Proc.ExitCode, $Command['op'])
+    }
+    $script:Writer.WriteLine(($Command | ConvertTo-Json -Compress -Depth 6))
+    $line = $script:Reader.ReadLine()
+    if ($null -eq $line) {
+        if ($script:Proc.HasExited) {
+            throw ("PRODUCT_EXIT: the seam pipe closed and the app exited " +
+                "(code {0}) during '{1}'" -f $script:Proc.ExitCode, $Command['op'])
+        }
+        throw ("HARNESS: the seam closed the connection without a " +
+            "response to '{0}'" -f $Command['op'])
+    }
+    $response = $line | ConvertFrom-Json
+    if ($null -eq $response) {
+        throw ("HARNESS: the seam answered '{0}' with a non-JSON line" -f
+            $Command['op'])
+    }
+    if (-not $response.ok) {
+        throw ("PRODUCT_FAIL: {0} -> {1}" -f $Command['op'], $response.error)
+    }
+    Write-Host ("OK {0}" -f $Command['op'])
+    return $response
+}
+
+function Assert-Order {
+    param($State, [string[]]$Want, [string]$What)
+    $got = @($State.state.tabs | ForEach-Object { $_.title })
+    if (($got -join ',') -ne ($Want -join ',')) {
+        throw ("PRODUCT_FAIL: {0}: order is [{1}], wanted [{2}]" -f
+            $What, ($got -join ','), ($Want -join ','))
+    }
+}
+
+function Assert-SeamGroup {
+    param($State, [string]$Title, [string[]]$Members, [bool]$Collapsed)
+    $groups = @($State.state.groups)
+    if ($groups.Count -ne 1) {
+        throw ("PRODUCT_FAIL: expected one group, saw {0}" -f $groups.Count)
+    }
+    $group = $groups[0]
+    $got = @($group.members)
+    if ($group.title -ne $Title -or ($got -join ',') -ne ($Members -join ',') `
+        -or [bool]$group.collapsed -ne $Collapsed) {
+        throw ("PRODUCT_FAIL: group is title={0} members=[{1}] collapsed={2}, " +
+            "wanted title={3} members=[{4}] collapsed={5}" -f
+            $group.title, ($got -join ','), $group.collapsed,
+            $Title, ($Members -join ','), $Collapsed)
+    }
+}
+
+# ---- run -----------------------------------------------------------------
+
+try {
+    $env:XDG_CONFIG_HOME = $tempXdg
+    $env:WINTTY_TEST_SEAM = '1'
+    $proc = Start-Process -FilePath $ExePath -PassThru `
+        -WorkingDirectory (Split-Path -Parent (Resolve-Path $ExePath))
+    $script:Proc = $proc
+    Write-Host "pid=$($proc.Id) pipe=wintty-test-seam iterations=$Iterations"
+
+    # The seam pipe appears once OnLaunched has built the window.
+    $deadline = [datetime]::UtcNow.AddSeconds(90)
+    while ($true) {
+        if ($proc.HasExited) {
+            throw ("HARNESS: the app exited (code {0}) before the seam pipe " +
+                "appeared" -f $proc.ExitCode)
+        }
+        if ([datetime]::UtcNow -gt $deadline) {
+            throw 'HARNESS: the seam pipe never appeared (WINTTY_TEST_SEAM=1 not seen by the app?)'
+        }
+        if ([System.IO.Directory]::GetFiles('\\.\pipe\') -contains '\\.\pipe\wintty-test-seam') {
+            break
+        }
+        Start-Sleep -Milliseconds 150
+    }
+
+    $script:Pipe = [System.IO.Pipes.NamedPipeClientStream]::new(
+        '.', 'wintty-test-seam', [System.IO.Pipes.PipeDirection]::InOut)
+    $script:Pipe.Connect(20000)
+    $script:Reader = [System.IO.StreamReader]::new($script:Pipe)
+    $script:Writer = [System.IO.StreamWriter]::new(
+        $script:Pipe, [System.Text.UTF8Encoding]::new($false))
+    $script:Writer.AutoFlush = $true
+    $script:Writer.NewLine = "`n"
+    Write-Host 'seam connected'
+
+    for ($i = 1; $i -le $Iterations; $i++) {
+        $seeded = Invoke-Seam @{
+            op = 'seed-tabs'; count = 5; titles = $titles }
+        Assert-Order $seeded $titles "iteration $i seed"
+
+        $pinned = Invoke-Seam @{ op = 'pin'; index = 1 }
+        Assert-Order $pinned @('tab-2', 'tab-1', 'tab-3', 'tab-4', 'tab-5') `
+            "iteration $i pin"
+        if (-not $pinned.state.tabs[0].pinned) {
+            throw "PRODUCT_FAIL: iteration ${i}: tab-2 did not land pinned"
+        }
+
+        $grouped = Invoke-Seam @{ op = 'group'; indices = @(2, 3) }
+        Assert-Order $grouped @('tab-2', 'tab-1', 'tab-3', 'tab-4', 'tab-5') `
+            "iteration $i group"
+        Assert-SeamGroup $grouped 'group-1' @('tab-3', 'tab-4') $false
+
+        $collapsed = Invoke-Seam @{
+            op = 'collapse'; index = 2; collapsed = $true }
+        if (-not $collapsed.state.tabs[2].collapsedGroup) {
+            throw "PRODUCT_FAIL: iteration ${i}: group did not collapse"
+        }
+
+        # There and back: one of the two always switches INTO vertical with
+        # pins, groups and collapsed chips in the strip.
+        [void](Invoke-Seam @{ op = 'toggle-layout' })
+        [void](Invoke-Seam @{ op = 'toggle-layout' })
+
+        $state = Invoke-Seam @{ op = 'get-state' }
+        if (-not $state.state.vertical) {
+            throw "PRODUCT_FAIL: iteration ${i}: window did not come back vertical"
+        }
+        if ($state.state.switching) {
+            throw "PRODUCT_FAIL: iteration ${i}: layout still switching at ack"
+        }
+        Assert-Order $state @('tab-2', 'tab-1', 'tab-3', 'tab-4', 'tab-5') `
+            "iteration $i final"
+        Assert-SeamGroup $state 'group-1' @('tab-3', 'tab-4') $true
+        if ($proc.HasExited) {
+            throw ("PRODUCT_EXIT: the app exited (code {0}) during iteration {1}" -f
+                $proc.ExitCode, $i)
+        }
+        Write-Host "PASS iteration $i"
+    }
+
+    # The drag leg: the engine itself, through the seam. Fresh state, then
+    # one unpinned body row walked two slots down.
+    $fresh = Invoke-Seam @{ op = 'seed-tabs'; count = 5; titles = $titles }
+    Assert-Order $fresh $titles 'drag leg seed'
+    [void](Invoke-Seam @{ op = 'unpin'; index = 0 })
+    $drag = Invoke-Seam @{ op = 'drag'; from = 1; to = 3 }
+    Assert-Order $drag @('tab-1', 'tab-3', 'tab-4', 'tab-2', 'tab-5') 'drag leg'
+    if ($drag.landed -ne 3) {
+        throw ("PRODUCT_FAIL: drag landed at {0}, wanted 3" -f $drag.landed)
+    }
+    if ($proc.HasExited) {
+        throw ("PRODUCT_EXIT: the app exited (code {0}) during the drag leg" -f
+            $proc.ExitCode)
+    }
+    Write-Host 'PASS drag leg'
+
+    if (Test-Path $crashPath) {
+        $now = (Get-Item $crashPath).LastWriteTimeUtc
+        if ($now -gt $crashStamp) {
+            throw 'PRODUCT_FAIL: crash.log grew during the run'
+        }
+    }
+
+    Write-Host ("SEAM-ACCEPTANCE PASS: {0} iterations + drag leg, " +
+        "no flakes, no input injected" -f $Iterations)
+    exit 0
+}
+catch {
+    $message = $_.Exception.Message
+    Write-Host $message
+    if ($message -like 'HARNESS:*') { exit 1 }
+    exit 2
+}
+finally {
+    if ($script:Writer) { try { $script:Writer.Dispose() } catch { } }
+    if ($script:Reader) { try { $script:Reader.Dispose() } catch { } }
+    if ($script:Pipe) { try { $script:Pipe.Dispose() } catch { } }
+
+    # Only the instance this run started; identified by stamp and exe path.
+    try {
+        Stop-WinttyStartedAfter -Since $stamp -ExePath (Resolve-Path $ExePath).Path
+    } catch {
+        Write-Host ("HARNESS: cleanup could not confirm every process it " +
+            "started: {0}" -f $_.Exception.Message)
+    }
+
+    if ($origXdgSet) { $env:XDG_CONFIG_HOME = $origXdg }
+    else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
+    if ($origSeamSet) { $env:WINTTY_TEST_SEAM = $origSeam }
+    else { Remove-Item Env:WINTTY_TEST_SEAM -ErrorAction SilentlyContinue }
+    Remove-Item $tempXdg -Recurse -Force -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
The test automation's actuation layer - SendInput probes fighting focus, UIA tree loss, and occluder windows - burned three rungs of the tab epic. This lands the replacement's foundation: an env-gated named-pipe channel inside the app whose commands drive the REAL handlers the pointer drives.

WINTTY_TEST_SEAM=1 in the MainWindow ctor starts the pipe; without it, nothing exists. Eight commands, each through the real path: seed-tabs, pin/unpin, group, collapse, toggle-layout (via the router action the keyboard chord raises), drag(from,to) (the strip's pointer handlers are parameterized, not duplicated - PointerRoutedEventArgs is non-constructible, so the handlers resolve origin/pointerId/Y and feed the same DragPress/DragMove/DragRelease cores the seam feeds with arranged row geometry), and get-state (manager truth as the assert surface). Every command marshals through one UI-thread funnel; acks land after the work settles.

The acceptance: ~30 app launches during normal machine use, zero flakes, zero focus steals, zero synthetic input - and the layout-toggle crash that three actuation attempts could not reach now reproduces on demand, both with and without the router path, under full state control.

Size-override: ~1100 countable vs the 900 gate - the seam is one instrument (pipe, protocol, eight commands, acceptance script, gate facts); the owner approved the overrun during the spike and the strategic direction explicitly. The trust model is documented spike-honest: no ACL, same-local-user can drive an opted-in instance; the user-scoped ACL lands with hardening.