### PR TITLE
tabs: the Ctrl+Tab switcher learns the strip's chip grammar

### DIFF
--- a/windows/Ghostty.Core/Tabs/TabStripProjection.cs
+++ b/windows/Ghostty.Core/Tabs/TabStripProjection.cs
@@ -163,6 +163,10 @@ internal static class TabStripProjection
     /// beside it would draw the same run twice, so the chip is suppressed
     /// and the run reads as its member.
     ///
+    /// The Ctrl+Tab switcher popup reads these rows too, so the cycle
+    /// stops on exactly what a strip renders: the chip row stands for the
+    /// collapsed run and the hidden members are not cycle stops.
+    ///
     /// The suppression is the reading's one deliberate loss: the other
     /// members of an active-holding collapsed run appear nowhere in these
     /// rows. That is why <see cref="ModelIndexToVisibleIndex"/> answers

--- a/windows/Ghostty.Tests/Wiring/TabSwitcherChipWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabSwitcherChipWiringTests.cs
@@ -1,0 +1,182 @@
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// The Ctrl+Tab switcher's chip wiring: the popup reads the strip
+/// projection's rows, a collapsed group renders as ONE chip row carrying
+/// the strip chip's four-part anatomy, and a chip activation expands
+/// through the same command door the strip's own chip selection uses.
+/// The shell cannot load into this test host, so these parse it; the
+/// projection's row semantics are tested outright in
+/// TabStripProjectionTests.
+/// </summary>
+public sealed class TabSwitcherChipWiringTests
+{
+    private const string PopupSource = "Tabs.TabSwitcherPopup.xaml.cs";
+    private const string MainWindowSource = "MainWindow.xaml.cs";
+    private const string TabHostSource = "Tabs.TabHost.xaml.cs";
+
+    [Fact]
+    public void The_switcher_rows_come_from_the_strips_projection()
+    {
+        var popup = ShellSource.Load(PopupSource);
+        var show = popup.Method("Show");
+
+        // The popup takes the manager and reads the projection at call
+        // time, so a cycle step that expanded a group is rendered expanded
+        // in step with the strip -- never from a stale row list captured
+        // before the step.
+        Assert.Equal("TabManager", show.ParameterList.Parameters[0].Type.ToString());
+        Assert.True(
+            show.Calls("TabStripProjection.HorizontalRows").Count == 1,
+            "Show must read the projection once; a second walk is a parallel reading.");
+
+        // One case per row kind, each landing on its own builder: the chip
+        // row builds no pane preview, because the members it stands for
+        // were suppressed by the projection -- a preview here would be a
+        // second decision about what a collapsed run shows.
+        var chip = popup.Case("Show", "HorizontalRow.Chip");
+        var item = popup.Case("Show", "HorizontalRow.Item");
+        Assert.True(chip.Calls("BuildGroupChip").Count == 1,
+            "the chip case must build the chip card.");
+        Assert.Empty(chip.Calls("BuildTabTile"));
+        Assert.True(item.Calls("BuildTabTile").Count == 1,
+            "the item case must build the tab tile.");
+
+        // The preview belongs to the tile builder alone: a pane layout on a
+        // chip row would be a second decision about what a collapsed run
+        // shows, and the projection already made it.
+        var tile = popup.Method("BuildTabTile");
+        Assert.True(tile.Calls("renderer.BuildMiniLayout").Count == 1,
+            "the tab tile's preview is the pane layout.");
+        var groupChip = popup.Method("BuildGroupChip");
+        Assert.Empty(groupChip.Calls("renderer.BuildMiniLayout"));
+    }
+
+    [Fact]
+    public void A_chip_row_carries_the_strips_chip_anatomy()
+    {
+        var build = ShellSource.Load(PopupSource).Method("BuildGroupChip");
+
+        // The strip chip's four parts (TabHost.AddGroupChip): color dot,
+        // title, member count, chevron. Two TextBlocks -- title and count;
+        // one FontIcon -- the chevron; two Borders -- the dot and the card
+        // the anatomy sits on.
+        var creations = build.DescendantNodes().OfType<ObjectCreationExpressionSyntax>().ToList();
+        Assert.Equal(2, creations.Count(o => o.Type.ToString().Contains("Border")));
+        Assert.Equal(2, creations.Count(o => o.Type.ToString().Contains("TextBlock")));
+        Assert.Equal(1, creations.Count(o => o.Type.ToString().Contains("FontIcon")));
+
+        // The chevron points right (the strip's collapsed glyph) and its
+        // font is pinned, or the glyph can render as nothing. Spelled at
+        // the source level so an escape that lost its slash fails here.
+        var chevron = creations.Single(o => o.Type.ToString().Contains("FontIcon"));
+        Assert.Contains(chevron.DescendantNodes().OfType<LiteralExpressionSyntax>(),
+            l => l.ToString() == "\"\\uE76C\"");
+        Assert.Contains(build.DescendantNodes().OfType<LiteralExpressionSyntax>(),
+            l => l.Token.ValueText == "SymbolThemeFontFamily");
+
+        // The count answers the manager, not the rows: the projection
+        // suppressed the members, so only MembersOf can say how many the
+        // chip stands for.
+        Assert.True(
+            build.Calls("manager.MembersOf").Count == 1,
+            "the chip's member count comes from the manager.");
+        var textSets = build.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.Left.ToString() == "Text")
+            .Select(a => a.Right.ToString())
+            .ToList();
+        Assert.Equal(2, textSets.Count);
+        Assert.Contains("group.Title", textSets);
+        Assert.Contains("manager.MembersOf(group).Count.ToString()", textSets);
+
+        // The card takes the tile's outer width so both row kinds share
+        // the wrap grid's column math, tinted like the popup's colored
+        // tiles: translucent preset wash over a preset border ring.
+        var widths = build.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.Left.ToString() == "Width")
+            .Select(a => a.Right.ToString())
+            .ToList();
+        Assert.Contains("CellOuterWidth", widths);
+        Assert.Contains("10", widths);
+        Assert.Contains(build.DescendantNodes().OfType<InvocationExpressionSyntax>(),
+            c => c.CalleeText() == "TabColorPalette.Background");
+        Assert.Equal(2, build.Calls("TabColorPalette.Border").Count); // dot + card ring
+    }
+
+    [Fact]
+    public void The_highlight_never_parks_on_a_chip()
+    {
+        var popup = ShellSource.Load(PopupSource);
+
+        // Chips are cycle stops, never the cycle's target -- a chip
+        // activation lands on manager truth -- so there is no cell map a
+        // group could be highlighted through. A chip-keyed map here is how
+        // a ring ends up parked on a group nobody can activate.
+        Assert.DoesNotContain(
+            popup.Root.DescendantNodes().OfType<GenericNameSyntax>().ToList(),
+            g => g.Identifier.ValueText == "Dictionary"
+                 && g.TypeArgumentList.ToString().Contains("TabGroup"));
+
+        // Highlight walks the tab-keyed map alone.
+        var highlight = popup.Method("Highlight");
+        Assert.Contains(highlight.DescendantNodes().OfType<IdentifierNameSyntax>(),
+            i => i.Identifier.ValueText == "_cellByTab");
+        Assert.DoesNotContain(
+            highlight.DescendantNodes().OfType<InvocationExpressionSyntax>().ToList(),
+            c => c.CalleeText().EndsWith(".Activate"));
+    }
+
+    [Fact]
+    public void A_chip_activation_expands_through_the_shared_command_and_lands_on_manager_truth()
+    {
+        var window = ShellSource.Load(MainWindowSource);
+        var cycle = window.Method("CycleTab");
+
+        // The cycle walks the projection's rows, not the raw tab list.
+        Assert.True(
+            cycle.Calls("TabStripProjection.HorizontalRows").Count == 1,
+            "the cycle must walk the projection once.");
+
+        // A chip is the expand gesture, through the same command path the
+        // strip's own chip selection uses -- and the polarity is expand.
+        // collapsed: true here would fold the run the user aimed at.
+        var chip = window.Case("CycleTab", "HorizontalRow.Chip");
+        var expand = chip.Call("_router.RequestCollapseGroup");
+        Assert.Contains("collapsed: false", expand.ArgumentList.ToString());
+        Assert.DoesNotContain(
+            chip.DescendantNodes().OfType<InvocationExpressionSyntax>().ToList(),
+            c => c.CalleeText().EndsWith(".Activate"));
+
+        // A tab row activates through the manager, and it is the only
+        // Activate in the method: no second door outside the switch.
+        var item = window.Case("CycleTab", "HorizontalRow.Item");
+        Assert.True(item.Calls("_tabManager.Activate").Count == 1,
+            "the item case activates through the manager.");
+        Assert.True(cycle.Calls("_tabManager.Activate").Count == 1,
+            "the manager Activate is the method's only one.");
+
+        // The popup is shown the manager's active tab -- never the row the
+        // step landed on -- so after a chip's expansion the ring sits on
+        // manager truth.
+        Assert.Equal("_tabManager.ActiveTab",
+            cycle.Call("TabSwitcherPopupUI.Show").Arg(1));
+
+        // The active row's slot is found by matching item rows by identity:
+        // chips are slots, never the active row, so the lookup must not
+        // answer a chip's slot for the active tab.
+        var indexOf = ShellSource.Load(MainWindowSource).Method("CycleRowsIndexOf");
+        Assert.Contains(indexOf.DescendantNodes().OfType<InvocationExpressionSyntax>(),
+            c => c.CalleeText() == "ReferenceEquals");
+        Assert.Contains("HorizontalRow.Item", indexOf.Body!.Statements.ToString());
+
+        // The door is shared: the strip's own chip selection expands
+        // through the same command with the same polarity.
+        var stripSelection = ShellSource.Load(TabHostSource).Method("OnSelectionChanged");
+        var stripExpand = stripSelection.Call("_router.RequestCollapseGroup");
+        Assert.Contains("collapsed: false", stripExpand.ArgumentList.ToString());
+    }
+}

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -2254,26 +2254,60 @@ public sealed partial class MainWindow : Window
     // order, wrapping at the ends, then flash the preview popup. Each press
     // commits and restarts the popup's auto-dismiss timer, so repeated presses
     // cycle through tabs with the preview visible and it fades after a pause.
