### PR TITLE
seam: the test seam leaves shipping builds and its pipe admits one user

### DIFF
--- a/windows/Directory.Build.props
+++ b/windows/Directory.Build.props
@@ -11,6 +11,20 @@
          constant that merely contains the substring "DEMO" can't false-match. -->
     <DemoEnabled Condition="'$(Demo)' == 'true' or '$(Configuration)' == 'Debug'">true</DemoEnabled>
     <DefineConstants Condition="'$(DemoEnabled)' == 'true'">$(DefineConstants);DEMO</DefineConstants>
+
+    <!--
+      NOTE: Configuration is still empty here. Microsoft.Common.props imports
+      this file before it defaults Configuration to Debug, so the condition
+      above only matches when Configuration arrives as a global property
+      (`-c Debug`, or Visual Studio). A bare `dotnet build` leaves DemoEnabled
+      unset and defines no DEMO, which is not what the comment above expects.
+      Left alone here: changing it changes what a Debug build contains, which
+      is a decision of its own rather than part of the seam work.
+
+      The test seam's own gate is the same shape but cannot afford that
+      ambiguity, so it lives in Directory.Build.targets, which is imported
+      after Configuration is settled. See the comment there.
+    -->
   </PropertyGroup>
   <!--
     'dotnet build' resolves AppxMSBuildToolsPath to the SDK directory which

--- a/windows/Directory.Build.targets
+++ b/windows/Directory.Build.targets
@@ -1,0 +1,29 @@
+<Project>
+  <!--
+    The in-process test seam's build gate.
+
+    The seam is a named pipe whose commands drive the app's real handlers, and
+    one of them (send-text) hands arbitrary bytes to a live shell: on a machine
+    where the seam is compiled in, whatever can reach the pipe can run commands
+    as the user. A shipping build has no business carrying that, and no user
+    has a harness to run, so Release defines nothing and every seam op compiles
+    to nothing. See windows/Ghostty/Testing/TestSeam.cs.
+
+    Debug has it, so `dotnet test` and the GUI harnesses keep working. A Release
+    build that needs driving (a harness measuring the optimised binary) opts in
+    with `-p:TestSeam=true`, and is then a build nobody should install.
+
+    This is a .targets file, not Directory.Build.props, and that is the whole
+    point. Microsoft.Common.props imports Directory.Build.props BEFORE it
+    defaults Configuration to Debug, so a condition on '$(Configuration)' there
+    is empty for a bare `dotnet build`, and the gate then silently fails shut:
+    every harness would find no pipe, with nothing to say why. Directory.Build.targets
+    is imported once Configuration is settled, so this reads the configuration
+    the build is actually using. Property evaluation still happens long before
+    CoreCompile, so DefineConstants set here reaches the compiler.
+  -->
+  <PropertyGroup>
+    <TestSeamEnabled Condition="'$(TestSeam)' == 'true' or '$(Configuration)' == 'Debug'">true</TestSeamEnabled>
+    <DefineConstants Condition="'$(TestSeamEnabled)' == 'true'">$(DefineConstants);TESTSEAM</DefineConstants>
+  </PropertyGroup>
+</Project>

--- a/windows/Ghostty.Tests/Ghostty.Tests.csproj
+++ b/windows/Ghostty.Tests/Ghostty.Tests.csproj
@@ -243,6 +243,16 @@
                       Exclude="..\Ghostty.Core\obj\**\*.cs;..\Ghostty.Core\bin\**\*.cs;..\Ghostty.Core\Version\LibGhosttyBuildInfo.cs"
                       Link="Interop\Sources\Ghostty.Core\%(RecursiveDir)%(Filename)%(Extension)"
                       LogicalName="Ghostty.Tests.Interop.Sources.Ghostty.Core.%(RecursiveDir)%(Filename)%(Extension)" />
+    <!--
+      The shared build targets, for TestSeamWiringTests. The test seam is
+      compiled out of shipping builds by a property in here, and that property
+      is the only reason the `#if TESTSEAM` regions mean anything; no C# scan
+      can see MSBuild, so the file itself is the evidence. Deliberately NOT
+      under the Interop.Sources prefix, which the shell-source sweeps read.
+    -->
+    <EmbeddedResource Include="..\Directory.Build.targets"
+                      Link="Build\Directory.Build.targets"
+                      LogicalName="Ghostty.Tests.Build.Directory.Build.targets" />
   </ItemGroup>
 
   <ItemGroup>

