### PR TITLE
tabs: the pinned zone reads by structure, and the latch rides the item

### DIFF
--- a/windows/Ghostty.Tests/Wiring/PinnedPanelWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/PinnedPanelWiringTests.cs
@@ -6,12 +6,14 @@ using Xunit;
 namespace Ghostty.Tests.Wiring;
 
 /// <summary>
-/// The pinned panel's structure (spec 5.1): a fixed, non-scrolling section
-/// above the list, headed by a small-caps header, holding icon-only rows
-/// for the pinned prefix. The strip now has TWO row containers, and the
-/// guards here pin the seams that two containers create: where the shelf
-/// is hosted, who owns order and membership, how a row is measured, and
-/// the one trap a fixed section above the scroller sets for the drag
+/// The pinned panel's structure (spec 5.1, restated by the zone-visual
+/// design): a fixed, non-scrolling section above the list, announced by
+/// structure rather than a label -- body-row anatomy in the expanded
+/// pane, icon-only in the compact pane, and one confident boundary line
+/// under the last pinned row. The guards here pin the seams the two row
+/// containers create: where the shelf is hosted, who owns order and
+/// membership, how a row is measured, the zone's visual anchor, and the
+/// one trap a fixed section above the scroller sets for the drag
 /// machine's autoscroll.
 ///
 /// Wiring guards, not behaviour tests: whether the panel paints on the
@@ -20,6 +22,13 @@ namespace Ghostty.Tests.Wiring;
 public class PinnedPanelWiringTests
 {
     private static ShellSource Strip() => ShellSource.Load("Tabs.VerticalTabStrip.xaml.cs");
+
+    // Assignments spelled through a member (the boundary stroke's chrome)
+    // -- SyntaxQueries.AssignsTo matches bare identifiers only.
+    private static System.Collections.Generic.IEnumerable<AssignmentExpressionSyntax>
+        Assignments(SyntaxNode node, string left)
+        => node.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.Left.ToString() == left);
 
     /// <summary>
     /// The shelf rides PaneCustomContent, and that placement is the whole
@@ -53,45 +62,145 @@ public class PinnedPanelWiringTests
     }
 
     /// <summary>
-    /// "Pinned" is a section heading, not a row: it carries heading
-    /// semantics, it is named for find-by-name, and it is chrome of the
-    /// shelf rather than an item of the row panel -- a client that walks
-    /// the panel's children must find tabs, never the title.
+    /// The zone is announced by structure, not a label: no header element
+    /// is built, named, or gated anywhere in the shelf's wiring, and the
+    /// shelf's children are exactly the row panel and the boundary stroke.
+    /// The per-row "Pinned" ItemStatus (PinnedRows_KeepTheirNameAndStatus)
+    /// is what keeps the zone in the automation tree after the heading's
+    /// removal.
     /// </summary>
     [Fact]
