### PR TITLE
tabs: a group gets a field, in both strips

### DIFF
--- a/windows/Ghostty.Core/Tabs/TabGroupField.cs
+++ b/windows/Ghostty.Core/Tabs/TabGroupField.cs
@@ -1,0 +1,244 @@
+using System.Collections.Generic;
+using Ghostty.Core.Shell;
+using Ghostty.Core.Windows;
+
+namespace Ghostty.Core.Tabs;
+
+/// <summary>
+/// One contiguous stretch of slots a group owns, in the slot space of
+/// whichever strip asked. <see cref="First"/> and <see cref="Last"/> are
+/// inclusive, so a run that renders as a single slot -- a collapsed group's
+/// header alone, or its chip -- has First == Last rather than a zero span.
+/// </summary>
+internal readonly record struct GroupFieldRun(TabGroup Group, int First, int Last)
+{
+    public int SlotCount => Last - First + 1;
+}
+
+/// <summary>
+/// The group FIELD: the one grammar both strips draw a group with.
+///
+/// A group used to be inferable only by counting. Vertically it was a
+/// header plus a 14px content indent, which moves content and not the
+/// container, so a member's chrome was identical to a stranger's;
+/// horizontally it was a 2px rail on each member, which says "these are
+/// alike" and never says where the run stops. Neither had an end marker,
+/// so a run's extent was a thing you worked out rather than a thing you
+/// saw.
+///
+/// The field is a container instead of a decoration: the members sit on a
+/// tinted ground that begins at a cap and finishes at an end bar, so the
+/// run has a visible beginning and a visible end. Vertically the cap sits
+/// along the header row's leading edge; horizontally there is no header
+/// row, so the cap is the run's leading edge itself. Same three parts
+/// either way -- ground, cap, end -- which is what keeps the two layouts
+/// one language rather than two dialects that happen to agree.
+///
+/// The tint is an INK WASH, never a colour. A colour cannot be chosen
+/// here: under Mica the strip is not a surface anyone picked, it is the
+/// desktop, and a tint mixed for one wallpaper is invisible over the next.
+/// A wash is white or black at low alpha, and whichever pole has headroom
+/// moves the ground in a direction that survives whatever is behind it.
+/// The pole is scored with <see cref="ThemeResolution.PreferLightForegroundAtAlpha"/>
+/// at the alpha it is actually painted at, for the reason that helper
+/// documents: at 8% both candidates are pulled most of the way to the
+/// ground and the luminance split answers for the wrong one either side of
+/// mid grey.
+///
+/// The cap and the end bar are the one place the group's own colour is
+/// spent, because they are the parts that carry identity rather than
+/// extent: WHICH group, not HOW FAR. They go through
+/// <see cref="ChromeSeparator.EnsureVisible"/>, so a preset that lands
+/// within a hair of the field it sits on comes back as a lighter or darker
+/// version of itself rather than as the 1.57:1 chip that shipped.
+///
+/// Everything here is arithmetic over packed 0x00RRGGBB and index spans,
+/// so the grammar is pinnable without a WinUI host and BOTH strips can be
+/// tested against the same rules.
+/// </summary>
+internal static class TabGroupField
+{
+    /// <summary>
+    /// The wash: 8% ink over the strip's own ground.
+    ///
+    /// Picked against the whole grey ramp rather than against one theme.
+    /// Below this the field stops separating from the strip on the mid
+    /// grounds a translucent frame makes of the chrome, which is exactly
+    /// where a wash is needed most; above it the field reads as a surface
+    /// of its own and starts competing with the selected row's fill, which
+    /// is the one thing in the strip allowed to be a fill.
+    /// </summary>
+    public const byte WashAlpha = 20;
+
+    /// <summary>
+    /// The cap and the end bar, in device-independent pixels. Two, the
+    /// same weight the pin boundary stroke and the horizontal group rail
+    /// already use: a terminal that reads heavier than the strip's other
+    /// rules would claim more than "the run stops here".
+    /// </summary>
+    public const double TerminalThicknessPx = 2;
+
+    /// <summary>
+    /// The field's corner radius. Enough to read as a container edge and
+    /// not as a clipped rectangle; the selected row keeps its square
+    /// corners, so the two never compete for the same reading.
+    /// </summary>
+    public const double CornerRadiusPx = 4;
+
+    /// <summary>
+    /// WCAG's non-text floor, which the terminals are held to against the
+    /// field they sit on -- not against the strip. The field is what is
+    /// behind them once the wash has landed, and scoring against the strip
+    /// is how a bar ends up marginal on precisely the grounds where the
+    /// wash moved the most.
+    /// </summary>
+    public const double TerminalMinContrast = ChromeSeparator.DefaultMinContrast;
+
+    /// <summary>
+    /// The field's own motion, in milliseconds. It follows the rows rather
+    /// than leading them, so it borrows the strip's Existing Elements
+    /// glide (<see cref="TabStripMotion.GapGlideMs"/>) for a field that
+    /// grows, shrinks or slides, and the Fade token for one that arrives
+    /// or leaves. Sharing the numbers is the point: a field on a clock of
+    /// its own separates from the rows it is drawn around, which is the
+    /// one way this can look worse than no field at all.
+    /// </summary>
+    public const double GlideMs = TabStripMotion.GapGlideMs;
+
+    public const double FadeMs = TabStripMotion.FadeMs;
+
+    /// <summary>
+    /// The glide's easing, as the two control points of a cubic bezier --
+    /// the strip's Existing Elements curve, written once so the composition
+    /// path and the Storyboard path cannot drift apart.
+    /// </summary>
+    public const double GlideEaseX1 = 0.55;
+    public const double GlideEaseY1 = 0.55;
+    public const double GlideEaseX2 = 0.0;
+    public const double GlideEaseY2 = 1.0;
+
+    /// <summary>
+    /// White or black, whichever moves <paramref name="groundRgb"/> the
+    /// furthest at <see cref="WashAlpha"/>. Packed 0x00RRGGBB.
+    /// </summary>
+    public static uint WashInkRgb(uint groundRgb)
+        => ThemeResolution.PreferLightForegroundAtAlpha(groundRgb, WashAlpha)
+            ? 0xFFFFFFu
+            : 0x000000u;
+
+    /// <summary>
+    /// What the compositor leaves on screen where the field is painted:
+    /// the wash composited over <paramref name="groundRgb"/>. Every
+    /// contrast question about something drawn ON the field is asked
+    /// against this, never against the strip.
+    /// </summary>
+    public static uint FieldGroundRgb(uint groundRgb)
+        => ThemeResolution.CompositeOver(WashInkRgb(groundRgb), WashAlpha, groundRgb);
+
+    /// <summary>
+    /// The wash as an ARGB a brush can be built from directly, 0xAARRGGBB.
+    ///
+    /// The field is painted TRANSLUCENT, never as the composite
+    /// <see cref="FieldGroundRgb"/> names. That composite is what the wash
+    /// lands as over the ground the strip believes it has, and it is the
+    /// right thing to score contrast against -- but painting it would put
+    /// an opaque patch over Mica, which is the colour this design rejected
+    /// wearing a different hat. Ink at 8% is the same wash over whatever is
+    /// really back there.
+    /// </summary>
+    public static uint WashArgb(uint groundRgb)
+        => ((uint)WashAlpha << 24) | WashInkRgb(groundRgb);
+
+    /// <summary>
+    /// The cap and end bar colour for a group coloured
+    /// <paramref name="color"/>, over a strip whose ground is
+    /// <paramref name="groundRgb"/>: the preset itself where it already
+    /// clears the floor against the field, and a lightness-shifted version
+    /// of itself where it does not.
+    ///
+    /// The preset goes in opaque (<see cref="TabColorPalette.Border"/>),
+    /// not at the swatch's 89/255. The alpha is what put the header chip
+    /// at 1.57:1 against its own row in both themes, and a terminal is a
+    /// 2px line -- there is no thickness here to spend on being faint.
+    /// </summary>
+    public static uint TerminalRgb(uint groundRgb, TabColor color)
+    {
+        var preset = TabColorPalette.Border(color);
+        var groupRgb = ((uint)preset.R << 16) | ((uint)preset.G << 8) | preset.B;
+        return ChromeSeparator.EnsureVisible(
+            FieldGroundRgb(groundRgb), groupRgb, TerminalMinContrast);
+    }
+
+    /// <summary>
+    /// The group owning each slot of the vertical strip's projection, or
+    /// null for a slot no group owns. A header slot counts as its group's:
+    /// the header is the field's cap, so the field starts at its top edge
+    /// and not at the first member's.
+    /// </summary>
+    public static IReadOnlyList<TabGroup?> SlotGroups(
+        IReadOnlyList<TabStripProjection.ProjectedRow> rows)
+    {
+        var owners = new List<TabGroup?>(rows.Count);
+        foreach (var row in rows)
+        {
+            owners.Add(row switch
+            {
+                TabStripProjection.ProjectedRow.Header { Group: { } group } => group,
+                TabStripProjection.ProjectedRow.Item { Tab: { } tab } => tab.Group,
+                _ => null,
+            });
+        }
+        return owners;
+    }
+
+    /// <summary>
+    /// The same reading for the horizontal strip. A chip is its group's
+    /// slot -- it IS the collapsed run, so the field is drawn around it
+    /// exactly as it is drawn around an expanded run's members, and a
+    /// collapsed group does not lose its field for being folded.
+    /// </summary>
+    public static IReadOnlyList<TabGroup?> SlotGroups(
+        IReadOnlyList<TabStripProjection.HorizontalRow> rows)
+    {
+        var owners = new List<TabGroup?>(rows.Count);
+        foreach (var row in rows)
+        {
+            owners.Add(row switch
+            {
+                TabStripProjection.HorizontalRow.Chip { Group: { } group } => group,
+                TabStripProjection.HorizontalRow.Item { Tab: { } tab } => tab.Group,
+                _ => null,
+            });
+        }
+        return owners;
+    }
+
+    /// <summary>
+    /// The fields to draw for a slot sequence: one run per stretch of
+    /// consecutive slots owned by the same group.
+    ///
+    /// A group that somehow held two separate stretches would get two
+    /// fields rather than one field swallowing the stranger between them.
+    /// Contiguity is a manager invariant (Normalize re-gathers a run a move
+    /// split), so this is not a shape that should arrive -- but drawing one
+    /// container around a tab that is not a member is a lie about
+    /// membership, and the honest reading of a broken invariant is two
+    /// fields that visibly do not add up.
+    /// </summary>
+    public static IReadOnlyList<GroupFieldRun> Runs(IReadOnlyList<TabGroup?> slotGroups)
+    {
+        var runs = new List<GroupFieldRun>();
+        var at = 0;
+        while (at < slotGroups.Count)
+        {
+            if (slotGroups[at] is not { } group) { at++; continue; }
+            var last = at;
+            while (last + 1 < slotGroups.Count
+                   && ReferenceEquals(slotGroups[last + 1], group))
+                last++;
+            runs.Add(new GroupFieldRun(group, at, last));
+            at = last + 1;
+        }
+        return runs;
+    }
+}

--- a/windows/Ghostty.Core/Tabs/TabGroupField.cs
+++ b/windows/Ghostty.Core/Tabs/TabGroupField.cs
@@ -147,7 +147,29 @@ internal static class TabGroupField
     /// really back there.
     /// </summary>
     public static uint WashArgb(uint groundRgb)
-        => ((uint)WashAlpha << 24) | WashInkRgb(groundRgb);
+        => WashArgbAt(groundRgb, WashAlpha);
+
+    /// <summary>
+    /// The same wash at a different strength, for the two states a member
+    /// still owes the pointer.
+    ///
+    /// MUXC gives an unstyled tab its own pointer-over and pressed brushes,
+    /// and washing a run wrote ONE value into all three states -- so every
+    /// member of a group, and the chip that stands for a folded one, stopped
+    /// answering the pointer at all. The chip is a click target: it expands
+    /// the run. Deepening the ink the field already chose keeps that feedback
+    /// inside the field's grammar, where a second hue on top of the wash
+    /// would be one more colour in a strip whose whole argument is that runs
+    /// are grounds rather than colours.
+    /// </summary>
+    public static uint WashArgbAt(uint groundRgb, byte alpha)
+        => ((uint)alpha << 24) | WashInkRgb(groundRgb);
+
+    /// <summary>The wash under a pointer. Same ink, enough deeper to read.</summary>
+    public const byte WashHoverAlpha = 34;
+
+    /// <summary>The wash under a press: one more step along the same ramp.</summary>
+    public const byte WashPressedAlpha = 46;
 
     /// <summary>
     /// The cap and end bar colour for a group coloured
@@ -162,11 +184,27 @@ internal static class TabGroupField
     /// 2px line -- there is no thickness here to spend on being faint.
     /// </summary>
     public static uint TerminalRgb(uint groundRgb, TabColor color)
+        => TerminalRgbOn(FieldGroundRgb(groundRgb), color);
+
+    /// <summary>
+    /// The same bar, scored against the surface it is actually PAINTED on.
+    ///
+    /// The vertical field is a Border the bars are edges of, so its ground is
+    /// the field's and <see cref="TerminalRgb"/> answers. Horizontally there is
+    /// no Border: the cap is drawn on the run's first slot and the end bar on
+    /// its last, and neither slot is guaranteed to be wearing the wash. The
+    /// selected tab keeps the terminal background, and a member with a preset
+    /// of its own keeps that preset -- so a Blue cap on a selected tab over a
+    /// blue-ish terminal lands near 2.2:1, and a Red end bar on a Red member is
+    /// very nearly invisible, while a rule scored against the field reports
+    /// both as clearing the floor.
+    /// </summary>
+    public static uint TerminalRgbOn(uint paintedOnRgb, TabColor color)
     {
         var preset = TabColorPalette.Border(color);
         var groupRgb = ((uint)preset.R << 16) | ((uint)preset.G << 8) | preset.B;
         return ChromeSeparator.EnsureVisible(
-            FieldGroundRgb(groundRgb), groupRgb, TerminalMinContrast);
+            paintedOnRgb, groupRgb, TerminalMinContrast);
     }
 
     /// <summary>

--- a/windows/Ghostty.Tests/Tabs/TabGroupFieldTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabGroupFieldTests.cs
@@ -361,11 +361,7 @@ public sealed class TabGroupFieldTests
         Assert.All(runs, r => Assert.Equal(1, r.SlotCount));
     }
 
-    /// <summary>
-    /// The field's clocks are the strip's clocks. A field animating on
-    /// numbers of its own separates from the rows it is drawn around,
-    /// which looks worse than no field at all.
-    /// </summary>
+
     /// <summary>
     /// The wash is painted as ink at an alpha, not as the composite it
     /// lands as. Handing a painter the composite is how an opaque patch
@@ -383,6 +379,11 @@ public sealed class TabGroupFieldTests
         }
     }
 