+    //
+    // The cycle walks the strip projection's rows, not the raw tab list: a
+    // collapsed group is ONE chip row and its hidden members are not stops,
+    // so the switcher agrees with what the strips render.
     private void CycleTab(bool forward)
     {
-        var tabs = _tabManager.Tabs;
-        if (tabs.Count < 2) return;
+        var rows = TabStripProjection.HorizontalRows(_tabManager);
+        if (rows.Count < 2) return;
 
-        var idx = tabs.IndexOf(_tabManager.ActiveTab);
+        var idx = CycleRowsIndexOf(rows, _tabManager.ActiveTab);
         if (idx < 0) idx = 0;
         var next = forward
-            ? (idx + 1) % tabs.Count
-            : (idx - 1 + tabs.Count) % tabs.Count;
-        var target = tabs[next];
+            ? (idx + 1) % rows.Count
+            : (idx - 1 + rows.Count) % rows.Count;
 
-        _tabManager.Activate(target);
+        switch (rows[next])
+        {
+            case TabStripProjection.HorizontalRow.Item { Tab: { } tab }:
+                _tabManager.Activate(tab);
+                break;
+            case TabStripProjection.HorizontalRow.Chip { Group: { } group }:
+                // The strip's chip grammar: a chip is the expand gesture,
+                // through the same command path the chip's own selection
+                // uses -- never an Activate onto a group that has no single
+                // tab to name. The command never moves activation, so the
+                // step below lands on manager truth (the active tab), and
+                // Show() re-reads the rows the expansion just widened.
+                _router.RequestCollapseGroup(group, collapsed: false);
+                break;
+        }
         FocusActiveLeaf();
 
         SizeTabSwitcherPopup();
-        TabSwitcherPopupUI.Show(tabs, target, _configService.FontFamily);
+        TabSwitcherPopupUI.Show(_tabManager, _tabManager.ActiveTab, _configService.FontFamily);
         TabSwitcherPopupHost.IsOpen = true;
         _cyclePopupTimer?.Stop();
         _cyclePopupTimer?.Start();
+    }
+
+    /// <summary>
+    /// Row slot of <paramref name="tab"/> among the cycle's rows. The
+    /// Edge-135 walk always projects the active tab as an item -- chips are
+    /// slots, never the active row -- so -1 only means an empty strip.
+    /// </summary>
+    private static int CycleRowsIndexOf(
+        IReadOnlyList<TabStripProjection.HorizontalRow> rows, TabModel tab)
+    {
+        for (var i = 0; i < rows.Count; i++)
+        {
+            if (rows[i] is TabStripProjection.HorizontalRow.Item { Tab: { } candidate }
+                && ReferenceEquals(candidate, tab))
+                return i;
+        }
+        return -1;
     }
 
     // Stretch the full-window cycle popup to the current window size so its