-    public void TheHeader_IsAHeading_AndNotARowOfThePanel()
+    public void TheZone_IsAnnouncedByStructure_WithNoHeaderLabel()
     {
         var build = Strip().Method("BuildPinnedShelf");
 
-        var named = build.Calls("AutomationProperties.SetName").Single();
-        Assert.Equal("_pinnedHeader", named.Arg(0));
-        Assert.Equal("\"Pinned\"", named.Arg(1));
-
-        var heading = build.Calls("AutomationProperties.SetHeadingLevel").Single();
-        Assert.Equal("_pinnedHeader", heading.Arg(0));
-        Assert.Equal("AutomationHeadingLevel.Level2", heading.Arg(1));
-
-        // The shelf's own children: header, then the row panel, then the
-        // boundary stroke. The header must not land inside the row panel,
-        // where it would read as one of the things it titles.
+        // The shelf's own children: the row panel, then the boundary
+        // stroke. Nothing else -- a label would be a second answer to a
+        // question the anatomy already settles.
         var adds = build.Calls("_pinnedShelf.Children.Add")
             .Select(c => c.Arg(0))
             .ToList();
-        Assert.Equal(new[] { "_pinnedHeader", "_pinnedPanel", "_boundaryStroke" }, adds);
+        Assert.Equal(new[] { "_pinnedPanel", "_boundaryStroke" }, adds);
         Assert.Empty(build.Calls("_pinnedPanel.Children.Add"));
 
-        // BuildPinnedShelf only parks the header collapsed as the initial
-        // state; the anyPins gate in the chrome refresh is the one thing
-        // that ever flips it. Asserted on the ternary's polarity, because a
-        // header that never becomes visible is 24px of chrome and a heading
-        // no client ever finds -- the build-time collapse alone passes a
-        // visibility-blind guard.
+        // And the header is gone from the class, not just from the build:
+        // a field kept "for later" is a label that comes back.
+        var source = Strip().Root.ToString();
+        Assert.DoesNotContain("_pinnedHeader", source, StringComparison.Ordinal);
+
+        // The chrome refresh drives the shelf's two remaining states --
+        // visibility and the boundary -- and nothing header-shaped.
         var shelf = Strip().Method("UpdatePinnedShelfChrome");
-        var headerVisible = shelf.DescendantNodes().OfType<AssignmentExpressionSyntax>()
-            .Single(a => a.Left.ToString() == "_pinnedHeader.Visibility");
+        Assert.DoesNotContain("Header", shelf.ToFullString(), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The boundary line is the zone's one anchor, so its placement and
+    /// presence are pinned at the parsed call sites: twice an ordinary row
+    /// line, aligned to the rows' left inset with a breath below the
+    /// cluster and a small right inset so it reads as drawn between the
+    /// zones, visible exactly while both zones exist, and painted by the
+    /// brush that carries the drag's aiming feedback and the High
+    /// Contrast opaque override.
+    /// </summary>
+    [Fact]
+    public void TheBoundary_IsTheZoneAnchor()
+    {
+        var build = Strip().Method("BuildPinnedShelf");
+
+        Assert.Equal("BoundaryStrokeHeight",
+            Assignments(build, "_boundaryStroke.Height").Single().Right.ToString());
         Assert.Equal(
-            "anyPins ? Visibility.Visible : Visibility.Collapsed",
-            headerVisible.Right.ToString());
+            "new Thickness(RowInsetLeft, 3, 4, 0)",
+            Assignments(build, "_boundaryStroke.Margin").Single().Right.ToString());
+
+        var shelf = Strip().Method("UpdatePinnedShelfChrome");
+        var visible = Assignments(shelf, "_boundaryStroke.Visibility").Single();
+        Assert.Equal("bothZones ? Visibility.Visible : Visibility.Collapsed",
+            visible.Right.ToString());
+        // The brush is only written under the same gate: a boundary painted
+        // while hidden is chrome nobody sees, and a gate without the paint
+        // is a line that never brightens.
+        var paint = Assignments(shelf, "_boundaryStroke.Background").Single();
+        Assert.True(visible.Span.End < paint.Span.Start,
+            "the boundary's visibility gate must precede its paint");
+
+        var brush = Strip().Method("BoundaryStrokeBrush");
+        // The drag gate rides the alpha declaration: idle presence while
+        // no drag holds the strip, near-full while one aims at it.
+        var alpha = brush.DescendantNodes().OfType<VariableDeclaratorSyntax>()
+            .Single(v => v.Identifier.ValueText == "alpha");
+        var ternary = Assert.IsType<ConditionalExpressionSyntax>(alpha.Initializer!.Value);
+        Assert.Equal("_drag is null", ternary.Condition.ToString());
+        Assert.Equal("idle", ternary.WhenTrue.ToString());
+        Assert.Equal("live", ternary.WhenFalse.ToString());
+
+        // High Contrast overrides translucency: both states resolve
+        // opaque there, on the system's HC accent.
+        var declarators = brush.DescendantNodes().OfType<VariableDeclaratorSyntax>().ToList();
+        Assert.Contains(declarators, v => v.Identifier.ValueText == "idle"
+            && v.Initializer!.Value.ToString().Contains("_highContrast")
+            && v.Initializer.Value.ToString().Contains("0xFF"));
+        Assert.Contains(declarators, v => v.Identifier.ValueText == "live"
+            && v.Initializer!.Value.ToString().Contains("0xFF"));
+    }
+
+    /// <summary>
+    /// The pinned row's anatomy follows the pane: full body-row anatomy --
+    /// icon, title, bell -- once the pane is wide enough to read a
+    /// trimmed title, and the icon-only slot the compact pane fits below
+    /// that. The strip drives it from ApplyPaneLayout, the one pass every
+    /// width change rides, and the row degrades by collapsing the title
+    /// column, never by re-building the row.
+    /// </summary>
+    [Fact]
+    public void PinnedRows_WearBodyAnatomy_WhenThePaneIsWide()
+    {
+        var shelf = Strip().Method("UpdatePinnedShelfChrome");
+        var flip = Assignments(shelf, "row.ShowTitle").Single();
+        Assert.Equal("showTitles", flip.Right.ToString());
+        var threshold = shelf.DescendantNodes().OfType<VariableDeclaratorSyntax>()
+            .Single(v => v.Identifier.ValueText == "showTitles");
+        Assert.Equal("_paneWidth >= VerticalTabPinnedRow.TitlePaneWidthThreshold",
+            threshold.Initializer!.Value.ToString());
+
+        // ApplyPaneLayout is the choke point: the width lands there, the
+        // chrome refresh runs on the change, and the pane stays honest.
+        var layout = Strip().Method("ApplyPaneLayout");
+        var stored = layout.AssignsTo("_paneWidth").Single();
+        Assert.Equal("width", stored.Right.ToString());
+        var refresh = layout.Calls("UpdatePinnedShelfChrome").Single();
+        var gate = layout.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString() == "_paneWidth != width");
+        Assert.True(gate.Span.Contains(refresh.Span),
+            "the shelf refresh must ride the width-changed gate");
+
+        // The row degrades structurally: the title column collapses, and
+        // the bell re-parents between the icon slot's corner and the
+        // title column's trailing edge -- the two states a compact pane
+        // and an expanded one wear.
+        var rowSource = ShellSource.Load("Tabs.VerticalTabPinnedRow.cs");
+        var showTitle = rowSource.Root.DescendantNodes()
+            .OfType<PropertyDeclarationSyntax>()
+            .Single(p => p.Identifier.ValueText == "ShowTitle");
+        var setter = showTitle.AccessorList!.Accessors
+            .Single(a => a.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.SetAccessorDeclaration));
+        var collapse = setter.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Single(a => a.Left.ToString() == "_textColumn.Visibility");
+        Assert.Contains("value", collapse.Right.ToString(), StringComparison.Ordinal);
+        Assert.Contains("_iconSlot.Children.Remove(_bell)",
+            setter.ToFullString(), StringComparison.Ordinal);
+        Assert.Contains("_textColumn.Children.Add(_bell)",
+            setter.ToFullString(), StringComparison.Ordinal);
+        Assert.Contains("_iconSlot.Children.Add(_bell)",
+            setter.ToFullString(), StringComparison.Ordinal);
+
+        // And the title takes the row's ink -- the same active/inactive
+        // brush the icon follows -- so a pinned row's title matches a body
+        // row's in every state the strip paints.
+        var ink = rowSource.Method("ApplyInk");
+        Assert.Contains(Assignments(ink, "_title.Foreground").ToList(),
+            a => a.Right.ToString() == "foreground");
     }
 
     /// <summary>

--- a/windows/Ghostty.Tests/Wiring/TabPinZoneWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabPinZoneWiringTests.cs
@@ -187,11 +187,24 @@ public class TabPinZoneWiringTests
         // is live. Inverting it darkens the boundary exactly when the
         // gesture needs it.
         var brush = strip.Method("BoundaryStrokeBrush");
-        var alpha = brush.DescendantNodes().OfType<LocalDeclarationStatementSyntax>()
-            .Single(l => l.Declaration.Variables.Any(v => v.Identifier.ValueText == "alpha"));
-        Assert.Equal(
-            "_drag is null ? (byte)0x59 : (byte)0xE6",
-            alpha.Declaration.Variables.Single().Initializer!.Value.ToString());
+        var alpha = brush.DescendantNodes().OfType<VariableDeclaratorSyntax>()
+            .Single(v => v.Identifier.ValueText == "alpha");
+        var gate = Assert.IsType<ConditionalExpressionSyntax>(
+            alpha.Initializer!.Value);
+        Assert.Equal("_drag is null", gate.Condition.ToString());
+        // Dim while idle, bright while a drag is live -- and High Contrast
+        // takes opaque in both states, so the line never leans on alpha.
+        Assert.Equal("idle", gate.WhenTrue.ToString());
+        Assert.Equal("live", gate.WhenFalse.ToString());
+        var arms = brush.DescendantNodes().OfType<VariableDeclaratorSyntax>().ToList();
+        byte IdleAlpha() => byte.Parse(arms.Single(v => v.Identifier.ValueText == "idle")
+            .Initializer!.Value.ToString().Split(':').Last().Trim()
+            .Replace("(byte)0x", string.Empty), System.Globalization.NumberStyles.HexNumber);
+        byte LiveAlpha() => byte.Parse(arms.Single(v => v.Identifier.ValueText == "live")
+            .Initializer!.Value.ToString().Split(':').Last().Trim()
+            .Replace("(byte)0x", string.Empty), System.Globalization.NumberStyles.HexNumber);
+        Assert.True(IdleAlpha() < LiveAlpha(),
+            "the boundary must brighten while a drag aims at it, not dim");
     }
 
     /// <summary>

