### PR TITLE
tests: the latch fact evolves to the #854 contract

### DIFF
--- a/windows/Ghostty.Tests/Wiring/VerticalTabSelectionRowWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/VerticalTabSelectionRowWiringTests.cs
@@ -20,9 +20,12 @@ namespace Ghostty.Tests.Wiring;
 /// item's bounds are non-zero, just measured against the old layout.
 ///
 /// These are wiring guards. They prove the one-shot LayoutUpdated pass is
-/// still on the path a refresh takes and is still one-shot; whether the
-/// fill lands on the right row is only observable on a live strip, which is
-/// what scripts/mouse-fuzz-tab-close-selection.ps1 is for.
+/// still on the path a refresh takes and is still one-shot; since the
+/// realization latch (#854) the strip carries a second replay beside it,
+/// and Strip_CarriesNoStandingLayoutUpdatedSubscription pins that one to
+/// the same discipline. Whether the fill lands on the right row is only
+/// observable on a live strip, which is what
+/// scripts/mouse-fuzz-tab-close-selection.ps1 is for.
 /// </summary>
 public class VerticalTabSelectionRowWiringTests
 {
@@ -37,6 +40,9 @@ public class VerticalTabSelectionRowWiringTests
 
     private static int IndexOfCall(SyntaxList<StatementSyntax> statements, string target) =>
         statements.TakeWhile(s => !s.Calls(target).Any()).Count();
+
+    private static string ContainingMethod(SyntaxNode node) =>
+        node.Ancestors().OfType<MethodDeclarationSyntax>().First().Identifier.ValueText;
 
     /// <summary>
     /// Every refresh has to arm the settle pass, and it has to do so before
@@ -101,24 +107,100 @@ public class VerticalTabSelectionRowWiringTests
     }
 
     /// <summary>