--- a/windows/Ghostty/Tabs/TabSwitcherPopup.xaml.cs
+++ b/windows/Ghostty/Tabs/TabSwitcherPopup.xaml.cs
@@ -10,10 +10,17 @@ using Windows.UI;
 namespace Ghostty.Tabs;
 
 /// <summary>
-/// The transient Ctrl+Tab cycle popup. <see cref="Show"/> builds a row of tab
-/// tiles -- icon + title over a small colored preview -- and highlights the
-/// active one with an accent ring. MainWindow flashes it on each Ctrl+Tab press
+/// The transient Ctrl+Tab cycle popup. <see cref="Show"/> builds one card
+/// per row of the cycle -- tab tiles (icon + title over a small colored
+/// preview) and chip rows for collapsed groups -- and highlights the active
+/// one with an accent ring. MainWindow flashes it on each Ctrl+Tab press
 /// and auto-dismisses it shortly after.
+///
+/// The rows come from <see cref="TabStripProjection.HorizontalRows"/>, the
+/// same reading the horizontal strip renders: a collapsed group is ONE chip
+/// row (color dot + title + member count + chevron), its members suppressed
+/// except the active one, which the Edge-135 walk projects as an ordinary
+/// tile. The popup never decides visibility itself.
 /// </summary>
 internal sealed partial class TabSwitcherPopup : UserControl
 {
@@ -46,7 +53,8 @@ internal sealed partial class TabSwitcherPopup : UserControl
     /// <summary>
     /// Outer width of one tile: the preview plus the cell's padding, border
     /// and margin. Drives the column count, so it has to track the values
-    /// the build loop actually applies.
+    /// the build loop actually applies. Chip cells take the same width so
+    /// both row kinds share one column math.
     /// </summary>
     private const double CellOuterWidth =
         PreviewWidth + (CellPadding * 2) + (CellBorder * 2) + (CellMargin * 2);
@@ -63,7 +71,7 @@ internal sealed partial class TabSwitcherPopup : UserControl
 
     public TabSwitcherPopup() => InitializeComponent();
 
-    public void Show(IReadOnlyList<TabModel> tabs, TabModel active, string? fontFamily)
+    public void Show(TabManager manager, TabModel active, string? fontFamily)
     {
         CandidateRow.Children.Clear();
         _cellByTab.Clear();
@@ -74,7 +82,10 @@ internal sealed partial class TabSwitcherPopup : UserControl
         // time). Prefer the explicit size.
         var hostWidth = double.IsNaN(Width) ? ActualWidth : Width;
         var hostHeight = double.IsNaN(Height) ? ActualHeight : Height;
-        CandidateRow.MaximumRowsOrColumns = ColumnsFor(tabs.Count, hostWidth);
+        // Read at call time: a cycle step that expanded a group (a chip
+        // activation) is rendered expanded, in step with the strip.
+        var rows = TabStripProjection.HorizontalRows(manager);
+        CandidateRow.MaximumRowsOrColumns = ColumnsFor(rows.Count, hostWidth);
         if (hostHeight > 0)
             CandidateScroll.MaxHeight = hostHeight * MaxGridHeightRatio;
         // A scroll offset left over from the previous open would show the
@@ -82,73 +93,172 @@ internal sealed partial class TabSwitcherPopup : UserControl
         CandidateScroll.ChangeView(null, 0, null, disableAnimation: true);
 
         var renderer = new PanePreviewRenderer(PreviewFont.Resolve(fontFamily));
-        foreach (var tab in tabs)
+        foreach (var row in rows)
         {
-            var icon = new TabIconPresenter
+            switch (row)
             {
-                VerticalAlignment = VerticalAlignment.Center,
-                Margin = new Thickness(0, 0, 6, 0),
-            };
-            icon.Attach(tab.TabIcon);
-
-            var title = new TextBlock
-            {
-                Text = tab.EffectiveTitle,
-                VerticalAlignment = VerticalAlignment.Center,
-                TextTrimming = TextTrimming.CharacterEllipsis,
-                MaxWidth = TitleMaxWidth,
-                FontSize = _theme.CaptionFontSize,
-            };
-
-            var header = new StackPanel
-            {
-                Orientation = Orientation.Horizontal,
-                Margin = new Thickness(2, 0, 2, 6),
-            };
-            header.Children.Add(icon);
-            header.Children.Add(title);
-
-            // Shared slate fill so the 1px per-pane inset reads as dividers
-            // between splits (matches the overview); panes paint near-black over it.
-            var body = new Canvas
-            {
-                Width = PreviewWidth,
-                Height = PreviewHeight,
-                Background = PanePreviewRenderer.DividerFill,
-            };
-            renderer.BuildMiniLayout(tab.PaneHost.RootNode, body, PreviewFontSize);
-
-            var content = new StackPanel { Orientation = Orientation.Vertical };
-            content.Children.Add(header);
-            content.Children.Add(new Border { CornerRadius = new CornerRadius(4), Child = body });
-
-            // A tab's preset color reaches the preview the same way it
-            // reaches the strip: the tint composites over the card fill
-            // rather than replacing it, so a colored tile still reads as the
-            // same surface as an uncolored one.
-            var colored = tab.Color != TabColor.None;
-            var idleBorder = colored
-                ? TabColorBrush.From(TabColorPalette.Border(tab.Color))
-                : _theme.BorderIdle;
-            _idleBorderByTab[tab] = idleBorder;
-
-            var cell = new Border
-            {
-                CornerRadius = new CornerRadius(8),
-                BorderThickness = new Thickness(CellBorder),
-                BorderBrush = idleBorder,
-                Background = colored
-                    ? TabColorBrush.From(TabColorPalette.Background(tab.Color, selected: false))
-                    : _theme.CardBackground,
-                Padding = new Thickness(CellPadding),
-                Margin = new Thickness(CellMargin),
-                Child = content,
-            };
-            _cellByTab[tab] = cell;
-            CandidateRow.Children.Add(cell);
+                case TabStripProjection.HorizontalRow.Chip { Group: { } group }:
+                    CandidateRow.Children.Add(BuildGroupChip(manager, group));
+                    break;
+                case TabStripProjection.HorizontalRow.Item { Tab: { } tab }:
+                    CandidateRow.Children.Add(BuildTabTile(tab, renderer));
+                    break;
+            }
         }
 
         Highlight(active);
+    }
+
+    /// <summary>
+    /// One tab tile: icon + title over the pane preview, ringed by the
+    /// active accent when it is the cycle's target.
+    /// </summary>
+    private Border BuildTabTile(TabModel tab, PanePreviewRenderer renderer)
+    {
+        var icon = new TabIconPresenter
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(0, 0, 6, 0),
+        };
+        icon.Attach(tab.TabIcon);
+
+        var title = new TextBlock
+        {
+            Text = tab.EffectiveTitle,
+            VerticalAlignment = VerticalAlignment.Center,
+            TextTrimming = TextTrimming.CharacterEllipsis,
+            MaxWidth = TitleMaxWidth,
+            FontSize = _theme.CaptionFontSize,
+        };
+
+        var header = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Margin = new Thickness(2, 0, 2, 6),
+        };
+        header.Children.Add(icon);
+        header.Children.Add(title);
+
+        // Shared slate fill so the 1px per-pane inset reads as dividers
+        // between splits (matches the overview); panes paint near-black over it.
+        var body = new Canvas
+        {
+            Width = PreviewWidth,
+            Height = PreviewHeight,
+            Background = PanePreviewRenderer.DividerFill,
+        };
+        renderer.BuildMiniLayout(tab.PaneHost.RootNode, body, PreviewFontSize);
+
+        var content = new StackPanel { Orientation = Orientation.Vertical };
+        content.Children.Add(header);
+        content.Children.Add(new Border { CornerRadius = new CornerRadius(4), Child = body });
+
+        // A tab's preset color reaches the preview the same way it
+        // reaches the strip: the tint composites over the card fill
+        // rather than replacing it, so a colored tile still reads as the
+        // same surface as an uncolored one.
+        var colored = tab.Color != TabColor.None;
+        var idleBorder = colored
+            ? TabColorBrush.From(TabColorPalette.Border(tab.Color))
+            : _theme.BorderIdle;
+        _idleBorderByTab[tab] = idleBorder;
+
+        var cell = new Border
+        {
+            CornerRadius = new CornerRadius(8),
+            BorderThickness = new Thickness(CellBorder),
+            BorderBrush = idleBorder,
+            Background = colored
+                ? TabColorBrush.From(TabColorPalette.Background(tab.Color, selected: false))
+                : _theme.CardBackground,
+            Padding = new Thickness(CellPadding),
+            Margin = new Thickness(CellMargin),
+            Child = content,
+        };
+        _cellByTab[tab] = cell;
+        return cell;
+    }
+
+    /// <summary>
+    /// One collapsed group as ONE chip row: the strip chip's four-part
+    /// anatomy (color dot, title, member count, chevron) on a card of the
+    /// tile's outer width, so both row kinds share the wrap grid's column
+    /// math. The members render nowhere -- the projection suppressed them
+    /// -- and the card is never the highlighted cell: a chip activation
+    /// lands on manager truth, never on the chip.
+    /// </summary>
+    private Border BuildGroupChip(TabManager manager, TabGroup group)
+    {
+        // The dot paints the opaque preset: the card wash below is the
+        // translucent one a tinted tile uses, so a translucent dot would
+        // disappear into its own card.
+        var dot = new Border
+        {
+            Width = 10,
+            Height = 10,
+            CornerRadius = new CornerRadius(2),
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(0, 0, 6, 0),
+            Background = TabColorBrush.From(TabColorPalette.Border(group.Color)),
+        };
+        var title = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            TextTrimming = TextTrimming.CharacterEllipsis,
+            MaxWidth = TitleMaxWidth,
+            Margin = new Thickness(0, 0, 4, 0),
+            Text = group.Title,
+        };
+        var count = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(0, 0, 4, 0),
+            Opacity = 0.7,
+            Text = manager.MembersOf(group).Count.ToString(),
+        };
+        var chevron = new FontIcon
+        {
+            // FontIcon's default FontFamily is not guaranteed to be the
+            // symbol font, so pin it explicitly or the glyph can render
+            // as nothing.
+            FontFamily = Application.Current.Resources.TryGetValue(
+                "SymbolThemeFontFamily", out var ff) && ff is FontFamily fam
+                ? fam
+                : null,
+            Glyph = "\uE76C", // Segoe Fluent / MDL2 "ChevronRight"
+            FontSize = 10,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        var anatomy = new StackPanel { Orientation = Orientation.Horizontal };
+        anatomy.Children.Add(dot);
+        anatomy.Children.Add(title);
+        anatomy.Children.Add(count);
+        anatomy.Children.Add(chevron);
+
+        // Centered in the cell so a short row does not hug the top of a
+        // slot the tiles size.
+        var content = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        content.Children.Add(anatomy);
+
+        // The group always has a color, so the card always takes the tint:
+        // the same translucent wash a tinted tile gets, ringed by the
+        // preset's border color as its idle border.
+        return new Border
+        {
+            CornerRadius = new CornerRadius(8),
+            BorderThickness = new Thickness(CellBorder),
+            BorderBrush = TabColorBrush.From(TabColorPalette.Border(group.Color)),
+            Background = TabColorBrush.From(
+                TabColorPalette.Background(group.Color, selected: false)),
+            Padding = new Thickness(CellPadding),
+            Margin = new Thickness(CellMargin),
+            Width = CellOuterWidth,
+            Child = content,
+        };
     }
 
     // Fallbacks mirror the Fluent dark-theme token values; they only apply if a
@@ -166,7 +276,7 @@ internal sealed partial class TabSwitcherPopup : UserControl
             new SolidColorBrush(Color.FromArgb(0xFF, 0x60, 0xCD, 0xFF))));
 
     /// <summary>
-    /// Column count for <paramref name="count"/> tiles: square-ish, so a
+    /// Column count for <paramref name="count"/> rows: square-ish, so a
     /// handful of tabs still make a compact card, but never wider than the
     /// window can show.
     /// </summary>


### PR DESCRIPTION
The Ctrl+Tab switcher was group-blind: every member of a collapsed group rendered as its own full tile, and activating one silently expanded nothing. The switcher now renders TabStripProjection.HorizontalRows - the same lowered reading the horizontal strip renders - so a collapsed run is ONE chip row (color dot + title + member count + chevron), members are suppressed per the Edge-135 rule (the active member stays visible), and the cycle order is the strip's visual order.

Activation lands on manager truth through the same doors the strips use: item rows activate through the manager; chip rows expand through the identical router command and polarity the strip's chip selection uses - the expansion renders on the next press, chips can never hold the highlight (the cell map matches Item rows by reference identity), and no parallel visibility logic exists anywhere.