--- a/windows/Ghostty.Tests/Wiring/VerticalTabGroupDragWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/VerticalTabGroupDragWiringTests.cs
@@ -695,47 +695,50 @@ public class VerticalTabGroupDragWiringTests
     /// will never attend.
     /// </summary>
     [Fact]
-    public void TheRealizationLatch_AttemptsPerPass_AndDetachesWhenLanded()
+    public void TheRealizationLatch_RidesTheItem_AndDetachesWhenLanded()
     {
         var defer = Strip().Method("DeferSelectionSync");
         var guard = defer.DescendantNodes().OfType<IfStatementSyntax>()
-            .Single(i => i.Condition.ToString() == "_selectionRealizationLatch");
+            .Single(i => i.Condition.ToString()
+                == "ReferenceEquals(_selectionRealizationItem, item)");
         Assert.True(guard.Statement is ReturnStatementSyntax);
-        // Event subscriptions parse as assignments, not invocations.
-        var subscribe = defer.AssignsTo("LayoutUpdated").Single();
+        // Event subscriptions parse as assignments, not invocations: the
+        // latch rides the deferred item's own Loaded -- the realization
+        // event -- never a strip-rooted per-pass handler.
+        var subscribe = defer.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.Left.ToString() == "item.Loaded").ToList();
+        Assert.Equal(2, subscribe.Count);
+        Assert.All(subscribe, a => Assert.Equal(
+            "OnSelectionRealized", a.Right.ToString()));
         Assert.True(
-            guard.Span.End < subscribe.Span.Start,
-            "the not-latched guard must precede the subscription");
-        Assert.Equal("OnSelectionRealizationPass", subscribe.Right.ToString());
+            guard.Span.End < subscribe[0].Span.Start,
+            "the not-this-item guard must precede the resubscription");
 
-        var pass = Strip().Method("OnSelectionRealizationPass");
-        var landed = pass.DescendantNodes().OfType<IfStatementSyntax>()
-            .Single(i => i.Condition.ToString() == "!_selectionSyncDeferred");
-        var detach = landed.Statement.AssignsTo("LayoutUpdated").Single();
-        Assert.Equal("OnSelectionRealizationPass", detach.Right.ToString());
-        Assert.Contains(landed.Statement.AssignsTo("_selectionRealizationLatch").ToList(),
-            a => a.Right.ToString() == "false");
-        // Every pass attempts the sync once: the flag clears, the sync
-        // runs, and a still-unrealized strip re-defers from inside it.
-        var retry = Assert.IsType<ExpressionStatementSyntax>(pass.Body!.Statements.Last());
+        var realized = Strip().Method("OnSelectionRealized");
+        var ifRealized = Assert.IsType<IfStatementSyntax>(
+            realized.Body!.Statements.First());
+        var block = Assert.IsType<BlockSyntax>(ifRealized.Statement);
+        var detach = Assert.IsType<AssignmentExpressionSyntax>(
+            Assert.IsType<ExpressionStatementSyntax>(block.Statements.First()).Expression);
+        Assert.Equal("item.Loaded", detach.Left.ToString());
+        Assert.Equal("OnSelectionRealized", detach.Right.ToString());
+        var clear = realized.AssignsTo("_selectionRealizationItem").Single();
+        Assert.Equal("null", clear.Right.ToString());
+        var retry = Assert.IsType<ExpressionStatementSyntax>(realized.Body!.Statements.Last());
         Assert.Equal("SyncSelectionFromManager",
             Assert.IsType<InvocationExpressionSyntax>(retry.Expression).CalleeText());
-        var passClear = pass.AssignsTo("_selectionSyncDeferred")
+        var realizedClear = realized.AssignsTo("_selectionSyncDeferred")
             .Single(a => a.Right.ToString() == "false");
-        Assert.True(passClear.Span.End < retry.Span.Start,
-            "the pass must clear the flag before the attempt, or the landed "
+        Assert.True(realizedClear.Span.End < retry.Span.Start,
+            "the handler must clear the flag before the attempt, or the "
             + "detach can never fire");
 
-        // Teardown detaches: the Unloaded handler the ctor wires must name
-        // the same detach, or a closed strip latches a handler forever.
-        var ctor = Strip().Root.DescendantNodes()
-            .OfType<ConstructorDeclarationSyntax>()
-            .First(c => c.Identifier.ValueText == "VerticalTabStrip");
-        var unloaded = ctor.DescendantNodes().OfType<AssignmentExpressionSyntax>()
-            .Single(a => a.Left.ToString() == "Unloaded");
-        Assert.NotEmpty(unloaded.Right.DescendantNodesAndSelf()
+        // And the strip stays free of a second standing LayoutUpdated
+        // latch: the realization wait lives on the item, not on every
+        // pass anywhere in the window.
+        Assert.Equal(1, Strip().Root.DescendantNodes()
             .OfType<AssignmentExpressionSyntax>()
-            .Where(a => a.Left.ToString() == "LayoutUpdated"
-                        && a.Right.ToString() == "OnSelectionRealizationPass"));
+            .Count(a => a.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.AddAssignmentExpression)
+                && a.Left.ToString() == "LayoutUpdated"));
     }
 }

--- a/windows/Ghostty.Tests/Wiring/VerticalTabSelectionRowWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/VerticalTabSelectionRowWiringTests.cs
@@ -20,12 +20,15 @@ namespace Ghostty.Tests.Wiring;
 /// item's bounds are non-zero, just measured against the old layout.
 ///
 /// These are wiring guards. They prove the one-shot LayoutUpdated pass is