+    /// <summary>
+    /// The field's clocks are the strip's clocks. A field animating on
+    /// numbers of its own separates from the rows it is drawn around,
+    /// which looks worse than no field at all.
+    /// </summary>
     [Fact]
     public void TheFieldMotion_BorrowsTheStripsOwnTokens()
     {

--- a/windows/Ghostty.Tests/Tabs/TabGroupFieldTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabGroupFieldTests.cs
@@ -1,0 +1,392 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Ghostty.Core.Tabs;
+using Ghostty.Core.Windows;
+using Xunit;
+
+namespace Ghostty.Tests.Tabs;
+
+/// <summary>
+/// The group field's arithmetic: where a field starts and stops, and what
+/// colour it and its two terminals come out.
+///
+/// Executable rather than syntactic. Every rule here runs the real helper
+/// over real inputs, so a change to the constants is answered by the
+/// numbers rather than by whether the constant is still spelled the same
+/// way. The strips' end of it -- that they call these and place elements
+/// from the answer -- is the wiring guard's job, and neither test can see
+/// what the field actually looks like on a live window.
+/// </summary>
+public sealed class TabGroupFieldTests
+{
+    // The grey ramp, which is the only ground corpus that means anything
+    // here: Mica leaves the strip whatever the desktop is, and a wash
+    // tuned on the two built-in themes is a wash tuned on two points.
+    private static IEnumerable<uint> GreyRamp()
+    {
+        for (uint v = 0; v <= 255; v++) yield return (v << 16) | (v << 8) | v;
+    }
+
+    // The two built-in strip shades named in #882, plus the poles.
+    private static readonly uint[] NamedGrounds =
+    {
+        0x17181Au, // wintty-dark's strip
+        0xF4F5F5u, // wintty-light's strip
+        0x0C0C0Cu, // the strip's own default backdrop guess
+        0x000000u,
+        0xFFFFFFu,
+    };
+
+    private static double LStar(uint rgb)
+    {
+        var luminance = ThemeResolution.ContrastRatio(rgb, 0x000000u) * 0.05 - 0.05;
+        return luminance > 0.008856
+            ? 116.0 * Math.Cbrt(luminance) - 16.0
+            : 903.3 * luminance;
+    }
+
+    /// <summary>
+    /// The wash always moves the ground. A field that composites back to
+    /// the strip it sits on is the "no field" the design decision was made
+    /// against, and it is what a wash alpha of 0 -- or a pole with no
+    /// headroom -- silently produces.
+    /// </summary>
+    [Fact]
+    public void TheWash_MovesEveryGround()
+    {
+        foreach (var ground in GreyRamp().Concat(NamedGrounds))
+        {
+            Assert.True(
+                TabGroupField.FieldGroundRgb(ground) != ground,
+                $"the field composited back to the strip on {ground:X6}");
+        }
+    }
+
+    /// <summary>
+    /// And moves it far enough to see, everywhere.
+    ///
+    /// In L*, not in channel counts: sRGB is gamma encoded, so a fixed
+    /// alpha buys markedly more visible separation at the black end than
+    /// at the white end, and the mid grounds a translucent frame makes of
+    /// the chrome are the worst case for both poles at once. Three L* is
+    /// the floor a wash has to clear to be a field rather than a rounding
+    /// error.
+    /// </summary>
+    [Fact]
+    public void TheWash_SeparatesFromEveryGround()
+    {
+        foreach (var ground in GreyRamp().Concat(NamedGrounds))
+        {
+            var delta = Math.Abs(
+                LStar(TabGroupField.FieldGroundRgb(ground)) - LStar(ground));
+            Assert.True(
+                delta >= 3.0,
+                $"the field is {delta:F2} L* from the strip on {ground:X6}");
+        }
+    }
+
+    /// <summary>
+    /// And not so far that it stops being a wash.
+    ///
+    /// The upper bound is the half of this that a bigger alpha would quietly
+    /// break: past about a dozen L* the field reads as a surface of its own
+    /// and competes with the selected row's fill, which is the one element
+    /// in the strip that is allowed to be a fill. A wash that loud is the
+    /// colour the decision rejected, arrived at from the other side.
+    /// </summary>
+    [Fact]
+    public void TheWash_StaysAWash()
+    {
+        foreach (var ground in GreyRamp().Concat(NamedGrounds))
+        {
+            var delta = Math.Abs(
+                LStar(TabGroupField.FieldGroundRgb(ground)) - LStar(ground));
+            Assert.True(
+                delta <= 12.0,
+                $"the field is {delta:F2} L* from the strip on {ground:X6}");
+        }
+    }
+
+    /// <summary>
+    /// The pole is picked, never assumed. On a near-black strip only white
+    /// has headroom and on a near-white one only black does; a field that
+    /// always washed one way would be invisible at one end of the ramp.
+    /// </summary>
+    [Theory]
+    [InlineData(0x000000u, 0xFFFFFFu)]
+    [InlineData(0x17181Au, 0xFFFFFFu)]
+    [InlineData(0xFFFFFFu, 0x000000u)]
+    [InlineData(0xF4F5F5u, 0x000000u)]
+    public void TheWashPole_HasHeadroom(uint ground, uint expected)
+        => Assert.Equal(expected, TabGroupField.WashInkRgb(ground));
+
+    /// <summary>
+    /// Every preset, on every ground, comes out of the terminal resolution
+    /// clearing the non-text floor against the FIELD -- which is the
+    /// surface the bar is drawn on, and is not the strip once the wash has
+    /// landed.
+    ///
+    /// This is the rule the shipped header swatch fails at 1.57:1, and it
+    /// is the whole reason the terminals go through EnsureVisible rather
+    /// than taking the preset as given.
+    /// </summary>
+    [Fact]
+    public void EveryTerminal_ClearsTheNonTextFloorAgainstItsField()
+    {
+        foreach (var color in Enum.GetValues<TabColor>())
+        {
+            if (color == TabColor.None) continue;
+
+            foreach (var ground in GreyRamp().Concat(NamedGrounds))
+            {
+                var field = TabGroupField.FieldGroundRgb(ground);
+                var bar = TabGroupField.TerminalRgb(ground, color);
+                var ratio = ThemeResolution.ContrastRatio(field, bar);
+                Assert.True(
+                    ratio >= TabGroupField.TerminalMinContrast,
+                    $"{color} terminal is {ratio:F2}:1 on ground {ground:X6}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// A preset that already clears the floor is left alone. EnsureVisible
+    /// keeps identity where it can, and a rule that shifted every preset on
+    /// every ground would hand back a palette nobody chose.
+    /// </summary>
+    [Fact]
+    public void ATerminalThatAlreadyReads_IsNotShifted()
+    {
+        // Blue on the dark strip: comfortably past the floor already.
+        var preset = TabColorPalette.Border(TabColor.Blue);
+        var groupRgb = ((uint)preset.R << 16) | ((uint)preset.G << 8) | preset.B;
+        Assert.Equal(groupRgb, TabGroupField.TerminalRgb(0x17181Au, TabColor.Blue));
+    }
+
+    // ---- run geometry -------------------------------------------------
+
+    private static TabManager NewManager() => new(_ => new FakePaneHost());
+
+    private static List<TabModel> Seed(TabManager manager, int total)
+    {
+        while (manager.Tabs.Count < total) manager.NewTab();
+        return manager.Tabs.ToList();
+    }
+
+    private static TabGroup Group(TabManager manager, params TabModel[] members)
+    {
+        var group = new TabGroup();
+        manager.GroupTabs(members, group);
+        return group;
+    }
+
+    /// <summary>
+    /// The vertical reading: a field spans its header AND its members, so
+    /// the header row is inside the container it caps rather than a row
+    /// sitting above one.
+    /// </summary>
+    [Fact]
+    public void Vertical_TheFieldStartsAtTheHeaderAndEndsAtTheLastMember()
+    {
+        var manager = NewManager();
+        var tabs = Seed(manager, 4);
+        Group(manager, tabs[1], tabs[2]);
+
+        var rows = TabStripProjection.GroupedRows(manager);
+        var run = Assert.Single(TabGroupField.Runs(TabGroupField.SlotGroups(rows)));
+
+        // slot 0 = tabs[0], 1 = header, 2 = tabs[1], 3 = tabs[2], 4 = tabs[3]
+        Assert.Equal(1, run.First);
+        Assert.Equal(3, run.Last);
+        Assert.Equal(3, run.SlotCount);
+        Assert.IsType<TabStripProjection.ProjectedRow.Header>(rows[run.First]);
+    }
+
+    /// <summary>
+    /// The horizontal reading of the same state: the same one group gets
+    /// the same one field, over the members alone -- that strip draws no
+    /// header row, so its cap is the run's own leading edge.
+    /// </summary>
+    [Fact]
+    public void Horizontal_TheFieldSpansTheRunsMembers()
+    {
+        var manager = NewManager();
+        var tabs = Seed(manager, 4);
+        Group(manager, tabs[1], tabs[2]);
+
+        var rows = TabStripProjection.HorizontalRows(manager);
+        var run = Assert.Single(TabGroupField.Runs(TabGroupField.SlotGroups(rows)));
+
+        Assert.Equal(1, run.First);
+        Assert.Equal(2, run.Last);
+        Assert.Equal(2, run.SlotCount);
+    }
+
+    /// <summary>
+    /// Layout parity, stated as the thing that can actually break: for one
+    /// manager state, both strips draw a field for the same groups. The
+    /// spans differ on purpose (vertical counts a header slot the
+    /// horizontal strip does not render); WHICH groups get a container
+    /// must not.
+    /// </summary>
+    [Fact]
+    public void BothLayouts_DrawAFieldForTheSameGroups()
+    {
+        var manager = NewManager();
+        var tabs = Seed(manager, 7);
+        Group(manager, tabs[1], tabs[2]);
+        Group(manager, tabs[4], tabs[5]);
+        manager.SetPinned(tabs[0], true);
+        manager.Activate(tabs[6]);
+
+        foreach (var collapseSecond in new[] { false, true })
+        {
+            if (collapseSecond)
+                manager.CollapseGroup(manager.Groups[1], true);
+
+            var vertical = TabGroupField
+                .Runs(TabGroupField.SlotGroups(TabStripProjection.GroupedRows(manager)))
+                .Select(r => r.Group);
+            var horizontal = TabGroupField
+                .Runs(TabGroupField.SlotGroups(TabStripProjection.HorizontalRows(manager)))
+                .Select(r => r.Group);
+
+            Assert.Equal(manager.Groups.ToList(), vertical.ToList());
+            Assert.Equal(manager.Groups.ToList(), horizontal.ToList());
+        }
+    }
+
+    /// <summary>
+    /// A folded group keeps its field. Vertically it is the header alone,
+    /// horizontally it is the chip alone -- one slot either way, which is
+    /// the shape that makes a chip self-evidently a container rather than
+    /// a tab with a dot on it.
+    /// </summary>
+    [Fact]
+    public void ACollapsedRun_IsAOneSlotFieldInBothLayouts()
+    {
+        var manager = NewManager();
+        var tabs = Seed(manager, 3);
+        Group(manager, tabs[0], tabs[1]);
+        manager.Activate(tabs[2]);
+        manager.CollapseGroup(manager.Groups[0], true);
+
+        var vertical = Assert.Single(TabGroupField.Runs(
+            TabGroupField.SlotGroups(TabStripProjection.GroupedRows(manager))));
+        var horizontal = Assert.Single(TabGroupField.Runs(
+            TabGroupField.SlotGroups(TabStripProjection.HorizontalRows(manager))));
+
+        Assert.Equal(1, vertical.SlotCount);
+        Assert.Equal(1, horizontal.SlotCount);
+    }
+
+    /// <summary>
+    /// A collapsed run that holds the active tab keeps that member visible
+    /// (the Edge-135 rule), and the field has to grow to cover it: the
+    /// member is inside the group, so a container that stopped at the
+    /// header would leave a member outside its own field.
+    /// </summary>
+    [Fact]
+    public void ACollapsedRunHoldingTheActiveTab_KeepsThatMemberInsideItsField()
+    {
+        var manager = NewManager();
+        var tabs = Seed(manager, 3);
+        Group(manager, tabs[0], tabs[1]);
+        manager.Activate(tabs[1]);
+        manager.CollapseGroup(manager.Groups[0], true);
+
+        var vertical = Assert.Single(TabGroupField.Runs(
+            TabGroupField.SlotGroups(TabStripProjection.GroupedRows(manager))));
+        Assert.Equal(2, vertical.SlotCount);
+
+        // Horizontally the chip is suppressed and the member renders as
+        // itself, so the field is that member's own slot.
+        var horizontal = Assert.Single(TabGroupField.Runs(
+            TabGroupField.SlotGroups(TabStripProjection.HorizontalRows(manager))));
+        Assert.Equal(1, horizontal.SlotCount);
+    }
+
+    /// <summary>
+    /// Two adjacent runs are two fields, not one. Neighbouring groups have
+    /// no gap between them in the projection, so a walk that merged on
+    /// "the previous slot was grouped" would draw a single container over
+    /// both and lose the boundary the field exists to show.
+    /// </summary>
+    [Fact]
+    public void TwoAdjacentRuns_AreTwoFields()
+    {
+        var manager = NewManager();
+        var tabs = Seed(manager, 4);
+        Group(manager, tabs[0], tabs[1]);
+        Group(manager, tabs[2], tabs[3]);
+
+        var runs = TabGroupField.Runs(
+            TabGroupField.SlotGroups(TabStripProjection.GroupedRows(manager)));
+        Assert.Equal(2, runs.Count);
+        Assert.NotSame(runs[0].Group, runs[1].Group);
+        Assert.True(runs[0].Last < runs[1].First);
+    }
+
+    /// <summary>
+    /// No groups, no fields. The strip must not pay for a container it has
+    /// no group to draw.
+    /// </summary>
+    [Fact]
+    public void AStripWithNoGroups_DrawsNoField()
+    {
+        var manager = NewManager();
+        Seed(manager, 3);
+        Assert.Empty(TabGroupField.Runs(
+            TabGroupField.SlotGroups(TabStripProjection.GroupedRows(manager))));
+        Assert.Empty(TabGroupField.Runs(
+            TabGroupField.SlotGroups(TabStripProjection.HorizontalRows(manager))));
+    }
+
+    /// <summary>
+    /// A group whose slots are not contiguous comes back as two fields
+    /// rather than one container swallowing the stranger between them. The
+    /// manager's Normalize makes this shape unreachable; the point is that
+    /// the walk cannot be the thing that lies about membership if it ever
+    /// does arrive.
+    /// </summary>
+    [Fact]
+    public void ASplitRun_DrawsOneFieldPerStretch()
+    {
+        var group = new TabGroup();
+        var slots = new TabGroup?[] { group, null, group };
+        var runs = TabGroupField.Runs(slots);
+
+        Assert.Equal(2, runs.Count);
+        Assert.All(runs, r => Assert.Equal(1, r.SlotCount));
+    }
+
+    /// <summary>
+    /// The field's clocks are the strip's clocks. A field animating on
+    /// numbers of its own separates from the rows it is drawn around,
+    /// which looks worse than no field at all.
+    /// </summary>
+    /// <summary>
+    /// The wash is painted as ink at an alpha, not as the composite it
+    /// lands as. Handing a painter the composite is how an opaque patch
+    /// ends up over Mica, and it is a one-identifier mistake: both are
+    /// uints off this same class.
+    /// </summary>
+    [Fact]
+    public void TheWashIsHandedToThePainter_WithItsAlphaStillOnIt()
+    {
+        foreach (var ground in new[] { 0x17181Au, 0xF4F5F5u, 0x808080u })
+        {
+            var argb = TabGroupField.WashArgb(ground);
+            Assert.Equal(TabGroupField.WashAlpha, (byte)(argb >> 24));
+            Assert.Equal(TabGroupField.WashInkRgb(ground), argb & 0x00FFFFFFu);
+        }
+    }
+
+    [Fact]
+    public void TheFieldMotion_BorrowsTheStripsOwnTokens()
+    {
+        Assert.Equal(TabStripMotion.GapGlideMs, TabGroupField.GlideMs);
+        Assert.Equal(TabStripMotion.FadeMs, TabGroupField.FadeMs);
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/TabGroupFieldWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabGroupFieldWiringTests.cs
@@ -217,22 +217,25 @@ public sealed class TabGroupFieldWiringTests
     {
         Washes(file, sites);
 
-        // Calling the helper is allowed and now necessary: it is the ground
-        // contrast is scored against, and the horizontal terminals ask it per
-        // slot. What stays forbidden is PAINTING it. Banning the call outright
-        // was the cheaper rule and it stopped being true the moment anything
-        // needed to score against the field, so the rule names the actual
-        // defect instead: a brush built out of the composite.
+        // Banning the call outright was the rule, and it stopped being true the
+        // moment anything needed to SCORE against the field. Ancestry was the
+        // first replacement and it is a spelling guard, not an API one: one
+        // local in between, or `new SolidColorBrush(...)` instead of the
+        // helper, walks straight past it.
+        //
+        // So the ban stands, with a named door. A method on this allowlist is
+        // one whose job is to answer "what is the ground here"; anywhere else
+        // the composite is unreachable and cannot be painted.
+        var scorers = new[] { "SlotGroundRgb" };
         foreach (var call in ShellSource.Load(file).Root.Calls("TabGroupField.FieldGroundRgb"))
         {
-            var brush = call.Ancestors().OfType<InvocationExpressionSyntax>()
-                .FirstOrDefault(i => i.CalleeText()
-                    .StartsWith("TabColorBrush.", StringComparison.Ordinal));
+            var owner = call.FirstAncestorOrSelf<MethodDeclarationSyntax>();
             Assert.True(
-                brush is null,
-                "the composited field ground is being made into a brush, which paints "
-                + "an opaque patch over Mica -- the colour this design rejected, "
-                + "arriving through the scoring door: " + brush);
+                owner is not null && scorers.Contains(owner.Identifier.ValueText),
+                "the composited field ground is read outside the methods that exist to "
+                + $"score against it (in '{owner?.Identifier.ValueText ?? "<none>"}'). "
+                + "Painting it puts an opaque patch over Mica -- the colour this design "
+                + "rejected, arriving through the scoring door.");
         }
     }
 
@@ -275,6 +278,42 @@ public sealed class TabGroupFieldWiringTests
         // a bar hard-coded to one preset would have passed the rule written to
         // pin it to the group's.
         Assert.Equal("group.Color", call.Arg(1));
+    }
+
+    /// <summary>
+    /// The ground a slot is scored against is resolved in the order the slot is
+    /// PAINTED in: a preset beats being active.
+    ///
+    /// ApplyTabChrome gives a preset-coloured tab the opaque preset as its
+    /// selected handle, and only a tab with no preset gets
+    /// _selectedTabFillBrush. Asking "is this active" first therefore answers
+    /// "the terminal background" for a slot painted its own colour -- and for
+    /// an active Red member of a Red group that is an end bar scored against
+    /// near-black, returned unlifted, and painted onto opaque Red. 1:1, which
+    /// is the defect SlotGroundRgb was added to remove, reintroduced by the
+    /// order of two ifs with every literal correct.
+    /// </summary>
+    [Fact]
+    public void Horizontal_TheSlotGroundResolvesInThePaintOrder()
+    {
+        var ground = ShellSource.Load(HorizontalStrip).Method("SlotGroundRgb");
+        var branches = ground.DescendantNodes().OfType<IfStatementSyntax>()
+            .Select(i => i.Condition.ToString())
+            .ToList();
+
+        Assert.Equal(
+            new[]
+            {
+                "row is TabStripProjection.HorizontalRow.Item { Tab: { } tab }",
+                "tab.Color != TabColor.None",
+                "selected && _selectedTabFillBrush is not null",
+            },
+            branches);
+
+        // And the preset is scored at the alpha the slot actually wears: an
+        // active coloured tab is opaque, an inactive one is the 89-alpha tint.
+        var preset = ground.Call("TabColorPalette.EffectiveBackgroundRgb");
+        Assert.Equal("selected", preset.Arg(1));
     }
 
     /// <summary>
@@ -325,13 +364,20 @@ public sealed class TabGroupFieldWiringTests
             a => a.Left.ToString() == "field.BorderThickness");
 
         var thickness = Assert.IsType<ObjectCreationExpressionSyntax>(assignment.Right);
+        // The sides stay zero and each end is its token or nothing -- an end
+        // the viewport clipped away is DROPPED rather than slid to the edge of
+        // the scroller, where it would claim a run starts or stops at whatever
+        // row happens to be there. The ternaries are the whole of that rule, so
+        // they are pinned as text: replacing either with the bare token brings
+        // back the false terminal, and replacing either with 0 removes an end
+        // the design says every run has.
         Assert.Equal(
             new[]
             {
                 "0",
-                "TabGroupField.TerminalThicknessPx",
+                "capVisible ? TabGroupField.TerminalThicknessPx : 0",
                 "0",
-                "TabGroupField.TerminalThicknessPx",
+                "endVisible ? TabGroupField.TerminalThicknessPx : 0",
             },
             thickness.ArgumentList!.Arguments.Select(a => a.ToString()).ToArray());
     }
@@ -514,6 +560,32 @@ public sealed class TabGroupFieldWiringTests
             pass.DescendantNodes().OfType<IfStatementSyntax>(),
             i => i.Condition.ToString().Contains("_manager.Groups", StringComparison.Ordinal));
         Assert.Equal("_manager.Groups.Contains(group)", stillHeld.Condition.ToString());
+
+        // Which arm does what, not merely that both exist. Swapping the two
+        // bodies satisfies every assertion above while retiring every LIVE
+        // group's field on every pass and keeping a dissolved group's forever
+        // -- the exact inversion of the property this test is named for, with
+        // the condition and the call sites all still present.
+        Assert.Empty(stillHeld.Statement.Calls("RemoveGroupField"));
+        Assert.Contains(
+            "Visibility.Collapsed", stillHeld.Statement.ToString(), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Both washed surfaces actually ask for the three-state ramp.
+    ///
+    /// The ramp's own test loads ApplyFieldWashStates by name, and the wash
+    /// count is taken file-wide, so deleting both CALLS leaves the method as
+    /// dead code, the count unchanged, and every other assertion green -- while
+    /// every member of a group and every chip goes back to not answering the
+    /// pointer.
+    /// </summary>
+    [Fact]
+    public void Horizontal_BothWashedSurfacesTakeTheRamp()
+    {
+        var strip = ShellSource.Load(HorizontalStrip);
+        Assert.NotEmpty(strip.Method("ApplyTabChrome").Calls("ApplyFieldWashStates"));
+        Assert.NotEmpty(strip.Method("RefreshChip").Calls("ApplyFieldWashStates"));
     }
 
     /// <summary>

--- a/windows/Ghostty.Tests/Wiring/TabGroupFieldWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabGroupFieldWiringTests.cs
@@ -1,0 +1,390 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// The group field, as the two strips wire it.
+///
+/// The arithmetic -- which slots a run owns, what the wash and the
+/// terminals come out -- is executable and lives in
+/// <c>TabGroupFieldTests</c>. What no unit test can reach is whether the
+/// strips ASK, whether they ask about the right surface, and whether both
+/// of them do it: the shell assembly cannot be loaded into a test host, so
+/// these read the source.
+///
+/// Written against the syntax rather than the text, because the mutations
+/// that matter here all keep every literal in place: handing the painter
+/// the composited ground instead of the wash (an opaque patch over Mica),
+/// dropping the end bar and keeping the cap (which is the rail this design
+/// replaced, drawn from the other end), washing the selected tab (which
+/// breaks the seam between the active tab and its pane), and dropping the
+/// negation on the run-boundary divider skip (which deletes every INTERIOR
+/// separator instead of the two at the ends).
+///
+/// What these cannot see: what the field looks like. Whether the wash
+/// reads over a given wallpaper, whether the terminals land on the pixels
+/// the geometry names, and whether the glide is smooth are all live-window
+/// questions.
+/// </summary>
+public sealed class TabGroupFieldWiringTests
+{
+    private const string VerticalStrip = "Tabs.VerticalTabStrip.xaml.cs";
+    private const string HorizontalStrip = "Tabs.TabHost.xaml.cs";
+
+    /// <summary>
+    /// Both strips, and the projection each one's field grammar is read
+    /// from. This is the parity rule in its load-bearing form: the same
+    /// helper, over the reading that belongs to that layout. A strip
+    /// reading the other one's projection compiles and draws a field
+    /// around the wrong slots.
+    /// </summary>
+    public static TheoryData<string, string> BothStrips => new()
+    {
+        { VerticalStrip, "GroupedRows" },
+        { HorizontalStrip, "HorizontalRows" },
+    };
+
+    /// <summary>
+    /// Each strip's wash paints, and how many it has: the vertical one
+    /// paints the field itself; the horizontal one has no single element to
+    /// paint, so it washes an expanded run's members and a folded run's
+    /// chip -- two sites.
+    ///
+    /// The count is stated rather than left to "at least one" because
+    /// every rule below walks the sites it finds, and a rule that walks an
+    /// empty list passes for exactly the reason it would pass on a branch
+    /// that paints nothing at all.
+    /// </summary>
+    public static TheoryData<string, int> WashSites => new()
+    {
+        { VerticalStrip, 1 },
+        { HorizontalStrip, 2 },
+    };
+
+    private static List<InvocationExpressionSyntax> Washes(string file, int expected)
+    {
+        var found = ShellSource.Load(file).Root.Calls("TabColorBrush.FromPackedArgb");
+        Assert.True(
+            found.Count == expected,
+            $"expected {expected} wash paint(s) in {file}, found {found.Count}");
+        return found;
+    }
+
+    // ---- the grammar is read from Core, per layout ---------------------
+
+    /// <summary>
+    /// Every field either strip draws comes out of one walk, in Core, over
+    /// that layout's own projection. Anything else -- iterating
+    /// <c>_manager.Groups</c>, counting members by hand -- is a second
+    /// implementation of the run walk that the executable tests do not
+    /// cover and that can disagree with the other strip.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(BothStrips))]
+    public void EachStrip_ReadsItsRunsFromTheSharedWalk(string file, string projection)
+    {
+        var runs = ShellSource.Load(file).Root.Call("TabGroupField.Runs");
+        var slots = runs.ArgExpression(0).AssertCallTo("TabGroupField.SlotGroups");
+        Assert.Equal(
+            "TabStripProjection." + projection + "(_manager)",
+            Resolved(slots.ArgExpression(0)));
+    }
+
+    /// <summary>
+    /// An expression as written, or -- when it is a bare local -- that
+    /// local's initializer in the same method. Both strips hold the row
+    /// list in a variable because they index it afterwards, and a rule
+    /// that could only read an inline argument would answer "rows" and
+    /// pin nothing.
+    /// </summary>
+    private static string Resolved(ExpressionSyntax expression)
+    {
+        if (expression is not IdentifierNameSyntax local) return expression.ToString();
+
+        var scope = expression.FirstAncestorOrSelf<MethodDeclarationSyntax>();
+        Assert.NotNull(scope);
+        var declared = Assert.Single(
+            scope!.DescendantNodes().OfType<VariableDeclaratorSyntax>(),
+            v => v.Identifier.ValueText == local.Identifier.ValueText);
+        Assert.NotNull(declared.Initializer);
+        return declared.Initializer!.Value.ToString();
+    }
+
+    /// <summary>
+    /// And nothing else in the shell draws one. A third caller is a third
+    /// field grammar; the point of putting the walk in Core was that there
+    /// is one.
+    /// </summary>
+    [Fact]
+    public void NothingOutsideTheTwoStrips_DrawsAField()
+    {
+        var callers = ShellSource.AllShellSources()
+            .Where(s => s.Root.Calls("TabGroupField.Runs").Count > 0)
+            .Select(s => s.Resource)
+            .ToList();
+
+        Assert.Equal(2, callers.Count);
+        Assert.All(
+            new[] { VerticalStrip, HorizontalStrip },
+            expected => Assert.Contains(callers, c => c.EndsWith("." + expected, StringComparison.Ordinal)));
+    }
+
+    // ---- the wash ------------------------------------------------------
+
+    /// <summary>
+    /// The wash is handed to the painter with its alpha still on it, and
+    /// scored against the strip's own ground.
+    ///
+    /// Both halves, because either one alone reproduces a shipped-shaped
+    /// bug: <c>FieldGroundRgb</c> is one identifier away and answers with
+    /// the OPAQUE composite, which paints a solid patch over Mica -- the
+    /// colour this decision rejected, arriving by a different door -- and
+    /// scoring against anything but the strip's ground is the mistake the
+    /// muted ink already shipped once.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(WashSites))]
+    public void TheWash_KeepsItsAlpha_AndIsScoredAgainstTheStripGround(string file, int sites)
+    {
+        foreach (var wash in Washes(file, sites))
+        {
+            var argb = wash.ArgExpression(0).AssertCallTo("TabGroupField.WashArgb");
+            Assert.Equal("_stripBackdropPacked", argb.Arg(0));
+        }
+    }
+
+    /// <summary>
+    /// Nothing in either strip paints the field as the composite the wash
+    /// LANDS as. That helper exists to score contrast against, and using
+    /// it as a fill is the opaque-patch bug above.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(WashSites))]
+    public void NoStrip_PaintsTheFieldAsItsCompositedGround(string file, int sites)
+    {
+        Washes(file, sites);
+        Assert.Empty(ShellSource.Load(file).Root.Calls("TabGroupField.FieldGroundRgb"));
+    }
+
+    /// <summary>
+    /// Horizontal only, and the sharpest rule here: the wash lands on the
+    /// UNSELECTED handle, never on the selected one.
+    ///
+    /// The selected tab keeps the terminal's own background so it reads as
+    /// continuous with the pane below it -- that continuity is what the
+    /// whole seam-cover machinery exists to protect. Washing over it is an
+    /// 8% shift on exactly the one surface that has to match another
+    /// surface exactly, and it is invisible in review: the two handles are
+    /// named one word apart and both are in scope at the site.
+    /// </summary>
+    [Fact]
+    public void Horizontal_TheWashNeverLandsOnTheSelectedHandle()
+    {
+        var chrome = ShellSource.Load(HorizontalStrip).Method("ApplyTabChrome");
+        var wash = Assert.Single(chrome.Calls("TabColorBrush.FromPackedArgb"));
+
+        var assignment = wash.FirstAncestorOrSelf<AssignmentExpressionSyntax>();
+        Assert.NotNull(assignment);
+        Assert.Equal("normalHandle", assignment!.Left.ToString());
+    }
+
+    // ---- the terminals -------------------------------------------------
+
+    /// <summary>
+    /// The cap and the end bar take the group's colour, lifted against the
+    /// strip's ground. A terminal painted straight from the palette is the
+    /// 1.57:1 chip #882 measured, and it compiles.
+    /// </summary>
+    [Theory]
+    [InlineData(VerticalStrip)]
+    [InlineData(HorizontalStrip)]
+    public void TheTerminals_TakeTheGroupColourAgainstTheStripGround(string file)
+    {
+        var call = ShellSource.Load(file).Root.Call("TabGroupField.TerminalRgb");
+        Assert.Equal("_stripBackdropPacked", call.Arg(0));
+        Assert.Contains("Color", call.Arg(1), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Vertical: the field is capped at the top and closed at the bottom,
+    /// and open on both sides.
+    ///
+    /// The bottom is the whole point. A field with a cap and no end bar is
+    /// the rail this design replaced -- a mark that says where a run
+    /// begins and leaves its extent to be counted -- and dropping one
+    /// argument of four produces exactly that.
+    /// </summary>
+    [Fact]
+    public void Vertical_TheFieldIsCappedAtTheTopAndClosedAtTheBottom()
+    {
+        var paint = ShellSource.Load(VerticalStrip).Method("PaintGroupField");
+        var assignment = Assert.Single(
+            paint.DescendantNodes().OfType<AssignmentExpressionSyntax>(),
+            a => a.Left.ToString() == "field.BorderThickness");
+
+        var thickness = Assert.IsType<ObjectCreationExpressionSyntax>(assignment.Right);
+        Assert.Equal(
+            new[]
+            {
+                "0",
+                "TabGroupField.TerminalThicknessPx",
+                "0",
+                "TabGroupField.TerminalThicknessPx",
+            },
+            thickness.ArgumentList!.Arguments.Select(a => a.ToString()).ToArray());
+    }
+
+    /// <summary>
+    /// Horizontal: two terminals per run, one at each end.
+    ///
+    /// Asserted on the offsets rather than on the count alone, because two
+    /// bars drawn at the same edge is the same defect as one bar with a
+    /// different symptom -- and "right" written where "left" belongs is a
+    /// four-character edit.
+    /// </summary>
+    [Fact]
+    public void Horizontal_EveryRunGetsBothATerminalAtEachEnd()
+    {
+        var pass = ShellSource.Load(HorizontalStrip).Method("UpdateGroupFieldTerminals");
+        var placed = pass.Calls("PlaceFieldTerminal");
+
+        Assert.Equal(2, placed.Count);
+        Assert.Equal("left", placed[0].Arg(1));
+        Assert.Equal("right - TabGroupField.TerminalThicknessPx", placed[1].Arg(1));
+    }
+
+    // ---- when it is placed ---------------------------------------------
+
+    /// <summary>
+    /// Each strip's field placement rides the pass that already runs on
+    /// every mutation, exactly once. Its own caller list would be a second
+    /// set of doors to remember, and the ones that get forgotten are the
+    /// exit paths.
+    /// </summary>
+    [Theory]
+    [InlineData(VerticalStrip, "UpdateRowSeparators", "UpdateGroupFields")]
+    [InlineData(HorizontalStrip, "UpdateSelectedTabBridge", "UpdateGroupFieldTerminals")]
+    public void TheFieldRidesTheStripsOwnPlacementPass(
+        string file, string pass, string placement)
+        => Assert.Single(ShellSource.Load(file).Method(pass).Calls(placement));
+
+    /// <summary>
+    /// Every push that moves the strip's ground re-derives the field.
+    ///
+    /// The wash's pole and the terminals' lift are both scored against
+    /// that ground, so a push that recalibrates the muted ink and leaves
+    /// the field alone is the same defect the ink already shipped once,
+    /// one surface along -- and a fill-only push (a frame style change)
+    /// reaches no other placement pass in either strip, so this is the
+    /// only door it can arrive by.
+    /// </summary>
+    [Theory]
+    [InlineData(VerticalStrip, "UpdateGroupFields")]
+    [InlineData(HorizontalStrip, "RefreshGroupFieldWash")]
+    public void EveryPushThatMovesTheGround_ReDerivesTheField(string file, string rederive)
+        => Assert.Single(ShellSource.Load(file)
+            .Method("RefreshShellInactiveInk").Calls(rederive));
+
+    /// <summary>
+    /// Vertical: the field is suppressed while a drag is live, the same
+    /// rule and for the same reason as the horizontal terminals below --
+    /// mid-drag the rows' arranged slots run ahead of their visuals, so a
+    /// field placed from them brackets a run the eye can see is elsewhere.
+    ///
+    /// Stated here because this pass now has a second caller that does not
+    /// go through the selection row's own drag check.
+    /// </summary>
+    [Fact]
+    public void Vertical_TheFieldIsSuppressedWhileADragIsLive()
+    {
+        var pass = ShellSource.Load(VerticalStrip).Method("UpdateGroupFields");
+        var guard = Assert.Single(
+            pass.DescendantNodes().OfType<IfStatementSyntax>(),
+            i => i.Condition.ToString().Contains("_drag", StringComparison.Ordinal));
+
+        Assert.Equal("_drag is not null", guard.Condition.ToString());
+        Assert.IsType<ReturnStatementSyntax>(guard.Statement);
+    }
+
+    /// <summary>
+    /// Horizontal: the terminals are suppressed while a drag is live. The
+    /// strip's slots are TabView's reorder preview then, not the manager's
+    /// order, so a run's ends are not where the projection says -- an
+    /// unsuppressed end bar sits over a stranger for the length of the
+    /// gesture.
+    /// </summary>
+    [Fact]
+    public void Horizontal_TheTerminalsAreSuppressedWhileADragIsLive()
+    {
+        var pass = ShellSource.Load(HorizontalStrip).Method("UpdateGroupFieldTerminals");
+        var guard = Assert.Single(
+            pass.DescendantNodes().OfType<IfStatementSyntax>(),
+            i => i.Condition.ToString().Contains("_stripDragActive", StringComparison.Ordinal));
+
+        // Negated: the placement happens when a drag is NOT live. Dropping
+        // the "!" inverts the rule into placing ONLY during a drag, which
+        // is a strip with no fields at rest.
+        var negation = Assert.IsType<PrefixUnaryExpressionSyntax>(guard.Condition);
+        Assert.True(negation.IsKind(SyntaxKind.LogicalNotExpression));
+    }
+
+    /// <summary>
+    /// Vertical: the field's motion is on the strip's motion gate, read
+    /// with the polarity the gate documents -- animations on, High
+    /// Contrast off. An inverted second argument animates in exactly the
+    /// configuration that asked for no animation.
+    /// </summary>
+    [Fact]
+    public void Vertical_TheFieldMotionIsOnTheStripsMotionGate()
+    {
+        var pass = ShellSource.Load(VerticalStrip).Method("UpdateGroupFields");
+        var gate = Assert.Single(pass.Calls("TabStripMotion.Enabled"));
+
+        Assert.Equal("SystemAnimationsEnabled()", gate.Arg(0));
+        Assert.IsType<IdentifierNameSyntax>(gate.ArgExpression(1));
+        Assert.Equal("_highContrast", gate.Arg(1));
+    }
+
+    /// <summary>
+    /// Vertical: a dissolved group's field goes out the same door its
+    /// header row does. A field that outlives its run is a container drawn
+    /// around tabs that are no longer in it.
+    /// </summary>
+    [Fact]
+    public void Vertical_TheFieldIsRetiredWithItsHeaderRow()
+        => Assert.Single(ShellSource.Load(VerticalStrip)
+            .Method("RemoveGroupRow").Calls("RemoveGroupField"));
+
+    /// <summary>
+    /// Vertical: the generic divider is dropped at a run's two boundaries,
+    /// and only there.
+    ///
+    /// The negation is the load-bearing character. Without it the rule
+    /// reads "skip the divider between two rows of the SAME group", which
+    /// deletes every interior separator in every run and leaves the two at
+    /// the ends doubled up with the cap and the end bar -- the exact
+    /// inverse of the intent, in one keystroke, with every literal intact.
+    /// </summary>
+    [Fact]
+    public void Vertical_TheDividerIsDroppedWhereTheFieldsOwnRuleAlreadyDrawsOne()
+    {
+        var pass = ShellSource.Load(VerticalStrip).Method("UpdateRowSeparators");
+        var skip = Assert.Single(
+            pass.DescendantNodes().OfType<IfStatementSyntax>(),
+            i => i.Condition.ToString().Contains(".Group", StringComparison.Ordinal));
+
+        var negation = Assert.IsType<PrefixUnaryExpressionSyntax>(skip.Condition);
+        Assert.True(negation.IsKind(SyntaxKind.LogicalNotExpression));
+
+        var compare = negation.Operand.AssertCallTo("ReferenceEquals");
+        Assert.Equal("tabs[i].Group", compare.Arg(0));
+        Assert.Equal("tabs[i + 1].Group", compare.Arg(1));
+        Assert.IsType<ContinueStatementSyntax>(skip.Statement);
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/TabGroupFieldWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabGroupFieldWiringTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Ghostty.Core.Tabs;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -61,10 +62,17 @@ public sealed class TabGroupFieldWiringTests
     /// empty list passes for exactly the reason it would pass on a branch
     /// that paints nothing at all.
     /// </summary>
+    /// <remarks>
+    /// Four horizontally: the member's rest state, and the three states one
+    /// item on a field wears (rest, pointer-over, pressed). The last three are
+    /// one ink at three strengths -- MUXC owns those brushes for an unstyled
+    /// tab, and writing the rest value into all of them left every member of a
+    /// group unable to answer the pointer.
+    /// </remarks>
     public static TheoryData<string, int> WashSites => new()
     {
         { VerticalStrip, 1 },
-        { HorizontalStrip, 2 },
+        { HorizontalStrip, 4 },
     };
 
     private static List<InvocationExpressionSyntax> Washes(string file, int expected)
@@ -154,9 +162,48 @@ public sealed class TabGroupFieldWiringTests
     {
         foreach (var wash in Washes(file, sites))
         {
-            var argb = wash.ArgExpression(0).AssertCallTo("TabGroupField.WashArgb");
+            // WashArgb or WashArgbAt: the deepened hover and pressed states are
+            // the same ink at another alpha, and both must still be scored
+            // against the strip's ground rather than against the composite.
+            var argb = Assert.IsType<InvocationExpressionSyntax>(wash.ArgExpression(0));
+            var callee = argb.CalleeText();
+            Assert.True(
+                callee is "TabGroupField.WashArgb" or "TabGroupField.WashArgbAt",
+                $"a wash paint is built from '{callee}', which is neither of the two "
+                + "helpers that keep the alpha on: " + wash);
             Assert.Equal("_stripBackdropPacked", argb.Arg(0));
         }
+    }
+
+    /// <summary>
+    /// A member on a field still answers the pointer: its three unselected
+    /// states are three different strengths of the wash, deepening.
+    ///
+    /// MUXC gives an unstyled tab its own pointer-over and pressed brushes, and
+    /// the field's first draft wrote one value into all three -- so a run of
+    /// members, and the chip that stands for a folded one, stopped responding
+    /// to the pointer entirely. The chip is a click target: it expands the run.
+    /// Equal alphas compile and look deliberate.
+    /// </summary>
+    [Fact]
+    public void Horizontal_AWashedItemStillAnswersThePointer()
+    {
+        var states = ShellSource.Load(HorizontalStrip).Method("ApplyFieldWashStates");
+        var keys = states.Calls("SetItemHeaderBrush").Select(c => c.Arg(1)).ToList();
+        Assert.Equal(
+            new[]
+            {
+                "\"TabViewItemHeaderBackground\"",
+                "\"TabViewItemHeaderBackgroundPointerOver\"",
+                "\"TabViewItemHeaderBackgroundPressed\"",
+            },
+            keys);
+
+        Assert.True(
+            TabGroupField.WashAlpha < TabGroupField.WashHoverAlpha
+                && TabGroupField.WashHoverAlpha < TabGroupField.WashPressedAlpha,
+            "the three states must deepen: equal or inverted alphas are a member "
+            + "that reads as unresponsive, or one that lightens under the finger");
     }
 
     /// <summary>
@@ -169,7 +216,24 @@ public sealed class TabGroupFieldWiringTests
     public void NoStrip_PaintsTheFieldAsItsCompositedGround(string file, int sites)
     {
         Washes(file, sites);
-        Assert.Empty(ShellSource.Load(file).Root.Calls("TabGroupField.FieldGroundRgb"));
+
+        // Calling the helper is allowed and now necessary: it is the ground
+        // contrast is scored against, and the horizontal terminals ask it per
+        // slot. What stays forbidden is PAINTING it. Banning the call outright
+        // was the cheaper rule and it stopped being true the moment anything
+        // needed to score against the field, so the rule names the actual
+        // defect instead: a brush built out of the composite.
+        foreach (var call in ShellSource.Load(file).Root.Calls("TabGroupField.FieldGroundRgb"))
+        {
+            var brush = call.Ancestors().OfType<InvocationExpressionSyntax>()
+                .FirstOrDefault(i => i.CalleeText()
+                    .StartsWith("TabColorBrush.", StringComparison.Ordinal));
+            Assert.True(
+                brush is null,
+                "the composited field ground is being made into a brush, which paints "
+                + "an opaque patch over Mica -- the colour this design rejected, "
+                + "arriving through the scoring door: " + brush);
+        }
     }
 
     /// <summary>
@@ -201,14 +265,46 @@ public sealed class TabGroupFieldWiringTests
     /// strip's ground. A terminal painted straight from the palette is the
     /// 1.57:1 chip #882 measured, and it compiles.
     /// </summary>
-    [Theory]
-    [InlineData(VerticalStrip)]
-    [InlineData(HorizontalStrip)]
-    public void TheTerminals_TakeTheGroupColourAgainstTheStripGround(string file)
+    [Fact]
+    public void Vertical_TheTerminalsTakeTheGroupColourAgainstTheStripGround()
     {
-        var call = ShellSource.Load(file).Root.Call("TabGroupField.TerminalRgb");
+        var call = ShellSource.Load(VerticalStrip).Root.Call("TabGroupField.TerminalRgb");
         Assert.Equal("_stripBackdropPacked", call.Arg(0));
-        Assert.Contains("Color", call.Arg(1), StringComparison.Ordinal);
+        // Exact, not a substring: "Color" is satisfied by TabColor.Red, by
+        // _selectedBorderColor, and by any identifier with the word in it, so
+        // a bar hard-coded to one preset would have passed the rule written to
+        // pin it to the group's.
+        Assert.Equal("group.Color", call.Arg(1));
+    }
+
+    /// <summary>
+    /// Horizontal: each end is scored against the slot it is PAINTED on.
+    ///
+    /// There is no Border here -- the cap is drawn on the run's first slot and
+    /// the end bar on its last -- and those two slots need not be wearing the
+    /// field. The selected tab keeps the terminal background, a member with a
+    /// preset keeps that preset. One ink for both ends, scored against the
+    /// field, answered for a surface neither bar sits on: a Blue cap on a
+    /// selected tab over a blue-ish terminal is about 2.2:1, and a Red end bar
+    /// on a Red member is very nearly invisible, while the rule reports both as
+    /// clearing the floor.
+    /// </summary>
+    [Fact]
+    public void Horizontal_EachTerminalIsScoredAgainstTheSlotItIsPaintedOn()
+    {
+        var terminals = ShellSource.Load(HorizontalStrip)
+            .Method("UpdateGroupFieldTerminals");
+        var calls = terminals.Calls("TabGroupField.TerminalRgbOn");
+        Assert.True(
+            calls.Count == 2,
+            $"expected the two ends to be inked separately, found {calls.Count}");
+
+        // Two DIFFERENT slots, or the split bought nothing.
+        var grounds = calls
+            .Select(c => c.ArgExpression(0).AssertCallTo("SlotGroundRgb").Arg(0))
+            .ToList();
+        Assert.Equal(new[] { "rows[run.First]", "rows[run.Last]" }, grounds);
+        Assert.All(calls, c => Assert.Equal("run.Group.Color", c.Arg(1)));
     }
 
     /// <summary>
@@ -292,6 +388,28 @@ public sealed class TabGroupFieldWiringTests
             .Method("RefreshShellInactiveInk").Calls(rederive));
 
     /// <summary>
+    /// Horizontal: the ground push reaches the TERMINALS too, not only the
+    /// surfaces the wash lands on.
+    ///
+    /// The guard above proves the call exists; it cannot see that the callee
+    /// does the whole job. RefreshGroupFieldWash repainted header brushes --
+    /// members and chip -- and nothing else, while a bar's Fill is only ever
+    /// set by UpdateGroupFieldTerminals, which rides a pass neither
+    /// SetChromeFill nor SetChromeGround reaches. So a frame-style flip moved
+    /// the ground, the members repainted around the new pole, and the cap and
+    /// end bar kept a colour lifted against the field they used to sit on: a
+    /// Graphite bar lifted for a light field is a dark grey, and lands near
+    /// 1.5:1 once that field goes dark. The method's own comment claimed it
+    /// re-derived the terminals while it did not.
+    /// </summary>
+    [Fact]
+    public void Horizontal_TheGroundPushAlsoReInksTheTerminals()
+    {
+        var wash = ShellSource.Load(HorizontalStrip).Method("RefreshGroupFieldWash");
+        Assert.NotEmpty(wash.Calls("QueueBridgeUpdate"));
+    }
+
+    /// <summary>
     /// Vertical: the field is suppressed while a drag is live, the same
     /// rule and for the same reason as the horizontal terminals below --
     /// mid-drag the rows' arranged slots run ahead of their visuals, so a
@@ -313,11 +431,17 @@ public sealed class TabGroupFieldWiringTests
     }
 
     /// <summary>
-    /// Horizontal: the terminals are suppressed while a drag is live. The
-    /// strip's slots are TabView's reorder preview then, not the manager's
-    /// order, so a run's ends are not where the projection says -- an
-    /// unsuppressed end bar sits over a stranger for the length of the
-    /// gesture.
+    /// Horizontal: the terminals are suppressed while a drag is live, and
+    /// suppressed the way the vertical field is -- by LEAVING them, not by
+    /// hiding them.
+    ///
+    /// The strip's slots are TabView's reorder preview mid-drag, not the
+    /// manager's order, so a run's ends are not where the projection says and
+    /// an unsuppressed end bar sits over a stranger for the length of the
+    /// gesture. But falling through to the collapse loop instead of returning
+    /// hid every bar while the wash on the members stayed, so a run read as a
+    /// tint with no beginning and no end -- and the vertical field, which
+    /// returns, did not do that. Two strips, one gesture, one answer.
     /// </summary>
     [Fact]
     public void Horizontal_TheTerminalsAreSuppressedWhileADragIsLive()
@@ -327,11 +451,18 @@ public sealed class TabGroupFieldWiringTests
             pass.DescendantNodes().OfType<IfStatementSyntax>(),
             i => i.Condition.ToString().Contains("_stripDragActive", StringComparison.Ordinal));
 
-        // Negated: the placement happens when a drag is NOT live. Dropping
-        // the "!" inverts the rule into placing ONLY during a drag, which
-        // is a strip with no fields at rest.
-        var negation = Assert.IsType<PrefixUnaryExpressionSyntax>(guard.Condition);
-        Assert.True(negation.IsKind(SyntaxKind.LogicalNotExpression));
+        // Un-negated and an early return, which is the vertical rule exactly.
+        // A "!" here would mean placing ONLY during a drag; falling through
+        // instead of returning is the vanishing bar.
+        Assert.Equal("_stripDragActive", guard.Condition.ToString());
+        Assert.IsType<ReturnStatementSyntax>(guard.Statement);
+
+        // And it stands before anything is measured, so a drag costs no
+        // projection walk and no TransformToVisual sweep either.
+        var firstWalk = pass.Calls("TabStripProjection.HorizontalRows").FirstOrDefault();
+        Assert.True(
+            firstWalk is not null && guard.SpanStart < firstWalk.SpanStart,
+            "the drag guard runs after the strip has already been measured");
     }
 
     /// <summary>
@@ -352,14 +483,38 @@ public sealed class TabGroupFieldWiringTests
     }
 
     /// <summary>
-    /// Vertical: a dissolved group's field goes out the same door its
-    /// header row does. A field that outlives its run is a container drawn
-    /// around tabs that are no longer in it.
+    /// Vertical: a field is retired when the MANAGER stops holding the group,
+    /// and never merely because the header row was rebuilt.
+    ///
+    /// A field that outlives its run is a container drawn around tabs that are
+    /// no longer in it, so the retirement has to happen -- but tying it to the
+    /// header row's lifetime made it happen constantly. A collapse changes how
+    /// many rows the strip shows; ReconcileRowOrder answers a changed count
+    /// with RebuildAllItems; that removes and re-adds every group's row. So
+    /// every field on the strip was destroyed and re-created on any collapse,
+    /// expand, group creation or dissolution -- precisely the four events that
+    /// change a field's size, and the only ones the 250ms glide exists for. It
+    /// cut and faded instead, and the earlier form of this guard held that in
+    /// place while reading like a safety rule.
     /// </summary>
     [Fact]
-    public void Vertical_TheFieldIsRetiredWithItsHeaderRow()
-        => Assert.Single(ShellSource.Load(VerticalStrip)
-            .Method("RemoveGroupRow").Calls("RemoveGroupField"));
+    public void Vertical_TheFieldIsRetiredWhenTheManagerDropsTheGroup()
+    {
+        var strip = ShellSource.Load(VerticalStrip);
+
+        Assert.Empty(strip.Method("RemoveGroupRow").Calls("RemoveGroupField"));
+
+        // Retired from the placement pass, and only for a group the manager
+        // no longer holds -- the same pass that merely HIDES a field it could
+        // not place this time round.
+        var pass = strip.Method("UpdateGroupFields");
+        Assert.NotEmpty(pass.Calls("RemoveGroupField"));
+
+        var stillHeld = Assert.Single(
+            pass.DescendantNodes().OfType<IfStatementSyntax>(),
+            i => i.Condition.ToString().Contains("_manager.Groups", StringComparison.Ordinal));
+        Assert.Equal("_manager.Groups.Contains(group)", stillHeld.Condition.ToString());
+    }
 
     /// <summary>
     /// Vertical: the generic divider is dropped at a run's two boundaries,

--- a/windows/Ghostty.Tests/Wiring/TabStripSyncWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabStripSyncWiringTests.cs
@@ -1020,12 +1020,39 @@ public sealed class TabStripSyncWiringTests
             "A collapse must run the presence pass BEFORE the order pass: the chip "
             + "the fold mints (or retires) has to exist before the order pass reads it.");
 
-        var fallThrough = handler.Call("RefreshChip");
+        // The two arms are exclusive, expressed as CONTAINMENT rather than as
+        // source order. They are an if/else now, so the collapse branch's span
+        // ends after the in-place arm's body and an ordering test reads the
+        // structure backwards -- it would fail on correct code and pass on a
+        // rewrite that put the refresh back inside the collapse.
+        var collapseArm = collapsedBranch.Statement;
+        var refreshArm = collapsedBranch.Else?.Statement;
+        Assert.True(refreshArm is not null,
+            "the in-place refresh has no arm of its own, so a collapse and a rename "
+            + "cannot be doing different work");
+
+        Assert.Empty(collapseArm.Calls("RefreshChip"));
+        Assert.NotEmpty(refreshArm!.Calls("RefreshChip"));
         Assert.True(
-            collapsedBranch.Span.End < fallThrough.SpanStart,
-            "Title and Color changes must fall through to RefreshChip alone: re-running "
-            + "the presence and order passes for an in-place refresh churns the strip "
-            + "for nothing.");
+            refreshArm.Calls("ReconcileChips").Count == 0
+                && refreshArm.Calls("ReconcileStripOrder").Count == 0,
+            "Title and Color changes must not re-run the presence and order passes: "
+            + "re-running them for an in-place refresh churns the strip for nothing.");
+
+        // Both arms end at the bridge pass, which is the only thing that places
+        // and inks the field's cap and end bar. Outside the arms rather than in
+        // each, because both need it and neither raises a manager event the
+        // pass already rides: the active-visible rule keeps the active tab out
+        // of the hidden set, so a collapse raises no ActiveTabChanged, and the
+        // control's own size does not move. Without it a collapse left both
+        // bars spanning the run they used to cover -- in the middle of
+        // unrelated tabs, since equal width re-lays every remaining one -- and
+        // a recolour left them the old colour.
+        var bridge = Assert.Single(handler.Calls("QueueBridgeUpdate"));
+        Assert.True(
+            bridge.SpanStart > collapsedBranch.Span.End,
+            "the bridge update sits inside one arm, so the other group change "
+            + "leaves the field's terminals where and how they were");
 
         // The ride site is only as live as its wiring, and the wiring's
         // LIFETIME is the whole point.

