### PR TITLE
tabs: pin, unpin, and group moves become chord-bindable end to end

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -704,6 +704,11 @@ typedef struct {
   ssize_t amount;
 } ghostty_action_move_tab_s;
 
+// apprt.action.MoveGroup
+typedef struct {
+  ssize_t amount;
+} ghostty_action_move_group_s;
+
 // apprt.action.GotoTab
 typedef enum {
   GHOSTTY_GOTO_TAB_PREVIOUS = -1,
@@ -1074,12 +1079,18 @@ typedef enum {
   GHOSTTY_ACTION_PROMPT_READY,
   GHOSTTY_ACTION_FIRST_RENDER,
   GHOSTTY_ACTION_CUSTOM_SHADER_FAILED,
+  // Windows-apprt tab-shell actions. Appended so every upstream
+  // ordinal stays stable; keep in sync with apprt.action.Action.Key.
+  GHOSTTY_ACTION_PIN_TAB,
+  GHOSTTY_ACTION_UNPIN_TAB,
+  GHOSTTY_ACTION_MOVE_GROUP,
 } ghostty_action_tag_e;
 
 typedef union {
   ghostty_action_split_direction_e new_split;
   ghostty_action_fullscreen_e toggle_fullscreen;
   ghostty_action_move_tab_s move_tab;
+  ghostty_action_move_group_s move_group;
   ghostty_action_goto_tab_e goto_tab;
   ghostty_action_goto_split_e goto_split;
   ghostty_action_goto_window_e goto_window;

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -5466,6 +5466,26 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             .{ .amount = position },
         ),
 
+        // Windows-apprt tab-shell actions: the strip lives apprt-side, so
+        // these forward unchanged and the apprt decides refusals.
+        .pin_tab => return try self.rt_app.performAction(
+            .{ .surface = self },
+            .pin_tab,
+            {},
+        ),
+
+        .unpin_tab => return try self.rt_app.performAction(
+            .{ .surface = self },
+            .unpin_tab,
+            {},
+        ),
+
+        .move_group => |position| return try self.rt_app.performAction(
+            .{ .surface = self },
+            .move_group,
+            .{ .amount = position },
+        ),
+
         .move_tab_to_new_window => return try self.rt_app.performAction(
             .{ .surface = self },
             .move_tab_to_new_window,

--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -373,6 +373,19 @@ pub const Action = union(Key) {
     /// the only signal that the setting silently did nothing.
     custom_shader_failed: renderer.CustomShaderFailure,
 
+    // Windows-apprt tab-shell actions. Appended so the union field order
+    // keeps matching the Key enum below, whose tail mirrors this block.
+
+    /// Pin the focused tab into the pinned prefix of its tab strip.
+    pin_tab,
+
+    /// Unpin the focused tab from the pinned prefix of its tab strip.
+    unpin_tab,
+
+    /// Move the group (contiguous run) the focused tab belongs to by a
+    /// relative offset: -1 for one group left, +1 for one group right.
+    move_group: MoveGroup,
+
     /// Sync with: ghostty_action_tag_e
     pub const Key = enum(c_int) {
         quit,
@@ -447,6 +460,12 @@ pub const Action = union(Key) {
         prompt_ready,
         first_render,
         custom_shader_failed,
+
+        // Windows-apprt tab-shell actions. Appended so every upstream
+        // ordinal stays stable; keep in sync with ghostty_action_tag_e.
+        pin_tab,
+        unpin_tab,
+        move_group,
 
         test "ghostty.h Action.Key" {
             try lib.checkGhosttyHEnum(Key, "GHOSTTY_ACTION_");
@@ -579,6 +598,13 @@ pub const ResizeSplit = extern struct {
 };
 
 pub const MoveTab = extern struct {
+    amount: isize,
+};
+
+/// The group (contiguous run) the focused tab belongs to, moved by a
+/// relative offset. Same shape as `MoveTab`; a separate type so the C
+/// header can name the member per action.
+pub const MoveGroup = extern struct {
     amount: isize,
 };
 

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -594,6 +594,24 @@ pub const Action = union(enum) {
     /// macOS.
     move_tab_to_new_window,
 
+    // Windows-apprt tab-shell actions below. They carry no default keybind;
+    // they exist so a user keybind has a verb to name, and the embedded
+    // apprt owns whatever the action does to its tab strip.
+
+    /// Pin the focused tab into the pinned prefix of its tab strip.
+    pin_tab,
+
+    /// Unpin the focused tab from the pinned prefix of its tab strip.
+    unpin_tab,
+
+    /// Move the group (the contiguous run) the focused tab belongs to by a
+    /// relative offset, keeping the group's internal order.
+    ///
+    /// Positive values move the group forwards, and negative values move it
+    /// backwards, one neighbouring group per step. An ungrouped tab moves
+    /// nothing. A group never lands inside the pinned prefix.
+    move_group: isize,
+
     /// Toggle the tab overview.
     ///
     /// This is only supported on Linux and when the system's libadwaita
@@ -1454,6 +1472,9 @@ pub const Action = union(enum) {
             .goto_tab,
             .move_tab,
             .move_tab_to_new_window,
+            .pin_tab,
+            .unpin_tab,
+            .move_group,
             .toggle_tab_overview,
             .new_split,
             .goto_split,

--- a/src/input/command.zig
+++ b/src/input/command.zig
@@ -737,6 +737,14 @@ fn actionCommands(action: Action.Key) []const Command {
         .crash,
         => comptime &.{},
 
+        // No commands because the action only does something in the
+        // Windows apprt: the GTK shell has no pinned prefix or grouped
+        // runs for these to act on.
+        .pin_tab,
+        .unpin_tab,
+        .move_group,
+        => comptime &.{},
+
         // No commands because I'm not sure they make sense in a command
         // palette context.
         .toggle_command_palette,

--- a/windows/Ghostty.Core/Input/ApprtActionMap.cs
+++ b/windows/Ghostty.Core/Input/ApprtActionMap.cs
@@ -64,6 +64,19 @@ internal static class ApprtActionMap
             _ => null,
         },
 
+        // Windows tab-shell actions. pin_tab/unpin_tab are payload-free;
+        // move_group reads its signed offset by sign like move_tab, and a
+        // zero amount names no direction so it falls through unhandled.
+        GhosttyActionTag.PinTab => PaneAction.PinTab,
+        GhosttyActionTag.UnpinTab => PaneAction.UnpinTab,
+
+        GhosttyActionTag.MoveGroup => value switch
+        {
+            > 0 => PaneAction.MoveGroupRight,
+            < 0 => PaneAction.MoveGroupLeft,
+            _ => null,
+        },
+
         GhosttyActionTag.GotoWindow => (GhosttyGotoWindow)value switch
         {
             GhosttyGotoWindow.Previous => PaneAction.GotoWindowPrevious,

--- a/windows/Ghostty.Core/Input/KeybindActionCatalog.cs
+++ b/windows/Ghostty.Core/Input/KeybindActionCatalog.cs
@@ -32,6 +32,9 @@ public static class KeybindActionCatalog
         ["goto_tab"] = ("Tabs", "Go To Tab"),
         ["move_tab"] = ("Tabs", "Move Tab"),
         ["last_tab"] = ("Tabs", "Last Tab"),
+        ["pin_tab"] = ("Tabs", "Pin Tab"),
+        ["unpin_tab"] = ("Tabs", "Unpin Tab"),
+        ["move_group"] = ("Groups", "Move Group"),
         ["scroll_page_up"] = ("Scroll", "Scroll Page Up"),
         ["scroll_page_down"] = ("Scroll", "Scroll Page Down"),
         ["scroll_to_top"] = ("Scroll", "Scroll To Top"),
@@ -74,9 +77,11 @@ public static class KeybindActionCatalog
             return new ActionDescription("Other", action);
 
         var friendly = hit.Friendly;
-        // Append a direction word for split/focus/resize so each row is distinct.
+        // Append a direction word for split/focus/resize/group-move so each
+        // row is distinct.
         if (arg is not null && ArgLabel.TryGetValue(arg, out var dir)
-            && (verb == "new_split" || verb == "goto_split" || verb == "resize_split"))
+            && (verb == "new_split" || verb == "goto_split" || verb == "resize_split"
+                || verb == "move_group"))
         {
             friendly = $"{hit.Friendly} {dir}";
         }

--- a/windows/Ghostty.Core/Input/PaneAction.cs
+++ b/windows/Ghostty.Core/Input/PaneAction.cs
@@ -138,22 +138,22 @@ public enum PaneAction
     MruCyclePrev = 64,
     ShowTabOverview = 65,
 
-    // Pin the active tab into / out of the pinned prefix. Palette and
-    // context menu only: no default chord ships (owner decided: no
-    // defaults in v1), so these are not matched in KeyBindings and have
-    // no keybind-catalog verb -- the palette entry is the keyboard path.
+    // Pin the active tab into / out of the pinned prefix. Reachable from
+    // the palette, the per-tab context menu, and (since pin_tab/unpin_tab
+    // became libghostty verbs) any chord the user binds in config; no
+    // default chord ships (owner decided: no defaults in v1), so nothing
+    // in KeyBindings matches them.
     PinTab = 66,
     UnpinTab = 67,
 
     // Group operations on the ACTIVE TAB'S GROUP (ungrouped active tab is
-    // a silent no-op; the router's refusal guards decide the rest). Same
-    // palette-and-menu-only ruling as PinTab/UnpinTab: no KeyBindings
-    // match and no keybind-catalog verb -- catalog verbs for these are a
-    // separately approved follow-up. AddToGroup is deliberately absent:
-    // the palette has no group chooser, so joining stays a context-menu
-    // op until one exists. RenameGroup/ColorGroup are dialog ops: the
-    // router forwards them to the window, which owns the XamlRoot the
-    // dialog and the picker need.
+    // a silent no-op; the router's refusal guards decide the rest). No
+    // default chord ships either; move_group is a bindable libghostty
+    // verb, the rest stay palette-and-menu-only. AddToGroup is
+    // deliberately absent: the palette has no group chooser, so joining
+    // stays a context-menu op until one exists. RenameGroup/ColorGroup
+    // are dialog ops: the router forwards them to the window, which owns
+    // the XamlRoot the dialog and the picker need.
     NewGroupWithTab = 68,
     RemoveFromGroup = 69,
     CollapseGroup = 70,
@@ -162,4 +162,11 @@ public enum PaneAction
     CloseGroup = 73,
     RenameGroup = 74,
     ColorGroup = 75,
+
+    // Move the ACTIVE TAB'S GROUP one neighbouring group left/right, the
+    // group-as-unit counterpart of MoveTabLeft/Right. Apprt-matched via
+    // the move_group libghostty verb (signed offset, like move_tab);
+    // appended past ColorGroup so every earlier value stays stable.
+    MoveGroupLeft = 76,
+    MoveGroupRight = 77,
 }

--- a/windows/Ghostty.Core/Interop/GhosttyActions.cs
+++ b/windows/Ghostty.Core/Interop/GhosttyActions.cs
@@ -78,6 +78,12 @@ internal enum GhosttyActionTag
     PromptReady    = 69,
     FirstRender    = 70,
     CustomShaderFailed = 71,
+    // Fork-appended tail tags (Windows-apprt tab-shell actions). Appended
+    // rather than inserted so every upstream ordinal stays stable; the
+    // parity test against include/ghostty.h holds the positions.
+    PinTab = 72,
+    UnpinTab = 73,
+    MoveGroup = 74,
 }
 
 // ghostty_target_tag_e: which half of OnAction the action is addressed to.
@@ -183,6 +189,18 @@ internal struct GhosttyActionResizeSplit
 // 64-bit builds. Negative moves left, positive moves right.
 [StructLayout(LayoutKind.Sequential)]
 internal struct GhosttyActionMoveTab
+{
+    public nint Amount;
+}
+
+// ghostty_action_move_group_s:
+//   { ssize_t amount; }
+// Same shape as MoveTab for the group-as-unit move: the signed offset is
+// one neighbouring group per step, negative left, positive right. A
+// separate mirror (rather than reusing GhosttyActionMoveTab) so the
+// struct parity test pins this header typedef by name.
+[StructLayout(LayoutKind.Sequential)]
+internal struct GhosttyActionMoveGroup
 {
     public nint Amount;
 }

--- a/windows/Ghostty.Tests/Ghostty.Tests.csproj
+++ b/windows/Ghostty.Tests/Ghostty.Tests.csproj
@@ -131,6 +131,15 @@
                       Link="Cli\Shim\main.zig"
                       LogicalName="Ghostty.Tests.Cli.Shim.main.zig" />
     <!--
+      The curated default keybinds, for GroupPinKeybindWiringTests' fact
+      that the tab-shell verbs (pin_tab/unpin_tab/move_group) ship with no
+      default chord. The defaults live compiled in this file, so the file
+      is the thing that could contradict the ruling.
+    -->
+    <EmbeddedResource Include="..\..\src\config\Config.zig"
+                      Link="Config\Defaults\Config.zig"
+                      LogicalName="Ghostty.Tests.Config.Defaults.Config.zig" />
+    <!--
       Every settings page, for SettingsCardConfigKeyParityTests. A wildcard
       rather than a file list: a page added later is picked up without anyone
       remembering this entry, which is the failure mode the other blocks above

--- a/windows/Ghostty.Tests/Input/ApprtActionMapTests.cs
+++ b/windows/Ghostty.Tests/Input/ApprtActionMapTests.cs
@@ -58,6 +58,17 @@ public class ApprtActionMapTests
         Assert.Equal(expected, ApprtActionMap.Map(GhosttyActionTag.MoveTab, amount));
 
     [Theory]
+    [InlineData(1,   PaneAction.MoveGroupRight)]
+    [InlineData(-1,  PaneAction.MoveGroupLeft)]
+    public void MoveGroup_MapsBySign(int amount, PaneAction expected) =>
+        Assert.Equal(expected, ApprtActionMap.Map(GhosttyActionTag.MoveGroup, amount));
+
+    [Fact] public void PinTab_Maps() =>
+        Assert.Equal(PaneAction.PinTab, ApprtActionMap.Map(GhosttyActionTag.PinTab, 0));
+    [Fact] public void UnpinTab_Maps() =>
+        Assert.Equal(PaneAction.UnpinTab, ApprtActionMap.Map(GhosttyActionTag.UnpinTab, 0));
+
+    [Theory]
     [InlineData(0, PaneAction.GotoWindowPrevious)]
     [InlineData(1, PaneAction.GotoWindowNext)]
     public void GotoWindow_Maps_By_Direction(int value, PaneAction expected)
@@ -94,6 +105,7 @@ public class ApprtActionMapTests
     [InlineData((int)GhosttyActionTag.GotoTab, 0)]   // below the 1..8 index range
     [InlineData((int)GhosttyActionTag.GotoTab, 9)]   // above the 1..8 index range
     [InlineData((int)GhosttyActionTag.MoveTab, 0)]   // zero amount has no direction
+    [InlineData((int)GhosttyActionTag.MoveGroup, 0)] // zero amount has no direction
     [InlineData((int)GhosttyActionTag.NewSplit, (int)GhosttySplitDirection.Left)] // not in PaneAction
     [InlineData((int)GhosttyActionTag.NewSplit, (int)GhosttySplitDirection.Up)]   // not in PaneAction
     public void UnrepresentedValue_ReturnsNull(int tag, int value) =>

--- a/windows/Ghostty.Tests/Input/KeybindActionCatalogTests.cs
+++ b/windows/Ghostty.Tests/Input/KeybindActionCatalogTests.cs
@@ -46,6 +46,45 @@ public class KeybindActionCatalogTests
         Assert.Contains(actions, a => a.RawAction == "new_split:right" && a.Friendly == "Split Right");
     }
 
+    // The pin/group verbs are bindable (a user keybind line can name them)
+    // but ship no default chord, so the only rows they can ever produce are
+    // ones the user bound. Describe is the whole cheat-sheet wiring: it is
+    // what turns the raw verb into the row the dialog renders.
+    [Theory]
+    [InlineData("pin_tab", "Tabs", "Pin Tab")]
+    [InlineData("unpin_tab", "Tabs", "Unpin Tab")]
+    [InlineData("move_group:left", "Groups", "Move Group Left")]
+    [InlineData("move_group:right", "Groups", "Move Group Right")]
+    public void TabShellVerbs_RenderWithCategoryAndFriendly(string action, string category, string friendly)
+    {
+        var entry = KeybindActionCatalog.Describe(action);
+        Assert.Equal(category, entry.Category);
+        Assert.Equal(friendly, entry.Friendly);
+    }
+
+    // Directionless move_group keeps its bare friendly, like move_tab.
+    [Fact]
+    public void MoveGroup_WithoutArgument_RendersBare()
+    {
+        var entry = KeybindActionCatalog.Describe("move_group");
+        Assert.Equal("Groups", entry.Category);
+        Assert.Equal("Move Group", entry.Friendly);
+    }
+
+    [Fact]
+    public void TabShellVerbs_AreOfferedOnceBound()
+    {
+        var binds = new[]
+        {
+            MakeBind("pin_tab"),
+            MakeBind("move_group:left"),
+        };
+        var actions = KeybindActionCatalog.AllActions(binds);
+
+        Assert.Contains(actions, a => a.RawAction == "pin_tab" && a.Friendly == "Pin Tab");
+        Assert.Contains(actions, a => a.RawAction == "move_group:left" && a.Friendly == "Move Group Left");
+    }
+
     private static EnumeratedKeybind MakeBind(string action) =>
         new(new[] { new KeybindTrigger(0, (uint)KeyNames.OrdinalOf("key_a")!.Value, 1u << 1) },
             action, GhosttyBindingFlags.Consumed);

--- a/windows/Ghostty.Tests/Input/KeybindCatalogTests.cs
+++ b/windows/Ghostty.Tests/Input/KeybindCatalogTests.cs
@@ -129,4 +129,24 @@ public class KeybindCatalogTests
         Assert.Equal(KeybindSource.Default, items.Single(i => i.RawAction == "new_tab").Source);
         Assert.Equal(KeybindSource.User, items.Single(i => i.RawAction == "new_window").Source);
     }
+
+    // The cheat sheet renders exactly what Build produces, so a user-bound
+    // pin/group verb must land as a named row in its own category rather
+    // than fall into "Other" with the raw action as its text.
+    [Fact]
+    public void Build_TabShellVerbs_RenderAsNamedRows()
+    {
+        var binds = new System.Collections.Generic.List<EnumeratedKeybind>
+        {
+            Kb("pin_tab", 39, 1u | 2u),        // Ctrl+Shift+T
+            Kb("move_group:left", 20, 1u << 1) // Ctrl+key_u(20)
+        };
+        var cat = KeybindCatalog.Build(binds);
+
+        var pin = cat.Categories.Single(c => c.Name == "Tabs").Items.Single(i => i.RawAction == "pin_tab");
+        Assert.Equal("Pin Tab", pin.Friendly);
+
+        var move = cat.Categories.Single(c => c.Name == "Groups").Items.Single(i => i.RawAction == "move_group:left");
+        Assert.Equal("Move Group Left", move.Friendly);
+    }
 }

--- a/windows/Ghostty.Tests/Input/PaneActionTests.cs
+++ b/windows/Ghostty.Tests/Input/PaneActionTests.cs
@@ -37,4 +37,15 @@ public class PaneActionTests
         // Pinned so a future enum reorder is a deliberate, visible change.
         Assert.Equal(52, (int)PaneAction.ShowAbout);
     }
+
+    [Fact]
+    public void MoveGroupLR_AreAppendedPastColorGroup()
+    {
+        // The group-move pair is the enum's tail: appended rather than
+        // inserted, so every earlier member keeps its value (these are
+        // ordinals in code nobody recompiles together with this).
+        Assert.Equal(76, (int)PaneAction.MoveGroupLeft);
+        Assert.Equal(77, (int)PaneAction.MoveGroupRight);
+        Assert.Equal((int)PaneAction.ColorGroup + 1, (int)PaneAction.MoveGroupLeft);
+    }
 }

--- a/windows/Ghostty.Tests/Interop/GhosttyStructHeaderParityTests.cs
+++ b/windows/Ghostty.Tests/Interop/GhosttyStructHeaderParityTests.cs
@@ -83,6 +83,10 @@ public class GhosttyStructHeaderParityTests
         AssertLayoutMatchesHeader<GhosttyActionMoveTab>("ghostty_action_move_tab_s");
 
     [Fact]
+    public void MoveGroup_Layout_Matches_Header() =>
+        AssertLayoutMatchesHeader<GhosttyActionMoveGroup>("ghostty_action_move_group_s");
+
+    [Fact]
     public void ProgressReport_Layout_Matches_Header() =>
         AssertLayoutMatchesHeader<GhosttyActionProgressReport>("ghostty_action_progress_report_s");
 

--- a/windows/Ghostty.Tests/Wiring/GroupPinKeybindWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/GroupPinKeybindWiringTests.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// The tail-rung keybind plumbing for the tab-shell verbs, as wiring
+/// guards: pin_tab/unpin_tab/move_group arrive from libghostty as plain
+/// tags, so every hop between the tag and the TabManager op is a place a
+/// silent misroute can live. Routing facts here; mapping facts in
+/// ApprtActionMapTests; the renderable catalog facts in
+/// KeybindActionCatalogTests.
+/// </summary>
+public class GroupPinKeybindWiringTests
+{
+    private static ShellSource Router() => ShellSource.Load("Input.PaneActionRouter.cs");
+    private static ShellSource Host() => ShellSource.Load("Hosting.GhosttyHost.cs");
+
+    /// <summary>
+    /// A keybind naming move_group lands on the manager's MoveGroup, the
+    /// same commit the drag surfaces hand over. The polarity decides the
+    /// neighbour run whose width the run is displaced by: left swaps with
+    /// the run ending at start-1, right with the run beginning at
+    /// start+run.Count. Inverting either turns "move group left" into a
+    /// jump across two groups.
+    /// </summary>
+    [Fact]
+    public void GroupMove_RoutesThroughMoveGroup_ByNeighbourRunWidth()
+    {
+        var section = Router().Case("Invoke", "PaneAction.MoveGroupRight");
+        var moves = section.Calls("_tabs.MoveGroup");
+        Assert.Equal(2, moves.Count);
+
+        var ordered = moves.OrderBy(m => m.Span.Start).ToList();
+        Assert.Equal(
+            "start - _tabs.RunOf(_tabs.Tabs[start - 1]).Count",
+            ordered[0].Arg(1));
+        Assert.Equal(
+            "start + _tabs.RunOf(_tabs.Tabs[start + run.Count]).Count",
+            ordered[1].Arg(1));
+    }
+
+    /// <summary>
+    /// The refusals are positional, not a policy of their own: an
+    /// ungrouped (or pinned, which implies ungrouped) active tab falls out
+    /// before any index math, the left arm refuses at the pinned prefix,
+    /// and the right arm refuses at the end of the list -- MoveTabLeft/Right's
+    /// guard shape, one level up.
+    /// </summary>
+    [Fact]
+    public void GroupMove_GuardsPrecedeTheirMove_AtBothBoundaries()
+    {
+        var section = Router().Case("Invoke", "PaneAction.MoveGroupRight");
+
+        var conditions = section.DescendantNodes().OfType<IfStatementSyntax>()
+            .Select(i => i.Condition.ToString())
+            .ToList();
+        Assert.Contains("group is null", conditions);
+        Assert.Contains("start <= _tabs.PinCount", conditions);
+        Assert.Contains("start + run.Count >= _tabs.Tabs.Count", conditions);
+
+        // Span order inside the section: the ungrouped guard, then the
+        // left guard before the left move, then the right guard before
+        // the right move. A guard that drifts after its move would let a
+        // -1 index (or a land-on-self) reach the manager first.
+        var ungrouped = section.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "group is null");
+        var moves = section.Calls("_tabs.MoveGroup").OrderBy(m => m.Span.Start).ToList();
+        var leftGuard = section.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "start <= _tabs.PinCount");
+        var rightGuard = section.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "start + run.Count >= _tabs.Tabs.Count");
+
+        Assert.True(ungrouped.Span.Start < moves[0].Span.Start);
+        Assert.True(leftGuard.Span.Start < moves[0].Span.Start);
+        Assert.True(moves[0].Span.Start < rightGuard.Span.Start);
+        Assert.True(rightGuard.Span.Start < moves[1].Span.Start);
+    }
+
+    /// <summary>
+    /// The host hands the tail tags to the pane-action arm, which is where
+    /// ApprtActionMap lives: pin/unpin are payload-free, and move_group
+    /// reads its signed offset from the payload at +8 like move_tab.
+    /// Collapsing pin_tab to "is it MoveGroup" (the SetTitle/Tab mistake)
+    /// would move a group when the user asked to pin.
+    /// </summary>
+    [Fact]
+    public void Host_DispatchesTailTags_ThroughThePaneActionArm()
+    {
+        var host = Host();
+
+        var pin = host.Case("OnAction", "GhosttyActionTag.PinTab");
+        var pinDispatch = pin.Calls("DispatchPaneAction").Single();
+        Assert.Equal("owner", pinDispatch.Arg(0));
+        Assert.Equal("tag.Value", pinDispatch.Arg(1));
+        Assert.Equal("0", pinDispatch.Arg(2));
+
+        var move = host.Case("OnAction", "GhosttyActionTag.MoveGroup");
+        Assert.Contains(
+            move.DescendantNodes().OfType<InvocationExpressionSyntax>()
+                .Select(i => i.CalleeText())
+                .Where(t => t.Contains("ReadUnaligned<"))
+                .ToList(),
+            t => t.EndsWith("ReadUnaligned<GhosttyActionMoveGroup>"));
+        var moveDispatch = move.Calls("DispatchPaneAction").Single();
+        Assert.Equal("(int)mg.Amount", moveDispatch.Arg(2));
+    }
+
+    /// <summary>
+    /// No curated default chord names the tab-shell verbs: the v1 ruling
+    /// is that these are bindable, not bound, and the palette/context menu
+    /// stay the primary paths. The defaults live compiled in Config.zig,
+    /// so the fact reads that file; a curated default (or even a doc
+    /// mention) is a deliberate product decision that has to delete this
+    /// assertion to land.
+    /// </summary>
+    [Fact]
+    public void TabShellVerbs_ShipNoDefaultChord()
+    {
+        const string resource = "Ghostty.Tests.Config.Defaults.Config.zig";
+        var asm = typeof(ShellSource).Assembly;
+        using var stream = asm.GetManifestResourceStream(resource);
+        Assert.True(stream is not null, $"{resource} is not embedded; see Ghostty.Tests.csproj");
+        using var reader = new System.IO.StreamReader(stream!);
+        var config = reader.ReadToEnd();
+
+        foreach (var verb in new[] { "pin_tab", "unpin_tab", "move_group" })
+        {
+            Assert.True(
+                !config.Contains(verb, StringComparison.Ordinal),
+                $"src/config/Config.zig mentions '{verb}'. The tab-shell verbs ship " +
+                "with no default chord (owner decision, v1); a curated default or a " +
+                "doc mention there means this no-default fact must be revisited first.");
+        }
+    }
+}

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -582,6 +582,14 @@ internal sealed partial class GhosttyHost : IDisposable
                 case GhosttyActionTag.FloatWindow:
                     return DispatchPaneAction(owner, tag.Value, Marshal.ReadInt32(actionPtr, 8));
 