--- a/windows/Ghostty.Tests/Wiring/PipeSecurityProbe.cs
+++ b/windows/Ghostty.Tests/Wiring/PipeSecurityProbe.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// Reads the security descriptor Windows actually holds on a named-pipe
+/// handle.
+///
+/// The managed accessor for this (<c>PipeStreamAclExtensions.GetAccessControl</c>)
+/// lives in a package this test project does not carry, and asking the kernel
+/// is the stronger question anyway: the claim under test is what the OS
+/// granted, not what .NET believes it asked for. Two calls, no state, Windows
+/// only.
+/// </summary>
+internal static class PipeSecurityProbe
+{
+    private const int SE_KERNEL_OBJECT = 6;
+    private const int OWNER_SECURITY_INFORMATION = 0x1;
+    private const int GROUP_SECURITY_INFORMATION = 0x2;
+    private const int DACL_SECURITY_INFORMATION = 0x4;
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    private static extern uint GetSecurityInfo(
+        IntPtr handle, int objectType, int securityInfo,
+        IntPtr owner, IntPtr group, IntPtr dacl, IntPtr sacl,
+        out IntPtr securityDescriptor);
+
+    [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern bool ConvertSecurityDescriptorToStringSecurityDescriptorW(
+        IntPtr securityDescriptor, uint revision, int securityInfo,
+        out IntPtr sddl, out int length);
+
+    [DllImport("kernel32.dll")]
+    private static extern IntPtr LocalFree(IntPtr handle);
+
+    /// <summary>The handle's owner, group and DACL, in SDDL.</summary>
+    public static string Sddl(SafeHandle handle)
+    {
+        const int wanted = OWNER_SECURITY_INFORMATION
+            | GROUP_SECURITY_INFORMATION
+            | DACL_SECURITY_INFORMATION;
+
+        var rc = GetSecurityInfo(
+            handle.DangerousGetHandle(), SE_KERNEL_OBJECT, wanted,
+            IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero,
+            out var descriptor);
+        if (rc != 0) throw new InvalidOperationException($"GetSecurityInfo failed: {rc}");
+
+        try
+        {
+            if (!ConvertSecurityDescriptorToStringSecurityDescriptorW(
+                    descriptor, 1, wanted, out var sddl, out _))
+            {
+                throw new InvalidOperationException(
+                    "ConvertSecurityDescriptorToStringSecurityDescriptor failed: "
+                    + Marshal.GetLastWin32Error());
+            }
+
+            try
+            {
+                return Marshal.PtrToStringUni(sddl)!;
+            }
+            finally
+            {
+                LocalFree(sddl);
+            }
+        }
+        finally
+        {
+            LocalFree(descriptor);
+        }
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/ShellSource.cs
+++ b/windows/Ghostty.Tests/Wiring/ShellSource.cs
@@ -40,13 +40,20 @@ internal sealed class ShellSource
     /// destructive developer actions live: those are precisely the ones a
     /// gating guard has to be able to see.
     ///
-    /// Both symbols hide their opposite branch, and <see cref="Load"/>'s
+    /// TESTSEAM, because the in-process test seam is compiled out of shipping
+    /// builds (windows/Directory.Build.props) and a scan that could not see it
+    /// would report the seam's wiring guards green while reading an empty
+    /// file. The seam's own gating -- that it is absent from a build a user
+    /// installs -- is not a claim this parse can make; it belongs to the build,
+    /// and <c>TestSeamWiringTests</c> checks the props file for it directly.
+    ///
+    /// All three symbols hide their opposite branch, and <see cref="Load"/>'s
     /// refusal of any remaining disabled text is what keeps that from
     /// widening silently. A file whose Release half needs checking needs a
     /// text-level rule, the way <c>ParseForCorpusScan</c> describes.
     /// </summary>
     private static readonly CSharpParseOptions ParseOptions =
-        new(preprocessorSymbols: new[] { "DEMO", "DEBUG" });
+        new(preprocessorSymbols: new[] { "DEMO", "DEBUG", "TESTSEAM" });
 
     /// <summary>
     /// Load an embedded shell source by its dotted path tail, e.g.

--- a/windows/Ghostty.Tests/Wiring/TestSeamWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TestSeamWiringTests.cs
@@ -1,26 +1,99 @@
+using System.Collections.Generic;
 using System.Linq;
 using Ghostty.Tests.Wiring;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
 using Xunit;
 
 namespace Ghostty.Tests.Wiring;
 
 /// <summary>
-/// The test seam's opt-in is its only safety property, so the spike pins the
-/// two facts that keep it true: the gate reads before any pipe exists, and
-/// the pipe's life is bounded by the window that opened it. The full fact
-/// campaign waits for the seam to harden; these are the two that cannot be
-/// allowed to rot quietly.
+/// The seam's gates ARE its safety, so they are what these pin.
 ///
-/// What they can catch: the gate inverted or widened, the server started
-/// unconditionally, the window closing without the server dying, and a
-/// command bypassing the UI-thread marshal.
+/// The seam is a named pipe that drives the app's real handlers, and one of
+/// its ops (send-text) hands arbitrary bytes to a live shell. Whatever can
+/// talk to the pipe can therefore run commands as the user. Four things keep
+/// that from being a hole, and each has a test here: the build gate (a
+/// shipping binary has no seam at all), the session token (the pipe's name is
+/// a secret, not an address), the pipe's ACL (this user and nobody else), and
+/// send-text's own second opt-in.
+///
+/// What they can catch: the build gate deleted or widened to Release, the
+/// token gate inverted or slackened back to a fixed name, the ACL flag
+/// dropped, send-text ungated, the request reader losing its length cap, the
+/// server started unconditionally, the window closing without the server
+/// dying, and a command bypassing the UI-thread marshal.
 ///
 /// What they cannot catch: whether a command really drives the same handlers
 /// the pointer path does. That is what the seam acceptance script proves
-/// against the running app.
+/// against the running app. The reader's cap is likewise a wiring claim here
+/// and a behavioural one only against a live pipe -- the shell assembly
+/// cannot be loaded into this host, so nothing here executes seam code.
 /// </summary>
 public class TestSeamWiringTests
 {
+    /// <summary>
+    /// Assert that <paramref name="span"/> sits inside this file's one
+    /// <c>#if TESTSEAM</c> region.
+    ///
+    /// This is the guard that says a shipping build carries none of it.
+    /// ShellSource parses with TESTSEAM defined -- it must, or every scan
+    /// below would be reading an empty file -- so the code is visible here
+    /// and the directives survive as trivia. Reading the directives back is
+    /// the only way to check, from a parse that sees the region, that the
+    /// region exists at all.
+    /// </summary>
+    private static void AssertInsideTheBuildGate(SyntaxNode root, TextSpan span, string what)
+    {
+        var directives = root.DescendantTrivia()
+            .Where(t => t.IsKind(SyntaxKind.IfDirectiveTrivia)
+                        || t.IsKind(SyntaxKind.EndIfDirectiveTrivia)
+                        || t.IsKind(SyntaxKind.ElseDirectiveTrivia)
+                        || t.IsKind(SyntaxKind.ElifDirectiveTrivia))
+            .OrderBy(t => t.SpanStart)
+            .ToList();
+
+        var opens = directives
+            .Where(t => t.IsKind(SyntaxKind.IfDirectiveTrivia)
+                        && ((IfDirectiveTriviaSyntax)t.GetStructure()!)
+                            .Condition.ToString() == "TESTSEAM")
+            .ToList();
+        Assert.True(
+            opens.Count == 1,
+            $"expected exactly one '#if TESTSEAM' region, found {opens.Count}. "
+            + "The seam's absence from a shipping build is what that region is for.");
+
+        // Walk to the #endif that closes it, counting nesting, so an unrelated
+        // conditional inside the region cannot be mistaken for the close.
+        var open = opens[0];
+        var depth = 0;
+        TextSpan? close = null;
+        foreach (var t in directives.Where(t => t.SpanStart >= open.SpanStart))
+        {
+            if (t.IsKind(SyntaxKind.IfDirectiveTrivia)) depth++;
+            else if (t.IsKind(SyntaxKind.EndIfDirectiveTrivia))
+            {
+                depth--;
+                if (depth == 0) { close = t.Span; break; }
+            }
+            else if (depth == 1)
+            {
+                // An #else or #elif would leave a branch this parse cannot
+                // see, and ShellSource.Load already refuses that; catching it
+                // here names the reason.
+                Assert.Fail($"the '#if TESTSEAM' region has an {t.Kind()}, which "
+                    + "splits it into a branch the wiring scans cannot read");
+            }
+        }
+        Assert.True(close is not null, "the '#if TESTSEAM' region is never closed");
+        Assert.True(
+            span.Start > open.Span.End && span.End < close!.Value.Start,
+            $"{what} is outside the '#if TESTSEAM' region, so a shipping build "
+            + "would still carry it");
+    }
+
     private static void CtorCallsTestSeamStart()
     {
         var window = ShellSource.Load("MainWindow.xaml.cs");
@@ -31,49 +104,85 @@ public class TestSeamWiringTests
             $"found {calls.Count}");
 
         var ctor = window.Root.DescendantNodes()
-            .OfType<Microsoft.CodeAnalysis.CSharp.Syntax.ConstructorDeclarationSyntax>()
+            .OfType<ConstructorDeclarationSyntax>()
             .Where(c => c.Identifier.ValueText == "MainWindow"
                         && c.Span.Contains(calls[0].Span))
             .ToList();
         Assert.True(
             ctor.Count == 1,
             "TestSeam.Start is not called from exactly one MainWindow constructor");
+
+        // The call site is inside the build gate too. Compiling the seam out
+        // while leaving the call behind does not build, but leaving the call
+        // OUTSIDE the gate while the seam stays in is exactly how the gate
+        // gets quietly reverted.
+        AssertInsideTheBuildGate(
+            window.Root, calls[0].Span, "the TestSeam.Start call");
     }
 
     [Fact]
-    public void TheSeamIsGated_OnAnExplicitOptInEnvValue()
+    public void TheSeamIsGated_OnTheBuild_AndOnASessionToken()
     {
         CtorCallsTestSeamStart();
 
         var source = ShellSource.Load("Testing.TestSeam.cs");
         var start = source.Method("Start");
+
+        // Everything the seam does lives behind the build gate. Start is the
+        // door, so pinning Start pins the rest.
+        AssertInsideTheBuildGate(source.Root, start.Span, "TestSeam.Start");
+
+        // Two env reads, one per variable, both named through their consts so
+        // a rename cannot split the gate from the name it reads.
         var reads = start.Calls("Environment.GetEnvironmentVariable");
         Assert.True(
-            reads.Count == 1,
-            $"expected exactly one env-var read in TestSeam.Start, found {reads.Count}");
+            reads.Count == 2,
+            $"expected exactly two env-var reads in TestSeam.Start (the session "
+            + $"token and the send-text opt-in), found {reads.Count}");
+        Assert.Equal(
+            new[] { "EnvVar", "InputEnvVar" },
+            reads.Select(r => r.ArgumentList.Arguments[0].ToString()).OrderBy(s => s).ToArray());
 
-        // The name lives in one const; the gate reads that const, and the
-        // const is the opt-in literal. Pinning both halves keeps a rename
-        // of either side from splitting them apart.
-        var envVar = source.Field("EnvVar").Variable;
-        Assert.True(
-            envVar.Initializer is not null
-            && envVar.Initializer.Value.ToString().Contains(
-                "WINTTY_TEST_SEAM", StringComparison.Ordinal),
-            "the seam's env-var const no longer names WINTTY_TEST_SEAM");
-        Assert.Equal("EnvVar", reads[0].ArgumentList.Arguments[0].ToString());
+        foreach (var (constName, spelling) in new[]
+        {
+            ("EnvVar", "WINTTY_TEST_SEAM"),
+            ("InputEnvVar", "WINTTY_TEST_SEAM_INPUT"),
+        })
+        {
+            var field = source.Field(constName).Variable;
+            Assert.True(
+                field.Initializer is not null
+                && field.Initializer.Value.ToString().Contains(spelling, StringComparison.Ordinal),
+                $"the seam's {constName} const no longer names {spelling}");
+        }
 
-        // The polarity is the surface: "1" means on, anything else -- unset,
-        // empty, "0", "true" -- is off. A comparison whose text no longer
-        // demands the literal "1" has widened the gate.
-        var guard = start.Body!.Statements
-            .OfType<Microsoft.CodeAnalysis.CSharp.Syntax.IfStatementSyntax>()
-            .FirstOrDefault();
+        // The gate is the FIRST thing Start does, and it demands a session
+        // token rather than a magic word. A fixed opt-in value would put the
+        // pipe back at a name anything on the box can guess and squat.
+        var guard = start.Body!.Statements.OfType<IfStatementSyntax>().FirstOrDefault();
         Assert.True(guard is not null, "TestSeam.Start has no gate guard");
-        Assert.Contains(
-            "\"1\"", guard!.Condition.ToString(), StringComparison.Ordinal);
-        Assert.Contains(
-            "!=", guard!.Condition.ToString(), StringComparison.Ordinal);
+        var call = Assert.IsType<InvocationExpressionSyntax>(
+            Assert.IsType<PrefixUnaryExpressionSyntax>(guard!.Condition).Operand);
+        Assert.Equal("IsSessionToken", call.CalleeText());
+
+        // And the token really is a token: an exact length and a closed
+        // alphabet. "at least N" or an open alphabet would let "1" back in
+        // and would also stop guaranteeing the value is safe to paste into a
+        // pipe name.
+        var predicate = source.Method("IsSessionToken").ToString();
+        Assert.Contains("TokenLength", predicate, StringComparison.Ordinal);
+        Assert.Contains("!=", predicate, StringComparison.Ordinal);
+        Assert.Contains("IsAsciiHexDigit", predicate, StringComparison.Ordinal);
+        Assert.Equal(
+            "32", source.Field("TokenLength").Variable.Initializer!.Value.ToString());
+
+        // The name is built from the token, so it cannot be a fixed const any
+        // more. A literal pipe name reappearing here is the regression.
+        var pipeName = source.Field("_pipeName");
+        Assert.Null(pipeName.Variable.Initializer);
+        var assignment = Assert.Single(start.AssignsTo("_pipeName"));
+        Assert.Contains("PipeNamePrefix", assignment.Right.ToString(), StringComparison.Ordinal);
+        Assert.Contains("sessionToken", assignment.Right.ToString(), StringComparison.Ordinal);
 
         // And the gate has to run before the server does: nothing may spawn
         // a pipe from Start ahead of it.
@@ -91,11 +200,34 @@ public class TestSeamWiringTests
 
         // One server loop, and it is the only place a pipe exists.
         var serve = source.Method("ServeAsync");
+        var creations = serve.DescendantNodes().OfType<ObjectCreationExpressionSyntax>()
+            .Where(c => c.Type.ToString().Contains("NamedPipeServerStream"))
+            .ToList();
         Assert.True(
-            serve.DescendantNodes().OfType<Microsoft.CodeAnalysis.CSharp.Syntax
-                .ObjectCreationExpressionSyntax>().Count(c =>
-                    c.Type.ToString().Contains("NamedPipeServerStream")) == 1,
+            creations.Count == 1,
             "expected exactly one NamedPipeServerStream creation, in ServeAsync");
+
+        // The ACL. Without CurrentUserOnly the DACL Windows puts on an
+        // unsecured pipe grants Everyone and ANONYMOUS LOGON generic read,
+        // which is enough for another account on the box (or an authenticated
+        // SMB peer, since named pipes answer on \\host\pipe\) to take the one
+        // server instance and hold it. ThePipeAclAdmitsThisUserAlone proves
+        // the flag still means that; this proves it is still passed.
+        //
+        // Matched as a syntax node rather than as text: a substring search
+        // over the argument would be satisfied by
+        // `PipeOptions.Asynchronous /* | PipeOptions.CurrentUserOnly */`,
+        // which is the removal it exists to catch.
+        var options = creations[0].ArgumentList!.Arguments.Last().Expression;
+        var flags = options.DescendantNodesAndSelf()
+            .OfType<MemberAccessExpressionSyntax>()
+            .Select(m => m.ToString())
+            .ToList();
+        Assert.Contains("PipeOptions.CurrentUserOnly", flags);
+        Assert.Contains("PipeOptions.Asynchronous", flags);
+
+        // The name comes off the field the token built, never a literal.
+        Assert.Equal("_pipeName!", creations[0].ArgumentList!.Arguments[0].ToString());
         Assert.True(
             serve.Calls("pipe.WaitForConnectionAsync").Count == 1,
             "the server loop no longer waits for exactly one connection per pipe");
@@ -153,6 +285,201 @@ public class TestSeamWiringTests
         Assert.True(
             execute.Calls("RunOnUiThreadAsync").Count == 1,
             "commands no longer funnel through the single UI marshal");
+    }
+
+    /// <summary>
+    /// send-text is the op that is not "drive the UI": it hands bytes to a
+    /// live shell, which is running commands as the user. It carries its own
+    /// opt-in so that reaching the pipe is not by itself a shell, and the
+    /// refusal has to be the FIRST thing the case does -- a check after the
+    /// text has already been dispatched is not a gate.
+    /// </summary>
+    [Fact]
+    public void SendText_IsBehindItsOwnSecondOptIn()
+    {
+        var source = ShellSource.Load("Testing.TestSeam.cs");
+        var sendText = source.Case("ExecuteOnUiThreadAsync", "send-text");
+
+        var statements = sendText.Statements
+            .OfType<BlockSyntax>().SelectMany(b => b.Statements)
+            .Concat(sendText.Statements.Where(s => s is not BlockSyntax))
+            .ToList();
+        var first = Assert.IsType<IfStatementSyntax>(statements.First());
+        Assert.Equal(
+            "!_inputAllowed",
+            first.Condition.ToString());
+        Assert.Contains(
+            "InputEnvVar",
+            first.Statement.ToString(),
+            StringComparison.Ordinal);
+
+        // The flag it reads is set once, from the second env var, and nowhere
+        // else: a second writer is how a gate ends up open by default.
+        var writes = source.Root.AssignsTo("_inputAllowed").ToList();
+        var write = Assert.Single(writes);
+        var read = Assert.IsType<InvocationExpressionSyntax>(write.Right is BinaryExpressionSyntax b
+            ? b.Left
+            : write.Right);
+        Assert.Equal("Environment.GetEnvironmentVariable", read.CalleeText());
+        Assert.Equal("InputEnvVar", read.Arg(0));
+
+        // And nothing else in the seam consults it, so the gate is exactly one
+        // op wide and cannot have quietly become the gate for everything.
+        var mentions = source.Root.DescendantNodes()
+            .OfType<IdentifierNameSyntax>()
+            .Count(i => i.Identifier.ValueText == "_inputAllowed");
+        Assert.Equal(2, mentions); // the one write, the one read
+    }
+
+    /// <summary>
+    /// The request reader has a ceiling.
+    ///
+    /// StreamReader.ReadLineAsync does not: it buffers until a newline
+    /// arrives, so a client that opens the pipe and streams bytes without one
+    /// walks the whole terminal out of memory without ever dispatching an op.
+    /// The cap has to sit under the reader, which means the reader cannot be
+    /// a StreamReader.
+    /// </summary>
+    [Fact]
+    public void Requests_AreLengthCapped_BeforeAnythingParsesThem()
+    {
+        var source = ShellSource.Load("Testing.TestSeam.cs");
+        var serve = source.Method("ServeConnectionAsync");
+
+        var reader = Assert.Single(
+            serve.DescendantNodes().OfType<ObjectCreationExpressionSyntax>(),
+            c => c.Type.ToString() == "BoundedLineReader");
+        Assert.Equal("MaxRequestBytes", reader.ArgumentList!.Arguments[1].ToString());
+
+        // No StreamReader over the pipe anywhere in the seam: the unbounded
+        // reader coming back is the regression, and it comes back by someone
+        // reaching for the obvious type.
+        Assert.DoesNotContain(
+            source.Root.DescendantNodes().OfType<ObjectCreationExpressionSyntax>(),
+            c => c.Type.ToString() == "StreamReader");
+
+        // The cap is a real number, not a sentinel that disables it.
+        var cap = source.Field("MaxRequestBytes").Variable.Initializer!.Value.ToString();
+        Assert.Equal("64 * 1024", cap);
+
+        // An overlong line ends the connection rather than being trimmed and
+        // parsed: the bytes after the cap are of unknown shape, and treating
+        // whatever follows as the next request turns a length bug into a
+        // parsing bug.
+        var tooLong = Assert.Single(
+            serve.DescendantNodes().OfType<IfStatementSyntax>(),
+            i => i.Condition.ToString().Contains("LineStatus.TooLong", StringComparison.Ordinal));
+        Assert.Contains(
+            tooLong.Statement.DescendantNodesAndSelf(),
+            n => n is ReturnStatementSyntax);
+    }
+
+    /// <summary>
+    /// The build gate: a shipping Release defines no TESTSEAM, so every seam
+    /// op compiles to nothing and a binary a user installs has no pipe to
+    /// reach. The `#if` regions the other tests pin are only as good as the
+    /// property that decides the symbol, and that property lives in MSBuild
+    /// where no C# scan can see it.
+    ///
+    /// Read as XML rather than as text, so a commented-out property or a
+    /// condition moved into an attribute cannot pass on a substring.
+    /// </summary>
+    [Fact]
+    public void TheSeam_IsCompiledOutOfShippingBuilds()
+    {
+        var asm = System.Reflection.Assembly.GetExecutingAssembly();
+        using var stream = asm.GetManifestResourceStream(
+            "Ghostty.Tests.Build.Directory.Build.targets")!;
+        var doc = System.Xml.Linq.XDocument.Load(stream);
+
+        var enabled = Assert.Single(
+            doc.Descendants(), e => e.Name.LocalName == "TestSeamEnabled");
+        var condition = enabled.Attribute("Condition")?.Value;
+        Assert.False(
+            string.IsNullOrWhiteSpace(condition),
+            "TestSeamEnabled has no Condition, so every build defines TESTSEAM "
+            + "and the seam ships");
+        // Debug, or an explicit opt-in. Anything else -- notably a condition
+        // that also admits Release -- is the gate gone.
+        Assert.Contains("'$(Configuration)' == 'Debug'", condition!, StringComparison.Ordinal);
+        Assert.Contains("'$(TestSeam)' == 'true'", condition!, StringComparison.Ordinal);
+        Assert.DoesNotContain("Release", condition!, StringComparison.Ordinal);
+
+        // And the symbol is defined only when that property says so.
+        var define = Assert.Single(
+            doc.Descendants(),
+            e => e.Name.LocalName == "DefineConstants"
+                 && e.Value.Contains("TESTSEAM", StringComparison.Ordinal));
+        Assert.Equal(
+            "'$(TestSeamEnabled)' == 'true'",
+            define.Attribute("Condition")?.Value);
+    }
+
+    /// <summary>
+    /// What CurrentUserOnly actually produces, asked of the kernel rather
+    /// than of the documentation.
+    ///
+    /// This is the one test here that runs rather than reads. It stands up a
+    /// pipe with the seam's own options and reads back the DACL Windows put
+    /// on it, because the finding that started this work was that the DEFAULT
+    /// DACL grants Everyone and ANONYMOUS LOGON generic read -- which no
+    /// amount of reading the constructor would have told anyone. If a future
+    /// runtime changes what the flag means, the flag being present in the
+    /// source stops being evidence and only this notices.
+    /// </summary>
+    [Fact]
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    public void ThePipeAclAdmitsThisUserAlone()
+    {
+        // xunit 2.9 has no runtime skip. The whole suite is Windows-only in
+        // practice, so this guard is for a hypothetical host rather than a
+        // configuration anyone runs; on Windows it never returns early.
+        if (!OperatingSystem.IsWindows()) return;
+
+        var world = new System.Security.Principal.SecurityIdentifier(
+            System.Security.Principal.WellKnownSidType.WorldSid, null);
+        var anonymous = new System.Security.Principal.SecurityIdentifier(
+            System.Security.Principal.WellKnownSidType.AnonymousSid, null);
+        var me = System.Security.Principal.WindowsIdentity.GetCurrent().User!;
+
+        // The unsecured pipe first, so this test is an oracle rather than an
+        // assertion that could pass because the probe returned nothing useful.
+        // This is the finding, reproduced: Everyone and ANONYMOUS LOGON in the
+        // DACL of a pipe created exactly the way the seam used to create one.
+        var unsecured = GrantedSids(System.IO.Pipes.PipeOptions.Asynchronous);
+        Assert.Contains(world, unsecured);
+        Assert.Contains(anonymous, unsecured);
+
+        // And the same constructor with the flag the seam now passes.
+        var secured = GrantedSids(
+            System.IO.Pipes.PipeOptions.Asynchronous
+            | System.IO.Pipes.PipeOptions.CurrentUserOnly);
+        Assert.DoesNotContain(world, secured);
+        Assert.DoesNotContain(anonymous, secured);
+        Assert.Equal(new[] { me }, secured);
+    }
+
+    /// <summary>
+    /// The SIDs an access-allowed ACE names on a pipe created with these
+    /// options, read back off the handle.
+    /// </summary>
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    private static List<System.Security.Principal.SecurityIdentifier> GrantedSids(
+        System.IO.Pipes.PipeOptions options)
+    {
+        var name = "wintty-seam-acl-" + System.Guid.NewGuid().ToString("N");
+        using var pipe = new System.IO.Pipes.NamedPipeServerStream(
+            name, System.IO.Pipes.PipeDirection.InOut, 1,
+            System.IO.Pipes.PipeTransmissionMode.Byte, options);
+
+        var descriptor = new System.Security.AccessControl.RawSecurityDescriptor(
+            PipeSecurityProbe.Sddl(pipe.SafePipeHandle));
+        Assert.NotNull(descriptor.DiscretionaryAcl);
+        return descriptor.DiscretionaryAcl!
+            .OfType<System.Security.AccessControl.CommonAce>()
+            .Where(a => a.AceType == System.Security.AccessControl.AceType.AccessAllowed)
+            .Select(a => a.SecurityIdentifier)
+            .ToList();
     }
 
     /// <summary>

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1301,10 +1301,15 @@ public sealed partial class MainWindow : Window
         _beepSuppressor = new SysCharBeepSuppressor();
         Activated += OnActivatedInstallBeepSuppressor;
 
-        // The opt-in test seam: zero surface unless WINTTY_TEST_SEAM=1,
-        // and then one named pipe whose commands drive the real handlers
-        // on this UI thread. See Testing.TestSeam.
+        // The opt-in test seam: not compiled at all unless the build defines
+        // TESTSEAM (Debug does, a shipping Release does not), and then still
+        // silent unless WINTTY_TEST_SEAM carries a session token. Armed, it
+        // is one named pipe whose commands drive the real handlers on this UI
+        // thread -- send-text included, which is why the build gate is here
+        // and not only the env one. See Testing.TestSeam.
+#if TESTSEAM
         Testing.TestSeam.Start(this);
+#endif
 
         Closed += OnClosedAsync;
     }

--- a/windows/Ghostty/Testing/TestSeam.cs
+++ b/windows/Ghostty/Testing/TestSeam.cs
@@ -19,37 +19,102 @@ namespace Ghostty.Testing;
 /// No OS input is synthesized, nothing is focused, and the user can be using
 /// the machine while a script drives the app.
 ///
-/// The gate is the whole surface: without WINTTY_TEST_SEAM=1 in the app's
-/// environment this class never creates a pipe and costs one env-var read
-/// per window. With it, the pipe is session-local and serves one client at
-/// a time; a second command connection waits for the first to hang up. A
-/// second opted-in process does not spin: the fixed name belongs to
-/// whoever took it first, and the loser goes quiet (one seam per machine).
+/// What the seam grants, stated plainly, because it is no longer only "drive
+/// its UI": send-text hands arbitrary bytes to a live shell, which is
+/// arbitrary command execution as the user, and the read ops report tab
+/// titles and working directories. Whoever can talk to this pipe can do
+/// both. Everything below follows from taking that seriously.
 ///
-/// Trust model, spike-honest: the pipe carries no ACL of its own, so any
-/// process running as the same local user can connect to an opted-in
-/// instance and drive its UI -- the same-user bar every dev tool on the
-/// box already clears. A user-scoped ACL (or a per-start nonce in the
-/// pipe name) is the hardening step for when the seam ships beyond this
-/// opt-in.
+/// Three gates, none of which is the pipe's name:
+///
+/// 1. The build. Nothing in here exists unless TESTSEAM is defined, which
+///    Debug does and a shipping Release does not (windows/Directory.Build.props,
+///    the same shape demo mode uses). A user's install carries zero seam bytes,
+///    so the rest of this only concerns machines that build the seam in.
+/// 2. The environment. WINTTY_TEST_SEAM must hold a 32-character hex session
+///    token -- not "1", not "true". The token is the credential and the pipe
+///    is named after it, so a process that did not launch this app cannot
+///    guess the name, and cannot take the name first either (see below).
+///    Rejecting the weak spellings is deliberate: an operator who sets "1"
+///    gets no seam rather than a seam anybody can reach.
+/// 3. The ACL. PipeOptions.CurrentUserOnly, so the pipe's DACL is one ACE for
+///    the launching user. Without it .NET's default DACL grants Everyone AND
+///    ANONYMOUS LOGON generic read, which is enough for any other account on
+///    the box -- or an authenticated peer over SMB, since named pipes are
+///    reachable as \\host\pipe\name -- to occupy the single server instance
+///    and shut the seam down. Not enough to send commands (the default grants
+///    no write), but a denial of service reachable from off the machine.
+///
+/// send-text carries a fourth gate of its own, WINTTY_TEST_SEAM_INPUT=1,
+/// because "move this tab" and "run this command in my shell" should not be
+/// the same permission.
+///
+/// What none of this defends against: a process already running as this user
+/// at medium integrity. It can read the token out of this process's
+/// environment block, and could equally well inject a thread. That is the
+/// same-user bar every dev tool on the box clears, and it is the honest
+/// boundary. A LOWER integrity process of the same user -- a sandboxed
+/// browser tab -- is outside it: the pipe has no explicit label, so it sits
+/// at medium and the no-write-up policy refuses its commands.
+///
+/// The pipe serves one client at a time; a second command connection waits
+/// for the first to hang up. A second opted-in process with a different token
+/// gets a different name and runs alongside. A name collision now means
+/// something took the token's name first, which cannot happen by accident;
+/// the server goes quiet rather than hot-spinning on a name it can never
+/// take, and the driver's connect times out.
 ///
 /// Protocol: each request is one line of JSON, {"op": "...", ...args}; each
 /// response is one line, {"ok": true, ...} or {"ok": false, "error": "..."}.
-/// Commands marshal to the UI thread and every ack answers after the work
-/// settled, so a driver never races the app.
+/// Requests are length-capped (see MaxRequestBytes). Commands marshal to the
+/// UI thread and every ack answers after the work settled, so a driver never
+/// races the app.
 ///
 /// One window is served (the first): the spike scenario is a single window.
 /// Multi-window routing is hardening, not architecture.
 /// </summary>
 internal static class TestSeam
 {
+#if TESTSEAM
     private const string EnvVar = "WINTTY_TEST_SEAM";
 
-    /// <summary>The pipe the driver connects to, when the seam is on.</summary>
-    internal const string PipeName = "wintty-test-seam";
+    /// <summary>
+    /// The second opt-in, for send-text alone. Everything else the seam does
+    /// moves chrome or reports state; send-text runs commands as the user, so
+    /// a harness that only drags tabs should not be carrying that power.
+    /// </summary>
+    private const string InputEnvVar = "WINTTY_TEST_SEAM_INPUT";
+
+    /// <summary>
+    /// The pipe is named after the session token, so the name is a secret
+    /// rather than a well-known address. A squatter cannot pre-create a name
+    /// it cannot guess, which is the half of squatting that silences the app;
+    /// the client's own CurrentUserOnly and its token cover the other half.
+    /// </summary>
+    private const string PipeNamePrefix = "wintty-test-seam-";
+
+    /// <summary>
+    /// 128 bits, hex. The length is exact and the alphabet is closed, which
+    /// is also what keeps the pipe name well-formed: no separator, no
+    /// traversal, nothing a caller-supplied string could smuggle into it.
+    /// </summary>
+    internal const int TokenLength = 32;
+
+    /// <summary>
+    /// The ceiling on one request line.
+    ///
+    /// StreamReader.ReadLineAsync has no ceiling: it grows until a newline
+    /// arrives, so a client that sends bytes and never a newline walks this
+    /// process out of memory. The largest honest request is a seed-tabs title
+    /// list, three orders of magnitude under this; the cap is far above every
+    /// harness and far below anything that hurts.
+    /// </summary>
+    private const int MaxRequestBytes = 64 * 1024;
 
     private static CancellationTokenSource? _lifetime;
     private static int _started;
+    private static string? _pipeName;
+    private static bool _inputAllowed;
 
     /// <summary>
     /// Called once per window from the MainWindow constructor. The first
@@ -58,8 +123,14 @@ internal static class TestSeam
     /// </summary>
     internal static void Start(MainWindow window)
     {
-        if (Environment.GetEnvironmentVariable(EnvVar) != "1") return;
+        // The gate reads before anything else happens, and it demands a real
+        // session token: an unset, empty, "0", "1" or "true" value is off.
+        var sessionToken = Environment.GetEnvironmentVariable(EnvVar);
+        if (!IsSessionToken(sessionToken)) return;
         if (Interlocked.Exchange(ref _started, 1) == 1) return;
+
+        _pipeName = PipeNamePrefix + sessionToken;
+        _inputAllowed = Environment.GetEnvironmentVariable(InputEnvVar) == "1";
 
         _lifetime = new CancellationTokenSource();
         var token = _lifetime.Token;
@@ -68,6 +139,22 @@ internal static class TestSeam
             try { _lifetime.Cancel(); } catch (ObjectDisposedException) { }
         };
         _ = Task.Run(() => ServeAsync(window, token));
+    }
+
+    /// <summary>
+    /// Exactly 32 hex characters and nothing else. Exact rather than
+    /// "at least", so there is one spelling of an armed seam and no sliding
+    /// scale of weak ones; closed alphabet, so the value can be concatenated
+    /// into a pipe name without any further sanitising.
+    /// </summary>
+    private static bool IsSessionToken(string? value)
+    {
+        if (value is null || value.Length != TokenLength) return false;
+        foreach (var c in value)
+        {
+            if (!char.IsAsciiHexDigit(c)) return false;
+        }
+        return true;
     }
 
     /// <summary>
@@ -82,15 +169,27 @@ internal static class TestSeam
             NamedPipeServerStream pipe;
             try
             {
+                // CurrentUserOnly is the ACL. Without it the DACL Windows
+                // hands an unsecured pipe grants Everyone and ANONYMOUS LOGON
+                // generic read -- measured, not assumed:
+                //   D:(A;;FA;;;SY)(A;;FA;;;BA)(A;;FA;;;<user>)(A;;FR;;;WD)(A;;FR;;;AN)
+                // Read is not enough to send a command, but it IS enough to
+                // take the one server instance and hold it, from another
+                // account on the box or from an authenticated SMB peer over
+                // \\host\pipe\. With the flag the DACL is a single ACE for
+                // this user.
                 pipe = new NamedPipeServerStream(
-                    PipeName, PipeDirection.InOut, maxNumberOfServerInstances: 1,
-                    PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+                    _pipeName!, PipeDirection.InOut, maxNumberOfServerInstances: 1,
+                    PipeTransmissionMode.Byte,
+                    PipeOptions.Asynchronous | PipeOptions.CurrentUserOnly);
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {
-                // The name belongs to another opted-in instance. One seam
-                // per machine is the honest semantics, so this process goes
-                // quiet instead of hot-spinning on a name it can never take.
+                // Something already owns a name derived from this session's
+                // token, which is not something that happens by accident.
+                // Going quiet is still the right move -- a retry loop would
+                // hot-spin on a name it can never take -- and the driver
+                // hears about it as a connect that times out.
                 return;
             }
             try
@@ -116,7 +215,7 @@ internal static class TestSeam
     private static async Task ServeConnectionAsync(
         NamedPipeServerStream pipe, MainWindow window, CancellationToken token)
     {
-        var reader = new StreamReader(pipe, Encoding.UTF8);
+        var reader = new BoundedLineReader(pipe, MaxRequestBytes);
         var writer = new StreamWriter(pipe, new UTF8Encoding(false))
         {
             AutoFlush = true,
@@ -124,11 +223,86 @@ internal static class TestSeam
         };
         while (!token.IsCancellationRequested && pipe.IsConnected)
         {
-            var line = await reader.ReadLineAsync(token);
-            if (line is null) return; // client hung up
+            var (status, line) = await reader.ReadLineAsync(token);
+            if (status == LineStatus.Eof) return; // client hung up
+            if (status == LineStatus.TooLong)
+            {
+                // There is no resyncing after this: the rest of the oversized
+                // line is bytes of unknown shape, and treating whatever
+                // follows the cap as the next request is how a length bug
+                // becomes a parsing bug. Say so once and drop the connection;
+                // the accept loop takes the next client.
+                await writer.WriteLineAsync(
+                    Error("parse", $"request exceeds {MaxRequestBytes} bytes"));
+                return;
+            }
             if (string.IsNullOrWhiteSpace(line)) continue;
             var response = await ExecuteAsync(window, line);
             await writer.WriteLineAsync(response);
+        }
+    }
+
+    private enum LineStatus
+    {
+        /// <summary>A complete line, within the cap.</summary>
+        Ok,
+
+        /// <summary>The client hung up.</summary>
+        Eof,
+
+        /// <summary>The cap was reached before a newline was.</summary>
+        TooLong,
+    }
+
+    /// <summary>
+    /// Reads newline-delimited UTF-8 requests off the pipe with a hard
+    /// ceiling on one line.
+    ///
+    /// This exists because StreamReader.ReadLineAsync has no ceiling. It
+    /// buffers until it sees a newline, so a client that opens the pipe and
+    /// streams bytes without one grows the buffer until the app dies -- a
+    /// memory exhaustion of the whole terminal, driven from outside it, with
+    /// no op ever dispatched and nothing in the JSON layer able to see it
+    /// coming. The cap has to sit under the reader, not over it.
+    /// </summary>
+    private sealed class BoundedLineReader(Stream stream, int maxBytes)
+    {
+        private readonly byte[] _chunk = new byte[4096];
+        private readonly MemoryStream _line = new();
+        private int _next;
+        private int _filled;
+
+        public async Task<(LineStatus Status, string Line)> ReadLineAsync(
+            CancellationToken token)
+        {
+            _line.SetLength(0);
+            while (true)
+            {
+                if (_next == _filled)
+                {
+                    _filled = await stream.ReadAsync(_chunk, token);
+                    _next = 0;
+                    // A read of zero is the hang-up. A partial line before it
+                    // is a truncated request, not a request: dropping it is
+                    // what keeps half a command from being executed.
+                    if (_filled == 0) return (LineStatus.Eof, string.Empty);
+                }
+
+                var newline = Array.IndexOf(_chunk, (byte)'\n', _next, _filled - _next);
+                var take = (newline >= 0 ? newline : _filled) - _next;
+                if (_line.Length + take > maxBytes) return (LineStatus.TooLong, string.Empty);
+
+                _line.Write(_chunk, _next, take);
+                _next += take;
+                if (newline < 0) continue;
+
+                _next++; // step over the newline itself
+                var bytes = _line.GetBuffer().AsSpan(0, (int)_line.Length);
+                // Trailing CR, because a driver on Windows may spell the
+                // terminator "\r\n" even though the protocol says "\n".
+                if (bytes.Length > 0 && bytes[^1] == (byte)'\r') bytes = bytes[..^1];
+                return (LineStatus.Ok, Encoding.UTF8.GetString(bytes));
+            }
         }
     }
 
@@ -211,21 +385,6 @@ internal static class TestSeam
         {
             done.SetResult(Error("ui", "dispatcher unavailable"));
         }
-        return done.Task;
-    }
-
-    /// <summary>
-    /// A handoff one priority below the strip's Normal-priority drag tick:
-    /// when the awaited task completes, everything the last synthetic move
-    /// scheduled -- crossings included -- has already run. This is what
-    /// makes a seam drag deterministic without sleeps.
-    /// </summary>
-    internal static Task WaitForLowPriorityAsync(DispatcherQueue queue)
-    {
-        var done = new TaskCompletionSource(
-            TaskCreationOptions.RunContinuationsAsynchronously);
-        if (!queue.TryEnqueue(DispatcherQueuePriority.Low, () => done.SetResult()))
-            done.SetException(new InvalidOperationException("dispatcher unavailable"));
         return done.Task;
     }
 
@@ -526,6 +685,14 @@ internal static class TestSeam
 
             case "send-text":
             {
+                // The one op that is not "drive the UI". Bytes handed to a
+                // live shell are commands run as the user, so this is a
+                // different power from every other op here and carries its
+                // own opt-in. A harness that drags tabs does not set it, and
+                // therefore cannot be turned into a shell by whatever reaches
+                // the pipe.
+                if (!_inputAllowed)
+                    return Error(op, $"send-text is off; set {InputEnvVar}=1 to arm it");
                 var text = ArgString(args, "text");
                 if (string.IsNullOrEmpty(text)) return Error(op, "send-text needs text");
                 var index = ArgInt(args, "index", manager.IndexOf(manager.ActiveTab));
@@ -1087,6 +1254,30 @@ internal static class TestSeam
         null => "none",
         _ => icon.GetType().Name,
     };
+#endif
+
+    // ---- outside the build gate ---------------------------------------
+    //
+    // The strip's own drag walkers call this, and they are ordinary internal
+    // methods on VerticalTabStrip rather than seam code. Guarding it with the
+    // rest would take the strip down with it in a build that has no seam, so
+    // this one handoff stays. It opens nothing: a dispatcher hop no caller
+    // outside this process can reach.
+
+    /// <summary>
+    /// A handoff one priority below the strip's Normal-priority drag tick:
+    /// when the awaited task completes, everything the last synthetic move
+    /// scheduled -- crossings included -- has already run. This is what
+    /// makes a seam drag deterministic without sleeps.
+    /// </summary>
+    internal static Task WaitForLowPriorityAsync(DispatcherQueue queue)
+    {
+        var done = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        if (!queue.TryEnqueue(DispatcherQueuePriority.Low, () => done.SetResult()))
+            done.SetException(new InvalidOperationException("dispatcher unavailable"));
+        return done.Task;
+    }
 }
 
 /// <summary>