--- a/windows/Ghostty/Tabs/TabColorBrush.cs
+++ b/windows/Ghostty/Tabs/TabColorBrush.cs
@@ -21,4 +21,13 @@ internal static class TabColorBrush
     public static SolidColorBrush FromPackedRgb(uint packed)
         => new(Windows.UI.Color.FromArgb(
             0xFF, (byte)(packed >> 16), (byte)(packed >> 8), (byte)packed));
+
+    /// <summary>
+    /// Brush from a 0xAARRGGBB value, for the one thing in the strips that
+    /// is deliberately not opaque: the group field's ink wash, which has to
+    /// let Mica through or it stops being a wash.
+    /// </summary>
+    public static SolidColorBrush FromPackedArgb(uint packed)
+        => new(Windows.UI.Color.FromArgb(
+            (byte)(packed >> 24), (byte)(packed >> 16), (byte)(packed >> 8), (byte)packed));
 }

--- a/windows/Ghostty/Tabs/TabHost.xaml
+++ b/windows/Ghostty/Tabs/TabHost.xaml
@@ -94,5 +94,13 @@
                 </Grid>
             </controls:TabView.TabStripFooter>
         </controls:TabView>
+
+        <!-- The group field's cap and end bar. OVER the strip, because the
+             wash half of the field is painted into the members' own header
+             brushes and the two terminals have nothing to sit behind: a
+             canvas under the TabView is covered outright the moment the
+             palette gives the strip an opaque fill. Hit-test invisible, so
+             the tabs under it keep their own hover, press and drag. -->
+        <Canvas x:Name="GroupFieldHost" IsHitTestVisible="False"/>
     </Grid>
 </UserControl>

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -885,6 +885,16 @@ internal sealed partial class TabHost : UserControl, ITabHost
         // The swatch paints unconditionally: a group has no "no color" state.
         chip.Swatch.Background = TabColorBrush.From(
             TabColorPalette.Background(group.Color, selected: false));