-    /// The arm is the only subscriber. A second one anywhere in the file is
-    /// the per-layout-pass cost the class was built to avoid, and it would
-    /// also outlive the one-shot guard.
+    /// LayoutUpdated fires for every layout pass anywhere in the window, so
+    /// the standing subscription this control refuses to carry is one that
+    /// is attached for the strip's whole life. Since #854 the file arms two
+    /// replays, and the contract is that both stay self-detaching, not that
+    /// the file carries one: the settle arm re-arms per selection refresh,
+    /// and the realization latch subscribes once behind the
+    /// not-already-latched early-return in DeferSelectionSync, gives each
+    /// pass one attempt at landing the deferred sync, and is dropped by its
+    /// own handler on the first pass that arrives with nothing left to
+    /// replay and by the Unloaded teardown with the rest of the wiring.
+    /// The hazard is a latch that never detaches, which a count alone
+    /// cannot see, so the detach statements are pinned where they live.
     /// </summary>
     [Fact]
     public void Strip_CarriesNoStandingLayoutUpdatedSubscription()
     {
-        var adds = Strip().Root.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+        var strip = Strip();
+
+        var adds = strip.Root.DescendantNodes().OfType<AssignmentExpressionSyntax>()
             .Where(a => a.IsKind(SyntaxKind.AddAssignmentExpression)
                         && a.Left.ToString() == "LayoutUpdated")
             .ToList();
 
         Assert.True(
-            adds.Count == 1,
-            $"expected exactly one `LayoutUpdated +=` in VerticalTabStrip, found {adds.Count}");
-        Assert.Equal(
-            "PlaceSelectionRowAfterLayout",
-            adds[0].Ancestors().OfType<MethodDeclarationSyntax>().First().Identifier.ValueText);
+            adds.Count == 2,
+            $"expected exactly two `LayoutUpdated +=` in VerticalTabStrip (the settle arm and "
+                + $"the realization latch), found {adds.Count}");
+
+        Assert.Contains(
+            adds, a => a.Right.ToString() == "OnSelectionRowPlacementSettled"
+                       && ContainingMethod(a) == "PlaceSelectionRowAfterLayout");
+        Assert.Contains(
+            adds, a => a.Right.ToString() == "OnSelectionRealizationPass"
+                       && ContainingMethod(a) == "DeferSelectionSync");
+
+        // The latch subscribes once: the arm sits behind the guard that
+        // bails while a latch is already standing, so a pass that finds the
+        // containers still unrealized re-defers (re-arms the latch) instead
+        // of stacking a second subscription.
+        var deferBody = strip.Method("DeferSelectionSync").Body!.Statements;
+        var latchArm = deferBody.FirstOrDefault(s => IsEventHook(
+            s, SyntaxKind.AddAssignmentExpression,
+            "LayoutUpdated", "OnSelectionRealizationPass"));
+        Assert.True(latchArm is not null, "DeferSelectionSync must arm the realization latch");
+
+        var latchGuard = deferBody
+            .TakeWhile(s => s is not IfStatementSyntax
+            {
+                Condition: IdentifierNameSyntax { Identifier.Text: "_selectionRealizationLatch" }
+            })
+            .Count();
+        Assert.True(
+            latchGuard < deferBody.Count, "expected the _selectionRealizationLatch early-return");
+        Assert.True(
+            deferBody.IndexOf(latchArm!) > latchGuard,
+            "the latch arm must sit behind the _selectionRealizationLatch early-return, or a "
+            + "still-unrealized pass stacks a second subscription instead of re-arming the one "
+            + "already standing");
+
+        // A latch is temporary only while its handler drops it. The detach
+        // lives in the branch a pass takes when nothing is left to replay,
+        // which is both the cleanup after a landed sync and the cleanup for
+        // a defer another path already satisfied; a handler that never
+        // unhooks is the standing LayoutUpdated hook this control refuses
+        // to carry.
+        var idleBranch = strip.Method("OnSelectionRealizationPass").Body!.Statements
+            .Select(s => s as IfStatementSyntax)
+            .FirstOrDefault(guard => guard is not null
+                && guard.Condition is PrefixUnaryExpressionSyntax negation
+                && negation.IsKind(SyntaxKind.LogicalNotExpression)
+                && negation.Operand.ToString() == "_selectionSyncDeferred");
+        Assert.True(
+            idleBranch?.Statement is BlockSyntax idleBlock
+            && idleBlock.Statements.Any(s => IsEventHook(
+                s, SyntaxKind.SubtractAssignmentExpression,
+                "LayoutUpdated", "OnSelectionRealizationPass")),
+            "the latch handler must detach itself on the pass with nothing left to replay: a "
+            + "handler that never unhooks is the standing LayoutUpdated hook this control "
+            + "refuses to carry");
+
+        // Teardown drops the latch with the rest of the wiring, so a strip
+        // unloaded mid-replay does not leave the subscription behind.
+        var unhooks = strip.Root.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.IsKind(SyntaxKind.SubtractAssignmentExpression)
+                        && a.Left.ToString() == "LayoutUpdated"
+                        && a.Right.ToString() == "OnSelectionRealizationPass")
+            .ToList();
+        Assert.True(
+            unhooks.Count == 2,
+            $"the realization latch must detach in exactly two places (its handler and the "
+                + $"Unloaded teardown), found {unhooks.Count}");
+        Assert.Contains(
+            unhooks, u => u.Ancestors().OfType<AssignmentExpressionSyntax>().Any(a =>
+                a.IsKind(SyntaxKind.AddAssignmentExpression) && a.Left.ToString() == "Unloaded"));
     }
 
     /// <summary>


### PR DESCRIPTION
The realization guard (#854) added a second LayoutUpdated subscription - the latched replay that waits out container realization - and the standing-subscription perf fact went red on the tip, still expecting one. The perf contract was never 'one subscription': it is 'no subscription that stands for the strip's whole life'. The fact now pins both subscriptions by handler identity and containing method, the arm-behind-guard discipline (indices compared), and the self-detach on both paths - the idle-branch detach inside the handler and the teardown detach inside the Unloaded lambda, verified by ancestor walk. Test-only.