-/// still on the path a refresh takes and is still one-shot; since the
-/// realization latch (#854) the strip carries a second replay beside it,
-/// and Strip_CarriesNoStandingLayoutUpdatedSubscription pins that one to
-/// the same discipline. Whether the fill lands on the right row is only
-/// observable on a live strip, which is what
-/// scripts/mouse-fuzz-tab-close-selection.ps1 is for.
+/// still on the path a refresh takes and is still one-shot. The second
+/// LayoutUpdated replay #854 armed beside it -- the strip-rooted
+/// realization latch -- is gone: the realization wait now rides the
+/// deferred item's own Loaded, and
+/// Strip_CarriesNoStandingLayoutUpdatedSubscription pins the strip back
+/// to the single settle arm plus the item latch's detach discipline.
+/// Whether the fill lands on the right row is only observable on a live
+/// strip, which is what scripts/mouse-fuzz-tab-close-selection.ps1 is
+/// for.
 /// </summary>
 public class VerticalTabSelectionRowWiringTests
 {
@@ -109,16 +112,20 @@ public class VerticalTabSelectionRowWiringTests
     /// <summary>
     /// LayoutUpdated fires for every layout pass anywhere in the window, so
     /// the standing subscription this control refuses to carry is one that
-    /// is attached for the strip's whole life. Since #854 the file arms two
-    /// replays, and the contract is that both stay self-detaching, not that
-    /// the file carries one: the settle arm re-arms per selection refresh,
-    /// and the realization latch subscribes once behind the
-    /// not-already-latched early-return in DeferSelectionSync, gives each
-    /// pass one attempt at landing the deferred sync, and is dropped by its
-    /// own handler on the first pass that arrives with nothing left to
-    /// replay and by the Unloaded teardown with the rest of the wiring.
-    /// The hazard is a latch that never detaches, which a count alone
-    /// cannot see, so the detach statements are pinned where they live.
+    /// is attached for the strip's whole life. #854 armed a second replay
+    /// beside the settle arm -- a strip-rooted realization latch on
+    /// LayoutUpdated -- and #858 evolved this fact to a count of two with
+    /// the latch's detach discipline pinned prong by prong. That latch has
+    /// been replaced: the realization wait now rides the deferred item's
+    /// own Loaded (_selectionRealizationItem), the precise realization
+    /// event, so the strip is back to exactly one `LayoutUpdated +=` --
+    /// the settle arm -- with zero standing subscriptions beyond it, and
+    /// the item latch needs no Unloaded teardown because the subscription
+    /// dies with the element it rides. This supersedes the #858 count-two
+    /// contract; the detach discipline it demanded of the old latch is
+    /// re-pinned here against the item's Loaded handler, and the latch's
+    /// full anatomy is pinned by
+    /// TheRealizationLatch_RidesTheItem_AndDetachesWhenLanded.
     /// </summary>
     [Fact]
     public void Strip_CarriesNoStandingLayoutUpdatedSubscription()
@@ -130,77 +137,52 @@ public class VerticalTabSelectionRowWiringTests
                         && a.Left.ToString() == "LayoutUpdated")
             .ToList();
 
-        Assert.True(
-            adds.Count == 2,
-            $"expected exactly two `LayoutUpdated +=` in VerticalTabStrip (the settle arm and "
-                + $"the realization latch), found {adds.Count}");
+        var settleArm = Assert.Single(adds);
+        Assert.Equal("OnSelectionRowPlacementSettled", settleArm.Right.ToString());
+        Assert.Equal("PlaceSelectionRowAfterLayout", ContainingMethod(settleArm));
 
-        Assert.Contains(
-            adds, a => a.Right.ToString() == "OnSelectionRowPlacementSettled"
-                       && ContainingMethod(a) == "PlaceSelectionRowAfterLayout");
-        Assert.Contains(
-            adds, a => a.Right.ToString() == "OnSelectionRealizationPass"
-                       && ContainingMethod(a) == "DeferSelectionSync");
+        // The realization wait that used to be the second LayoutUpdated arm
+        // rides the item now: DeferSelectionSync subscribes the deferred
+        // item's own Loaded, behind the same-item early-return, so a pass
+        // that re-defers onto the item it already latched re-arms nothing
+        // instead of stacking handlers on one element.
+        var itemArm = Assert.Single(
+            strip.Root.DescendantNodes().OfType<AssignmentExpressionSyntax>(),
+            a => a.IsKind(SyntaxKind.AddAssignmentExpression)
+                 && a.Left.ToString() == "item.Loaded");
+        Assert.Equal("OnSelectionRealized", itemArm.Right.ToString());
+        Assert.Equal("DeferSelectionSync", ContainingMethod(itemArm));
 