+        // A chip IS the folded run, so it takes the field's ground the same
+        // way an expanded run's members do -- with the cap and end bar
+        // around it, that is what makes it read as a container rather than
+        // as a tab with a dot on it. Never the selected brushes: a chip is
+        // never the selected item.
+        foreach (var key in TabViewItemHeaderNormalKeys)
+        {
+            SetItemHeaderBrush(chip.Item, key, TabColorBrush.FromPackedArgb(
+                TabGroupField.WashArgb(_stripBackdropPacked)));
+        }
         // A panel header gives a TabViewItem no name, so the chip is named
         // and statused the way tabs are -- else a screen reader hears how
         // many rows the strip holds and nothing about any of them.
@@ -1330,6 +1340,12 @@ internal sealed partial class TabHost : UserControl, ITabHost
 
     private void UpdateSelectedTabBridge()
     {
+        // The field's terminals ride this pass: it is already the one every
+        // add, remove, move, activation and resize funnels into, and it
+        // already knows how to wait for bounds. A placement of its own
+        // would be a second thing to remember on every one of those doors.
+        UpdateGroupFieldTerminals();
+
         if (_stripDragActive)
         {
             // Mid-drag the strip's slots are TabView's reorder preview,
@@ -1424,6 +1440,147 @@ internal sealed partial class TabHost : UserControl, ITabHost
         // every settle, and the frames it is wrong in are the frames where a
         // line appears between the tab and the pane.
         SelectedTabSeamChanged?.Invoke(left, width, _field.Brush);
+    }
+
+    // -----------------------------------------------------------------
+    // The group field, horizontal edition.
+    //
+    // Same three parts as the vertical strip's, same grammar, same
+    // arithmetic (TabGroupField): a wash for the ground, a cap where the
+    // run starts and an end bar where it stops. Only the mechanics differ,
+    // because the hosts do. Vertically the field is one Border under the
+    // rows, which is possible because that strip's rows sit on a canvas
+    // this control has no equivalent of; here the wash rides the members'
+    // own header brushes (see ApplyTabChrome) and only the two terminals
+    // are drawn, on a canvas over the strip.
+    //
+    // Pooled by index, hidden rather than removed, for the reason the
+    // vertical strip's separators are: this runs from the pass every strip
+    // mutation already funnels into, and rebuilding N Rectangles per call
+    // would put an allocation on every one of them.
+    // -----------------------------------------------------------------
+
+    private readonly List<Microsoft.UI.Xaml.Shapes.Rectangle> _fieldTerminals = new();
+
+    /// <summary>
+    /// Clearance above the terminals. A tab's top corners are rounded, and
+    /// a bar drawn flush with the top pokes out past the curve on both
+    /// ends of the run. The bars stay flush with the BOTTOM on purpose:
+    /// that edge is where the strip meets the pane, and a terminal rising
+    /// off it reads as a wall around the run rather than as a tick mark
+    /// floating in the strip.
+    /// </summary>
+    private const double FieldTerminalTopInset = 3;
+
+    private void UpdateGroupFieldTerminals()
+    {
+        var used = 0;
+        // Mid-drag the strip's slots are TabView's reorder preview rather
+        // than the manager's order, so a run's ends are not where the
+        // projection says they are. The drop re-places them -- the same
+        // rule the seam cover above follows, for the same reason.
+        if (!_stripDragActive)
+        {
+            var rows = TabStripProjection.HorizontalRows(_manager);
+            var viewport = TabStripViewport();
+            foreach (var run in TabGroupField.Runs(TabGroupField.SlotGroups(rows)))
+            {
+                if (SlotElement(rows[run.First]) is not { ActualWidth: > 0 } head) continue;
+                if (SlotElement(rows[run.Last]) is not { ActualWidth: > 0 } tail) continue;
+
+                double left, right, top, height;
+                try
+                {
+                    var headOrigin = head.TransformToVisual(this).TransformPoint(new Point(0, 0));
+                    var tailOrigin = tail.TransformToVisual(this).TransformPoint(new Point(0, 0));
+                    left = headOrigin.X;
+                    right = tailOrigin.X + tail.ActualWidth;
+                    top = headOrigin.Y + FieldTerminalTopInset;
+                    height = head.ActualHeight - FieldTerminalTopInset;
+                }
+                catch (Exception ex) when (ex is ArgumentException or InvalidOperationException
+                    or System.Runtime.InteropServices.COMException or NullReferenceException)
+                {
+                    // The item is not in the tree yet, or is leaving it.
+                    continue;
+                }
+
+                if (height <= 0) continue;
+
+                // Clipped to the list the tabs scroll inside, for the
+                // reason the seam cover is: a run scrolled out of view
+                // keeps reporting the offset it WOULD have, and an
+                // unclipped end bar walks off into the footer.
+                var ink = TabColorBrush.FromPackedRgb(
+                    TabGroupField.TerminalRgb(_stripBackdropPacked, run.Group.Color));
+                used = PlaceFieldTerminal(used, left, top, height, ink, viewport);
+                used = PlaceFieldTerminal(
+                    used, right - TabGroupField.TerminalThicknessPx, top, height, ink, viewport);
+            }
+        }
+
+        for (var i = used; i < _fieldTerminals.Count; i++)
+            _fieldTerminals[i].Visibility = Visibility.Collapsed;
+    }
+
+    /// <summary>
+    /// The element one horizontal slot renders as, or null while the strip
+    /// has not built it. A chip counts: it is the folded run's only slot,
+    /// so its own ends are the run's ends.
+    /// </summary>
+    private FrameworkElement? SlotElement(TabStripProjection.HorizontalRow row)
+        => row switch
+        {
+            TabStripProjection.HorizontalRow.Chip { Group: { } group }
+                => _chipByGroup.TryGetValue(group, out var chip) ? chip.Item : null,
+            TabStripProjection.HorizontalRow.Item { Tab: { } tab }
+                => _itemByModel.TryGetValue(tab, out var item) ? item : null,
+            _ => null,
+        };
+
+    private int PlaceFieldTerminal(
+        int index, double left, double top, double height, Brush ink, Rect? viewport)
+    {
+        if (viewport is { } clip
+            && (left + TabGroupField.TerminalThicknessPx <= clip.Left || left >= clip.Right))
+        {
+            // Scrolled out of the list entirely: no bar rather than a bar
+            // drawn over the header badge or the new-tab button.
+            return index;
+        }
+
+        Microsoft.UI.Xaml.Shapes.Rectangle bar;
+        if (index < _fieldTerminals.Count)
+        {
+            bar = _fieldTerminals[index];
+        }
+        else
+        {
+            bar = new Microsoft.UI.Xaml.Shapes.Rectangle
+            {
+                Width = TabGroupField.TerminalThicknessPx,
+                IsHitTestVisible = false,
+            };
+            _fieldTerminals.Add(bar);
+            GroupFieldHost.Children.Add(bar);
+        }
+
+        // A terminal arriving -- a group just created, a run just expanded
+        // out of its chip -- comes in on the Fade token, the same hand the
+        // chip/member swap already uses. Its POSITION is never animated:
+        // this strip's tabs cut to their new slots (there is no gap glide
+        // horizontally), and a bar gliding to an end its own tab has
+        // already jumped to would trail behind the run it marks.
+        var appearing = bar.Visibility != Visibility.Visible;
+
+        bar.Width = TabGroupField.TerminalThicknessPx;
+        bar.Height = height;
+        bar.Fill = ink;
+        bar.Visibility = Visibility.Visible;
+        Canvas.SetLeft(bar, left);
+        Canvas.SetTop(bar, top);
+        if (appearing) FadeInAppearing(bar);
+        return index + 1;
     }
 
     // The list the tab items scroll inside, looked up once out of the
@@ -1602,9 +1759,30 @@ internal sealed partial class TabHost : UserControl, ITabHost
             normalHandle = TabColorBrush.From(TabColorPalette.Background(tab.Color, selected: false));
             selectedHandle = TabColorBrush.From(TabColorPalette.Background(tab.Color, selected: true));
         }