+                // Windows tab-shell actions. pin_tab/unpin_tab carry no
+                // payload; they ride the value-free arm and land on the
+                // router's pin handling, the same one the palette and the
+                // per-tab context menu use.
+                case GhosttyActionTag.PinTab:
+                case GhosttyActionTag.UnpinTab:
+                    return DispatchPaneAction(owner, tag.Value, 0);
+
                 case GhosttyActionTag.ResizeSplit:
                 {
                     GhosttyActionResizeSplit rs;
@@ -602,6 +610,17 @@ internal sealed partial class GhosttyHost : IDisposable
                             (void*)(actionPtr + 8));
                     }
                     return DispatchPaneAction(owner, tag.Value, (int)mt.Amount);
+                }
+
+                case GhosttyActionTag.MoveGroup:
+                {
+                    GhosttyActionMoveGroup mg;
+                    unsafe
+                    {
+                        mg = System.Runtime.CompilerServices.Unsafe.ReadUnaligned<GhosttyActionMoveGroup>(
+                            (void*)(actionPtr + 8));
+                    }
+                    return DispatchPaneAction(owner, tag.Value, (int)mg.Amount);
                 }
 
                 case GhosttyActionTag.SetTitle:

--- a/windows/Ghostty/Input/PaneActionRouter.cs
+++ b/windows/Ghostty/Input/PaneActionRouter.cs
@@ -327,6 +327,35 @@ internal sealed class PaneActionRouter
                 if (i > 0) _tabs.Move(i, i - 1);
                 break;
             }