--- a/windows/scripts/README.md
+++ b/windows/scripts/README.md
@@ -222,7 +222,7 @@ Every script here that launches Wintty uses the helper except two:
 |---|---|
 | `splash-single-instance-race.ps1` | its gate is deliberately *narrower* than `Assert-NoWintty`: it refuses only over instances running from the exe under test, because the mutex it is measuring is keyed on that path, and it needs to be able to launch a second instance itself |
 | `mouse-smoke-run.ps1` | the operator drives it by hand and quits the app themselves |
-| `contrast-oracle.ps1`, `tab-tag-ink.ps1`, `switcher-preview-theme.ps1` | they are meant to be runnable beside a Wintty somebody else is using: they read crash.log not at all, launch with `windows-single-instance` off against an isolated `XDG_CONFIG_HOME`, move only their own window and reap only what they started. What they cannot share is the seam pipe, whose name belongs to the first opted-in process, so a second `WINTTY_TEST_SEAM=1` instance makes them exit 1 rather than measure the wrong window |
+| `contrast-oracle.ps1`, `tab-tag-ink.ps1`, `switcher-preview-theme.ps1` | they are meant to be runnable beside a Wintty somebody else is using: they read crash.log not at all, launch with `windows-single-instance` off against an isolated `XDG_CONFIG_HOME`, move only their own window and reap only what they started. Each session now names its pipe after its own token, so two runs no longer collide on the name; what still makes them exit 1 rather than measure the wrong window is that each waits for the pipe belonging to the app it launched |
 
 `vtabs-visual-qa.ps1` launches nothing directly - each sub-script gates and
 reaps its own, including `vtabs-layout-switch-capture.ps1`, which it runs