-        else if (selected && _selectedTabFillBrush is not null)
+        else
         {
-            selectedHandle = _selectedTabFillBrush;
+            // The group field's ground, horizontal edition: the wash goes
+            // on the members' own header brushes rather than on a rect
+            // behind them, because the strip's surface is owned by
+            // TabViewBackground and an opaque palette fill would paint
+            // straight over anything drawn under the TabView. Ink at 8%,
+            // so a bare frame still shows Mica through the run.
+            //
+            // Only where the tab has no colour of its own: a preset is the
+            // more specific statement about that one tab, and washing over
+            // it would make a coloured member of a group a shade nobody
+            // picked. And only the UNSELECTED brushes: the selected tab
+            // keeps the terminal's background in every combination, which
+            // is what makes it read as continuous with the pane below it.
+            if (tab.Group is not null)
+            {
+                normalHandle = TabColorBrush.FromPackedArgb(
+                    TabGroupField.WashArgb(_stripBackdropPacked));
+            }
+            if (selected && _selectedTabFillBrush is not null)
+            {
+                selectedHandle = _selectedTabFillBrush;
+            }
         }
 
         // The active tab does not take the colour, it takes the field's own
@@ -2931,6 +3109,27 @@ internal sealed partial class TabHost : UserControl, ITabHost
                 ? Windows.UI.Color.FromArgb(InactiveInkAlpha, 0xFF, 0xFF, 0xFF)
                 : Windows.UI.Color.FromArgb(InactiveInkAlpha, 0x00, 0x00, 0x00));
         RecolorTabText();
+        // The field's wash and its terminals are scored against the
+        // same ground this just moved, so they re-ask here rather than
+        // waiting for whatever pass happens next: SetChromeFill reaches
+        // no other painter, and a run left washed for the previous
+        // frame is the ink bug with a different surface.
+        RefreshGroupFieldWash();
+    }
+
+    /// <summary>
+    /// Re-derive every field's ground, through the painters that already
+    /// own it: the run's members and, when it is folded, its chip. No
+    /// second wash site -- a painter of its own here could disagree with
+    /// the one every other pass goes through.
+    /// </summary>
+    private void RefreshGroupFieldWash()
+    {
+        foreach (var group in _manager.Groups)
+        {
+            RefreshRunRails(group);
+            RefreshChip(group);
+        }
     }
 
     /// <summary>

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -1547,11 +1547,7 @@ internal sealed partial class TabHost : UserControl, ITabHost
             _fieldTerminals[i].Visibility = Visibility.Collapsed;
     }
 
-    /// <summary>
-    /// The element one horizontal slot renders as, or null while the strip
-    /// has not built it. A chip counts: it is the folded run's only slot,
-    /// so its own ends are the run's ends.
-    /// </summary>
+
     /// <summary>
     /// What is actually painted where a terminal drawn on <paramref name="row"/>
     /// lands, so the bar can be scored against it.
@@ -1567,16 +1563,29 @@ internal sealed partial class TabHost : UserControl, ITabHost
     {
         if (row is TabStripProjection.HorizontalRow.Item { Tab: { } tab })
         {
-            if (ReferenceEquals(tab, _manager.ActiveTab) && _selectedTabFillBrush is not null)
-                return PackColor(_selectedTabFillBrush.Color);
+            // The branch ORDER is ApplyTabChrome's, and has to be: a preset
+            // beats being active there, so an active coloured tab wears the
+            // opaque preset and not the terminal background. Asking about
+            // active first answered "terminal ground" for a slot painted its
+            // own colour -- and for a Red end bar on an active Red member that
+            // is a bar scored against near-black, returned unlifted, and
+            // painted onto opaque Red. 1:1, which is the exact defect this
+            // whole helper was added to remove.
+            var selected = ReferenceEquals(tab, _manager.ActiveTab);
             if (tab.Color != TabColor.None)
                 return TabColorPalette.EffectiveBackgroundRgb(
-                    tab.Color, selected: false, _stripBackdropPacked);
+                    tab.Color, selected, _stripBackdropPacked);
+            if (selected && _selectedTabFillBrush is not null)
+                return PackColor(_selectedTabFillBrush.Color);
         }
         return TabGroupField.FieldGroundRgb(_stripBackdropPacked);
     }
 
-    private FrameworkElement? SlotElement(TabStripProjection.HorizontalRow row)
+    /// <summary>
+    /// The element one horizontal slot renders as, or null while the strip
+    /// has not built it. A chip counts: it is the folded run's only slot,
+    /// so its own ends are the run's ends.
+    /// </summary>    private FrameworkElement? SlotElement(TabStripProjection.HorizontalRow row)
         => row switch
         {
             TabStripProjection.HorizontalRow.Chip { Group: { } group }
@@ -3264,6 +3273,13 @@ internal sealed partial class TabHost : UserControl, ITabHost
         // taken its ground from here since the same bug was fixed there.
         _stripBackdropPacked = groundRgb;
         RefreshTabColors();
+        // RefreshTabColors walks _itemByModel; chips live in _chipByGroup and
+        // are never re-chromed by it. Without this a folded run's chip keeps
+        // the old pole's wash through an OS light/dark flip while the expanded
+        // runs around it repaint and its own cap and end bar are re-inked --
+        // the same defect RefreshGroupFieldWash exists to prevent, on the path
+        // that never reaches RefreshShellInactiveInk.
+        RefreshGroupFieldWash();
     }
 
     private uint _chromeGroundPacked = 0x0C0C0C;

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -843,13 +843,30 @@ internal sealed partial class TabHost : UserControl, ITabHost
             ApplyLabelPhase(_labelRules.Collapsed());
             ReconcileChips();
             ReconcileStripOrder();
-            return;
         }
-        RefreshChip(group);
-        // The run's members carry the group's name and color on their own
-        // chrome now; the same single-door pass the chip's swatch rides
-        // repaints them, so a recolor never leaves a two-tone run.
-        RefreshRunRails(group);
+        else
+        {
+            RefreshChip(group);
+            // The run's members carry the group's name and color on their own
+            // chrome now; the same single-door pass the chip's swatch rides
+            // repaints them, so a recolor never leaves a two-tone run.
+            RefreshRunRails(group);
+        }
+
+        // Both arms move the field, and neither reaches it on its own.
+        //
+        // The cap and the end bar are placed and inked from
+        // UpdateSelectedTabBridge, which rides add, remove, move, activation,
+        // resize and the drag's end. A group change is none of those: the
+        // active-visible rule keeps the active tab out of the hidden set, so a
+        // collapse raises no ActiveTabChanged, and TabViewControl's own size
+        // does not move. So a collapse left both bars at the coordinates of the
+        // run they used to span -- in the middle of unrelated tabs, since equal
+        // width re-lays every remaining tab -- and a recolour left them the old
+        // colour, in both cases until something unrelated happened to run the
+        // pass. The vertical strip has no equivalent hole because its field
+        // rides the reconcile every group change already schedules.
+        QueueBridgeUpdate();
     }
 
     /// <summary>
@@ -890,11 +907,7 @@ internal sealed partial class TabHost : UserControl, ITabHost
         // around it, that is what makes it read as a container rather than
         // as a tab with a dot on it. Never the selected brushes: a chip is
         // never the selected item.
-        foreach (var key in TabViewItemHeaderNormalKeys)
-        {
-            SetItemHeaderBrush(chip.Item, key, TabColorBrush.FromPackedArgb(
-                TabGroupField.WashArgb(_stripBackdropPacked)));
-        }
+        ApplyFieldWashStates(chip.Item);
         // A panel header gives a TabViewItem no name, so the chip is named
         // and statused the way tabs are -- else a screen reader hears how
         // many rows the strip holds and nothing about any of them.
