### PR TITLE
tabs: the vertical selection sync waits out container realization

### DIFF
--- a/windows/Ghostty.Tests/Wiring/VerticalTabGroupDragWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/VerticalTabGroupDragWiringTests.cs
@@ -633,4 +633,109 @@ public class VerticalTabGroupDragWiringTests
         Assert.DoesNotContain("SetPinned(drag.Tab, false)", crossingGate.ToFullString(),
             StringComparison.Ordinal);
     }
+
+    // --- The churn crash's named root (dump 2026-08-31, artifacts) ------
+    // The fail-fast's stowed COMException (800F1000, "Cannot apply a Style
+    // with TargetType NavigationViewItem to an object of type
+    // ContentControl") was raised from set_SelectedItem reached through
+    // SyncSelectionFromManager <- ReconcileRetry.Rebuild <- ReconcileRowOrder
+    // <- ScheduleReconcile: a rebuild writes MenuItems, MUXC realizes the
+    // containers on the NEXT layout pass, and the selection assignment in
+    // that window resolves a base-class ContentControl container for the
+    // selected item. The fix makes the assignment wait out realization.
+
+    /// <summary>
+    /// The selection assignment may not run while the selected item's
+    /// container is still unrealized. The guard is polarity-sensitive in
+    /// exactly the way a flip survives compilation: inverted, the sync
+    /// runs only in the crashing window and defers once the strip is
+    /// healthy -- the strip renders and every churn still throws. The
+    /// landed path clears the defer flag before it assigns, so the
+    /// realization latch knows the sync landed.
+    /// </summary>
+    [Fact]
+    public void TheSelectionSync_WaitsOutContainerRealization()
+    {
+        var sync = Strip().Method("SyncSelectionFromManager");
+
+        var gate = sync.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "item is not null && !item.IsLoaded");
+        Assert.NotEmpty(gate.Statement.DescendantNodesAndSelf()
+            .OfType<InvocationExpressionSyntax>().Where(c => c.CalleeText() == "DeferSelectionSync"));
+
+        var assignment = sync.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Single(a => a.Left.ToString() == "NavView.SelectedItem");
+        Assert.Equal("item", assignment.Right.ToString());
+        Assert.True(
+            gate.Span.End < assignment.Span.Start,
+            "the realization guard must precede the selection assignment");
+
+        // The flag clears only on the path that assigns: a sync that
+        // deferred again leaves the latch armed.
+        var cleared = sync.AssignsTo("_selectionSyncDeferred")
+            .Single(a => a.Right.ToString() == "false");
+        Assert.True(
+            gate.Span.End < cleared.Span.Start,
+            "the defer flag must not clear before the realization gate");
+
+        // And the never-loaded fence still defers through the same flag:
+        // the pre-template hazard that predates this fix keeps its guard.
+        var unloaded = sync.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "!IsLoaded");
+        Assert.Contains("true", unloaded.Statement.AssignsTo("_selectionSyncDeferred")
+            .Single().Right.ToString(), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The latch is one subscription, re-armed by deferring again: the
+    /// defer subscribes the pass handler under the not-already-latched
+    /// guard, every pass attempts the sync once, and the handler detaches
+    /// on the first pass after the sync landed -- including teardown, so a
+    /// strip that is going away does not keep a handler for passes it
+    /// will never attend.
+    /// </summary>
+    [Fact]
+    public void TheRealizationLatch_AttemptsPerPass_AndDetachesWhenLanded()
+    {
+        var defer = Strip().Method("DeferSelectionSync");
+        var guard = defer.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "_selectionRealizationLatch");
+        Assert.True(guard.Statement is ReturnStatementSyntax);
+        // Event subscriptions parse as assignments, not invocations.
+        var subscribe = defer.AssignsTo("LayoutUpdated").Single();
+        Assert.True(
+            guard.Span.End < subscribe.Span.Start,
+            "the not-latched guard must precede the subscription");
+        Assert.Equal("OnSelectionRealizationPass", subscribe.Right.ToString());
+
+        var pass = Strip().Method("OnSelectionRealizationPass");
+        var landed = pass.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "!_selectionSyncDeferred");
+        var detach = landed.Statement.AssignsTo("LayoutUpdated").Single();
+        Assert.Equal("OnSelectionRealizationPass", detach.Right.ToString());
+        Assert.Contains(landed.Statement.AssignsTo("_selectionRealizationLatch").ToList(),
+            a => a.Right.ToString() == "false");
+        // Every pass attempts the sync once: the flag clears, the sync
+        // runs, and a still-unrealized strip re-defers from inside it.
+        var retry = Assert.IsType<ExpressionStatementSyntax>(pass.Body!.Statements.Last());
+        Assert.Equal("SyncSelectionFromManager",
+            Assert.IsType<InvocationExpressionSyntax>(retry.Expression).CalleeText());
+        var passClear = pass.AssignsTo("_selectionSyncDeferred")
+            .Single(a => a.Right.ToString() == "false");
+        Assert.True(passClear.Span.End < retry.Span.Start,
+            "the pass must clear the flag before the attempt, or the landed "
+            + "detach can never fire");
+
+        // Teardown detaches: the Unloaded handler the ctor wires must name
+        // the same detach, or a closed strip latches a handler forever.
+        var ctor = Strip().Root.DescendantNodes()
+            .OfType<ConstructorDeclarationSyntax>()
+            .First(c => c.Identifier.ValueText == "VerticalTabStrip");
+        var unloaded = ctor.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Single(a => a.Left.ToString() == "Unloaded");
+        Assert.NotEmpty(unloaded.Right.DescendantNodesAndSelf()
+            .OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.Left.ToString() == "LayoutUpdated"
+                        && a.Right.ToString() == "OnSelectionRealizationPass"));
+    }
 }

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -167,6 +167,13 @@ internal sealed partial class VerticalTabStrip : UserControl
         {
             CancelDrag("teardown");
             FinishPinFlight("teardown");
+            // A latched selection replay would fire for passes this strip
+            // no longer attends; drop it with the rest of the wiring.
+            if (_selectionRealizationLatch)
+            {
+                LayoutUpdated -= OnSelectionRealizationPass;
+                _selectionRealizationLatch = false;
+            }
         };
     }
 
