### PR TITLE
tabs: the derived containers register with the metadata provider so XAML resolves their real type

### DIFF
--- a/windows/Ghostty.Tests/Wiring/VerticalTabGroupHeaderWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/VerticalTabGroupHeaderWiringTests.cs
@@ -1,4 +1,6 @@
 using System.Linq;
+using System.Reflection;
+using System.Xml.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Xunit;
@@ -384,5 +386,43 @@ public class VerticalTabGroupHeaderWiringTests
             peer.Method("Expand").ExpressionBody!.ToString());
         Assert.Contains("collapsed: true",
             peer.Method("Collapse").ExpressionBody!.ToString());
+    }
+
+    /// <summary>
+    /// The header item is constructed only from C#, and a type never named
+    /// in markup gets no entry in the generated IXamlMetadataProvider: on
+    /// the first realization the XAML resolver caches it as unknown and
+    /// degrades it to the nearest built-in type (ContentControl -- in
+    /// lifted WinUI 3 the MUXC control set is not built-in), so
+    /// NavigationView's style TargetType check rejects the container and
+    /// the process fail-fasts (0x800F1000). The strip's markup anchor is
+    /// the one thing that makes the XamlTypeInfo generator emit the entry;
+    /// this fact pins the anchor and the comment that explains it.
+    /// </summary>
+    [Fact]
+    public void TheHeaderItem_IsAnchoredInMarkup_SoTheMetadataProviderKeepsItsType()
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+        const string Resource = "Ghostty.Tests.Tabs.VerticalTabStrip.xaml";
+        using var stream = assembly.GetManifestResourceStream(Resource);
+        Assert.NotNull(stream);
+
+        var doc = XDocument.Load(stream!);
+        XNamespace tabs = "using:Ghostty.Tabs";
+        var anchor = Assert.Single(doc.Descendants(tabs + "VerticalTabGroupHeaderItem"));
+
+        // Inside a keyed, never-instantiated DataTemplate in the control's
+        // own resources: present for the generator, inert at runtime.
+        XNamespace pres = "http://schemas.microsoft.com/winfx/2006/xaml/presentation";
+        var template = anchor.Parent!;
+        Assert.Equal(pres + "DataTemplate", template.Name);
+        Assert.Equal(pres + "UserControl.Resources", template.Parent!.Name);
+
+        // The why-comment rides beside it and names the degradation, so the
+        // anchor cannot be tidied away as an unused resource.
+        var comments = template.Parent!.Nodes().OfType<XComment>()
+            .Select(c => c.Value).ToList();
+        Assert.Contains(comments,
+            c => c.Contains("IXamlMetadataProvider") && c.Contains("ContentControl"));
     }
 }

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml
@@ -10,6 +10,21 @@
 
     <UserControl.Resources>
         <SolidColorBrush x:Key="StripAccentBrush" Color="{ThemeResource SystemAccentColor}" />
+
+        <!-- Never instantiated; the reference is the point. The group header
+             item is constructed only from C#, and a type never named in
+             markup gets no entry in the generated IXamlMetadataProvider.
+             When XAML then meets the first realized instance during a
+             measure pass it caches the type as unknown and degrades it to
+             the nearest built-in DO type, ContentControl (in lifted WinUI 3
+             the whole MUXC control set is not built-in), so the
+             NavigationViewItem style TargetType check rejects the container
+             and the process fail-fasts (0x800F1000). Naming the type here
+             makes the XamlTypeInfo generator emit its metadata entry, which
+             keeps its real type identity at resolve time. -->
+        <DataTemplate x:Key="VerticalTabGroupHeaderItemMetadataAnchor">
+            <tabs:VerticalTabGroupHeaderItem />
+        </DataTemplate>
     </UserControl.Resources>
 
     <!-- NavView is pane-only: terminal lives in MainWindow.PaneHostContainer.


### PR DESCRIPTION
The fail-fast crash family - collapse churn and pin-plus-layout-toggle dying 0x800F1000 then 0xC000027B - is type-identity degradation, concluded at mechanism grade from the platform source: a C# NavigationViewItem-derived container never referenced in XAML markup has no IXamlMetadataProvider entry, so the resolver caches it unknown and degrades it to the most derived BUILT-IN type - ContentControl, since lifted WinUI 3's whole control set is non-built-in - and the style TargetType check then correctly rejects the degraded identity on the container's first realization.

The census finds exactly one at-risk class: VerticalTabGroupHeaderItem, constructed only from code. The fix is a keyed, never-instantiated DataTemplate anchor in the strip's resources that names the type, forcing the XamlTypeInfo entry (verified 0 hits before, full entry after). The batteries prove it from both directions: the baseline dies on iteration 1 with the exact family every run; the anchored build never fires it across repeated paced and multi-pin batteries. A fact pins the anchor element and the mechanism comment so it cannot be tidied away as unused.

The platform report and the fork fix ride separately; a pre-existing coreclr access violation in heavy seed-tabs churn was unmasked by this fix and is filed for its own investigation.