-        // The latch subscribes once: the arm sits behind the guard that
-        // bails while a latch is already standing, so a pass that finds the
-        // containers still unrealized re-defers (re-arms the latch) instead
-        // of stacking a second subscription.
-        var deferBody = strip.Method("DeferSelectionSync").Body!.Statements;
-        var latchArm = deferBody.FirstOrDefault(s => IsEventHook(
-            s, SyntaxKind.AddAssignmentExpression,
-            "LayoutUpdated", "OnSelectionRealizationPass"));
-        Assert.True(latchArm is not null, "DeferSelectionSync must arm the realization latch");
-
-        var latchGuard = deferBody
-            .TakeWhile(s => s is not IfStatementSyntax
-            {
-                Condition: IdentifierNameSyntax { Identifier.Text: "_selectionRealizationLatch" }
-            })
-            .Count();
-        Assert.True(
-            latchGuard < deferBody.Count, "expected the _selectionRealizationLatch early-return");
-        Assert.True(
-            deferBody.IndexOf(latchArm!) > latchGuard,
-            "the latch arm must sit behind the _selectionRealizationLatch early-return, or a "
-            + "still-unrealized pass stacks a second subscription instead of re-arming the one "
-            + "already standing");
-
-        // A latch is temporary only while its handler drops it. The detach
-        // lives in the branch a pass takes when nothing is left to replay,
-        // which is both the cleanup after a landed sync and the cleanup for
-        // a defer another path already satisfied; a handler that never
-        // unhooks is the standing LayoutUpdated hook this control refuses
-        // to carry.
-        var idleBranch = strip.Method("OnSelectionRealizationPass").Body!.Statements
-            .Select(s => s as IfStatementSyntax)
-            .FirstOrDefault(guard => guard is not null
-                && guard.Condition is PrefixUnaryExpressionSyntax negation
-                && negation.IsKind(SyntaxKind.LogicalNotExpression)
-                && negation.Operand.ToString() == "_selectionSyncDeferred");
-        Assert.True(
-            idleBranch?.Statement is BlockSyntax idleBlock
-            && idleBlock.Statements.Any(s => IsEventHook(
-                s, SyntaxKind.SubtractAssignmentExpression,
-                "LayoutUpdated", "OnSelectionRealizationPass")),
-            "the latch handler must detach itself on the pass with nothing left to replay: a "
-            + "handler that never unhooks is the standing LayoutUpdated hook this control "
-            + "refuses to carry");
-
-        // Teardown drops the latch with the rest of the wiring, so a strip
-        // unloaded mid-replay does not leave the subscription behind.
-        var unhooks = strip.Root.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+        // Detach-proof, the discipline #858 pinned on the old latch,
+        // carried over to the item latch: the defensive detach ahead of
+        // the arm (so a re-latch of the same element after an external
+        // unload cannot double-subscribe) and the landed detach in the
+        // Loaded handler. Nowhere else -- an Unloaded teardown prong is
+        // absent on purpose, because the handler rides the item, not the
+        // strip, and dies with it.
+        var detaches = strip.Root.DescendantNodes().OfType<AssignmentExpressionSyntax>()
             .Where(a => a.IsKind(SyntaxKind.SubtractAssignmentExpression)
-                        && a.Left.ToString() == "LayoutUpdated"
-                        && a.Right.ToString() == "OnSelectionRealizationPass")
+                        && a.Left.ToString() == "item.Loaded"
+                        && a.Right.ToString() == "OnSelectionRealized")
             .ToList();
         Assert.True(
-            unhooks.Count == 2,
-            $"the realization latch must detach in exactly two places (its handler and the "
-                + $"Unloaded teardown), found {unhooks.Count}");
-        Assert.Contains(
-            unhooks, u => u.Ancestors().OfType<AssignmentExpressionSyntax>().Any(a =>
-                a.IsKind(SyntaxKind.AddAssignmentExpression) && a.Left.ToString() == "Unloaded"));
+            detaches.Count == 2,
+            $"expected exactly two `item.Loaded -=` detaches (the pre-arm reset and the landed "
+                + $"detach), found {detaches.Count}");
+        Assert.Contains(detaches, d => ContainingMethod(d) == "DeferSelectionSync");
+        var landed = detaches.Single(d => ContainingMethod(d) == "OnSelectionRealized");
+
+        // The landed detach must sit inside the sender-is-item guard: the
+        // handler can only unhook the element that raised it, and a detach
+        // hoisted outside the pattern would not compile against the right
+        // identifier anyway -- pin the shape so a rewrite cannot quietly
+        // detach some other latch.
+        Assert.True(
+            landed.Ancestors().OfType<IfStatementSyntax>().Any(guard =>
+                guard.Condition is IsPatternExpressionSyntax pattern
+                && pattern.Expression.ToString() == "sender"),
+            "the landed detach must live inside the `sender is NavigationViewItem item` guard "
+            + "of the Loaded handler");
     }
 
     /// <summary>

--- a/windows/Ghostty/Tabs/VerticalTabPinnedRow.cs
+++ b/windows/Ghostty/Tabs/VerticalTabPinnedRow.cs
@@ -9,13 +9,20 @@ using Microsoft.UI.Xaml.Media;
 namespace Ghostty.Tabs;
 
 /// <summary>
-/// Icon-only row for a pinned tab in the fixed panel above the scrolling
-/// list. Deliberately not a <see cref="NavigationViewItem"/>: the panel
-/// must neither scroll nor take part in MUXC selection, so the row is a
-/// plain element the strip hosts in its PaneCustomContent. There is no
-/// room for a title, so it rides the tooltip, and the accessible name and
-/// the "Pinned" status sit on the row itself, which is the leaf the
-/// automation tree sees here.
+/// A pinned tab in the fixed panel above the scrolling list. Deliberately
+/// not a <see cref="NavigationViewItem"/>: the panel must neither scroll
+/// nor take part in MUXC selection, so the row is a plain element the
+/// strip hosts in its PaneCustomContent.
+///
+/// One row, two widths. In the expanded pane the row is a body row in
+/// everything but scroll and close: icon, title, bell -- the anatomy the
+/// pane's scrolling rows wear, at the same 40px pitch, so the pinned
+/// cluster reads as ordinary tabs and the boundary line under the last
+/// one is what marks the zone. In the compact pane the title column
+/// collapses and the row degrades to the icon-only slot that fits 48px;
+/// the title rides the tooltip, and the accessible name and the "Pinned"
+/// status sit on the row itself, which is the leaf the automation tree
+/// sees here.
 /// </summary>
 internal sealed partial class VerticalTabPinnedRow : Grid
 {
@@ -25,10 +32,20 @@ internal sealed partial class VerticalTabPinnedRow : Grid
     /// <summary>The icon slot is a square, the one shape both pane widths agree on.</summary>
     private const double IconSlotSize = 40;
 
+    /// <summary>
+    /// Pane width at or above which the title column shows. The compact
+    /// pane is 48px wide; the expanded pane 220. Anything at or past this
+    /// is wide enough to read a trimmed title.
+    /// </summary>
+    internal const double TitlePaneWidthThreshold = 96;
+
     private readonly Grid _iconSlot;
     private readonly FontIcon _bell;
+    private readonly TextBlock _title;
+    private readonly Grid _textColumn;
     private IconElement? _icon;
     private TextBlock? _iconFallback;
+    private bool _showTitle;
 
     public VerticalTabPinnedRow(TabModel tab, SolidColorBrush accentBrush)
     {
@@ -52,16 +69,22 @@ internal sealed partial class VerticalTabPinnedRow : Grid
         AutomationProperties.SetAutomationControlType(
             this, AutomationControlType.ListItem);
 
+        ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(IconSlotSize) });
+        ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+
         _iconSlot = new Grid
         {
             Width = IconSlotSize,
             Height = IconSlotSize,
             VerticalAlignment = VerticalAlignment.Center,
         };
+        Grid.SetColumn(_iconSlot, 0);
         Children.Add(_iconSlot);
 