@@ -283,7 +283,48 @@ did not fall over. Whitespace is excluded deliberately: the UIA document
 keeps trailing spaces and the search haystack trims them, so their counts
 legitimately differ.
 
+## Arming the seam
+
+`WINTTY_TEST_SEAM=1` no longer arms anything. The variable now carries a
+per-session token - 32 hex characters - and the pipe is named after it
+(`wintty-test-seam-<token>`), so the name is a secret rather than a well-known
+address that anything on the box can find or take first. An unset, empty, `0`
+or `1` value leaves the seam off.
+
+Harnesses get this for free from `lib/seam-client.ps1`: `Start-SeamSession`
+mints the token, sets the variable and connects. Driving an app by hand:
+
+```powershell
+. windows/scripts/lib/seam-client.ps1
+$token = New-SeamToken
+$env:WINTTY_TEST_SEAM = $token
+# ... launch Wintty ...
+$pipe = Connect-SeamPipe -Token $token
+```
+
+Two more things will stop a seam session that used to work:
+
+- **The build.** The seam is compiled out of Release. A Debug build has it; a
+  Release build needs `-p:TestSeam=true`, and is then a build nobody should
+  install. Against a public build there is no pipe at all.
+- **`send-text`.** It hands arbitrary bytes to a live shell, which is running
+  commands as the user, so it has a second opt-in of its own and is off by
+  default. Pass `-AllowInput` to `Start-SeamSession` (or set
+  `WINTTY_TEST_SEAM_INPUT=1`) only in a harness that genuinely needs the shell
+  to run something. `seam-cwd-tab-label.ps1` is the only one that does.
+
 ## Driving input