@@ -1049,6 +1056,17 @@ internal sealed partial class VerticalTabStrip : UserControl
     /// The work is latched and replayed on Loaded instead; every path that
     /// makes this strip visible already calls back in here afterwards, so
     /// the latch only has to cover the case where nothing else does.
+    ///
+    /// The loaded-but-not-realized state is the same fence one level down,
+    /// and it is the churn crash (0xC000027B / XAML 800F1000) read out of
+    /// a full dump: a rebuild writes MenuItems, MUXC realizes containers
+    /// across the NEXT layout pass, and set_SelectedItem inside that
+    /// window resolves the item's container as the host's base-class
+    /// ContentControl -- the selection style targets NavigationViewItem,
+    /// the application fails, XAML stows it, and the dispatcher turn ends
+    /// in a fail-fast. The assignment therefore waits until the selected
+    /// item is realized (IsLoaded), on a latched LayoutUpdated replay;
+    /// deferring again re-arms the latch, so a re-churn cannot strand it.
     /// </remarks>
     internal void SyncSelectionFromManager()
     {
@@ -1062,6 +1080,16 @@ internal sealed partial class VerticalTabStrip : UserControl
 
         if (_manager.ActiveTab is null) return;
 
+        var item = _items.TryGetValue(_manager.ActiveTab, out var selected)
+            ? selected
+            : null;
+        if (item is not null && !item.IsLoaded)
+        {
+            DeferSelectionSync();
+            return;
+        }
+        _selectionSyncDeferred = false;
+
         _syncing = true;
         try
         {
@@ -1071,9 +1099,7 @@ internal sealed partial class VerticalTabStrip : UserControl
             // selected while the strip's active chrome sits on a pinned
             // row, so park the selection at null: the selection overlay is
             // the active chrome for a pinned row and does not consult MUXC.
-            NavView.SelectedItem = _items.TryGetValue(_manager.ActiveTab, out var item)
-                ? item
-                : null;
+            NavView.SelectedItem = item;
         }
         finally { _syncing = false; }
 
@@ -1081,6 +1107,35 @@ internal sealed partial class VerticalTabStrip : UserControl
         RecolorNavItems();
         EnsureActiveItemVisible();
         ScheduleSelectionLayoutPass(retryIfZeroBounds: true);
+    }
+
+    /// <summary>
+    /// The realization latch for the selection sync: subscribed once, and
+    /// every layout pass gives the deferred sync one attempt -- a pass
+    /// where MUXC has realized the churned containers lands it, and a pass
+    /// where it has not re-arms the latch through the defer. Detached the
+    /// moment the sync lands, and on teardown.
+    /// </summary>
+    private bool _selectionRealizationLatch;
+
+    private void DeferSelectionSync()
+    {
+        _selectionSyncDeferred = true;
+        if (_selectionRealizationLatch) return;
+        _selectionRealizationLatch = true;
+        LayoutUpdated += OnSelectionRealizationPass;
+    }
+
+    private void OnSelectionRealizationPass(object? sender, object e)
+    {
+        if (!_selectionSyncDeferred)
+        {
+            LayoutUpdated -= OnSelectionRealizationPass;
+            _selectionRealizationLatch = false;
+            return;
+        }
+        _selectionSyncDeferred = false;
+        SyncSelectionFromManager();
     }
 
     // The scroller the rows live inside, out of the NavigationView's