-        // Over the icon's corner, so the row reads as "this icon is ringing"
-        // whether the pane is 48px or 220px wide.
+        // Over the icon's corner while the row is icon-only, so the row
+        // reads as "this icon is ringing" at either pane width. When the
+        // title column shows, the bell moves inline after the title, the
+        // way a body row wears it.
         _bell = new FontIcon
         {
             Glyph = "\uEA8F",
@@ -73,7 +96,60 @@ internal sealed partial class VerticalTabPinnedRow : Grid
         };
         _iconSlot.Children.Add(_bell);
 
+        _title = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            TextTrimming = TextTrimming.CharacterEllipsis,
+            Margin = new Thickness(0, 0, 4, 0),
+            Text = tab.EffectiveTitle,
+        };
+        ToolTipService.SetToolTip(_title, tab.EffectiveTitle);
+        // The title column carries title + bell once the row goes wide;
+        // the bell itself starts in the icon slot's corner and re-parents
+        // in ShowTitle.
+        var bellHost = new Grid();
+        bellHost.Children.Add(_title);
+        _textColumn = new Grid { Visibility = Visibility.Collapsed };
+        Grid.SetColumn(_textColumn, 1);
+        _textColumn.Children.Add(bellHost);
+        Children.Add(_textColumn);
+
         Refresh(tab);
+    }
+
+    /// <summary>
+    /// Whether the title column shows. The strip drives this from the pane
+    /// width: expanded shows the body-row anatomy, compact collapses back
+    /// to the icon-only slot. A no-op when the state did not change, so a
+    /// width sweep does not re-parent the bell on every tick.
+    /// </summary>
+    internal bool ShowTitle
+    {
+        get => _showTitle;
+        set
+        {
+            if (_showTitle == value) return;
+            _showTitle = value;
+            _textColumn.Visibility = value ? Visibility.Visible : Visibility.Collapsed;
+            // The bell re-parents between the icon slot's corner (compact)
+            // and the title column's trailing edge (expanded).
+            if (value)
+            {
+                _iconSlot.Children.Remove(_bell);
+                _bell.HorizontalAlignment = HorizontalAlignment.Right;
+                _bell.VerticalAlignment = VerticalAlignment.Center;
+                _bell.Margin = new Thickness(0, 0, 4, 0);
+                _textColumn.Children.Add(_bell);
+            }
+            else
+            {
+                _textColumn.Children.Remove(_bell);
+                _bell.HorizontalAlignment = HorizontalAlignment.Right;
+                _bell.VerticalAlignment = VerticalAlignment.Bottom;
+                _bell.Margin = new Thickness(0);
+                _iconSlot.Children.Add(_bell);
+            }
+        }
     }
 
     /// <summary>Swap the row's icon for a freshly built one.</summary>
@@ -92,7 +168,7 @@ internal sealed partial class VerticalTabPinnedRow : Grid
         }
         else
         {
-            // An icon-only row with nothing in it is a blank slot: fall back
+            // A row with nothing in the icon slot is a blank slot: fall back
             // to the title's initial, the same stand-in a collapsed body row
             // reads as when the foreground process has no icon.
             if (Tag is not TabModel tab) return;
@@ -128,7 +204,12 @@ internal sealed partial class VerticalTabPinnedRow : Grid
     protected override AutomationPeer OnCreateAutomationPeer()
         => new VerticalTabPinnedRowAutomationPeer(this);
 
-    /// <summary>Apply the ink the icon draws with. The bell stays accent.</summary>
+    /// <summary>
+    /// Apply the ink the row draws with: the icon and the title take the
+    /// row's foreground (full strength when the selection overlay sits
+    /// behind it, muted otherwise) -- the same active/inactive rule a body
+    /// row's title follows -- and the bell stays accent.
+    /// </summary>
     public void ApplyInk(Brush? foreground)
     {
         if (_icon is not null)
@@ -141,6 +222,8 @@ internal sealed partial class VerticalTabPinnedRow : Grid
             if (foreground is not null) _iconFallback.Foreground = foreground;
             else _iconFallback.ClearValue(TextBlock.ForegroundProperty);
         }
+        if (foreground is not null) _title.Foreground = foreground;
+        else _title.ClearValue(TextBlock.ForegroundProperty);
     }
 
     /// <summary>
@@ -150,6 +233,7 @@ internal sealed partial class VerticalTabPinnedRow : Grid
     public void Refresh(TabModel tab)
     {
         ToolTipService.SetToolTip(this, tab.EffectiveTitle);
+        _title.Text = tab.EffectiveTitle;
         AutomationProperties.SetName(this, TabAccessibleText.Name(tab));
         AutomationProperties.SetItemStatus(this, TabAccessibleText.Status(tab));
         _bell.Visibility = tab.BellRinging ? Visibility.Visible : Visibility.Collapsed;

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -97,6 +97,15 @@ internal sealed partial class VerticalTabStrip : UserControl
     /// </summary>
     internal void ApplyPaneLayout(bool expanded, double width)
     {
+        // The pinned shelf's anatomy follows the pane's width (full
+        // body-row titles past the title threshold, icon-only below it),
+        // and this is the one pass every width change rides -- cold start,
+        // toggle, and the drag handle's live resize.
+        if (_paneWidth != width)
+        {
+            _paneWidth = width;
+            UpdatePinnedShelfChrome();
+        }
         NavView.Width = width;
         NavView.MaxWidth = width;
         NavView.OpenPaneLength = width;
@@ -167,13 +176,6 @@ internal sealed partial class VerticalTabStrip : UserControl
         {
             CancelDrag("teardown");
             FinishPinFlight("teardown");
-            // A latched selection replay would fire for passes this strip
-            // no longer attends; drop it with the rest of the wiring.
-            if (_selectionRealizationLatch)
-            {
-                LayoutUpdated -= OnSelectionRealizationPass;
-                _selectionRealizationLatch = false;
-            }
         };
     }
 
@@ -464,9 +466,11 @@ internal sealed partial class VerticalTabStrip : UserControl
     // MenuItems -- they must not scroll and must not take part in MUXC
     // selection -- so they get their own container and their own registry.
     private readonly StackPanel _pinnedShelf = new();
-    private readonly TextBlock _pinnedHeader = new();
     private readonly StackPanel _pinnedPanel = new();
     private readonly Border _boundaryStroke = new();
+
+    /// <summary>The pane width the last ApplyPaneLayout named.</summary>
+    private double _paneWidth;
     private readonly Dictionary<TabModel, VerticalTabPinnedRow> _pinnedRows = new();
     private readonly Dictionary<TabModel, TabHooks> _pinnedHooks = new();
 
@@ -602,7 +606,13 @@ internal sealed partial class VerticalTabStrip : UserControl
     private Brush BoundaryStrokeBrush()
     {
         var accent = AccentBrush.Color;
-        byte alpha = _drag is null ? (byte)0x59 : (byte)0xE6;
+        // The zone's one anchor now that the label is gone: present at a
+        // glance while idle, near-full while a drag aims at it. High
+        // Contrast rejects translucency, so there the line is opaque in
+        // both states -- the system's HC accent carries the color.
+        byte idle = _highContrast ? (byte)0xFF : (byte)0x99;
+        byte live = _highContrast ? (byte)0xFF : (byte)0xE6;
+        byte alpha = _drag is null ? idle : live;
         return new SolidColorBrush(Color.FromArgb(alpha, accent.R, accent.G, accent.B));
     }
 
@@ -1085,7 +1095,7 @@ internal sealed partial class VerticalTabStrip : UserControl
             : null;
         if (item is not null && !item.IsLoaded)
         {
-            DeferSelectionSync();
+            DeferSelectionSync(item);
             return;
         }
         _selectionSyncDeferred = false;
@@ -1110,29 +1120,32 @@ internal sealed partial class VerticalTabStrip : UserControl
     }
 
     /// <summary>