@@ -1474,12 +1487,20 @@ internal sealed partial class TabHost : UserControl, ITabHost
 
     private void UpdateGroupFieldTerminals()
     {
-        var used = 0;
         // Mid-drag the strip's slots are TabView's reorder preview rather
         // than the manager's order, so a run's ends are not where the
         // projection says they are. The drop re-places them -- the same
         // rule the seam cover above follows, for the same reason.
-        if (!_stripDragActive)
+        //
+        // Left where they were, rather than collapsed. Falling through to the
+        // tail loop below hid every bar for the length of the gesture while
+        // the wash on the members stayed, so a run read as a tint with no
+        // beginning and no end -- and the vertical field, which returns here,
+        // did not do that. The suppression is the same rule in both strips
+        // now, which is the only way one gesture means one thing.
+        if (_stripDragActive) return;
+
+        var used = 0;
         {
             var rows = TabStripProjection.HorizontalRows(_manager);
             var viewport = TabStripViewport();
@@ -1507,15 +1528,18 @@ internal sealed partial class TabHost : UserControl, ITabHost
 
                 if (height <= 0) continue;
 
-                // Clipped to the list the tabs scroll inside, for the
-                // reason the seam cover is: a run scrolled out of view
-                // keeps reporting the offset it WOULD have, and an
-                // unclipped end bar walks off into the footer.
-                var ink = TabColorBrush.FromPackedRgb(
-                    TabGroupField.TerminalRgb(_stripBackdropPacked, run.Group.Color));
-                used = PlaceFieldTerminal(used, left, top, height, ink, viewport);
+                // One ink per END, not one per run: the two bars sit on two
+                // different slots and those slots need not be wearing the same
+                // thing. Only the vertical field can score both against one
+                // ground, because there the bars are edges of a Border that IS
+                // the field.
+                var headInk = TabColorBrush.FromPackedRgb(TabGroupField.TerminalRgbOn(
+                    SlotGroundRgb(rows[run.First]), run.Group.Color));
+                var tailInk = TabColorBrush.FromPackedRgb(TabGroupField.TerminalRgbOn(
+                    SlotGroundRgb(rows[run.Last]), run.Group.Color));
+                used = PlaceFieldTerminal(used, left, top, height, headInk, viewport);
                 used = PlaceFieldTerminal(
-                    used, right - TabGroupField.TerminalThicknessPx, top, height, ink, viewport);
+                    used, right - TabGroupField.TerminalThicknessPx, top, height, tailInk, viewport);
             }
         }
 
@@ -1528,6 +1552,30 @@ internal sealed partial class TabHost : UserControl, ITabHost
     /// has not built it. A chip counts: it is the folded run's only slot,
     /// so its own ends are the run's ends.
     /// </summary>
+    /// <summary>
+    /// What is actually painted where a terminal drawn on <paramref name="row"/>
+    /// lands, so the bar can be scored against it.
+    ///
+    /// The field's wash is the usual answer and the only one the vertical strip
+    /// has, but two slots opt out of it: the selected tab, which keeps the
+    /// terminal background so it reads as continuous with its pane, and a
+    /// member carrying a preset of its own, which keeps that preset. A chip
+    /// falls through to the wash, which is correct -- a folded run's one slot
+    /// wears the field.
+    /// </summary>
+    private uint SlotGroundRgb(TabStripProjection.HorizontalRow row)
+    {
+        if (row is TabStripProjection.HorizontalRow.Item { Tab: { } tab })
+        {
+            if (ReferenceEquals(tab, _manager.ActiveTab) && _selectedTabFillBrush is not null)
+                return PackColor(_selectedTabFillBrush.Color);
+            if (tab.Color != TabColor.None)
+                return TabColorPalette.EffectiveBackgroundRgb(
+                    tab.Color, selected: false, _stripBackdropPacked);
+        }
+        return TabGroupField.FieldGroundRgb(_stripBackdropPacked);
+    }
+
     private FrameworkElement? SlotElement(TabStripProjection.HorizontalRow row)
         => row switch
         {
@@ -1538,6 +1586,12 @@ internal sealed partial class TabHost : UserControl, ITabHost
             _ => null,
         };
 
+    /// <summary>
+    /// One bar, placed and clipped to the list the tabs scroll inside -- for
+    /// the reason the seam cover is clipped: a run scrolled out of view keeps
+    /// reporting the offset it WOULD have, and an unclipped end bar walks off
+    /// into the footer.
+    /// </summary>
     private int PlaceFieldTerminal(
         int index, double left, double top, double height, Brush ink, Rect? viewport)
     {
@@ -1753,6 +1807,7 @@ internal sealed partial class TabHost : UserControl, ITabHost
     {
         SolidColorBrush? normalHandle = null;
         SolidColorBrush? selectedHandle = null;
+        var washedByField = false;
 
         if (tab.Color != TabColor.None)
         {
@@ -1778,6 +1833,7 @@ internal sealed partial class TabHost : UserControl, ITabHost
             {
                 normalHandle = TabColorBrush.FromPackedArgb(
                     TabGroupField.WashArgb(_stripBackdropPacked));
+                washedByField = true;
             }
             if (selected && _selectedTabFillBrush is not null)
             {
@@ -1801,6 +1857,14 @@ internal sealed partial class TabHost : UserControl, ITabHost
         }
 
         ApplyTabViewItemHeaderBrushes(viewItem, normalHandle, selectedHandle);
+
+        // That writes ONE brush into all three unselected states, which is what
+        // a preset tint wants and not what the field wants: a washed member
+        // whose pointer-over and pressed are identical to its rest state stops
+        // answering the pointer, and a run of them reads as disabled. The wash
+        // gets its own ramp instead, so hover and press still say something
+        // without introducing a colour the field did not choose.
+        if (washedByField) ApplyFieldWashStates(viewItem);
 
         // A tab carrying a preset colour takes that colour's border, the same
         // way its pane does, so the stroke keeps identifying which pane the
@@ -1891,6 +1955,26 @@ internal sealed partial class TabHost : UserControl, ITabHost
             && v is Windows.UI.Color accent)
             return new SolidColorBrush(Windows.UI.Color.FromArgb(alpha, accent.R, accent.G, accent.B));
         return new SolidColorBrush(Windows.UI.Color.FromArgb(alpha, 0x60, 0xCD, 0xFF));
+    }
+
+    /// <summary>
+    /// The three unselected header states of one item that sits on a field,
+    /// painted from one ink at three strengths.
+    ///
+    /// One place, because the chip and an expanded member are the same surface
+    /// wearing the same wash: two sites deriving it separately is how the
+    /// folded and unfolded readings of a run drift apart.
+    /// </summary>
+    private void ApplyFieldWashStates(TabViewItem item)
+    {
+        SetItemHeaderBrush(item, "TabViewItemHeaderBackground",
+            TabColorBrush.FromPackedArgb(TabGroupField.WashArgb(_stripBackdropPacked)));
+        SetItemHeaderBrush(item, "TabViewItemHeaderBackgroundPointerOver",
+            TabColorBrush.FromPackedArgb(TabGroupField.WashArgbAt(
+                _stripBackdropPacked, TabGroupField.WashHoverAlpha)));
+        SetItemHeaderBrush(item, "TabViewItemHeaderBackgroundPressed",
+            TabColorBrush.FromPackedArgb(TabGroupField.WashArgbAt(
+                _stripBackdropPacked, TabGroupField.WashPressedAlpha)));
     }
 
     private static void ApplyTabViewItemHeaderBrushes(
@@ -3122,6 +3206,18 @@ internal sealed partial class TabHost : UserControl, ITabHost
     /// own it: the run's members and, when it is folded, its chip. No
     /// second wash site -- a painter of its own here could disagree with
     /// the one every other pass goes through.
+    ///
+    /// The terminals need the same push and do not get it from those two.
+    /// <see cref="RefreshRunRails"/> and <see cref="RefreshChip"/> repaint
+    /// header brushes; only <see cref="UpdateGroupFieldTerminals"/> sets a
+    /// bar's Fill, and it rides <see cref="UpdateSelectedTabBridge"/>, which
+    /// neither SetChromeFill nor SetChromeGround reaches. So a frame-style
+    /// flip moved the ground, the members repainted around the new pole, and
+    /// the cap and end bar kept a colour lifted against the field they were
+    /// scored on a moment ago -- a Graphite bar lifted for a light field is a
+    /// dark grey, which lands near 1.5:1 once the field goes dark. That is the
+    /// defect this method exists to prevent, arriving through the one painter
+    /// it was not calling.
     /// </summary>
     private void RefreshGroupFieldWash()
     {
@@ -3130,6 +3226,7 @@ internal sealed partial class TabHost : UserControl, ITabHost
             RefreshRunRails(group);
             RefreshChip(group);
         }
+        QueueBridgeUpdate();
     }
 
     /// <summary>

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml
@@ -31,6 +31,11 @@
          LeftCompact+IsPaneOpen in a fixed-width column allocates pane AND
          content side-by-side and draws over the terminal. -->
     <Grid>
+        <!-- Under everything: the group field is the ground a run sits ON,
+             so the selection fill, the row separators and the rows
+             themselves all have to paint over it. -->
+        <Canvas x:Name="GroupFieldHost" IsHitTestVisible="False"/>
+
         <!-- Behind NavView so row fill does not paint over icons/text. -->
         <Canvas x:Name="SelectionRowHost" IsHitTestVisible="False">
             <Border x:Name="SelectionRow"

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -787,7 +787,22 @@ internal sealed partial class VerticalTabStrip : UserControl
     // ---------------------------------------------------------------
 
     private readonly Dictionary<TabGroup, Border> _groupFields = new();
-    private readonly Dictionary<TabGroup, Anim.Storyboard> _fieldMotion = new();
+    /// <summary>
+    /// One field clock per group, with the values it was flying to.
+    ///
+    /// The values are held because a Storyboard that is STOPPED puts the
+    /// animated property back to its base, and for the fade that base is the
+    /// zero the fade set on its way in. So a fade interrupted inside its 83ms
+    /// -- a tab added above the run it had just created -- left an invisible
+    /// Border that the following glide then animated the geometry of, and the
+    /// field stayed gone until the group was dissolved and remade. Relying on
+    /// Completed to put the value back is relying on Stop raising it, which is
+    /// a framework detail this control should not be betting on either way.
+    /// Landing is idempotent and both doors call it.
+    /// </summary>
+    private readonly Dictionary<TabGroup, FieldFlight> _fieldMotion = new();
+
+    private readonly record struct FieldFlight(Anim.Storyboard Board, Action Land);
 
     private void UpdateGroupFields()
     {
@@ -813,6 +828,9 @@ internal sealed partial class VerticalTabStrip : UserControl
         var motion = TabStripMotion.Enabled(SystemAnimationsEnabled(), _highContrast);
         var width = Math.Max(0, ActualWidth - RowInsetLeft);
         var placed = new HashSet<TabGroup>();
+        // Once, not per run: the answer is the same for all of them and it
+        // walks the template to find the scroller.
+        var viewport = RowsViewport();
 
         foreach (var run in runs)
         {
@@ -834,17 +852,52 @@ internal sealed partial class VerticalTabStrip : UserControl
                 continue;
             }
 
+            // Clipped to the band the rows are actually visible in, the way the
+            // horizontal placement clips to its strip's viewport. A row that
+            // has scrolled out of the list keeps reporting the offset it would
+            // have had, so an unclipped field walks up behind the pinned shelf
+            // and the strip's header -- and every pane surface up there is
+            // forced transparent, so there is nothing to hide it. A run
+            // entirely off-screen collapses to nothing and is skipped, which
+            // hides its field rather than drawing it somewhere untrue.
+            if (viewport is { } band)
+            {
+                top = Math.Max(top, band.Top);
+                bottom = Math.Min(bottom, band.Bottom);
+            }
+
             if (bottom - top <= 0) continue;
             placed.Add(run.Group);
             PlaceGroupField(run.Group, top, width, bottom - top, motion);
         }
 
+        // A field the manager still holds is only HIDDEN when it could not be
+        // placed this pass -- its rows are mid-rebuild, or it scrolled out --
+        // because the Border is what carries the glide, and destroying it makes
+        // the next placement an appearance instead of a move.
+        //
+        // That distinction is the whole of it. Retiring the field alongside the
+        // header row read as tidy and was not: a collapse changes how many rows
+        // the strip shows, ReconcileRowOrder answers a changed count with
+        // RebuildAllItems, and that removes and re-adds every group's row. So
+        // every field on the strip was destroyed and re-faded on any collapse,
+        // any expand, and any group being created or dissolved -- the four
+        // events the glide exists for, and the only ones where a field changes
+        // size. It cut and faded instead, and the guard that pinned the field
+        // to the header row's lifetime pinned that in place.
+        var retired = new List<TabGroup>();
         foreach (var (group, field) in _groupFields)
         {
             if (placed.Contains(group)) continue;
             StopFieldMotion(group);
-            field.Visibility = Visibility.Collapsed;
+            if (_manager.Groups.Contains(group))
+            {
+                field.Visibility = Visibility.Collapsed;
+                continue;
+            }
+            retired.Add(group);
         }
+        foreach (var group in retired) RemoveGroupField(group);
     }
 
     /// <summary>
@@ -946,13 +999,13 @@ internal sealed partial class VerticalTabStrip : UserControl
         // Storyboard that is stopped (teardown, a second change mid-glide)
         // leaves the property where it was, and the field would keep the
         // old geometry while the rows moved on.
-        board.Completed += (_, _) =>
+        void Land()
         {
-            _fieldMotion.Remove(group);
             Canvas.SetTop(field, top);
             field.Height = height;
-        };
-        _fieldMotion[group] = board;
+        }
+        board.Completed += (_, _) => { _fieldMotion.Remove(group); Land(); };
+        _fieldMotion[group] = new FieldFlight(board, Land);
         board.Begin();
     }
 
@@ -997,6 +1050,10 @@ internal sealed partial class VerticalTabStrip : UserControl
         field.Opacity = 0;
         var fade = new Anim.DoubleAnimation
         {
+            // From stated rather than inferred. Without it the animation's base
+            // is whatever the property held when it began -- the zero on the
+            // line above -- and that is the value a Stop restores.
+            From = 0,
             To = 1,
             Duration = new Duration(TimeSpan.FromMilliseconds(TabGroupField.FadeMs)),
         };
@@ -1004,8 +1061,9 @@ internal sealed partial class VerticalTabStrip : UserControl
         Anim.Storyboard.SetTargetProperty(fade, "Opacity");
         var board = new Anim.Storyboard();
         board.Children.Add(fade);
-        board.Completed += (_, _) => { _fieldMotion.Remove(group); field.Opacity = 1; };
-        _fieldMotion[group] = board;
+        void Land() => field.Opacity = 1;
+        board.Completed += (_, _) => { _fieldMotion.Remove(group); Land(); };
+        _fieldMotion[group] = new FieldFlight(board, Land);
         board.Begin();
     }
 
@@ -1016,20 +1074,30 @@ internal sealed partial class VerticalTabStrip : UserControl
     /// </summary>
     private void StopAllFieldMotion()
     {
-        foreach (var (_, board) in _fieldMotion) board.Stop();
+        // Teardown does not land: the element is going away, and writing a
+        // final geometry onto an unloaded Border is work for nobody.
+        foreach (var (_, flight) in _fieldMotion) flight.Board.Stop();
         _fieldMotion.Clear();
     }
 
     private void StopFieldMotion(TabGroup group)
     {
-        if (!_fieldMotion.Remove(group, out var board)) return;
-        board.Stop();
+        if (!_fieldMotion.Remove(group, out var flight)) return;
+        flight.Board.Stop();
+        // Landed here rather than left to Completed, which a Stop may never
+        // raise. An interrupted fade's base value is zero, so the alternative
+        // is a field that is still placed, still measured, and invisible.
+        flight.Land();
     }
 
     /// <summary>