--- a/windows/scripts/mouse-fuzz-tab-drag.ps1
+++ b/windows/scripts/mouse-fuzz-tab-drag.ps1
@@ -1178,6 +1178,26 @@ try {
         }
     }
 
+    # Task #33: the layout-toggle crash battery. The owner's hand test
+    # hit a UI-thread COMException (0x800F1000 -- a NavigationViewItem-
+    # targeted style applied to a ContentControl) toggling the layout on
+    # a strip that carried pins, a group, and the collapsed chip. That
+    # state is exactly what exists here (pins from the boundary legs, the
+    # group collapsed by the chip roundtrip), so this leg toggles through
+    # the pane re-measure in both directions and requires the process to
+    # survive with the strip still rendering.
+    Add-Phase 'layout-toggle-crash' {
+        Toggle-Layout $hwnd64 $pid32
+        $proc.Refresh()
+        if ($proc.HasExited) { throw "PRODUCT_FAIL: the layout toggle killed the process (to vertical)" }
+        $null = Get-StripRows $V
+        Toggle-Layout $hwnd64 $pid32
+        $proc.Refresh()
+        if ($proc.HasExited) { throw "PRODUCT_FAIL: the layout toggle killed the process (to horizontal)" }
+        $null = Get-StripRows $H
+        $script:Orders.layoutToggle = 'survived'
+    }
+
     # The trace oracle, over the whole run's sessions. Six vertical-machine
     # drags: the two motion-on reorders, the motion-off reorder, the
     # boundary out-and-back, the pin drop, the drop-on-chip join. The