+            // Group-as-unit moves for the ACTIVE tab's group, one
+            // neighbouring group per step. An ungrouped active tab falls
+            // out silently -- and so does a pinned one, because a pinned
+            // tab can never be in a group. Where the run can land is
+            // MoveGroup's own clamp (clear of the pinned prefix), the
+            // same commit the drag surfaces hand over, so this adds no
+            // boundary policy of its own.
+            case PaneAction.MoveGroupRight:
+            case PaneAction.MoveGroupLeft:
+            {
+                var group = _tabs.ActiveTab?.Group;
+                if (group is null) break;
+                var run = _tabs.MembersOf(group);
+                var start = _tabs.IndexOf(run[0]);
+                if (action == PaneAction.MoveGroupLeft)
+                {
+                    // The pinned prefix is not a neighbour to swap with:
+                    // nothing unpinned to the left is a no-op, matching
+                    // MoveTabLeft's `i > 0` guard.
+                    if (start <= _tabs.PinCount) break;
+                    _tabs.MoveGroup(group, start - _tabs.RunOf(_tabs.Tabs[start - 1]).Count);
+                }
+                else
+                {
+                    if (start + run.Count >= _tabs.Tabs.Count) break;
+                    _tabs.MoveGroup(group, start + _tabs.RunOf(_tabs.Tabs[start + run.Count]).Count);
+                }
+                break;
+            }
             case PaneAction.PinTab:
             case PaneAction.UnpinTab:
             {


### PR DESCRIPTION
The keybind-catalog tail: pin, unpin, and group-move verbs run the whole stack so users can bind them in config. No default chords ship (the v1 ruling) - Config.zig is deliberately untouched, and a fact reads the embedded config to keep it that way.

Zig: Binding verbs pin_tab/unpin_tab/move_group(isize) with scope classification, Surface dispatch through exhaustive switches, apprt union entries + MoveGroup payload, and ghostty.h tags 72/73/74 appended after CustomShaderFailed - no upstream ordinal shifts, verified by the comptime header-parity check. C#: tag mirrors, the ssize_t payload read at +8 (matching the move_tab pattern), PaneAction.MoveGroupLeft/Right routed through the manager's MoveGroup with the same silent-no-op discipline the palette path enforces, and catalog entries whose Describe entry is the cheat-sheet wiring. The layered catalog facts are deliberate: three consumer surfaces over one Describe, verified to break together under the arg-append mutation.