-    /// Retire a dissolved group's field. Called from the same place the
-    /// header row is retired, so a field can never outlive the run it was
-    /// drawn around.
+    /// Retire a dissolved group's field.
+    ///
+    /// Driven by whether the MANAGER still holds the group, not by the header
+    /// row's lifetime: the row is removed and re-added by any rebuild, and a
+    /// field that came and went with it could never glide across the changes
+    /// that resize it. A field outliving its run is prevented by the same
+    /// check, one pass later.
     /// </summary>
     private void RemoveGroupField(TabGroup group)
     {
@@ -1501,6 +1569,32 @@ internal sealed partial class VerticalTabStrip : UserControl
     /// contains the row, so the clamp does nothing and a cover gets drawn
     /// across the pane at a height with no tab beside it.
     /// </remarks>
+    /// <summary>
+    /// The band the scrolling rows are visible in, in this control's own
+    /// coordinates.
+    ///
+    /// Not <see cref="SelectionViewport"/>: that one answers for whichever
+    /// container the ACTIVE row lives in, and returns the pinned shelf when the
+    /// active tab is pinned. A group's rows are never pinned, so a field
+    /// clamped to the shelf would collapse to nothing every time the user
+    /// happened to be on a pinned tab.
+    /// </summary>
+    private (double Top, double Bottom)? RowsViewport()
+    {
+        _menuItemsScroller ??= FindDescendantByName(NavView, "MenuItemsScrollViewer");
+        if (_menuItemsScroller is not { ActualHeight: > 0 } scroller) return null;
+        try
+        {
+            var top = scroller.TransformToVisual(this)
+                .TransformPoint(new Point(0, 0)).Y;
+            return (top, top + scroller.ActualHeight);
+        }
+        catch (Exception ex) when (IsLayoutReadFailure(ex))
+        {
+            return null;
+        }
+    }
+
     internal (double Top, double Bottom)? SelectionViewport(UIElement reference)
     {
         _menuItemsScroller ??= FindDescendantByName(NavView, "MenuItemsScrollViewer");
@@ -2031,7 +2125,10 @@ internal sealed partial class VerticalTabStrip : UserControl
 
     private void RemoveGroupRow(TabGroup group)
     {
-        RemoveGroupField(group);
+        // The field is NOT retired here. This runs on every rebuild, including
+        // the one a collapse triggers, and the field has to survive that to
+        // glide across it. UpdateGroupFields retires it when the manager stops
+        // holding the group.
         if (!_headers.Remove(group, out var item)) return;
         // One fence rule for every MenuItems mutation.
         _syncing = true;

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -20,6 +20,7 @@ using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Windows.Foundation;
 using Windows.UI;
+using Anim = Microsoft.UI.Xaml.Media.Animation;
 
 namespace Ghostty.Tabs;
 
@@ -157,6 +158,9 @@ internal sealed partial class VerticalTabStrip : UserControl
         RebuildAllItems();
         SyncSelectionFromManager();
 
+        // Under the selection fill and the separators, which both sit on
+        // SelectionRowHost: the field is the ground, not another overlay.
+        Canvas.SetZIndex(GroupFieldHost, -1);
         Canvas.SetZIndex(SelectionRowHost, 0);
         Canvas.SetZIndex(NavView, 1);
         // Deliberately not LayoutUpdated: it fires for every layout pass
@@ -196,6 +200,7 @@ internal sealed partial class VerticalTabStrip : UserControl
         {
             CancelDrag("teardown");
             FinishPinFlight("teardown");
+            StopAllFieldMotion();
         };
     }
 
@@ -275,6 +280,12 @@ internal sealed partial class VerticalTabStrip : UserControl
                 ? Color.FromArgb(InactiveInkAlpha, 0xFF, 0xFF, 0xFF)
                 : Color.FromArgb(InactiveInkAlpha, 0x00, 0x00, 0x00));
         ApplyInactiveForegroundResources(_shellInactiveTextBrush);
+        // The field's wash and its terminals are scored against the
+        // same ground this just moved. A push that recalibrates the ink
+        // and not the field leaves the run washed for the frame the
+        // strip no longer has -- and a fill-only push reaches no other
+        // placement pass, so this is the one door it can arrive by.
+        UpdateGroupFields();
     }
 
     /// <summary>
@@ -662,6 +673,13 @@ internal sealed partial class VerticalTabStrip : UserControl
         // own and cannot be forgotten on an exit path.
         UpdatePinnedShelfChrome();
 
+        // The group fields ride it for the same reason, and they have to
+        // be placed BEFORE the separators below: the field's cap and end
+        // bar are the run's boundaries, so the generic divider at those
+        // two gaps is a second line saying the same thing in a weaker
+        // voice, and the skip below needs the fields already standing.
+        UpdateGroupFields();
+
         // Pooled by index rather than rebuilt. This runs from the same
         // refresh the selection row rides, which the constructor keeps off
         // LayoutUpdated specifically so it does not allocate on every layout
@@ -689,6 +707,12 @@ internal sealed partial class VerticalTabStrip : UserControl
                 if (ReferenceEquals(tabs[i], _manager.ActiveTab)) continue;
                 if (ReferenceEquals(tabs[i + 1], _manager.ActiveTab)) continue;
             }
+            // A gap where a run begins or ends already has a line: the
+            // field's cap or its end bar. Drawing the generic divider
+            // there too doubles the rule and, worse, draws it in the
+            // neutral separator shade right beside the group's own colour,
+            // which reads as the field having a seam in it.
+            if (!ReferenceEquals(tabs[i].Group, tabs[i + 1].Group)) continue;
             if (!_items.TryGetValue(tabs[i], out var item)) continue;
             if (item.ActualHeight <= 0 || item.ActualWidth <= 0) continue;
 
@@ -744,6 +768,274 @@ internal sealed partial class VerticalTabStrip : UserControl
     {
         for (var i = index; i < _rowSeparators.Count; i++)
             _rowSeparators[i].Visibility = Visibility.Collapsed;
+    }
+
+    // ---------------------------------------------------------------
+    // The group field.
+    //
+    // One Border per run, on its own canvas under everything else, sized
+    // from the run's first and last realized rows. A container rather than
+    // a decoration: the wash says "these belong together", the cap and the
+    // end bar say where that stops. The grammar and every colour in it
+    // live in TabGroupField, which the horizontal strip reads too -- the
+    // two layouts are one language, and the arithmetic is pinned without a
+    // window.
+    //
+    // Placed from measured rows for the same reason the selection fill and
+    // the separators are: NavigationView owns the arrangement, and the only
+    // honest read of it is to ask the items where they landed.
+    // ---------------------------------------------------------------
+
+    private readonly Dictionary<TabGroup, Border> _groupFields = new();
+    private readonly Dictionary<TabGroup, Anim.Storyboard> _fieldMotion = new();
+
+    private void UpdateGroupFields()
+    {
+        // Mid-drag the rows' arranged slots run ahead of their visuals
+        // -- the glides ride the compositor -- so a field placed from
+        // them would bracket a run whose members are still visibly
+        // elsewhere. The last placement keeps matching what is on
+        // screen, and the refresh at the drop catches up. Same rule the
+        // selection row follows, for the same reason.
+        if (_drag is not null) return;
+
+        if (ActualWidth <= 0)
+        {
+            foreach (var (_, parked) in _groupFields) parked.Visibility = Visibility.Collapsed;
+            return;
+        }
+
+        var rows = TabStripProjection.GroupedRows(_manager);
+        var runs = TabGroupField.Runs(TabGroupField.SlotGroups(rows));
+        // Read once per pass: UISettings is thread-affine and allocating
+        // one per field would put the cost back that keeping this pass off
+        // LayoutUpdated exists to avoid.
+        var motion = TabStripMotion.Enabled(SystemAnimationsEnabled(), _highContrast);
+        var width = Math.Max(0, ActualWidth - RowInsetLeft);
+        var placed = new HashSet<TabGroup>();
+
+        foreach (var run in runs)
+        {
+            if (RowElementOfProjection(rows[run.First]) is not { } head) continue;
+            if (RowElementOfProjection(rows[run.Last]) is not { } tail) continue;
+            if (head.ActualHeight <= 0 || tail.ActualHeight <= 0) continue;
+
+            double top, bottom;
+            try
+            {
+                top = head.TransformToVisual(this).TransformPoint(new Point(0, 0)).Y;
+                bottom = tail.TransformToVisual(this)
+                    .TransformPoint(new Point(0, tail.ActualHeight)).Y;
+            }
+            catch (Exception ex) when (IsLayoutReadFailure(ex))
+            {
+                // A row that is not in the tree yet, or is leaving it. The
+                // next refresh places the field.
+                continue;
+            }
+
+            if (bottom - top <= 0) continue;
+            placed.Add(run.Group);
+            PlaceGroupField(run.Group, top, width, bottom - top, motion);
+        }
+
+        foreach (var (group, field) in _groupFields)
+        {
+            if (placed.Contains(group)) continue;
+            StopFieldMotion(group);
+            field.Visibility = Visibility.Collapsed;
+        }
+    }
+
+    /// <summary>
+    /// The element a projected row renders as, or null while the strip has
+    /// not built it. Headers and members both, because the field's cap IS
+    /// the header row: a field measured from the first member instead would
+    /// leave its own header sitting outside it.
+    /// </summary>
+    private FrameworkElement? RowElementOfProjection(TabStripProjection.ProjectedRow row)
+        => row switch
+        {
+            TabStripProjection.ProjectedRow.Header { Group: { } group }
+                => _headers.TryGetValue(group, out var header) ? header : null,
+            TabStripProjection.ProjectedRow.Item { Tab: { } tab }
+                => _items.TryGetValue(tab, out var item) ? item : null,
+            _ => null,
+        };
+
+    private void PlaceGroupField(
+        TabGroup group, double top, double width, double height, bool motion)
+    {
+        var appearing = false;
+        if (!_groupFields.TryGetValue(group, out var field))
+        {
+            field = new Border
+            {
+                IsHitTestVisible = false,
+                CornerRadius = new CornerRadius(TabGroupField.CornerRadiusPx),
+            };
+            _groupFields[group] = field;
+            GroupFieldHost.Children.Add(field);
+            appearing = true;
+        }
+
+        if (field.Visibility != Visibility.Visible)
+        {
+            appearing = true;
+            field.Visibility = Visibility.Visible;
+        }
+
+        PaintGroupField(field, group);
+        field.Width = width;
+        Canvas.SetLeft(field, RowInsetLeft);
+
+        var fromTop = Canvas.GetTop(field);
+        var fromHeight = field.Height;
+        StopFieldMotion(group);
+
+        // A field that has never been placed has nothing to travel from,
+        // and one arriving fades in instead of sliding out of a corner.
+        if (appearing || !motion || double.IsNaN(fromTop) || double.IsNaN(fromHeight))
+        {
+            Canvas.SetTop(field, top);
+            field.Height = height;
+            field.Opacity = 1;
+            if (appearing && motion) FadeInGroupField(group, field);
+            return;
+        }
+
+        if (Math.Abs(fromTop - top) < 0.5 && Math.Abs(fromHeight - height) < 0.5) return;
+        GlideGroupField(group, field, top, height);
+    }
+
+    /// <summary>
+    /// The three parts, all three off the strip's own ground: the wash as
+    /// translucent ink so Mica still shows through it, and the cap and end
+    /// bar as the group's colour lifted to the non-text floor against the
+    /// field it sits on.
+    /// </summary>
+    private void PaintGroupField(Border field, TabGroup group)
+    {
+        field.Background = TabColorBrush.FromPackedArgb(
+            TabGroupField.WashArgb(_stripBackdropPacked));
+        field.BorderBrush = TabColorBrush.FromPackedRgb(
+            TabGroupField.TerminalRgb(_stripBackdropPacked, group.Color));
+        // Vertical: the cap runs along the header row's leading edge and
+        // the end bar closes the run under its last member. The sides stay
+        // open -- the field meets the pane on its right the way the
+        // selected row does, and a fourth edge would box it in.
+        field.BorderThickness = new Thickness(
+            0, TabGroupField.TerminalThicknessPx, 0, TabGroupField.TerminalThicknessPx);
+    }
+
+    /// <summary>
+    /// The field follows its rows on their own clock: the strip's Existing
+    /// Elements glide, one Storyboard so the top edge and the bottom edge
+    /// can never arrive on different frames and shear the container.
+    ///
+    /// Dependent animations, both of them -- Canvas.Top and Height are
+    /// neither composition-backed -- which is affordable here and nowhere
+    /// else in this control: there is one field per group, not one per row.
+    /// </summary>
+    private void GlideGroupField(TabGroup group, Border field, double top, double height)
+    {
+        var board = new Anim.Storyboard();
+        board.Children.Add(FieldGlide(field, "(Canvas.Top)", top));
+        board.Children.Add(FieldGlide(field, "Height", height));
+        // The values land whether or not the clock is ever serviced: a
+        // Storyboard that is stopped (teardown, a second change mid-glide)
+        // leaves the property where it was, and the field would keep the
+        // old geometry while the rows moved on.
+        board.Completed += (_, _) =>
+        {
+            _fieldMotion.Remove(group);
+            Canvas.SetTop(field, top);
+            field.Height = height;
+        };
+        _fieldMotion[group] = board;
+        board.Begin();
+    }
+
+    /// <summary>
+    /// One glided property, on the gap glide's own curve.
+    ///
+    /// A spline keyframe rather than a DoubleAnimation with an easing
+    /// function: the strip states this curve by its two control points
+    /// everywhere else (the composition gap glide, the pin flight), and
+    /// the Storyboard clock's stock easings are a different family of
+    /// curves entirely. KeySpline is the same parameterization, so the
+    /// field and the rows it is drawn around decelerate together instead
+    /// of merely finishing together.
+    /// </summary>
+    private static Anim.DoubleAnimationUsingKeyFrames FieldGlide(
+        Border field, string property, double to)
+    {
+        var glide = new Anim.DoubleAnimationUsingKeyFrames { EnableDependentAnimation = true };
+        glide.KeyFrames.Add(new Anim.SplineDoubleKeyFrame
+        {
+            KeyTime = Anim.KeyTime.FromTimeSpan(TimeSpan.FromMilliseconds(TabGroupField.GlideMs)),
+            Value = to,
+            KeySpline = new Anim.KeySpline
+            {
+                ControlPoint1 = new Point(TabGroupField.GlideEaseX1, TabGroupField.GlideEaseY1),
+                ControlPoint2 = new Point(TabGroupField.GlideEaseX2, TabGroupField.GlideEaseY2),
+            },
+        });
+        Anim.Storyboard.SetTarget(glide, field);
+        Anim.Storyboard.SetTargetProperty(glide, property);
+        return glide;
+    }
+
+    /// <summary>
+    /// A field that has just arrived fades in on the Fade token rather
+    /// than popping: a group is created by a command the user just issued,
+    /// and the container appearing under their cursor at full strength
+    /// reads as a flash.
+    /// </summary>
+    private void FadeInGroupField(TabGroup group, Border field)
+    {
+        field.Opacity = 0;
+        var fade = new Anim.DoubleAnimation
+        {
+            To = 1,
+            Duration = new Duration(TimeSpan.FromMilliseconds(TabGroupField.FadeMs)),
+        };
+        Anim.Storyboard.SetTarget(fade, field);
+        Anim.Storyboard.SetTargetProperty(fade, "Opacity");
+        var board = new Anim.Storyboard();
+        board.Children.Add(fade);
+        board.Completed += (_, _) => { _fieldMotion.Remove(group); field.Opacity = 1; };
+        _fieldMotion[group] = board;
+        board.Begin();
+    }
+
+    /// <summary>
+    /// Every field clock, stopped. Teardown only: a Storyboard left running
+    /// on an unloaded element is the same leak the drag's glide census
+    /// exists to catch, one door along.
+    /// </summary>
+    private void StopAllFieldMotion()
+    {
+        foreach (var (_, board) in _fieldMotion) board.Stop();
+        _fieldMotion.Clear();
+    }
+
+    private void StopFieldMotion(TabGroup group)
+    {
+        if (!_fieldMotion.Remove(group, out var board)) return;
+        board.Stop();
+    }
+
+    /// <summary>
+    /// Retire a dissolved group's field. Called from the same place the
+    /// header row is retired, so a field can never outlive the run it was
+    /// drawn around.
+    /// </summary>
+    private void RemoveGroupField(TabGroup group)
+    {
+        StopFieldMotion(group);
+        if (!_groupFields.Remove(group, out var field)) return;
+        GroupFieldHost.Children.Remove(field);
     }
 
     /// <summary>
@@ -1739,6 +2031,7 @@ internal sealed partial class VerticalTabStrip : UserControl
 
     private void RemoveGroupRow(TabGroup group)
     {
+        RemoveGroupField(group);
         if (!_headers.Remove(group, out var item)) return;
         // One fence rule for every MenuItems mutation.
         _syncing = true;

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -860,15 +860,21 @@ internal sealed partial class VerticalTabStrip : UserControl
             // forced transparent, so there is nothing to hide it. A run
             // entirely off-screen collapses to nothing and is skipped, which
             // hides its field rather than drawing it somewhere untrue.
+            // The two ENDS are dropped when the clamp eats them, rather than
+            // clamped along with the ground -- see PaintGroupField.
+            var capVisible = true;
+            var endVisible = true;
             if (viewport is { } band)
             {
+                capVisible = top >= band.Top;
+                endVisible = bottom <= band.Bottom;
                 top = Math.Max(top, band.Top);
                 bottom = Math.Min(bottom, band.Bottom);
             }
 
             if (bottom - top <= 0) continue;
             placed.Add(run.Group);
-            PlaceGroupField(run.Group, top, width, bottom - top, motion);
+            PlaceGroupField(run.Group, top, width, bottom - top, motion, capVisible, endVisible);
         }
 
         // A field the manager still holds is only HIDDEN when it could not be
@@ -917,7 +923,8 @@ internal sealed partial class VerticalTabStrip : UserControl
         };
 
     private void PlaceGroupField(
-        TabGroup group, double top, double width, double height, bool motion)
+        TabGroup group, double top, double width, double height, bool motion,
+        bool capVisible, bool endVisible)
     {
         var appearing = false;
         if (!_groupFields.TryGetValue(group, out var field))
@@ -938,7 +945,7 @@ internal sealed partial class VerticalTabStrip : UserControl
             field.Visibility = Visibility.Visible;
         }
 
-        PaintGroupField(field, group);
+        PaintGroupField(field, group, capVisible, endVisible);
         field.Width = width;
         Canvas.SetLeft(field, RowInsetLeft);
 
@@ -957,8 +964,25 @@ internal sealed partial class VerticalTabStrip : UserControl
             return;
         }
 