+
+**Prefer the seam.** It exists because synthesized input is not targeted:
+`SendInput`, `keybd_event` and `mouse_event` go to whatever window is
+foreground, which on a machine somebody is using is *their* window, not the
+app under test. A harness that types has taken over the human's keyboard for
+as long as it runs, and a `Ctrl`+wheel in one of these has already been
+observed to zoom a bystander's terminal. The seam drives the real handlers
+in-process with nothing focused and nothing synthesized, which is the whole
+reason it can run beside a person. Reach for what follows only for the
+handful of facts the seam genuinely cannot reach - "did the framework deliver
+this key?" - and never on a machine in use.
 
 Posted `WM_CHAR` / `WM_KEYDOWN` messages **do not reach Wintty** - measured at
 zero characters landing across every inter-character delay. Use `SendInput`,

--- a/windows/scripts/contrast-oracle.ps1
+++ b/windows/scripts/contrast-oracle.ps1
@@ -19,7 +19,7 @@
     result, and that is what a user's eyes get.
 
     Shape. State is driven through the in-process test seam
-    (WINTTY_TEST_SEAM=1, lib/seam-client.ps1): seed-tabs, select, pin,
+    (WINTTY_TEST_SEAM=<session token>, lib/seam-client.ps1): seed-tabs, select, pin,
     group, collapse, cycle, toggle-sidebar, toggle-layout. No OS input is
     synthesized, nothing is focused, the machine stays usable. Surfaces are
     LOCATED read-only over UIA and MEASURED out of one capture per
