### PR TITLE
tests: the last two bench tests stop scripting by input-read count

### DIFF
--- a/windows/Ghostty.Tests/Bench/FakeTransport.cs
+++ b/windows/Ghostty.Tests/Bench/FakeTransport.cs
@@ -78,6 +78,23 @@ public sealed class FakeTransport : ITransport
     public Stream Input  => _inputClient;   // harness writes here
     public Stream Output => _outputClient;  // harness reads here
 
+    /// <summary>
+    /// Close the output after the next scripted response, in the same turn
+    /// that writes it.
+    /// </summary>
+    /// <remarks>
+    /// The responder is called once per input READ, so a test that wanted
+    /// "some data, then EOF" had to script it across two calls and therefore
+    /// assumed the harness's two Writes arrive as two Reads. They do not
+    /// reliably: a descheduled IO thread lets both Writes accumulate and one
+    /// Read drains them together, the second call never comes, and the test
+    /// times out instead of seeing the EOF it was about. Closing in the same
+    /// turn as the response makes the sequence a fact rather than a race.
+    /// </remarks>
+    public void CloseOutputAfterNextResponse() => Volatile.Write(ref _closeAfterResponse, 1);
+
+    private int _closeAfterResponse;
+
     // No-op: the in-process fake has no preamble. Scripted and echo modes
     // both skip any drain step; the caller is responsible for shaping the
     // pipe's initial state via the scripted responder if needed.
@@ -111,6 +128,12 @@ public sealed class FakeTransport : ITransport
                         break;
                     }
                     _outputServer.Write(response.Value.Span);
+                    if (Volatile.Read(ref _closeAfterResponse) == 1)
+                    {
+                        _outputServer.Flush();
+                        try { _outputServer.Dispose(); } catch { }
+                        break;
+                    }
                 }
             }
         }

--- a/windows/Ghostty.Tests/Bench/HarnessTests.cs
+++ b/windows/Ghostty.Tests/Bench/HarnessTests.cs
@@ -137,21 +137,27 @@ public class HarnessTests
         Buffer.BlockCopy(terminator, 0, combined, payload.Length, terminator.Length);
 
         int splitPoint = payload.Length + 15;   // mid-terminator
-        bool firstCall = true;
-        using var t = new FakeTransport(_ =>
-        {
-            if (firstCall)
-            {
-                firstCall = false;
-                byte[] first = new byte[splitPoint];
-                Buffer.BlockCopy(combined, 0, first, 0, splitPoint);
-                return first;
-            }
-            byte[] second = new byte[combined.Length - splitPoint];
-            Buffer.BlockCopy(combined, splitPoint, second, 0, second.Length);
-            return second;
-        });
-        byte[] scratch = new byte[64 * 1024];
+
+        // One response, and the split is forced by the SCRATCH size rather
+        // than by two responder calls.
+        //
+        // The boundary this test is about is the harness's own read boundary,
+        // and the harness reads at most scratch.Length bytes at a time -- so
+        // sizing scratch to splitPoint makes the first read end mid-terminator
+        // as a matter of arithmetic. Scripting it as two responder calls
+        // instead depended on the harness's two Writes arriving as two Reads,
+        // which under load they do not: both coalesce, the second call never
+        // comes, and the test times out. It would also have passed VACUOUSLY
+        // the other way -- two chunks into a 64 KB scratch can be drained by a
+        // single read, exercising no carryover at all.
+        // Answer once and then stay silent. Not a call-count SCRIPT -- the
+        // behaviour is the same however many calls arrive, which is the whole
+        // point; a responder that returns `combined` every time makes emitBytes
+        // depend on how many input reads happened (1055 or 2048).
+        int answered = 0;
+        using var t = new FakeTransport(
+            _ => Interlocked.Exchange(ref answered, 1) == 0 ? combined : Array.Empty<byte>());
+        byte[] scratch = new byte[splitPoint];
 
         var (_, emitBytes) = Runner.RunThroughputIteration(
             t, payload, terminator, TimeSpan.FromSeconds(5), scratch);
@@ -167,13 +173,13 @@ public class HarnessTests
         byte[] payload = new byte[256];
         byte[] terminator = System.Text.Encoding.ASCII.GetBytes(
             "\r\n~ENDOFBURST_" + Guid.NewGuid().ToString("N").Substring(0, 16) + "~");
-        int call = 0;
-        using var t = new FakeTransport(_ =>
-        {
-            call++;
-            if (call == 1) return payload;   // no terminator
-            return null;                     // close output
-        });
+        // Answer once with data that carries no terminator, and close in the
+        // SAME turn. Scripting this as call 1 = data, call 2 = close assumed
+        // the harness's two Writes arrive as two Reads; under load they
+        // coalesce into one, the second call never comes, the output never
+        // closes and the iteration times out instead of surfacing EOF.
+        using var t = new FakeTransport(_ => payload);
+        t.CloseOutputAfterNextResponse();
         byte[] scratch = new byte[64 * 1024];
 
         Assert.Throws<EndOfStreamException>(() =>


### PR DESCRIPTION
Follow-on to #916, which fixed one test that assumed the harness''s two `Write`s
arrive as two `Read`s. **Two more had the same assumption** and were missed —
both have since been reported as `TimeoutException`s on loaded runs.

- `ThrowsOnEndOfStreamBeforeTerminator` scripted call 1 = data, call 2 = close.
  Coalesced, the second call never comes, the output never closes, and it times
  out instead of surfacing the EOF it is named for. `FakeTransport` grows
  `CloseOutputAfterNextResponse`, closing in the **same turn** as the response.
- `DetectsTerminatorSplitAcrossReads` was wrong twice over: coalesced it times
  out, and split it could pass **vacuously**, because two chunks into a 64 KB
  scratch can be drained by one read and exercise no carryover. The boundary it
  is about is the *harness''s* read boundary, so the scratch is now sized to the
  split point and the straddle is arithmetic.

The first attempt at the second one failed instructively: a responder returning
the same buffer on every call made `emitBytes` depend on the input read count
(1055 or 2048) — the same defect wearing a different hat. It now answers once
and stays silent.

**Proven both ways.** With the two `Write`s coalesced (what a descheduled IO
thread produces): before, `ThrowsOnEndOfStream` fails in 5.0s; after, all 13
pass. With them split, all 13 pass. Neither framing is a verdict any more.