-    /// The realization latch for the selection sync: subscribed once, and
-    /// every layout pass gives the deferred sync one attempt -- a pass
-    /// where MUXC has realized the churned containers lands it, and a pass
-    /// where it has not re-arms the latch through the defer. Detached the
-    /// moment the sync lands, and on teardown.
+    /// The realization latch for the selection sync, held on the deferred
+    /// item itself: its Loaded is the realization event -- MUXC raises it
+    /// when the container lands in the tree -- and the handler detaches
+    /// before re-running the sync, so a re-churn that produced a fresh
+    /// unrealized element simply re-defers onto the new one. No standing
+    /// strip-rooted subscription: the handler dies with the element it
+    /// rides, and teardown owes it nothing.
     /// </summary>
-    private bool _selectionRealizationLatch;
+    private NavigationViewItem? _selectionRealizationItem;
 
-    private void DeferSelectionSync()
+    private void DeferSelectionSync(NavigationViewItem item)
     {
         _selectionSyncDeferred = true;
-        if (_selectionRealizationLatch) return;
-        _selectionRealizationLatch = true;
-        LayoutUpdated += OnSelectionRealizationPass;
+        if (ReferenceEquals(_selectionRealizationItem, item)) return;
+        _selectionRealizationItem = item;
+        item.Loaded -= OnSelectionRealized;
+        item.Loaded += OnSelectionRealized;
     }
 
-    private void OnSelectionRealizationPass(object? sender, object e)
+    private void OnSelectionRealized(object sender, RoutedEventArgs e)
     {
-        if (!_selectionSyncDeferred)
+        if (sender is NavigationViewItem item)
         {
-            LayoutUpdated -= OnSelectionRealizationPass;
-            _selectionRealizationLatch = false;
-            return;
+            item.Loaded -= OnSelectionRealized;
+            if (ReferenceEquals(_selectionRealizationItem, item))
+                _selectionRealizationItem = null;
         }
         _selectionSyncDeferred = false;
         SyncSelectionFromManager();
@@ -1332,38 +1345,25 @@ internal sealed partial class VerticalTabStrip : UserControl
     /// </remarks>
     private void BuildPinnedShelf()
     {
-        // "Pinned" reads as a section title, not a row: small caps, fixed
-        // 24px band, offered only while pins exist (UpdatePinnedShelfChrome),
-        // and carrying heading semantics so an assistive client can jump to
-        // the section instead of walking into it.
-        _pinnedHeader.Text = "Pinned";
-        _pinnedHeader.Height = PinnedHeaderHeight;
-        _pinnedHeader.FontSize = 12;
-        _pinnedHeader.CharacterSpacing = 60;
-        _pinnedHeader.Margin = new Thickness(RowInsetLeft + 4, 0, 0, 0);
-        _pinnedHeader.VerticalAlignment = VerticalAlignment.Center;
-        _pinnedHeader.Visibility = Visibility.Collapsed;
-        Microsoft.UI.Xaml.Documents.Typography.SetCapitals(
-            _pinnedHeader, Microsoft.UI.Xaml.FontCapitals.SmallCaps);
-        AutomationProperties.SetName(_pinnedHeader, "Pinned");
-        AutomationProperties.SetHeadingLevel(
-            _pinnedHeader, AutomationHeadingLevel.Level2);
-
+        // No section label: the zone is announced by structure -- the
+        // pinned rows wear full body-row anatomy in the expanded pane, and
+        // the boundary line under the last one is what marks the zone.
+        // (Per-row "Pinned" ItemStatus keeps the zone in the automation
+        // tree; the label's heading role went with it.)
         _boundaryStroke.Height = BoundaryStrokeHeight;
         _boundaryStroke.IsHitTestVisible = false;
-        _boundaryStroke.Margin = new Thickness(RowInsetLeft, 0, 0, 0);
+        // Aligned to the rows' left inset, a breath below the cluster's
+        // own 2px row insets, and off the right edge so the rule reads as
+        // drawn between the zones rather than painted edge to edge.
+        _boundaryStroke.Margin = new Thickness(RowInsetLeft, 3, 4, 0);
         _boundaryStroke.Visibility = Visibility.Collapsed;
 
-        _pinnedShelf.Children.Add(_pinnedHeader);
         _pinnedShelf.Children.Add(_pinnedPanel);
         _pinnedShelf.Children.Add(_boundaryStroke);
         _pinnedShelf.Visibility = Visibility.Collapsed;
 
         NavView.PaneCustomContent = _pinnedShelf;
     }
-
-    /// <summary>Height of the pinned section's header band.</summary>
-    private const double PinnedHeaderHeight = 24;
 
     /// <summary>
     /// The element rendering <paramref name="tab"/>, from whichever
@@ -2017,17 +2017,19 @@ internal sealed partial class VerticalTabStrip : UserControl
     {
         var anyPins = _manager.PinCount > 0;
         _pinnedShelf.Visibility = anyPins ? Visibility.Visible : Visibility.Collapsed;
-        // The header follows the shelf's gate: BuildPinnedShelf only parks
-        // it collapsed as the initial state, so this flip is the one thing
-        // that ever makes the 24px headline -- and its heading semantics --
-        // render.
-        _pinnedHeader.Visibility = anyPins ? Visibility.Visible : Visibility.Collapsed;
 
         var bothZones = anyPins && _manager.PinCount < _manager.Tabs.Count;
         _boundaryStroke.Visibility = bothZones ? Visibility.Visible : Visibility.Collapsed;
         // Brightens while a drag is live, via BoundaryStrokeBrush's drag
         // gate -- the aiming feedback the drag-to-pin gesture reads.
         if (bothZones) _boundaryStroke.Background = BoundaryStrokeBrush();
+
+        // The pinned rows wear full body-row anatomy when the pane is wide
+        // enough to read a title, and degrade to the icon-only slot the
+        // 48px compact pane fits when it is not.
+        var showTitles = _paneWidth >= VerticalTabPinnedRow.TitlePaneWidthThreshold;
+        foreach (var (_, row) in _pinnedRows)
+            row.ShowTitle = showTitles;
     }
 
     private void OnNavSelectionChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)