@@ -1051,7 +1051,7 @@ foreach ($leg in (New-ConfigLegs)) {
 # ---- report ----------------------------------------------------------------
 
 $result = [ordered]@{
-    actuation = 'seam (WINTTY_TEST_SEAM=1); zero synthesized OS input'
+    actuation = 'seam (WINTTY_TEST_SEAM=<session token>); zero synthesized OS input'
     instrument = 'rendered pixels, sampled out of a screen capture of the app window'
     mutate = $Mutate
     thresholds = [ordered]@{

--- a/windows/scripts/frame-keybind-check.ps1
+++ b/windows/scripts/frame-keybind-check.ps1
@@ -5,7 +5,7 @@
     action it is bound to, and a key that belongs to whatever holds focus
     must never be taken from it.
 
-    Actuation is the in-process test seam (WINTTY_TEST_SEAM=1, the named
+    Actuation is the in-process test seam (WINTTY_TEST_SEAM=<session token>, the named
     pipe). Zero OS input is synthesized: the 'focus' op moves real XAML
     focus and the 'chord' op calls the window's own frame-chord router --
     focus gate, residual table, libghostty match, dispatch -- with the
@@ -229,7 +229,7 @@ Invoke-Scenario 'frame-leaves-plain-keys' {
 # ---- verdict ---------------------------------------------------------------
 
 $result = [ordered]@{
-    actuation = 'seam (WINTTY_TEST_SEAM=1); zero synthesized OS input'
+    actuation = 'seam (WINTTY_TEST_SEAM=<session token>); zero synthesized OS input'
     scenarios = $script:Scenarios
 }
 $result | ConvertTo-Json -Depth 5 | Set-Content (Join-Path $OutDir 'result.json') -Encoding utf8

--- a/windows/scripts/lib/seam-client.ps1
+++ b/windows/scripts/lib/seam-client.ps1
@@ -1,12 +1,79 @@
 # The seam driver's shared plumbing: launch one Wintty with the in-process
-# test seam armed (WINTTY_TEST_SEAM=1), wait out the splash, connect the
-# named pipe, and speak the newline-delimited JSON protocol. No OS input is
-# ever synthesized here -- the seam drives the real handlers in-process, so
-# the machine stays usable while a harness runs. UIA and pixels remain the
-# harnesses' own read-only oracles.
+# test seam armed, wait out the splash, connect the named pipe, and speak the
+# newline-delimited JSON protocol. No OS input is ever synthesized here -- the
+# seam drives the real handlers in-process, so the machine stays usable while
+# a harness runs. UIA and pixels remain the harnesses' own read-only oracles.
+#
+# Arming the seam takes a per-session token, not WINTTY_TEST_SEAM=1. The token
+# is the credential and the pipe is named after it, which is what stops a
+# process that did not launch this app from either finding the pipe or taking
+# its name first. Every consumer goes through New-SeamToken / Wait-SeamPipe /
+# Connect-SeamPipe below rather than spelling a pipe name, so there is one
+# place that knows how the name is built.
+#
+# The seam is also compiled out of Release (see windows/Directory.Build.props),
+# so a harness pointed at a public build finds no pipe at all. Point them at a
+# Debug build, or a Release built with -p:TestSeam=true.
 #
 # Dot-source after lib/wintty-process.ps1 (Assert-NoWintty and the stamp
 # helpers live there and are the caller's own preamble).
+
+# 128 bits of hex: the shape TestSeam.IsSessionToken accepts, and the reason
+# the pipe name is unguessable. RandomNumberGenerator rather than Get-Random,
+# whose default seeding is not something to hang an access decision on.
+function New-SeamToken {
+    $bytes = [byte[]]::new(16)
+    [System.Security.Cryptography.RandomNumberGenerator]::Fill($bytes)
+    return [System.Convert]::ToHexString($bytes).ToLowerInvariant()
+}
+
+# The one place the pipe name is built. TestSeam.cs builds the same string from
+# PipeNamePrefix; if these two ever disagree the harness fails at the wait
+# below with a clear message rather than connecting to something else.
+function Get-SeamPipeName([Parameter(Mandatory)][string]$Token) {
+    return "wintty-test-seam-$Token"
+}
+
+# Wait for the armed app to publish its pipe. Enumerating \\.\pipe\ rather than
+# just attempting the connect keeps the failure legible: "never appeared" and
+# "appeared but refused us" are different findings.
+function Wait-SeamPipe(
+    [Parameter(Mandatory)][string]$Token,
+    [Parameter(Mandatory)]$Proc,
+    [int]$TimeoutSeconds = 90
+) {
+    $name = Get-SeamPipeName $Token
+    $deadline = [datetime]::UtcNow.AddSeconds($TimeoutSeconds)
+    while ($true) {
+        if ($Proc.HasExited) {
+            throw ("HARNESS: the app exited (code {0}) before the seam pipe appeared" -f $Proc.ExitCode)
+        }
+        if ([datetime]::UtcNow -gt $deadline) {
+            throw ("HARNESS: the seam pipe '{0}' never appeared. Either the app was " +
+                   "not launched with WINTTY_TEST_SEAM set to this session's token, " +
+                   'or it is a build with the seam compiled out (Release without ' +
+                   '-p:TestSeam=true).') -f $name
+        }
+        if ([System.IO.Directory]::GetFiles('\\.\pipe\') -contains "\\.\pipe\$name") { return $name }
+        Start-Sleep -Milliseconds 150
+    }
+}
+
+# Connect with CurrentUserOnly, which makes the client refuse a server running
+# as anyone else. It is not the whole answer to squatting -- a squatter running
+# as this same user still satisfies it, which is what the unguessable token is
+# for -- but it is free and it closes the cross-account half.
+function Connect-SeamPipe(
+    [Parameter(Mandatory)][string]$Token,
+    [int]$TimeoutMs = 20000
+) {
+    $pipe = [System.IO.Pipes.NamedPipeClientStream]::new(
+        '.', (Get-SeamPipeName $Token),
+        [System.IO.Pipes.PipeDirection]::InOut,
+        [System.IO.Pipes.PipeOptions]::CurrentUserOnly)
+    $pipe.Connect($TimeoutMs)
+    return $pipe
+}
 
 Add-Type -TypeDefinition @'
 using System;
@@ -107,7 +174,12 @@ function Start-SeamSession(
     # from $ConfigText because the two are not interchangeable: a leg that
     # measures the unconfigured build has to pass the flag AND still get an
     # isolated XDG dir, so nothing the developer has on disk leaks in.
-    [string[]]$Arguments = @()
+    [string[]]$Arguments = @(),
+    # Arm send-text. Off by default and deliberately opt-in per harness:
+    # send-text hands arbitrary bytes to a live shell, so a harness that only
+    # drags tabs should not be launching an app that can be told to run
+    # commands. Only a harness asserting on shell output needs this.
+    [switch]$AllowInput
 ) {
     $tempXdg = Join-Path $env:TEMP "wintty-seam-$([guid]::NewGuid().ToString('N'))"
     New-Item -ItemType Directory -Force -Path (Join-Path $tempXdg 'wintty') | Out-Null
@@ -117,13 +189,19 @@ function Start-SeamSession(
         TempXdg   = $tempXdg
         ExePath   = (Resolve-Path $ExePath).Path
         Stamp     = Get-WinttyLaunchStamp
+        Token     = New-SeamToken
         OrigXdg   = if (Test-Path Env:XDG_CONFIG_HOME) { $env:XDG_CONFIG_HOME } else { $null }
         OrigSeam  = if (Test-Path Env:WINTTY_TEST_SEAM) { $env:WINTTY_TEST_SEAM } else { $null }
+        OrigInput = if (Test-Path Env:WINTTY_TEST_SEAM_INPUT) { $env:WINTTY_TEST_SEAM_INPUT } else { $null }
         OrigTrace = if (Test-Path Env:WINTTY_TABDRAG_TRACE) { $env:WINTTY_TABDRAG_TRACE } else { $null }
         OrigNoColor = if (Test-Path Env:NO_COLOR) { $env:NO_COLOR } else { $null }
     }
     $env:XDG_CONFIG_HOME = $tempXdg
-    $env:WINTTY_TEST_SEAM = '1'
+    # The token travels in the environment block the child inherits, which is
+    # readable only by something that could already open this process anyway.
+    $env:WINTTY_TEST_SEAM = $session.Token
+    if ($AllowInput) { $env:WINTTY_TEST_SEAM_INPUT = '1' }
+    else { Remove-Item Env:WINTTY_TEST_SEAM_INPUT -ErrorAction SilentlyContinue }
     # The child inherits this shell's environment block, and NO_COLOR in it is
     # a harness trap rather than a user setting: Claude Code's PowerShell tool
     # exports NO_COLOR=1, so every agent-launched instance inherits it. Wintty
@@ -148,20 +226,8 @@ function Start-SeamSession(
     $session.Hwnd64 = [int64]$main.Hwnd64
 
     # The seam pipe appears once OnLaunched has built the window.
-    $deadline = [datetime]::UtcNow.AddSeconds(90)
-    while ($true) {
-        if ($proc.HasExited) {
-            throw ("HARNESS: the app exited (code {0}) before the seam pipe appeared" -f $proc.ExitCode)
-        }
-        if ([datetime]::UtcNow -gt $deadline) {
-            throw 'HARNESS: the seam pipe never appeared (WINTTY_TEST_SEAM=1 not seen by the app?)'
-        }
-        if ([System.IO.Directory]::GetFiles('\\.\pipe\') -contains '\\.\pipe\wintty-test-seam') { break }
-        Start-Sleep -Milliseconds 150
-    }
-    $session.Pipe = [System.IO.Pipes.NamedPipeClientStream]::new(
-        '.', 'wintty-test-seam', [System.IO.Pipes.PipeDirection]::InOut)
-    $session.Pipe.Connect(20000)
+    [void](Wait-SeamPipe -Token $session.Token -Proc $proc)
+    $session.Pipe = Connect-SeamPipe -Token $session.Token
     $session.Reader = [System.IO.StreamReader]::new($session.Pipe)
     $session.Writer = [System.IO.StreamWriter]::new(
         $session.Pipe, [System.Text.UTF8Encoding]::new($false))
@@ -220,6 +286,8 @@ function Stop-SeamSession([Parameter(Mandatory)]$Session) {
     else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
     if ($null -ne $Session.OrigSeam) { $env:WINTTY_TEST_SEAM = $Session.OrigSeam }
     else { Remove-Item Env:WINTTY_TEST_SEAM -ErrorAction SilentlyContinue }
+    if ($null -ne $Session.OrigInput) { $env:WINTTY_TEST_SEAM_INPUT = $Session.OrigInput }
+    else { Remove-Item Env:WINTTY_TEST_SEAM_INPUT -ErrorAction SilentlyContinue }
     if ($null -ne $Session.OrigTrace) { $env:WINTTY_TABDRAG_TRACE = $Session.OrigTrace }
     else { Remove-Item Env:WINTTY_TABDRAG_TRACE -ErrorAction SilentlyContinue }
     if ($null -ne $Session.OrigNoColor) { $env:NO_COLOR = $Session.OrigNoColor }

--- a/windows/scripts/mouse-fuzz-tab-drag.ps1
+++ b/windows/scripts/mouse-fuzz-tab-drag.ps1
@@ -1,7 +1,7 @@
 #requires -Version 7
 <#
     Tab drag end to end, seam-actuated: the scenarios drive the REAL drag
-    engine and manager ops over the in-process test seam (WINTTY_TEST_SEAM=1,
+    engine and manager ops over the in-process test seam (WINTTY_TEST_SEAM=<session token>,
     the named pipe), and the oracles stay what they were -- UIA order and
     ItemStatus asserts, visible-row count gates, the product's own drag
     trace read back session by session, and crash.log growth. Zero OS input
@@ -606,7 +606,7 @@ Invoke-Scenario 'layout-toggle' {
 # ---- verdict ---------------------------------------------------------------
 
 $result = [ordered]@{
-    actuation = 'seam (WINTTY_TEST_SEAM=1); zero synthesized OS input'
+    actuation = 'seam (WINTTY_TEST_SEAM=<session token>); zero synthesized OS input'
     scenarios = $script:Scenarios
 }
 $result | ConvertTo-Json -Depth 5 | Set-Content (Join-Path $OutDir 'result.json') -Encoding utf8

--- a/windows/scripts/pane-focus-tab-switch.ps1
+++ b/windows/scripts/pane-focus-tab-switch.ps1
@@ -346,7 +346,7 @@ Invoke-Scenario 'right-pane-survives-tab-switch' {
 # ---- verdict ---------------------------------------------------------------
 
 $result = [ordered]@{
-    actuation = 'seam (WINTTY_TEST_SEAM=1); zero synthesized OS input'
+    actuation = 'seam (WINTTY_TEST_SEAM=<session token>); zero synthesized OS input'
     scenarios = $script:Scenarios
 }
 $result | ConvertTo-Json -Depth 5 | Set-Content (Join-Path $OutDir 'result.json') -Encoding utf8

--- a/windows/scripts/seam-acceptance.ps1
+++ b/windows/scripts/seam-acceptance.ps1
@@ -1,8 +1,9 @@
 #requires -Version 7
 <#
-    The in-process test seam's acceptance run: one Wintty with
-    WINTTY_TEST_SEAM=1, driven over the named pipe with zero OS input, zero
-    focus steals, and the driver asserting manager truth after every step.
+    The in-process test seam's acceptance run: one Wintty armed with a
+    per-session seam token, driven over the named pipe with zero OS input,
+    zero focus steals, and the driver asserting manager truth after every
+    step.
 
     The scenario is the crash investigation's repro, made deterministic.
     Per iteration, all over the pipe:
@@ -35,6 +36,7 @@ param(
     [ValidateRange(0, 5000)][int]$GapMs = 0
 )
 . (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
+. (Join-Path $PSScriptRoot 'lib/seam-client.ps1')
 $ErrorActionPreference = 'Stop'
 
 $titles = @('tab-1', 'tab-2', 'tab-3', 'tab-4', 'tab-5')
@@ -132,31 +134,16 @@ function Assert-SeamGroup {
 
 try {
     $env:XDG_CONFIG_HOME = $tempXdg
-    $env:WINTTY_TEST_SEAM = '1'
+    $token = New-SeamToken
+    $env:WINTTY_TEST_SEAM = $token
     $proc = Start-Process -FilePath $ExePath -PassThru `
         -WorkingDirectory (Split-Path -Parent (Resolve-Path $ExePath))
     $script:Proc = $proc
-    Write-Host "pid=$($proc.Id) pipe=wintty-test-seam iterations=$Iterations"
+    Write-Host "pid=$($proc.Id) pipe=$(Get-SeamPipeName $token) iterations=$Iterations"
 
     # The seam pipe appears once OnLaunched has built the window.
-    $deadline = [datetime]::UtcNow.AddSeconds(90)
-    while ($true) {
-        if ($proc.HasExited) {
-            throw ("HARNESS: the app exited (code {0}) before the seam pipe " +
-                "appeared" -f $proc.ExitCode)
-        }
-        if ([datetime]::UtcNow -gt $deadline) {
-            throw 'HARNESS: the seam pipe never appeared (WINTTY_TEST_SEAM=1 not seen by the app?)'
-        }
-        if ([System.IO.Directory]::GetFiles('\\.\pipe\') -contains '\\.\pipe\wintty-test-seam') {
-            break
-        }
-        Start-Sleep -Milliseconds 150
-    }
-
-    $script:Pipe = [System.IO.Pipes.NamedPipeClientStream]::new(
-        '.', 'wintty-test-seam', [System.IO.Pipes.PipeDirection]::InOut)
-    $script:Pipe.Connect(20000)
+    [void](Wait-SeamPipe -Token $token -Proc $proc)
+    $script:Pipe = Connect-SeamPipe -Token $token
     $script:Reader = [System.IO.StreamReader]::new($script:Pipe)
     $script:Writer = [System.IO.StreamWriter]::new(
         $script:Pipe, [System.Text.UTF8Encoding]::new($false))

--- a/windows/scripts/seam-bisect.ps1
+++ b/windows/scripts/seam-bisect.ps1
@@ -7,11 +7,13 @@ param(
     [int]$GapMs = 0
 )
 $ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'lib/seam-client.ps1')
 
 $exe = $ExePath
 $xdg = Join-Path $env:TEMP ("wintty-seam-bisect-" + [guid]::NewGuid().ToString('N'))
 $env:XDG_CONFIG_HOME = $xdg
-$env:WINTTY_TEST_SEAM = '1'
+$token = New-SeamToken
+$env:WINTTY_TEST_SEAM = $token
 New-Item -ItemType Directory -Force -Path (Join-Path $xdg 'wintty') | Out-Null
 @'
 windows-single-instance = true
@@ -19,24 +21,20 @@ window-save-state = never
 vertical-tabs = true
 '@ | Set-Content (Join-Path $xdg 'wintty\config.wintty') -Encoding utf8
 
-# Wait out the previous scenario's instance: its pipe server may outlive
-# the client by a beat, and connecting to a dying process looks like a
-# broken pipe, not a crash.
+# Wait out the previous scenario's instance: connecting while the last one is
+# still dying looks like a broken pipe, not a crash. This used to watch the
+# fixed pipe name disappear, which no longer says anything -- every run now has
+# its own name -- so it watches the process instead, which is what the pipe was
+# standing in for.
 $goneBy = [datetime]::UtcNow.AddSeconds(15)
 while ([datetime]::UtcNow -lt $goneBy) {
-    if (-not ([System.IO.Directory]::GetFiles('\\.\pipe\') -contains '\\.\pipe\wintty-test-seam')) { break }
+    if (-not (Get-Process -Name 'Wintty' -ErrorAction SilentlyContinue)) { break }
     Start-Sleep -Milliseconds 200
 }
 
 $proc = Start-Process -FilePath $exe -PassThru -WorkingDirectory (Split-Path -Parent $exe)
-$deadline = [datetime]::UtcNow.AddSeconds(60)
-while ([datetime]::UtcNow -lt $deadline) {
-    if ($proc.HasExited) { throw "app exited before the pipe appeared" }
-    if ([System.IO.Directory]::GetFiles('\\.\pipe\') -contains '\\.\pipe\wintty-test-seam') { break }
-    Start-Sleep -Milliseconds 200
-}
-$pipe = [System.IO.Pipes.NamedPipeClientStream]::new('.', 'wintty-test-seam', [System.IO.Pipes.PipeDirection]::InOut)
-$pipe.Connect(10000)
+[void](Wait-SeamPipe -Token $token -Proc $proc -TimeoutSeconds 60)
+$pipe = Connect-SeamPipe -Token $token -TimeoutMs 10000
 $r = [System.IO.StreamReader]::new($pipe)
 $w = [System.IO.StreamWriter]::new($pipe, [System.Text.UTF8Encoding]::new($false)); $w.AutoFlush = $true
 $w.NewLine = "`n"

--- a/windows/scripts/seam-cdb.ps1
+++ b/windows/scripts/seam-cdb.ps1
@@ -21,13 +21,17 @@ param(
     [string]$DumpPath = (Join-Path $env:TEMP 'wintty-seam-crash.dmp')
 )
 $ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'lib/seam-client.ps1')
 $exe = $ExePath
 $cdb = 'C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\cdb.exe'
 $log = Join-Path $env:TEMP 'wintty-seam-cdb.log'
 $cmds = Join-Path $env:TEMP 'wintty-seam-cdb-cmds.txt'
 $xdg = Join-Path $env:TEMP ("wintty-seam-cdb-" + [guid]::NewGuid().ToString('N'))
 $env:XDG_CONFIG_HOME = $xdg
-$env:WINTTY_TEST_SEAM = '1'
+# cdb inherits this and the app under it inherits it in turn, so the token
+# reaches the seam the same way a direct launch delivers it.
+$token = New-SeamToken
+$env:WINTTY_TEST_SEAM = $token
 New-Item -ItemType Directory -Force -Path (Join-Path $xdg 'wintty') | Out-Null
 @'
 windows-single-instance = true
@@ -45,17 +49,8 @@ g
 Remove-Item $log, $DumpPath -ErrorAction SilentlyContinue
 $argLine = '-logo "' + $log + '" -c "$<' + $cmds + '" "' + $exe + '"'
 $debugger = Start-Process -FilePath $cdb -ArgumentList $argLine -PassThru
-$deadline = [datetime]::UtcNow.AddSeconds(90)
-while ([datetime]::UtcNow -lt $deadline) {
-    if ($debugger.HasExited) { throw "HARNESS: cdb exited before the pipe appeared" }
-    if ([System.IO.Directory]::GetFiles('\\.\pipe\') -contains '\\.\pipe\wintty-test-seam') {
-        break
-    }
-    Start-Sleep -Milliseconds 200
-}
-$pipe = [System.IO.Pipes.NamedPipeClientStream]::new(
-    '.', 'wintty-test-seam', [System.IO.Pipes.PipeDirection]::InOut)
-$pipe.Connect(10000)
+[void](Wait-SeamPipe -Token $token -Proc $debugger -TimeoutSeconds 90)
+$pipe = Connect-SeamPipe -Token $token -TimeoutMs 10000
 $reader = [System.IO.StreamReader]::new($pipe)
 $writer = [System.IO.StreamWriter]::new(
     $pipe, [System.Text.UTF8Encoding]::new($false))

--- a/windows/scripts/seam-crash-dump.ps1
+++ b/windows/scripts/seam-crash-dump.ps1
@@ -20,6 +20,7 @@ param(
 )
 $ErrorActionPreference = 'Stop'
 . (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
+. (Join-Path $PSScriptRoot 'lib/seam-client.ps1')
 
 Assert-NoWintty -Context 'The seam crash-dump capture'
 $stamp = Get-WinttyLaunchStamp
@@ -60,7 +61,8 @@ if ($check.DumpType -ne 2 -or $check.DumpFolder -ne $DumpFolder) {
 
 $xdg = Join-Path $env:TEMP ("wintty-seam-dump-" + [guid]::NewGuid().ToString('N'))
 $env:XDG_CONFIG_HOME = $xdg
-$env:WINTTY_TEST_SEAM = '1'
+$token = New-SeamToken
+$env:WINTTY_TEST_SEAM = $token
 New-Item -ItemType Directory -Force -Path (Join-Path $xdg 'wintty') | Out-Null
 @'
 windows-single-instance = true
@@ -73,17 +75,8 @@ $proc = $null
 try {
     $proc = Start-Process -FilePath $ExePath -PassThru `
         -WorkingDirectory (Split-Path -Parent (Resolve-Path $ExePath))
-    $deadline = [datetime]::UtcNow.AddSeconds(90)
-    while ([datetime]::UtcNow -lt $deadline) {
-        if ($proc.HasExited) { throw "HARNESS: app exited before the seam pipe" }
-        if ([System.IO.Directory]::GetFiles('\\.\pipe\') -contains '\\.\pipe\wintty-test-seam') {
-            break
-        }
-        Start-Sleep -Milliseconds 200
-    }
-    $pipe = [System.IO.Pipes.NamedPipeClientStream]::new(
-        '.', 'wintty-test-seam', [System.IO.Pipes.PipeDirection]::InOut)
-    $pipe.Connect(20000)
+    [void](Wait-SeamPipe -Token $token -Proc $proc -TimeoutSeconds 90)
+    $pipe = Connect-SeamPipe -Token $token
     $reader = [System.IO.StreamReader]::new($pipe)
     $writer = [System.IO.StreamWriter]::new(
         $pipe, [System.Text.UTF8Encoding]::new($false))

--- a/windows/scripts/seam-cwd-tab-label.ps1
+++ b/windows/scripts/seam-cwd-tab-label.ps1
@@ -163,7 +163,10 @@ default-profile = $Profile
     Write-Host "=== scenario $Name (profile $Profile) ==="
     try {
         Assert-NoWintty -Context "The cwd label scenario '$Name'"
-        $s = Start-SeamSession -ExePath $ExePath -ConfigText $config
+        # -AllowInput because this harness types a `cd` into the shell and
+        # reads the label that comes back; send-text is off without it. It is
+        # the only harness in the suite that needs the shell to run anything.
+        $s = Start-SeamSession -ExePath $ExePath -ConfigText $config -AllowInput
         $script:MainHwnd64 = $s.Hwnd64
 
         # The right shell has to be the one under test. The profile's icon
@@ -381,7 +384,7 @@ if ($cmdIcon -and $pwshIcon) {
 }
 
 $result = [ordered]@{
-    actuation = 'seam (WINTTY_TEST_SEAM=1); zero synthesized OS input'
+    actuation = 'seam (WINTTY_TEST_SEAM=<session token>); zero synthesized OS input'
     scenarios = $script:Scenarios
 }
 $result | ConvertTo-Json -Depth 5 | Set-Content (Join-Path $OutDir 'result.json') -Encoding utf8

--- a/windows/scripts/seam-probe.ps1
+++ b/windows/scripts/seam-probe.ps1
@@ -2,7 +2,11 @@ param(
     [Parameter(Mandatory)][string]$ExePath
 )
 $ErrorActionPreference = 'Stop'
-$env:WINTTY_TEST_SEAM = '1'
+# The token, the name and the connect all come from the shared client so this
+# probe cannot drift from how the seam is actually addressed.
+. (Join-Path $PSScriptRoot 'lib/seam-client.ps1')
+$token = New-SeamToken
+$env:WINTTY_TEST_SEAM = $token
 $xdg = Join-Path $env:TEMP ("wintty-seam-probe-" + [guid]::NewGuid().ToString('N'))
 $env:XDG_CONFIG_HOME = $xdg
 New-Item -ItemType Directory -Force -Path (Join-Path $xdg 'wintty') | Out-Null
@@ -14,14 +18,8 @@ vertical-tabs = true
 
 $exe = $ExePath
 $proc = Start-Process -FilePath $exe -PassThru -WorkingDirectory (Split-Path -Parent $exe)
-$deadline = [datetime]::UtcNow.AddSeconds(60)
-while ([datetime]::UtcNow -lt $deadline) {
-    if ($proc.HasExited) { throw "app exited early" }
-    if ([System.IO.Directory]::GetFiles('\\.\pipe\') -contains '\\.\pipe\wintty-test-seam') { break }
-    Start-Sleep -Milliseconds 200
-}
-$pipe = [System.IO.Pipes.NamedPipeClientStream]::new('.', 'wintty-test-seam', [System.IO.Pipes.PipeDirection]::InOut)
-$pipe.Connect(10000)
+[void](Wait-SeamPipe -Token $token -Proc $proc -TimeoutSeconds 60)
+$pipe = Connect-SeamPipe -Token $token -TimeoutMs 10000
 $r = [System.IO.StreamReader]::new($pipe)
 $w = [System.IO.StreamWriter]::new($pipe, [System.Text.UTF8Encoding]::new($false)); $w.AutoFlush = $true
 

--- a/windows/scripts/vtab-strip-geometry.ps1
+++ b/windows/scripts/vtab-strip-geometry.ps1
@@ -2,7 +2,7 @@
 <#
     The vertical strip's chrome geometry, seam-measured. The oracle is the
     strip's own arranged layout, read back over the seam's element-rects op
-    (WINTTY_TEST_SEAM=1) -- not sampled pixels. That is deliberate: the
+    (WINTTY_TEST_SEAM=<session token>) -- not sampled pixels. That is deliberate: the
     strip wears Mica, so what a screen grab shows depends on the desktop
     behind the window, and the questions asked here are about where things
     were laid out, which layout answers exactly.
@@ -249,7 +249,7 @@ if ((Test-Path $crashPath) -and ((Get-Item $crashPath).LastWriteTimeUtc -gt $cra
 }
 
 $result = [ordered]@{
-    actuation = 'seam (WINTTY_TEST_SEAM=1); geometry read from arranged layout, no pixels'
+    actuation = 'seam (WINTTY_TEST_SEAM=<session token>); geometry read from arranged layout, no pixels'
     tolerance = $Tolerance
     checks    = $script:Checks
     findings  = $script:Findings


### PR DESCRIPTION
Two findings against the test seam, both fixed.

**The seam was compiled into every Release binary.** The only thing standing
between a shipping build and a live control channel was a runtime env-var
read. It is now excluded at build time. Verified at the binary level rather
than from the build script: the pipe name is present in `Debug\Wintty.dll`
and absent from `Release\Wintty.dll`.

**The pipe's DACL, queried rather than assumed, was `(A;;FR;;;WD)(A;;FR;;;AN)`**
— Everyone and ANONYMOUS held `FILE_GENERIC_READ`. A read alone occupies the
single server instance, so any account could keep the seam down. The pipe is
now restricted to the owning user's token.

## One correction worth carrying

`PipeOptions.CurrentUserOnly` does **not** close pipe squatting. Tested against
a same-user squatter it connects happily — it verifies the *server's* user,
which an attacker satisfies trivially. Only the token closes it. That was my
error in the original brief and the next reader should not inherit it.

## Open, recorded on #863

Whether the pipe was reachable over SMB is **unproven** — there was no second
machine. Worth knowing the anonymous ACE was inert in the default
configuration: it only becomes live if the pipe is added to `NullSessionPipes`
or `RestrictNullSessAccess` is cleared. The fix was worth making regardless,
but the exposure was narrower than the raw DACL suggests.

Size-override: the build-time exclusion and the pipe ACL are one security posture, and the second commit's script changes are what stop the harnesses from hard-coding a pipe name the first commit just made a policy decision about.