-        if (Math.Abs(fromTop - top) < 0.5 && Math.Abs(fromHeight - height) < 0.5) return;
-        GlideGroupField(group, field, top, height);
+        // Nothing to travel: land on the NEW target rather than returning.
+        // StopFieldMotion has already written the abandoned flight's target
+        // over the property, so returning here leaves the field wherever that
+        // was -- a difference under half a pixel from where it should be, but
+        // only if the old target and the new one agree, which is exactly what
+        // this branch does not check.
+        if (Math.Abs(fromTop - top) < 0.5 && Math.Abs(fromHeight - height) < 0.5)
+        {
+            Canvas.SetTop(field, top);
+            field.Height = height;
+            return;
+        }
+
+        // The travel starts from where the field WAS, read before the stop.
+        // Without it the glide interpolates from whatever the property held at
+        // Begin -- and by then StopFieldMotion has landed the abandoned
+        // flight's target on it, so an interrupted glide jumped forward to the
+        // old destination and eased from there.
+        GlideGroupField(group, field, fromTop, fromHeight, top, height);
     }
 
     /// <summary>
@@ -967,7 +991,8 @@ internal sealed partial class VerticalTabStrip : UserControl
     /// bar as the group's colour lifted to the non-text floor against the
     /// field it sits on.
     /// </summary>
-    private void PaintGroupField(Border field, TabGroup group)
+    private void PaintGroupField(
+        Border field, TabGroup group, bool capVisible, bool endVisible)
     {
         field.Background = TabColorBrush.FromPackedArgb(
             TabGroupField.WashArgb(_stripBackdropPacked));
@@ -977,8 +1002,17 @@ internal sealed partial class VerticalTabStrip : UserControl
         // the end bar closes the run under its last member. The sides stay
         // open -- the field meets the pane on its right the way the
         // selected row does, and a fourth edge would box it in.
+        //
+        // An end the viewport clipped away is DROPPED, not moved. The ground
+        // can be clamped to the visible band harmlessly, but these two edges
+        // are statements: the cap says "the run starts here" and the end bar
+        // says "it ends here". Clamped along with the ground they would say it
+        // about whichever row happens to be at the edge of the scroller, which
+        // is a lie the horizontal strip does not tell -- PlaceFieldTerminal
+        // refuses a bar outside the viewport rather than sliding it inward.
         field.BorderThickness = new Thickness(
-            0, TabGroupField.TerminalThicknessPx, 0, TabGroupField.TerminalThicknessPx);
+            0, capVisible ? TabGroupField.TerminalThicknessPx : 0,
+            0, endVisible ? TabGroupField.TerminalThicknessPx : 0);
     }
 
     /// <summary>
@@ -990,11 +1024,13 @@ internal sealed partial class VerticalTabStrip : UserControl
     /// neither composition-backed -- which is affordable here and nowhere
     /// else in this control: there is one field per group, not one per row.
     /// </summary>
-    private void GlideGroupField(TabGroup group, Border field, double top, double height)
+    private void GlideGroupField(
+        TabGroup group, Border field,
+        double fromTop, double fromHeight, double top, double height)
     {
         var board = new Anim.Storyboard();
-        board.Children.Add(FieldGlide(field, "(Canvas.Top)", top));
-        board.Children.Add(FieldGlide(field, "Height", height));
+        board.Children.Add(FieldGlide(field, "(Canvas.Top)", fromTop, top));
+        board.Children.Add(FieldGlide(field, "Height", fromHeight, height));
         // The values land whether or not the clock is ever serviced: a
         // Storyboard that is stopped (teardown, a second change mid-glide)
         // leaves the property where it was, and the field would keep the
@@ -1004,8 +1040,22 @@ internal sealed partial class VerticalTabStrip : UserControl
             Canvas.SetTop(field, top);
             field.Height = height;
         }
-        board.Completed += (_, _) => { _fieldMotion.Remove(group); Land(); };
-        _fieldMotion[group] = new FieldFlight(board, Land);
+        // Only the flight that is still the CURRENT one may retire the entry.
+        // WinUI 3 raises Completed from Stop (unlike WPF), so an abandoned
+        // board's handler runs after its replacement has already been stored:
+        // it deleted the replacement's entry and wrote its own target over a
+        // property the replacement was animating. That left the new board
+        // unreachable -- the next StopFieldMotion found nothing, so a third
+        // glide began while the second was still running two clocks on
+        // Canvas.Top, and StopAllFieldMotion could no longer stop it at
+        // Unloaded, which is the leak that method exists to prevent.
+        board.Completed += (_, _) =>
+        {
+            if (!_fieldMotion.TryGetValue(group, out var current)
+                || !ReferenceEquals(current.Board, board)) return;
+            _fieldMotion.Remove(group);
+            Land();
+        };        _fieldMotion[group] = new FieldFlight(board, Land);
         board.Begin();
     }
 
@@ -1021,9 +1071,19 @@ internal sealed partial class VerticalTabStrip : UserControl
     /// of merely finishing together.
     /// </summary>
     private static Anim.DoubleAnimationUsingKeyFrames FieldGlide(
-        Border field, string property, double to)
+        Border field, string property, double from, double to)
     {
         var glide = new Anim.DoubleAnimationUsingKeyFrames { EnableDependentAnimation = true };
+        // The start is STATED, at time zero, not inferred from the property.
+        // Inferred, the curve begins wherever the value sits when Begin runs --
+        // and by then the abandoned flight's landing has written its own target
+        // there, so an interrupted glide jumped forward to the old destination
+        // and eased out of it.
+        glide.KeyFrames.Add(new Anim.DiscreteDoubleKeyFrame
+        {
+            KeyTime = Anim.KeyTime.FromTimeSpan(TimeSpan.Zero),
+            Value = from,
+        });
         glide.KeyFrames.Add(new Anim.SplineDoubleKeyFrame
         {
             KeyTime = Anim.KeyTime.FromTimeSpan(TimeSpan.FromMilliseconds(TabGroupField.GlideMs)),
@@ -1062,8 +1122,22 @@ internal sealed partial class VerticalTabStrip : UserControl
         var board = new Anim.Storyboard();
         board.Children.Add(fade);
         void Land() => field.Opacity = 1;
-        board.Completed += (_, _) => { _fieldMotion.Remove(group); Land(); };
-        _fieldMotion[group] = new FieldFlight(board, Land);
+        // Only the flight that is still the CURRENT one may retire the entry.
+        // WinUI 3 raises Completed from Stop (unlike WPF), so an abandoned
+        // board's handler runs after its replacement has already been stored:
+        // it deleted the replacement's entry and wrote its own target over a
+        // property the replacement was animating. That left the new board
+        // unreachable -- the next StopFieldMotion found nothing, so a third
+        // glide began while the second was still running two clocks on
+        // Canvas.Top, and StopAllFieldMotion could no longer stop it at
+        // Unloaded, which is the leak that method exists to prevent.
+        board.Completed += (_, _) =>
+        {
+            if (!_fieldMotion.TryGetValue(group, out var current)
+                || !ReferenceEquals(current.Board, board)) return;
+            _fieldMotion.Remove(group);
+            Land();
+        };        _fieldMotion[group] = new FieldFlight(board, Land);
         board.Begin();
     }
 
@@ -1569,31 +1643,6 @@ internal sealed partial class VerticalTabStrip : UserControl
     /// contains the row, so the clamp does nothing and a cover gets drawn
     /// across the pane at a height with no tab beside it.
     /// </remarks>
-    /// <summary>
-    /// The band the scrolling rows are visible in, in this control's own
-    /// coordinates.
-    ///
-    /// Not <see cref="SelectionViewport"/>: that one answers for whichever
-    /// container the ACTIVE row lives in, and returns the pinned shelf when the
-    /// active tab is pinned. A group's rows are never pinned, so a field
-    /// clamped to the shelf would collapse to nothing every time the user
-    /// happened to be on a pinned tab.
-    /// </summary>
-    private (double Top, double Bottom)? RowsViewport()
-    {
-        _menuItemsScroller ??= FindDescendantByName(NavView, "MenuItemsScrollViewer");
-        if (_menuItemsScroller is not { ActualHeight: > 0 } scroller) return null;
-        try
-        {
-            var top = scroller.TransformToVisual(this)
-                .TransformPoint(new Point(0, 0)).Y;
-            return (top, top + scroller.ActualHeight);
-        }
-        catch (Exception ex) when (IsLayoutReadFailure(ex))
-        {
-            return null;
-        }
-    }
 
     internal (double Top, double Bottom)? SelectionViewport(UIElement reference)
     {
@@ -1624,7 +1673,33 @@ internal sealed partial class VerticalTabStrip : UserControl
         }
     }
 
-    private static FrameworkElement? FindDescendantByName(DependencyObject root, string name)
+ 
+    /// <summary>
+    /// The band the scrolling rows are visible in, in this control's own
+    /// coordinates.
+    ///
+    /// Not <see cref="SelectionViewport"/>: that one answers for whichever
+    /// container the ACTIVE row lives in, and returns the pinned shelf when the
+    /// active tab is pinned. A group's rows are never pinned, so a field
+    /// clamped to the shelf would collapse to nothing every time the user
+    /// happened to be on a pinned tab.
+    /// </summary>
+    private (double Top, double Bottom)? RowsViewport()
+    {
+        _menuItemsScroller ??= FindDescendantByName(NavView, "MenuItemsScrollViewer");
+        if (_menuItemsScroller is not { ActualHeight: > 0 } scroller) return null;
+        try
+        {
+            var top = scroller.TransformToVisual(this)
+                .TransformPoint(new Point(0, 0)).Y;
+            return (top, top + scroller.ActualHeight);
+        }
+        catch (Exception ex) when (IsLayoutReadFailure(ex))
+        {
+            return null;
+        }
+    }
+   private static FrameworkElement? FindDescendantByName(DependencyObject root, string name)
     {
         var count = VisualTreeHelper.GetChildrenCount(root);
         for (var i = 0; i < count; i++)


### PR DESCRIPTION
Q1 of the tab-strip design pass, in both layouts: a group is now a FIELD —
members sit on a tinted ground that begins at a cap and finishes at an end
bar, so a run has a visible beginning and an end. Part of #882.

## What changed

**`Ghostty.Core.Tabs.TabGroupField`** — the grammar, shared by both strips
and pinnable without a window: which slots a run owns (over `GroupedRows`
vertically, `HorizontalRows` horizontally), the wash, and the terminals.

**The wash is ink, not a colour.** Under Mica the strip is the desktop, so a
tint mixed for one wallpaper is invisible over the next. White or black at
8%, pole scored with `PreferLightForegroundAtAlpha` at the alpha it is
painted at, painted translucent so the backdrop still shows through.

**The cap and end bar carry the group's colour**, through
`ChromeSeparator.EnsureVisible` against the field they sit on — so they
clear 3:1 on every ground rather than landing at the 1.57:1 the header
swatch measures today.

**Vertical**: one `Border` per run on a canvas under the rows, from the
header's top edge to the last visible member's bottom. The header is inside
the field it caps. The generic divider is dropped at the run's two
boundaries, where the cap and end bar already draw a line.

**Horizontal**: no header row and no slot under the tabs (`TabViewBackground`
paints over anything there), so the wash rides the members' own unselected
header brushes and the two terminals are drawn on a canvas over the strip.
The selected tab is never washed — it keeps the terminal background that
makes it read as continuous with its pane.

**Motion**: the vertical field follows its rows on the strip's own Existing
Elements glide (250ms, same cubic bezier), as one Storyboard so the top and
bottom edges cannot arrive on different frames and shear the container, and
fades in on the Fade token when it arrives. Horizontal terminals fade in on
the same token and never glide — that strip's tabs cut to their slots, and a
bar easing to an end its tab has already reached trails the run it marks.
Both on `TabStripMotion`'s gate. Nothing that already animated was touched.

## Tests

`TabGroupFieldTests` (executable, 19): the wash moves every ground on the
whole grey ramp and stays inside 3–12 L* (it lands in 3.92–9.28); the pole
has headroom at both ends; every preset's terminal clears 3:1 against its
own field on every ground; run spans for expanded, collapsed, collapsed-
holding-the-active-tab, adjacent runs, split runs; and both layouts draw a
field for the same groups.

`TabGroupFieldWiringTests` (21): both strips read the runs from the shared
walk over their own projection and nothing else does; the wash keeps its
alpha and is scored against `_stripBackdropPacked`; neither strip paints the
composited ground (that would be an opaque patch over Mica); the wash never
lands on the selected handle; the vertical thickness is capped AND closed;
the horizontal run gets a terminal at each end; each placement rides the
strip's own pass; both suppress mid-drag; the motion gate's polarity; the
field is retired with its header row; the divider skip keeps its negation.

All 14 guards were proven red by mutating the code they guard and reverting:
end bar dropped, wash painted opaque, wrong projection, field never retired,
divider skip inverted, motion gate flipped, placement dropped, wash on the
selected handle, both terminals at one edge, drag suppression inverted,
ground push stops re-deriving (x2), vertical drag suppression dropped.

## What the tests do NOT cover

- **Anything about how it looks.** No pixel is read. Whether the wash reads
  over a given wallpaper, whether the terminals land where the geometry says,
  and whether the glide is smooth are live-window questions. This branch was
  not run on a live window at all — build and unit suite only.
- **The horizontal wash's mechanics.** The guards pin that the wash goes on
  the unselected handles; they cannot see that MUXC actually honours a
  translucent `TabViewItemHeaderBackground`, or how it composites with the
  hover and pressed states that take the same brush.
- **The default (non-shell-theme) path.** `_stripBackdropPacked` is only
  recalculated while a shell theme is active — pre-existing, shared with the
  muted ink — so on that path the wash is scored against the strip's
  `0x0C0C0C` default guess. The built-in palette is the floor, so this is a
  fallback, but on a light default theme the wash would be near-invisible.
- **Scroll.** The field is placed from measured rows on the passes that
  already run; a scroll that moves rows without one of those passes leaves it
  where it was. Same limitation the selection fill and the row separators
  already have.

## Deliberately not in this PR

- The header swatch's own 1.57:1 (#882) — a separate defect in the same
  issue. The terminals already resolve the group colour through
  `EnsureVisible`; the swatch fix converges on the same helper.
- The horizontal 2px per-member rail stays. It is no longer the run's extent
  marker (the field is), but it is the only hue cue an expanded run's members
  carry, and removing it is its own change.
- #870 (vertical header drag) and #871 (horizontal collapse affordance,
  layout-switch flash, run-label position) are untouched.


---

## Review rounds

Two rounds. The first found that the horizontal field hung its whole placement and repaint story on `UpdateSelectedTabBridge`, and the three events that are *about groups* — collapse, expand, recolour — reach none of the doors that pass rides. A collapse left both bars spanning the run they used to cover, which after an equal-width relayout is the middle of unrelated tabs; a recolour left them the old colour; and a frame-style flip left them lifted against the field they had a moment ago. `RefreshGroupFieldWash`'s own comment said it re-derived the terminals, and it repainted header brushes only.

The second round found the blocker in the first round's own fix. `SlotGroundRgb` asked "is this active" before "does it have a preset", and `ApplyTabChrome` resolves them the other way — so the helper answered "terminal ground" for a slot painted its own colour, and an active Red member of a Red group got an end bar scored against near-black, returned unlifted, painted onto opaque Red. **1:1** — the exact defect the helper was added to remove.

Other findings worth naming:

- **The terminals are scored against the slot they are painted on.** There is no Border horizontally; the cap is drawn on the run's first slot and the end bar on its last, and neither need wear the wash.
- **A washed member answers the pointer again.** MUXC owns pointer-over and pressed for an unstyled tab, and the wash was written into all three states, so every member of a group — and the chip, which is a click target — stopped responding. Three strengths of one ink, not a second colour.
- **The field survives a rebuild.** A collapse changes the row count, `ReconcileRowOrder` answers that with `RebuildAllItems`, and that removed and re-created every field on the strip — so the glide never ran on any of the four events that change a field's size, and the guard pinned that in place.
- **Flights land once.** WinUI 3 raises `Completed` from `Stop` (unlike WPF), so an abandoned board's handler deleted its replacement's entry and wrote its own target over a live animation, leaving a `Storyboard` that `StopAllFieldMotion` could no longer reach at `Unloaded`.
- **A clipped end is dropped, not clamped.** Clamping moved the cap and end bar onto the viewport edge, asserting a boundary that is not there. The horizontal strip refuses a bar outside its viewport; the vertical one now does the same.
- **Drag suppression is one rule.** The horizontal terminals vanished mid-gesture while the wash stayed, so a run read as a tint with no beginning and no end.

**Three guards were weaker than they read** and are fixed: the retirement rule asserted both arms existed but not which was which (swapping the bodies passed); the composited-ground ban had become an ancestry check that one local walks past; and nothing pinned that the two washed surfaces actually call the ramp, so deleting both call sites left it as dead code, green.

**Watched red across both rounds:** the group-change bridge dropped, the ground-push bridge dropped, drag suppression removed, the field retired with its row, the hover alpha flattened, both ends scored on one slot, the slot-ground order inverted, the clipped cap restored, the retire/hide arms swapped, and the ramp's call site removed.

Debug **3351 passed, 0 failed**. `just signoff` green on `1ff69f80ce`.

**Deferred with issues rather than absorbed:** #933 (no placement pass runs on scroll, in either strip — the PR body discloses the staleness, but the field is a much larger surface than the selection fill; plus a rebuild that may leave the field fading rather than gliding) and #934 (the vertical bars are painted under the rows, so a preset-coloured member attenuates them — the same defect fixed horizontally here, and `TerminalRgbOn`'s doc comment currently claims the vertical case is safe).

Review item 4 needed no change here: #918 gave `TabHost` its ground from the chrome push on both paths.

Size-override: the bulk is one feature landing in two strips at once, which is the point — a grammar implemented in one strip only is the parity break every finding above is a variant of. `TabGroupField` (the shared Core walk) plus its executable tests are ~700 lines of the total, and the two strips' placements are the rest.