@@ -4211,6 +4213,9 @@ internal sealed partial class VerticalTabStrip : UserControl
 
     /// <summary>True while a gesture (seam-driven or real) holds the strip.</summary>
     internal bool TestSeamDragLive => _drag is not null;
+
+    /// <summary>The pane width the last ApplyPaneLayout named, for the seam.</summary>
+    internal double TestSeamPaneWidth => _paneWidth;
 
     /// <summary>
     /// One seam drag: press the row of manager index <paramref name="from"/>,

--- a/windows/Ghostty/Testing/TestSeam.cs
+++ b/windows/Ghostty/Testing/TestSeam.cs
@@ -334,6 +334,35 @@ internal static class TestSeam
                     : OkWithState(window, manager, op);
             }
 
+            case "toggle-sidebar":
+            {
+                // The pane-pinned toggle's own dispatch. The ack waits out
+                // the width tween by watching the strip's pane width stop
+                // moving, so a screenshot taken after this answer shows the
+                // settled width.
+                var before = window.TestSeamVerticalStrip?.TestSeamPaneWidth ?? -1;
+                window.TestSeamRouter.RequestToggleSidebarCollapse();
+                var deadline = Environment.TickCount64 + 5_000;
+                double stable = before;
+                var stableSince = Environment.TickCount64;
+                while (Environment.TickCount64 < deadline)
+                {
+                    await Task.Delay(30);
+                    var now = window.TestSeamVerticalStrip?.TestSeamPaneWidth ?? -1;
+                    if (now != stable)
+                    {
+                        stable = now;
+                        stableSince = Environment.TickCount64;
+                    }
+                    else if (Environment.TickCount64 - stableSince > 250)
+                    {
+                        break;
+                    }
+                }
+                window.TestSeamSettleLayout();
+                return OkWithState(window, manager, op);
+            }
+
             case "drag":
             {
                 var strip = window.TestSeamVerticalStrip;
@@ -406,6 +435,8 @@ internal static class TestSeam
         json.WriteStartObject("state");
         json.WriteBoolean("vertical", window.TestSeamVerticalTabs);
         json.WriteBoolean("switching", window.TestSeamLayoutSwitching);
+        json.WriteNumber("paneWidth",
+            window.TestSeamVerticalStrip?.TestSeamPaneWidth ?? 0);
         json.WriteStartArray("tabs");
         for (int i = 0; i < manager.Tabs.Count; i++)
         {

--- a/windows/scripts/mouse-fuzz-tab-drag.ps1
+++ b/windows/scripts/mouse-fuzz-tab-drag.ps1
@@ -1178,6 +1178,26 @@ try {
         }
     }
 
+    # Task #33: the layout-toggle crash battery. The owner's hand test
+    # hit a UI-thread COMException (0x800F1000 -- a NavigationViewItem-
+    # targeted style applied to a ContentControl) toggling the layout on
+    # a strip that carried pins, a group, and the collapsed chip. That
+    # state is exactly what exists here (pins from the boundary legs, the
+    # group collapsed by the chip roundtrip), so this leg toggles through
+    # the pane re-measure in both directions and requires the process to
+    # survive with the strip still rendering.
+    Add-Phase 'layout-toggle-crash' {
+        Toggle-Layout $hwnd64 $pid32
+        $proc.Refresh()
+        if ($proc.HasExited) { throw "PRODUCT_FAIL: the layout toggle killed the process (to vertical)" }
+        $null = Get-StripRows $V
+        Toggle-Layout $hwnd64 $pid32
+        $proc.Refresh()
+        if ($proc.HasExited) { throw "PRODUCT_FAIL: the layout toggle killed the process (to horizontal)" }
+        $null = Get-StripRows $H
+        $script:Orders.layoutToggle = 'survived'
+    }
+
     # The trace oracle, over the whole run's sessions. Six vertical-machine
     # drags: the two motion-on reorders, the motion-off reorder, the
     # boundary out-and-back, the pin drop, the drop-on-chip join. The


### PR DESCRIPTION
The owner's design directive for the vertical strip's pinned zone: no more label, pinned tabs render normally, and the boundary carries the zone. The small-caps 'Pinned' header and its band are gone (per-row ItemStatus keeps the automation tree honest); pinned rows wear full body-row anatomy - icon, title, bell - at the same pitch and insets as scrolling rows, degrading to icon-only in the compact pane exactly as before; and the boundary stroke becomes the zone's anchor: 2px at the rows' inset, idle presence raised so it reads at a glance, opaque under High Contrast, brightening under drags as before. The shelf stays fixed and the row geometry is untouched, so the drag engine's math reads the same inputs.

Disclosed rework riding along: the container-realization latch from the crash guard is replaced by a per-item Loaded latch - the precise realization event, zero standing LayoutUpdated subscriptions, no teardown obligation - superseding the count-two fact contract the previous evolution pinned; the fact now carries the item-latch anatomy with the same identity-and-detach rigor.

The multi-pin visual battery remains blocked on the platform crash the metadata rung kills; the surviving states are screenshot-verified in both pane widths.