### PR TITLE
tests: the prune size sum tolerates the pruner deleting

### DIFF
--- a/windows/Ghostty.Tests/Logging/FileLoggerProviderTests.cs
+++ b/windows/Ghostty.Tests/Logging/FileLoggerProviderTests.cs
@@ -196,7 +196,15 @@ public class FileLoggerProviderTests : IDisposable
         await DrainAsync(sink);
 
         var files = Directory.EnumerateFiles(_tempDir, "ghostty-*.log").ToArray();
-        long total = files.Sum(f => new FileInfo(f).Length);
+        // The sink is still live here (await using disposes after these
+        // asserts), so its pruner can delete a file we just listed before we
+        // read its length. That vanish is the budget working, not a failure;
+        // a file lost to the race contributes zero bytes.
+        long total = files.Sum(f =>
+        {
+            try { return new FileInfo(f).Length; }
+            catch (FileNotFoundException) { return 0L; }
+        });
 
         // The budget is enforced before each new roll file opens, so the
         // on-disk total may transiently exceed it by at most one full file.


### PR DESCRIPTION
Fixes the 1/3162 flake in `FileLoggerProviderTests.PrunesOldestRollFiles_WhenTotalSizeBudgetExceeded` (test-internal race; no product code touched).

Closes #859.

## Confirmed mechanism

The fact never stops the sink before asserting. `await using var sink` (windows/Ghostty.Tests/Logging/FileLoggerProviderTests.cs:190) disposes only after the asserts, and `DrainAsync` (same file, :274-281) is a fixed one-second wall clock, not a completion barrier, so the writer task is still live at assert time.

With `MaxBytesPerFile = 60` and ~56-58 byte records, the 200 records roll into about 100 files and every roll sweeps the budget before the next file opens (windows/Ghostty.Core/Logging/FileLoggerProvider.cs:326, and :289 on the day-rollover path). `EnforceTotalSizeBudget` (:181-214) enumerates, stats, sorts oldest-first and deletes until the total fits, so mid-burst the directory is being rewritten continuously.

The assert takes a name snapshot and then stats each name:

- :198 `Directory.EnumerateFiles(_tempDir, "ghostty-*.log").ToArray()` - point-in-time names;
- :199 `files.Sum(f => new FileInfo(f).Length)` - each `Length` stats its path again, later.

`new FileInfo(path)` does no I/O; the stat happens inside the property getter, and a path that no longer resolves throws `FileNotFoundException` out of `FileInfo.get_Length`. That is exactly the reported stack, and it is why the listing was non-empty while the read still failed. The vanished name in the issue, `ghostty-20260417-90.log`, is a roll counter that only exists while the burst is in flight (a settled directory holds the newest handful), so the writer was still several rolls from done when the snapshot was taken.

Product code already handles the mirror image of this race: `EnforceTotalSizeBudget` wraps its own stat in `catch (IOException) { continue; }` with the comment "vanished between enumerate and stat" (:192). The test's sum was the only party in the test that did not.

The 1/3162 rate fits. This is the only test in the file that leaves the pruner running past its drain, and deletion only ever happens once the budget is exceeded, so nothing else in a signoff run can throw here. On an idle runner the writer finishes inside the one second and the window is zero; on a loaded runner it does not, which is when the flake appears.

## Same-pattern audit of the file

No sibling. `FileInfo` / `.Length` appears exactly once in the test projects, at FileLoggerProviderTests.cs:199. The other enumerations in this file read names or file bodies and have no concurrent deleter to race:

- :40-44, :62-63, :79-81 - name-only assertions;
- :97, :129, :150, :177 - content reads through `ReadAllTextShared`, which shares the handle for read and write, and those configs keep the 512 MB default `MaxTotalBytes`, so the size pruner never runs there;
- :243 - `RetentionSweep` runs synchronously inside the constructor (provider :83), so it is complete before the enumeration.

Elsewhere in the tree, `LogEventsUniquenessTests.cs:64-65` enumerates source files, but it reads a static source tree nothing deletes. Not the same shape, not flagged for a fix here.

## The fix

Tolerance, not waiting. No sleeps, no second drain, no loosened bound:

```csharp
long total = files.Sum(f =>
{
    try { return new FileInfo(f).Length; }
    catch (FileNotFoundException) { return 0L; }
});
```

A deleted file is the very event the test is waiting for, so the vanished file counts as zero bytes. The catch is deliberately the narrow type (`FileNotFoundException` derives from `IOException`), so a genuine I/O problem still fails the test. Both asserts keep their full strength: the surviving files must still fit `MaxTotalBytes + MaxBytesPerFile`, and `files.Length <= 10` still pins that pruning really happened. If the pruner stopped working, no file would vanish, the sum would sit near 5.6 KB, and the budget assert would go red exactly as before.

## Verification

This host runs dotnet 8 and the project targets net10.0, so the Windows verification leg runs on the ladder box against this head. The edited statement shape was compile-checked and behavior-checked in isolation on .NET 8 here: the constructor does no I/O, `Length` throws `System.IO.FileNotFoundException: Could not find file '...'` for a vanished path, the tolerant sum returns 0 for it and the true size for a live file.