--- a/windows/scripts/seam-acceptance.ps1
+++ b/windows/scripts/seam-acceptance.ps1
@@ -28,7 +28,11 @@
 param(
     [Parameter(Mandatory)][string]$ExePath,
     [Parameter(Mandatory)][string]$OutDir,
-    [ValidateRange(1, 100)][int]$Iterations = 5
+    [ValidateRange(1, 100)][int]$Iterations = 5,
+    # Milliseconds between commands. 0 is the tight train; 400 is the
+    # pacing that let ordinary layout frames pass through freshly churned
+    # strip items and died 6/6 before the realization guard.
+    [ValidateRange(0, 5000)][int]$GapMs = 0
 )
 . (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
@@ -71,6 +75,7 @@ $stamp = Get-WinttyLaunchStamp
 
 function Invoke-Seam {
     param([Parameter(Mandatory)][hashtable]$Command)
+    if ($GapMs -gt 0) { Start-Sleep -Milliseconds $GapMs }
     if ($script:Proc.HasExited) {
         throw ("PRODUCT_EXIT: the app exited (code {0}) before '{1}'" -f
             $script:Proc.ExitCode, $Command['op'])

--- a/windows/scripts/seam-bisect.ps1
+++ b/windows/scripts/seam-bisect.ps1
@@ -1,0 +1,78 @@
+# Runs one scenario in a fresh app instance: steps are seam ops; reports
+# SURVIVED or CRASHED(op) so the crash's minimal compound can be found.
+param(
+    [Parameter(Mandatory)][string]$Scenario,
+    [Parameter(Mandatory)][string]$ExePath,
+    [string[]]$Ops,
+    [int]$GapMs = 0
+)
+$ErrorActionPreference = 'Stop'
+
+$exe = $ExePath
+$xdg = Join-Path $env:TEMP ("wintty-seam-bisect-" + [guid]::NewGuid().ToString('N'))
+$env:XDG_CONFIG_HOME = $xdg
+$env:WINTTY_TEST_SEAM = '1'
+New-Item -ItemType Directory -Force -Path (Join-Path $xdg 'wintty') | Out-Null
+@'
+windows-single-instance = true
+window-save-state = never
+vertical-tabs = true
+'@ | Set-Content (Join-Path $xdg 'wintty\config.wintty') -Encoding utf8
+
+# Wait out the previous scenario's instance: its pipe server may outlive
+# the client by a beat, and connecting to a dying process looks like a
+# broken pipe, not a crash.
+$goneBy = [datetime]::UtcNow.AddSeconds(15)
+while ([datetime]::UtcNow -lt $goneBy) {
+    if (-not ([System.IO.Directory]::GetFiles('\\.\pipe\') -contains '\\.\pipe\wintty-test-seam')) { break }
+    Start-Sleep -Milliseconds 200
+}
+
+$proc = Start-Process -FilePath $exe -PassThru -WorkingDirectory (Split-Path -Parent $exe)
+$deadline = [datetime]::UtcNow.AddSeconds(60)
+while ([datetime]::UtcNow -lt $deadline) {
+    if ($proc.HasExited) { throw "app exited before the pipe appeared" }
+    if ([System.IO.Directory]::GetFiles('\\.\pipe\') -contains '\\.\pipe\wintty-test-seam') { break }
+    Start-Sleep -Milliseconds 200
+}
+$pipe = [System.IO.Pipes.NamedPipeClientStream]::new('.', 'wintty-test-seam', [System.IO.Pipes.PipeDirection]::InOut)
+$pipe.Connect(10000)
+$r = [System.IO.StreamReader]::new($pipe)
+$w = [System.IO.StreamWriter]::new($pipe, [System.Text.UTF8Encoding]::new($false)); $w.AutoFlush = $true
+$w.NewLine = "`n"
+
+$outcome = 'SURVIVED'
+try {
+    foreach ($op in $Ops) {
+        Start-Sleep -Milliseconds $GapMs
+        if ($proc.HasExited) { $outcome = "CRASHED(before $op)"; break }
+        try {
+            $w.WriteLine($op)
+            $line = $r.ReadLine()
+        }
+        catch [System.IO.IOException] {
+            $outcome = if ($proc.HasExited) { "CRASHED(during $op)" } else { "PIPE-BROKEN($op)" }
+            break
+        }
+        if ($null -eq $line) {
+            $outcome = if ($proc.HasExited) { "CRASHED(during $op)" } else { "NO-REPLY($op)" }
+            break
+        }
+        $resp = $line | ConvertFrom-Json
+        if (-not $resp.ok) { $outcome = "REFUSED($op): $($resp.error)"; break }
+    }
+    Start-Sleep -Milliseconds 800
+    if ($outcome -eq 'SURVIVED' -and $proc.HasExited) {
+        $outcome = "CRASHED(after last op, code $($proc.ExitCode))"
+    }
+}
+catch {
+    $outcome = "HARNESS($($_.Exception.Message))"
+}
+finally {
+    try { $w.Dispose(); $r.Dispose(); $pipe.Dispose() } catch {}
+    if (-not $proc.HasExited) { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
+    Remove-Item $xdg -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+"$scenario => $outcome"

--- a/windows/scripts/seam-cdb.ps1
+++ b/windows/scripts/seam-cdb.ps1
@@ -1,0 +1,105 @@
+#requires -Version 7
+<#
+    Drives the gap scenario while the app runs under cdb, and takes a FULL
+    dump (.dump /ma) at the fail-fast. WER LocalDumps only ever produces
+    minidumps here, and a minidump cannot read the stowed exception's stack
+    (the pages are simply not in the file) -- the full dump is what names
+    the styled container.
+
+    Two sxe arms, because the fail-fast surfaces as either 0xC000027B or
+    its escalation 0xC0000602 depending on where the debugger first sees
+    it. The dump takes tens of seconds to minutes for a 400MB-commit
+    process; the script polls for the file and does not give up early.
+    sxe -c has been observed to not fire for this exception on some runs;
+    if the dump never appears, the fallback is WER LocalDumps
+    (seam-crash-dump.ps1) plus manual analysis of what the minidump holds.
+
+    Exits 0 with the dump path printed on success.
+#>
+param(
+    [Parameter(Mandatory)][string]$ExePath,
+    [string]$DumpPath = (Join-Path $env:TEMP 'wintty-seam-crash.dmp')
+)
+$ErrorActionPreference = 'Stop'
+$exe = $ExePath
+$cdb = 'C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\cdb.exe'
+$log = Join-Path $env:TEMP 'wintty-seam-cdb.log'
+$cmds = Join-Path $env:TEMP 'wintty-seam-cdb-cmds.txt'
+$xdg = Join-Path $env:TEMP ("wintty-seam-cdb-" + [guid]::NewGuid().ToString('N'))
+$env:XDG_CONFIG_HOME = $xdg
+$env:WINTTY_TEST_SEAM = '1'
+New-Item -ItemType Directory -Force -Path (Join-Path $xdg 'wintty') | Out-Null
+@'
+windows-single-instance = true
+window-save-state = never
+vertical-tabs = true
+'@ | Set-Content (Join-Path $xdg 'wintty\config.wintty') -Encoding utf8
+
+$dumpArg = ($DumpPath -replace '\\', '\\')
+@'
+sxe -c ".dump /ma DUMPPATH; q" 0xC000027B
+sxe -c ".dump /ma DUMPPATH; q" 0xC0000602
+g
+'@ -replace 'DUMPPATH', $dumpArg | Set-Content $cmds -Encoding ascii
+
+Remove-Item $log, $DumpPath -ErrorAction SilentlyContinue
+$argLine = '-logo "' + $log + '" -c "$<' + $cmds + '" "' + $exe + '"'
+$debugger = Start-Process -FilePath $cdb -ArgumentList $argLine -PassThru
+$deadline = [datetime]::UtcNow.AddSeconds(90)
+while ([datetime]::UtcNow -lt $deadline) {
+    if ($debugger.HasExited) { throw "HARNESS: cdb exited before the pipe appeared" }
+    if ([System.IO.Directory]::GetFiles('\\.\pipe\') -contains '\\.\pipe\wintty-test-seam') {
+        break
+    }
+    Start-Sleep -Milliseconds 200
+}
+$pipe = [System.IO.Pipes.NamedPipeClientStream]::new(
+    '.', 'wintty-test-seam', [System.IO.Pipes.PipeDirection]::InOut)
+$pipe.Connect(10000)
+$reader = [System.IO.StreamReader]::new($pipe)
+$writer = [System.IO.StreamWriter]::new(
+    $pipe, [System.Text.UTF8Encoding]::new($false))
+$writer.AutoFlush = $true
+$writer.NewLine = "`n"
+
+$seed = '{"op":"seed-tabs","count":5,"titles":["tab-1","tab-2","tab-3","tab-4","tab-5"]}'
+$pin = '{"op":"pin","index":1}'
+$group = '{"op":"group","indices":[2,3]}'
+$coll = '{"op":"collapse","index":2,"collapsed":true}'
+$ops = @($seed, $pin, $group, $coll)
+$crashed = $false
+foreach ($op in $ops) {
+    Start-Sleep -Milliseconds 400
+    try {
+        $writer.WriteLine($op)
+        [void]$reader.ReadLine()
+    }
+    catch [System.IO.IOException] {
+        $crashed = $true
+        break
+    }
+}
+
+# The dump write can take minutes; poll, do not assume.
+$dumpBy = [datetime]::UtcNow.AddSeconds(420)
+while ([datetime]::UtcNow -lt $dumpBy) {
+    if (Test-Path $DumpPath) {
+        $size = (Get-Item $DumpPath).Length
+        if ($size -gt 10MB) {
+            Start-Sleep -Seconds 5   # let the writer finish
+            break
+        }
+    }
+    Start-Sleep -Seconds 5
+}
+try { $writer.Dispose(); $reader.Dispose(); $pipe.Dispose() } catch {}
+if (-not $debugger.WaitForExit(60000)) {
+    "cdb still alive after the dump window; killing"
+    Stop-Process -Id $debugger.Id -Force -ErrorAction SilentlyContinue
+}
+if (Test-Path $DumpPath) {
+    Write-Host ("DUMP: {0} ({1:N0} bytes)" -f $DumpPath, (Get-Item $DumpPath).Length)
+    exit 0
+}
+Write-Host 'HARNESS: no dump produced; check the cdb log:' (Test-Path $log)
+exit 1

--- a/windows/scripts/seam-crash-dump.ps1
+++ b/windows/scripts/seam-crash-dump.ps1
@@ -1,0 +1,154 @@
+#requires -Version 7
+<#
+    Captures a FULL dump of the seam's churn crash (0xC000027B fail-fast,
+    XAML 800F1000 E_NER_INVALID_OPERATION underneath) through WER
+    LocalDumps, because cdb's sxe -c never fires for a non-continuable
+    fail-fast. The registry write is per-user, snapshot before, verified
+    after, restored in the finally: the harness holds the state it touches
+    and puts it back.
+
+    The scenario is the pacing discriminator's losing compound: 400ms
+    between commands, seed 5 tabs, pin, group, collapse. WER does not run
+    while a debugger is attached, so nothing else may hold the process.
+
+    Exits 0 with $DumpPath printed on success, 1 when the harness could
+    not run, 2 when the app survived (no crash to dump).
+#>
+param(
+    [Parameter(Mandatory)][string]$ExePath,
+    [string]$DumpFolder = (Join-Path $env:TEMP 'wintty-seam-dumps')
+)
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
+
+Assert-NoWintty -Context 'The seam crash-dump capture'
+$stamp = Get-WinttyLaunchStamp
+
+# ---- WER LocalDumps, snapshot / set / verify / restore -------------------
+
+$werKey = 'HKCU:\Software\Microsoft\Windows\Windows Error Reporting\LocalDumps'
+$exeKey = "$werKey\Wintty.exe"
+$snapshot = $null
+if (Test-Path $exeKey) {
+    $snapshot = Get-ItemProperty $exeKey
+}
+function Restore-Wer {
+    if ($snapshot) {
+        foreach ($prop in $snapshot.PSObject.Properties) {
+            if ($prop.Name -in @('PSPath', 'PSParentPath', 'PSChildName',
+                                 'PSDrive', 'PSProvider')) { continue }
+            Set-ItemProperty $exeKey -Name $prop.Name -Value $prop.Value
+        }
+    } elseif (Test-Path $exeKey) {
+        Remove-Item $exeKey -Recurse -Force
+    }
+}
+
+New-Item -ItemType Directory -Force -Path $DumpFolder | Out-Null
+New-Item -ItemType Directory -Force -Path $exeKey | Out-Null
+New-ItemProperty $exeKey -Name DumpFolder -Value $DumpFolder `
+    -PropertyType ExpandString -Force | Out-Null
+New-ItemProperty $exeKey -Name DumpType -Value 2 -PropertyType DWord -Force | Out-Null
+New-ItemProperty $exeKey -Name DumpCount -Value 10 -PropertyType DWord -Force | Out-Null
+
+# Read-back verification: the guard's rule -- a setting the harness set
+# but cannot read back is a setting it does not have.
+$check = Get-ItemProperty $exeKey
+if ($check.DumpType -ne 2 -or $check.DumpFolder -ne $DumpFolder) {
+    throw 'HARNESS: WER LocalDumps did not read back the values just set'
+}
+
+$xdg = Join-Path $env:TEMP ("wintty-seam-dump-" + [guid]::NewGuid().ToString('N'))
+$env:XDG_CONFIG_HOME = $xdg
+$env:WINTTY_TEST_SEAM = '1'
+New-Item -ItemType Directory -Force -Path (Join-Path $xdg 'wintty') | Out-Null
+@'
+windows-single-instance = true
+window-save-state = never
+vertical-tabs = true
+'@ | Set-Content (Join-Path $xdg 'wintty\config.wintty') -Encoding utf8
+
+$dumpPath = $null
+$proc = $null
+try {
+    $proc = Start-Process -FilePath $ExePath -PassThru `
+        -WorkingDirectory (Split-Path -Parent (Resolve-Path $ExePath))
+    $deadline = [datetime]::UtcNow.AddSeconds(90)
+    while ([datetime]::UtcNow -lt $deadline) {
+        if ($proc.HasExited) { throw "HARNESS: app exited before the seam pipe" }
+        if ([System.IO.Directory]::GetFiles('\\.\pipe\') -contains '\\.\pipe\wintty-test-seam') {
+            break
+        }
+        Start-Sleep -Milliseconds 200
+    }
+    $pipe = [System.IO.Pipes.NamedPipeClientStream]::new(
+        '.', 'wintty-test-seam', [System.IO.Pipes.PipeDirection]::InOut)
+    $pipe.Connect(20000)
+    $reader = [System.IO.StreamReader]::new($pipe)
+    $writer = [System.IO.StreamWriter]::new(
+        $pipe, [System.Text.UTF8Encoding]::new($false))
+    $writer.AutoFlush = $true
+    $writer.NewLine = "`n"
+
+    $ops = @(
+        '{"op":"seed-tabs","count":5,"titles":["tab-1","tab-2","tab-3","tab-4","tab-5"]}',
+        '{"op":"pin","index":1}',
+        '{"op":"group","indices":[2,3]}',
+        '{"op":"collapse","index":2,"collapsed":true}',
+        '{"op":"toggle-layout"}',
+        '{"op":"toggle-layout"}',
+        '{"op":"collapse","index":2,"collapsed":false}',
+        '{"op":"toggle-layout"}',
+        '{"op":"toggle-layout"}'
+    )
+    $crashed = $false
+    foreach ($op in $ops) {
+        Start-Sleep -Milliseconds 400
+        if ($proc.HasExited) { $crashed = $true; break }
+        try {
+            $writer.WriteLine($op)
+            [void]$reader.ReadLine()
+        }
+        catch [System.IO.IOException] {
+            $crashed = $true
+            break
+        }
+    }
+    if (-not $crashed) {
+        Write-Host 'PRODUCT-SURVIVED: the scenario did not crash this run'
+        exit 2
+    }
+
+    # WER owns the death now: wait for the dump to be written.
+    $dumpDeadline = [datetime]::UtcNow.AddSeconds(120)
+    while ([datetime]::UtcNow -lt $dumpDeadline) {
+        $dumpPath = Get-ChildItem $DumpFolder -Filter 'Wintty.exe.*.dmp' `
+            -ErrorAction SilentlyContinue |
+            Sort-Object LastWriteTimeUtc -Descending |
+            Select-Object -First 1
+        if ($dumpPath -and $dumpPath.Length -gt 0) {
+            Start-Sleep -Seconds 3   # let WER finish the write
+            break
+        }
+        Start-Sleep -Milliseconds 500
+    }
+    if (-not $dumpPath) {
+        throw 'HARNESS: the process died but WER produced no dump'
+    }
+    Write-Host ("DUMP: {0} ({1:N0} bytes)" -f $dumpPath.FullName, $dumpPath.Length)
+    exit 0
+}
+catch {
+    Write-Host $_.Exception.Message
+    exit 1
+}
+finally {
+    Restore-Wer
+    if ($proc -and -not $proc.HasExited) {
+        Stop-WinttyStartedAfter -Since $stamp -ExePath (Resolve-Path $ExePath).Path `
+            -ErrorAction SilentlyContinue
+    }
+    Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue
+    Remove-Item Env:WINTTY_TEST_SEAM -ErrorAction SilentlyContinue
+    Remove-Item $xdg -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/windows/scripts/seam-probe.ps1
+++ b/windows/scripts/seam-probe.ps1
@@ -1,0 +1,37 @@
+param(
+    [Parameter(Mandatory)][string]$ExePath
+)
+$ErrorActionPreference = 'Stop'
+$env:WINTTY_TEST_SEAM = '1'
+$xdg = Join-Path $env:TEMP ("wintty-seam-probe-" + [guid]::NewGuid().ToString('N'))
+$env:XDG_CONFIG_HOME = $xdg
+New-Item -ItemType Directory -Force -Path (Join-Path $xdg 'wintty') | Out-Null
+@'
+windows-single-instance = true
+window-save-state = never
+vertical-tabs = true
+'@ | Set-Content (Join-Path $xdg 'wintty\config.wintty') -Encoding utf8
+
+$exe = $ExePath
+$proc = Start-Process -FilePath $exe -PassThru -WorkingDirectory (Split-Path -Parent $exe)
+$deadline = [datetime]::UtcNow.AddSeconds(60)
+while ([datetime]::UtcNow -lt $deadline) {
+    if ($proc.HasExited) { throw "app exited early" }
+    if ([System.IO.Directory]::GetFiles('\\.\pipe\') -contains '\\.\pipe\wintty-test-seam') { break }
+    Start-Sleep -Milliseconds 200
+}
+$pipe = [System.IO.Pipes.NamedPipeClientStream]::new('.', 'wintty-test-seam', [System.IO.Pipes.PipeDirection]::InOut)
+$pipe.Connect(10000)
+$r = [System.IO.StreamReader]::new($pipe)
+$w = [System.IO.StreamWriter]::new($pipe, [System.Text.UTF8Encoding]::new($false)); $w.AutoFlush = $true
+
+$w.WriteLine('{"op":"get-state"}')
+"STATE: " + $r.ReadLine()
+$w.WriteLine('{"op":"seed-tabs","count":5,"titles":["tab-1","tab-2","tab-3","tab-4","tab-5"]}')
+"SEED RAW: " + $r.ReadLine()
+Start-Sleep -Seconds 2
+"alive=" + (-not $proc.HasExited)
+if ($proc.HasExited) { "exitcode=" + $proc.ExitCode }
+try { $w.Dispose(); $r.Dispose(); $pipe.Dispose() } catch {}
+Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+Remove-Item $xdg -Recurse -Force -ErrorAction SilentlyContinue


### PR DESCRIPTION
The layout-toggle and collapse crash family (0xC000027B fail-fasts) traced, via a full dump walked through its stowed exception, to a selection write landing inside NavigationView's container-realization window: the reconcile rebuild writes MenuItems, MUXC realizes containers on the next layout pass, and set_SelectedItem inside that window resolves the selected item's container as the base ContentControl and fails styling it (0x800F1000).

SyncSelectionFromManager now waits out realization: the assignment runs only when the selected item IsLoaded, otherwise defers on a latched LayoutUpdated replay that re-arms on re-churn and detaches when landed and on teardown. Tight-pattern deaths become catchable managed throws instead of fail-fasts. The remaining paced-churn fail-fast is a transient MUXC-internal container (dump-verified, escalated separately); the promoted seam diagnostic scripts and the authored harness leg ride along.