### PR TITLE
tabs: a group cannot be colourless, and the picker stops offering it

### DIFF
--- a/windows/Ghostty.Core/Tabs/TabColor.cs
+++ b/windows/Ghostty.Core/Tabs/TabColor.cs
@@ -121,6 +121,17 @@ internal static class TabColorPalette
     /// a defined member, so a hand-edited or forward-version session can hand
     /// <c>RestoreGroup</c> a <c>(TabColor)42</c>. Guarding None alone let that
     /// through to the same mid-paint crash under a different integer.
+    ///
+    /// Coercing here means the value is also PERSISTED coerced:
+    /// <c>SessionCapture</c> reads the resolved property, so a session written
+    /// by a future build carrying an extra swatch comes back as the default
+    /// and is written back that way on the next save. That is a repair for a
+    /// corrupt value and a downgrade loss for a forward one, and it is the
+    /// deliberate choice: keeping the raw value and coercing at the paint
+    /// boundary would preserve the colour, but it would give up the property
+    /// every group paint site depends on -- that the colour in hand can
+    /// always be looked up. wintty ships one lineage and has no downgrade
+    /// story, so the invariant is worth more than the swatch.
     /// </summary>
     public static TabColor EnsureGroupColor(TabColor color)
         => Colors.ContainsKey(color) ? color : DefaultGroupColor;
@@ -146,9 +157,11 @@ internal static class TabColorPalette
                     ? "TabColor.None has no preset: it means \"no tint\", so the caller "
                       + "chooses what to paint instead. A group cannot be None -- use "
                       + nameof(EnsureGroupColor) + "."
-                    : "no preset for this value: it is not a declared TabColor. A group "
-                      + "colour restored from a session is not validated by the JSON "
-                      + "reader -- pass it through " + nameof(EnsureGroupColor) + " first.");
+                    // States the rule, not a diagnosis: Preset serves the tab
+                    // path too, and a message naming sessions and groups would
+                    // send a reader the wrong way for a tab. The type and
+                    // ActualValue already carry the argument.
+                    : "not a declared TabColor: only declared members have presets.");
 
     /// <summary>Selected tab/header fill uses the full preset color.</summary>
     public const byte SelectedBackgroundAlpha = 255;

--- a/windows/Ghostty.Core/Tabs/TabColor.cs
+++ b/windows/Ghostty.Core/Tabs/TabColor.cs
@@ -97,6 +97,40 @@ internal static class TabColorPalette
         _                 => "None",
     };
 
+    /// <summary>
+    /// The swatch a group falls back to. A group has no "no color" state, so
+    /// its paint sites index <see cref="Colors"/> with no guard -- swatch,
+    /// chip ink, run label, vertical header row, and the switcher's card,
+    /// ring and dot. <see cref="TabGroup"/> coerces to this rather than
+    /// leaving the invariant to whoever happens to write the property.
+    /// </summary>
+    public const TabColor DefaultGroupColor = TabColor.Blue;
+
+    /// <summary>
+    /// A color a group can actually be painted in. <see cref="TabColor.None"/>
+    /// is a tab state, not a group state: on a tab it means "no tint" and the
+    /// tab's paint sites each choose a different brush, but a group's swatch
+    /// has nothing to fall back to.
+    /// </summary>
+    public static TabColor EnsureGroupColor(TabColor color)
+        => color == TabColor.None ? DefaultGroupColor : color;
+
+    /// <summary>
+    /// The preset behind a color. <see cref="TabColor.None"/> has no entry by
+    /// design -- it means "no tint", and only the caller knows what to paint
+    /// in its place -- so it is refused here saying exactly that. Indexing
+    /// <see cref="Colors"/> directly raised a bare <c>KeyNotFoundException</c>
+    /// from inside a paint pass, naming neither the value nor the rule.
+    /// </summary>
+    private static Color Preset(TabColor color)
+        => Colors.TryGetValue(color, out var rgb)
+            ? rgb
+            : throw new ArgumentOutOfRangeException(
+                nameof(color), color,
+                "TabColor.None has no preset: it means \"no tint\", so the caller "
+                + "chooses what to paint instead. A group cannot be None -- use "
+                + nameof(EnsureGroupColor) + ".");
+
     /// <summary>Selected tab/header fill uses the full preset color.</summary>
     public const byte SelectedBackgroundAlpha = 255;
 
@@ -108,13 +142,13 @@ internal static class TabColorPalette
     /// </summary>
     public static Color Background(TabColor color, bool selected)
     {
-        var rgb = Colors[color];
+        var rgb = Preset(color);
         var alpha = selected ? SelectedBackgroundAlpha : UnselectedBackgroundAlpha;
         return Color.FromArgb(alpha, rgb.R, rgb.G, rgb.B);
     }
 
     /// <summary>Opaque preset color for the active pane border.</summary>
-    public static Color Border(TabColor color) => Colors[color];
+    public static Color Border(TabColor color) => Preset(color);
 
     /// <summary>
     /// sRGB backdrop after compositing a preset tint over the strip fill.
@@ -124,7 +158,7 @@ internal static class TabColorPalette
     public static uint EffectiveBackgroundRgb(
         TabColor color, bool selected, uint stripBackdropRgb)
     {
-        var preset = Colors[color];
+        var preset = Preset(color);
         if (selected)
             return PackRgb(preset.R, preset.G, preset.B);
 

--- a/windows/Ghostty.Core/Tabs/TabColor.cs
+++ b/windows/Ghostty.Core/Tabs/TabColor.cs
@@ -111,25 +111,44 @@ internal static class TabColorPalette
     /// is a tab state, not a group state: on a tab it means "no tint" and the
     /// tab's paint sites each choose a different brush, but a group's swatch
     /// has nothing to fall back to.
+    ///
+    /// The test is "has a preset", not "is not None", and the difference is
+    /// the whole point. The invariant the paint sites rely on is that the
+    /// colour can be looked up, and every value outside the enum's declared
+    /// members fails that too. A group colour is persisted as a NUMBER (see
+    /// <c>GroupSession.Color</c>; the session context defines no string
+    /// converter) and System.Text.Json does not check that a numeric enum is
+    /// a defined member, so a hand-edited or forward-version session can hand
+    /// <c>RestoreGroup</c> a <c>(TabColor)42</c>. Guarding None alone let that
+    /// through to the same mid-paint crash under a different integer.
     /// </summary>
     public static TabColor EnsureGroupColor(TabColor color)
-        => color == TabColor.None ? DefaultGroupColor : color;
+        => Colors.ContainsKey(color) ? color : DefaultGroupColor;
 
     /// <summary>
     /// The preset behind a color. <see cref="TabColor.None"/> has no entry by
     /// design -- it means "no tint", and only the caller knows what to paint
-    /// in its place -- so it is refused here saying exactly that. Indexing
-    /// <see cref="Colors"/> directly raised a bare <c>KeyNotFoundException</c>
-    /// from inside a paint pass, naming neither the value nor the rule.
+    /// in its place -- and neither has any value outside the enum's declared
+    /// members. Indexing <see cref="Colors"/> directly raised a bare
+    /// <c>KeyNotFoundException</c> from inside a paint pass, naming neither
+    /// the value nor the rule.
     /// </summary>
     private static Color Preset(TabColor color)
         => Colors.TryGetValue(color, out var rgb)
             ? rgb
             : throw new ArgumentOutOfRangeException(
                 nameof(color), color,
-                "TabColor.None has no preset: it means \"no tint\", so the caller "
-                + "chooses what to paint instead. A group cannot be None -- use "
-                + nameof(EnsureGroupColor) + ".");
+                // The message must not name None: this fires for any value
+                // with no preset, and an out-of-range integer arriving from a
+                // persisted session is the case most in need of being read
+                // literally.
+                color == TabColor.None
+                    ? "TabColor.None has no preset: it means \"no tint\", so the caller "
+                      + "chooses what to paint instead. A group cannot be None -- use "
+                      + nameof(EnsureGroupColor) + "."
+                    : "no preset for this value: it is not a declared TabColor. A group "
+                      + "colour restored from a session is not validated by the JSON "
+                      + "reader -- pass it through " + nameof(EnsureGroupColor) + " first.");
 
     /// <summary>Selected tab/header fill uses the full preset color.</summary>
     public const byte SelectedBackgroundAlpha = 255;

--- a/windows/Ghostty.Core/Tabs/TabGroup.cs
+++ b/windows/Ghostty.Core/Tabs/TabGroup.cs
@@ -42,12 +42,26 @@ internal sealed class TabGroup : INotifyPropertyChanged
     /// <summary>
     /// Swatch shared with the per-tab tint palette: a group has no "no
     /// color" state, so the default is the palette's first swatch.
+    ///
+    /// The setter enforces that rather than trusting its writers, because
+    /// the writers cannot all be checked: the colour picker renders
+    /// <c>PaletteRows</c>, which leads with <see cref="TabColor.None"/>, and
+    /// it is opened for a group from two places; a restored session replays
+    /// whatever the last run persisted. The paint sites downstream index the
+    /// palette with no guard -- chip swatch and ink, run label, vertical
+    /// header row, and the switcher's card, ring and dot -- so a None
+    /// arriving here surfaced as a KeyNotFoundException in the middle of a
+    /// paint pass instead of at the point that wrote it.
     /// </summary>
     public TabColor Color
     {
         get => field;
-        set { if (field != value) { field = value; Raise(); } }
-    } = TabColor.Blue;
+        set
+        {
+            var resolved = TabColorPalette.EnsureGroupColor(value);
+            if (field != resolved) { field = resolved; Raise(); }
+        }
+    } = TabColorPalette.DefaultGroupColor;
 
     /// <summary>
     /// One bit shared by both strip modes, so a layout switch mid-collapse

--- a/windows/Ghostty.Tests/Tabs/TabColorSwatchAutomationTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabColorSwatchAutomationTests.cs
@@ -110,6 +110,13 @@ public class TabColorSwatchAutomationTests
     /// Flattening PaletteRows only stays faithful to the macOS layout if
     /// the grid wraps where the rows ended AND fills row-major. Vertical
     /// orientation would reinterpret the same wrap count as five rows.
+    ///
+    /// That faithfulness is the TAB picker's. A group picker is built with
+    /// allowNone: false, so it renders nine swatches into the same wrap of
+    /// five and reads 5 + 4; the wrap point no longer coincides with a
+    /// PaletteRows boundary there. This still guards the thing it always
+    /// guarded -- that the literal below tracks the palette's row width --
+    /// but it is not a statement about every picker.
     /// </summary>
     [Fact]
     public void WrapPoint_MatchesPaletteRowWidth()

--- a/windows/Ghostty.Tests/Tabs/TabGroupColorTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabGroupColorTests.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using Ghostty.Core.Tabs;
+using Xunit;
+
+namespace Ghostty.Tests.Tabs;
+
+/// <summary>
+/// A group has no "no color" state, and its paint sites index the palette
+/// with no guard. These pin that invariant at the model, because the two
+/// places that open a colour picker for a group and the session restore
+/// path are three writers, and guarding writers is what let None through in
+/// the first place.
+/// </summary>
+public class TabGroupColorTests
+{
+    [Fact]
+    public void Group_color_defaults_to_a_paintable_swatch()
+    {
+        var group = new TabGroup();
+
+        Assert.NotEqual(TabColor.None, group.Color);
+        Assert.Equal(TabColorPalette.DefaultGroupColor, group.Color);
+        Assert.True(TabColorPalette.Colors.ContainsKey(group.Color));
+    }
+
+    [Fact]
+    public void Setting_group_color_to_None_falls_back_instead_of_storing_it()
+    {
+        var group = new TabGroup { Color = TabColor.Red };
+
+        group.Color = TabColor.None;
+
+        Assert.Equal(TabColorPalette.DefaultGroupColor, group.Color);
+    }
+
+    [Fact]
+    public void A_None_write_that_changes_nothing_raises_nothing()
+    {
+        // The group already holds the default, so coercing None to the
+        // default is not a change -- the INPC contract is about the value
+        // that lands, not the value that was offered. Without this the ink
+        // pass would repaint on every no-op write.
+        var group = new TabGroup();
+        var raised = new List<string?>();
+        ((INotifyPropertyChanged)group).PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        group.Color = TabColor.None;
+
+        Assert.Empty(raised);
+    }
+
+    [Fact]
+    public void A_None_write_that_does_change_the_value_raises_once()
+    {
+        var group = new TabGroup { Color = TabColor.Teal };
+        var raised = new List<string?>();
+        ((INotifyPropertyChanged)group).PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        group.Color = TabColor.None;
+
+        Assert.Single(raised);
+        Assert.Equal(nameof(TabGroup.Color), raised[0]);
+    }
+
+    [Fact]
+    public void A_restored_group_saved_as_None_comes_back_paintable()
+    {
+        // RestoreGroup documents that it repairs rather than crashes on
+        // corrupt saved state. A colour is saved state like any other: a
+        // session written before the picker stopped offering None replays
+        // None here on every launch.
+        var mgr = new TabManager((_) => new FakePaneHost());
+        var group = mgr.RestoreGroup(
+            Guid.NewGuid(), "restored", TabColor.None,
+            collapsed: false, new[] { mgr.ActiveTab });
+
+        Assert.Equal(TabColorPalette.DefaultGroupColor, group.Color);
+    }
+
+    [Fact]
+    public void Every_group_paint_helper_takes_every_colour_a_group_can_hold()
+    {
+        // The end-to-end claim: whatever anyone writes, the helpers the
+        // chip swatch, chip ink, run label, vertical header and switcher
+        // card call cannot throw.
+        foreach (var offered in Enum.GetValues<TabColor>())
+        {
+            var group = new TabGroup { Color = offered };
+
+            TabColorPalette.Background(group.Color, selected: false);
+            TabColorPalette.Background(group.Color, selected: true);
+            TabColorPalette.Border(group.Color);
+            TabColorPalette.EffectiveBackgroundRgb(group.Color, selected: false, 0x1E1E1E);
+            TabColorPalette.ForegroundRgb(group.Color, selected: false, 0x1E1E1E);
+        }
+    }
+
+    [Fact]
+    public void EnsureGroupColor_replaces_None_and_passes_everything_else_through()
+    {
+        // Not a [Theory]: TabColor is internal, so it cannot appear in a
+        // public test signature (CS0051).
+        Assert.Equal(TabColorPalette.DefaultGroupColor,
+            TabColorPalette.EnsureGroupColor(TabColor.None));
+
+        foreach (var color in Enum.GetValues<TabColor>())
+        {
+            if (color == TabColor.None) continue;
+            Assert.Equal(color, TabColorPalette.EnsureGroupColor(color));
+        }
+    }
+
+    [Fact]
+    public void The_palette_refuses_None_by_name_rather_than_by_dictionary_miss()
+    {
+        // None is still invalid for the tab helpers -- it means "no tint",
+        // and each tab paint site picks a different brush for it. What
+        // changed is that the refusal says so: the old failure was a bare
+        // KeyNotFoundException raised inside a paint pass, naming neither
+        // the argument nor the rule.
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => TabColorPalette.Background(TabColor.None, selected: false));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => TabColorPalette.Border(TabColor.None));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => TabColorPalette.EffectiveBackgroundRgb(TabColor.None, selected: false, 0x1E1E1E));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => TabColorPalette.ForegroundRgb(TabColor.None, selected: false, 0x1E1E1E));
+
+        var thrown = Assert.Throws<ArgumentOutOfRangeException>(
+            () => TabColorPalette.Border(TabColor.None));
+        Assert.Contains("no tint", thrown.Message);
+    }
+
+    [Fact]
+    public void A_tab_still_holds_None_because_that_is_how_a_tint_is_cleared()
+    {
+        // The coercion is the GROUP's rule. If it ever leaks onto TabModel
+        // the tab palette loses its "no colour" state and every tab paints
+        // tinted, so this is the guard against fixing the wrong type.
+        var mgr = new TabManager((_) => new FakePaneHost());
+        var tab = mgr.ActiveTab;
+
+        tab.Color = TabColor.Red;
+        tab.Color = TabColor.None;
+
+        Assert.Equal(TabColor.None, tab.Color);
+    }
+}

--- a/windows/Ghostty.Tests/Tabs/TabGroupColorTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabGroupColorTests.cs
@@ -115,8 +115,9 @@ public class TabGroupColorTests
             () => TabColorPalette.Border((TabColor)42));
 
         Assert.Equal((TabColor)42, thrown.ActualValue);
-        Assert.DoesNotContain("TabColor.None", thrown.Message);
         Assert.Contains("not a declared TabColor", thrown.Message);
+        // The None branch's wording must not reach a value that is not None.
+        Assert.DoesNotContain("no tint", thrown.Message);
     }
 
     [Fact]

--- a/windows/Ghostty.Tests/Tabs/TabGroupColorTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabGroupColorTests.cs
@@ -8,10 +8,16 @@ namespace Ghostty.Tests.Tabs;
 
 /// <summary>
 /// A group has no "no color" state, and its paint sites index the palette
-/// with no guard. These pin that invariant at the model, because the two
-/// places that open a colour picker for a group and the session restore
-/// path are three writers, and guarding writers is what let None through in
-/// the first place.
+/// with no guard. These pin that invariant at the model, because guarding
+/// writers is what let None through in the first place.
+///
+/// There are two writers, not three: <c>PaneActionRouter.RequestColorGroup</c>
+/// (which both group pickers funnel through) and <c>TabManager.RestoreGroup</c>.
+/// The pickers are two CONSTRUCTION sites sharing one writer, and it was the
+/// shared writer that got overlooked.
+///
+/// The invariant is "the colour has a palette entry", which is stronger than
+/// "the colour is not None" and is the one the paint sites actually need.
 /// </summary>
 public class TabGroupColorTests
 {
@@ -80,12 +86,51 @@ public class TabGroupColorTests
     }
 
     [Fact]
+    public void A_group_colour_with_no_palette_entry_falls_back_too()
+    {
+        // Not hypothetical. GroupSession.Color is a plain TabColor and the
+        // session context defines no string converter, so it round-trips as a
+        // NUMBER -- and System.Text.Json does not check that a numeric enum is
+        // a defined member. A hand-edited session, or one written by a build
+        // with an extra swatch, replays an undefined value through
+        // RestoreGroup on every launch. Guarding None alone let that reach the
+        // same mid-paint crash under a different integer.
+        var mgr = new TabManager((_) => new FakePaneHost());
+        var group = mgr.RestoreGroup(
+            Guid.NewGuid(), "from a newer build", (TabColor)42,
+            collapsed: false, new[] { mgr.ActiveTab });
+
+        Assert.Equal(TabColorPalette.DefaultGroupColor, group.Color);
+        TabColorPalette.Background(group.Color, selected: false);
+    }
+
+    [Fact]
+    public void The_palette_names_the_value_it_refused_not_always_None()
+    {
+        // The message exists so a crash names the argument and the rule. It
+        // said "TabColor.None has no preset" for every miss, which is a lie
+        // for the out-of-range case -- the one most in need of reading
+        // literally, since it arrives from a file rather than from code.
+        var thrown = Assert.Throws<ArgumentOutOfRangeException>(
+            () => TabColorPalette.Border((TabColor)42));
+
+        Assert.Equal((TabColor)42, thrown.ActualValue);
+        Assert.DoesNotContain("TabColor.None", thrown.Message);
+        Assert.Contains("not a declared TabColor", thrown.Message);
+    }
+
+    [Fact]
     public void Every_group_paint_helper_takes_every_colour_a_group_can_hold()
     {
         // The end-to-end claim: whatever anyone writes, the helpers the
         // chip swatch, chip ink, run label, vertical header and switcher
         // card call cannot throw.
-        foreach (var offered in Enum.GetValues<TabColor>())
+        // Declared members plus values that are not members at all, since the
+        // restore path can produce either.
+        var offeredValues = Enum.GetValues<TabColor>()
+            .Concat(new[] { (TabColor)42, (TabColor)(-1), (TabColor)int.MaxValue });
+
+        foreach (var offered in offeredValues)
         {
             var group = new TabGroup { Color = offered };
 

--- a/windows/Ghostty.Tests/Wiring/TabColorPickerNoneWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabColorPickerNoneWiringTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Xunit;
 
@@ -105,9 +106,16 @@ public class TabColorPickerNoneWiringTests
             .Where(c => c.Identifier.ValueText == "TabColorPalettePicker")
             .ToList();
         var ctor = Assert.Single(ctors);
+
+        // `p.Default is null` is the half that matters. Without it,
+        // `bool allowNone = true` passes: one-argument construction is back
+        // and defaulting to the permissive answer, which is exactly the
+        // failure mode the deleted overload was.
         Assert.Contains(
             ctor.ParameterList.Parameters,
-            p => p.Identifier.ValueText == "allowNone" && p.Type?.ToString() == "bool");
+            p => p.Identifier.ValueText == "allowNone"
+                 && p.Type?.ToString() == "bool"
+                 && p.Default is null);
     }
 
     [Fact]
@@ -123,6 +131,18 @@ public class TabColorPickerNoneWiringTests
         // Asserting the rendered string would also fail the equivalent
         // `!allowNone && color == TabColor.None`, which is the same rule.
         var and = Assert.IsType<BinaryExpressionSyntax>(skip.Condition);
+
+        // The OPERATOR, not just the shape. && and || are both a
+        // BinaryExpressionSyntax and differ only by Kind, so without this the
+        // operand checks below pass for `||` -- which drops the None swatch
+        // from the TAB picker too and takes away the only way to clear a
+        // tint. Moving this assertion off string equality is what opened
+        // that hole; string equality had pinned the operator for free.
+        Assert.True(
+            and.IsKind(SyntaxKind.LogicalAndExpression),
+            "the None skip must be an AND -- an OR drops the swatch for tabs "
+            + "as well, and clearing a tab's tint becomes impossible: " + skip.Condition);
+
         var operands = new[] { and.Left.ToString(), and.Right.ToString() };
         Assert.Contains("color == TabColor.None", operands);
         Assert.Contains("!allowNone", operands);

--- a/windows/Ghostty.Tests/Wiring/TabColorPickerNoneWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabColorPickerNoneWiringTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -15,7 +16,6 @@ namespace Ghostty.Tests.Wiring;
 public class TabColorPickerNoneWiringTests
 {
     private static ShellSource Builder() => ShellSource.Load("Tabs.TabContextMenuBuilder.cs");
-    private static ShellSource Window() => ShellSource.Load("Ghostty.MainWindow.xaml.cs");
     private static ShellSource Picker() => ShellSource.Load("Tabs.TabColorPalettePicker.xaml.cs");
 
     /// <summary>
@@ -49,8 +49,8 @@ public class TabColorPickerNoneWiringTests
         var overloads = Builder().Root.DescendantNodes().OfType<MethodDeclarationSyntax>()
             .Where(m => m.Identifier.ValueText == "ShowColorPicker")
             .ToList();
-        var tabRoute = Assert.Single(overloads.Where(m => m.ParameterList.Parameters
-            .Any(p => p.Type?.ToString() == "TabModel")));
+        var tabRoute = Assert.Single(
+            overloads, m => m.ParameterList.Parameters.Any(p => p.Type?.ToString() == "TabModel"));
 
         var forwarded = tabRoute.Call("ShowColorPicker");
         AssertAllowNone(forwarded.ArgumentList, "true", "the per-tab ShowColorPicker");
@@ -59,19 +59,55 @@ public class TabColorPickerNoneWiringTests
     [Fact]
     public void EveryPickerBuiltForAGroup_IsBuiltWithoutNone()
     {
-        // A file-wide rule rather than one naming MainWindow's line: the
-        // defect was that a second entry point existed and nobody checked
-        // it, so a third must fail this rather than slip past it.
-        foreach (var source in new[] { Window(), Builder(), Picker() })
-        {
-            var built = source.Root.DescendantNodes().OfType<ObjectCreationExpressionSyntax>()
-                .Where(o => o.Type.ToString() == "TabColorPalettePicker")
-                .Where(o => o.ArgumentList is { Arguments.Count: > 0 }
-                            && o.ArgumentList.Arguments[0].ToString().Contains("group"));
+        // Swept across the WHOLE shell, not three named files. The defect was
+        // that a second entry point existed and nobody checked it; a third in
+        // a file this test did not think to name has to fail here rather than
+        // slip past, and VerticalTabHost already owns a group context-menu
+        // route that could grow one.
+        var groupBuilds = new List<(string Resource, ObjectCreationExpressionSyntax Creation)>();
+        var anyBuild = 0;
 
-            foreach (var creation in built)
-                AssertAllowNone(creation.ArgumentList!, "false", creation.ToString());
+        foreach (var (resource, root) in ShellSource.AllShellSources())
+        {
+            foreach (var creation in root.DescendantNodes().OfType<ObjectCreationExpressionSyntax>())
+            {
+                if (creation.Type.ToString() != "TabColorPalettePicker") continue;
+                if (creation.ArgumentList is not { Arguments.Count: > 0 } args) continue;
+                anyBuild++;
+
+                // "Built for a group" is decided by the argument's text, which
+                // is why the count below is asserted: rename the variable and
+                // this filter stops matching, silently.
+                if (args.Arguments[0].ToString().Contains("group"))
+                    groupBuilds.Add((resource, creation));
+            }
         }
+
+        Assert.True(anyBuild > 0, "found no TabColorPalettePicker construction at all");
+        Assert.True(
+            groupBuilds.Count == 1,
+            "expected exactly one picker built for a group (MainWindow's strip route); "
+                + "found " + groupBuilds.Count + ". A new one must pass allowNone: false, "
+                + "and a disappearing one means the arg[0] text stopped saying 'group' and "
+                + "this rule stopped matching: "
+                + string.Join(", ", groupBuilds.Select(b => b.Resource)));
+
+        foreach (var (_, creation) in groupBuilds)
+            AssertAllowNone(creation.ArgumentList!, "false", creation.ToString());
+    }
+
+    [Fact]
+    public void ThePicker_TakesTheFlagFromItsOnlyConstructor()
+    {
+        // No single-argument overload: every caller decides, because the
+        // permissive answer is the one that was wrong.
+        var ctors = Picker().Root.DescendantNodes().OfType<ConstructorDeclarationSyntax>()
+            .Where(c => c.Identifier.ValueText == "TabColorPalettePicker")
+            .ToList();
+        var ctor = Assert.Single(ctors);
+        Assert.Contains(
+            ctor.ParameterList.Parameters,
+            p => p.Identifier.ValueText == "allowNone" && p.Type?.ToString() == "bool");
     }
 
     [Fact]
@@ -82,10 +118,21 @@ public class TabColorPickerNoneWiringTests
         var skip = build.DescendantNodes().OfType<IfStatementSyntax>()
             .Single(i => i.Condition.ToString().Contains("TabColor.None"));
 
-        // Polarity, both halves. `color == None` alone would drop the swatch
-        // for tabs too; `!allowNone` alone would drop every swatch.
-        Assert.Equal("color == TabColor.None && !allowNone", skip.Condition.ToString());
-        Assert.Contains("continue", skip.Statement.ToString());
+        // Polarity as NODES, not as spelling. `color == None` alone would drop
+        // the swatch for tabs too; `!allowNone` alone would drop every swatch.
+        // Asserting the rendered string would also fail the equivalent
+        // `!allowNone && color == TabColor.None`, which is the same rule.
+        var and = Assert.IsType<BinaryExpressionSyntax>(skip.Condition);
+        var operands = new[] { and.Left.ToString(), and.Right.ToString() };
+        Assert.Contains("color == TabColor.None", operands);
+        Assert.Contains("!allowNone", operands);
+
+        // A `continue`, not the text "continue" somewhere in the statement:
+        // Log("continue") satisfied the substring form.
+        Assert.True(
+            skip.Statement is ContinueStatementSyntax
+                || skip.Statement.DescendantNodesAndSelf().OfType<ContinueStatementSyntax>().Any(),
+            "the None skip does not continue the loop: " + skip.Statement);
 
         // And the flag reaches it: BuildSwatches taking the parameter while
         // the constructor never forwards it would leave every check above

--- a/windows/Ghostty.Tests/Wiring/TabColorPickerNoneWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabColorPickerNoneWiringTests.cs
@@ -1,0 +1,101 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// The picker is opened for a group from two places and for a tab from one,
+/// and only the tab admits <see cref="Ghostty.Core.Tabs.TabColor.None"/>.
+/// Guarding call sites is what let None reach a group in the first place, so
+/// the model coerces (TabGroupColorTests) and these guards keep the UI from
+/// offering a swatch the model will refuse.
+/// </summary>
+public class TabColorPickerNoneWiringTests
+{
+    private static ShellSource Builder() => ShellSource.Load("Tabs.TabContextMenuBuilder.cs");
+    private static ShellSource Window() => ShellSource.Load("Ghostty.MainWindow.xaml.cs");
+    private static ShellSource Picker() => ShellSource.Load("Tabs.TabColorPalettePicker.xaml.cs");
+
+    /// <summary>
+    /// Named rather than positional, and asserted as the literal `false`:
+    /// `allowNone: !isGroup` or a variable would satisfy "an argument is
+    /// present" while deciding at runtime what this test exists to fix.
+    /// </summary>
+    private static void AssertAllowNone(ArgumentListSyntax args, string expected, string where)
+    {
+        var arg = args.Arguments.SingleOrDefault(a => a.NameColon?.Name.ToString() == "allowNone");
+        Assert.True(arg is not null, $"{where} does not pass allowNone by name: {args}");
+        Assert.Equal(expected, arg!.Expression.ToString());
+    }
+
+    [Fact]
+    public void TheGroupMenu_OpensThePicker_WithoutNone()
+    {
+        var menu = Builder().Method("BuildGroupMenu");
+        var call = menu.Call("ShowColorPicker");
+
+        Assert.Equal("group.Color", call.Arg(1));
+        AssertAllowNone(call.ArgumentList, "false", "the group menu's ShowColorPicker");
+    }
+
+    [Fact]
+    public void TheTabRoute_KeepsNone_BecauseThatIsHowATintIsCleared()
+    {
+        // The inverse guard. Without it, "no None anywhere" would pass by
+        // taking the clear-colour affordance away from every tab, which is
+        // a bigger regression than the crash this fixes.
+        var overloads = Builder().Root.DescendantNodes().OfType<MethodDeclarationSyntax>()
+            .Where(m => m.Identifier.ValueText == "ShowColorPicker")
+            .ToList();
+        var tabRoute = Assert.Single(overloads.Where(m => m.ParameterList.Parameters
+            .Any(p => p.Type?.ToString() == "TabModel")));
+
+        var forwarded = tabRoute.Call("ShowColorPicker");
+        AssertAllowNone(forwarded.ArgumentList, "true", "the per-tab ShowColorPicker");
+    }
+
+    [Fact]
+    public void EveryPickerBuiltForAGroup_IsBuiltWithoutNone()
+    {
+        // A file-wide rule rather than one naming MainWindow's line: the
+        // defect was that a second entry point existed and nobody checked
+        // it, so a third must fail this rather than slip past it.
+        foreach (var source in new[] { Window(), Builder(), Picker() })
+        {
+            var built = source.Root.DescendantNodes().OfType<ObjectCreationExpressionSyntax>()
+                .Where(o => o.Type.ToString() == "TabColorPalettePicker")
+                .Where(o => o.ArgumentList is { Arguments.Count: > 0 }
+                            && o.ArgumentList.Arguments[0].ToString().Contains("group"));
+
+            foreach (var creation in built)
+                AssertAllowNone(creation.ArgumentList!, "false", creation.ToString());
+        }
+    }
+
+    [Fact]
+    public void ThePicker_SkipsTheNoneSwatch_OnlyWhenItWasToldTo()
+    {
+        var build = Picker().Method("BuildSwatches");
+
+        var skip = build.DescendantNodes().OfType<IfStatementSyntax>()
+            .Single(i => i.Condition.ToString().Contains("TabColor.None"));
+
+        // Polarity, both halves. `color == None` alone would drop the swatch
+        // for tabs too; `!allowNone` alone would drop every swatch.
+        Assert.Equal("color == TabColor.None && !allowNone", skip.Condition.ToString());
+        Assert.Contains("continue", skip.Statement.ToString());
+
+        // And the flag reaches it: BuildSwatches taking the parameter while
+        // the constructor never forwards it would leave every check above
+        // green and every picker unchanged.
+        Assert.Contains(
+            build.ParameterList.Parameters,
+            p => p.Identifier.ValueText == "allowNone" && p.Type?.ToString() == "bool");
+        var forwarded = Picker().Root.DescendantNodes().OfType<ConstructorDeclarationSyntax>()
+            .SelectMany(c => c.Calls("BuildSwatches"))
+            .Single();
+        Assert.Equal("allowNone", forwarded.Arg(1));
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/VerticalTabGroupCommandsWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/VerticalTabGroupCommandsWiringTests.cs
@@ -393,8 +393,13 @@ public class VerticalTabGroupCommandsWiringTests
         Assert.Contains("0, old)", raise.ToString());
 
         var color = Router().Method("RequestColorGroup");
+        // The no-op refusal compares the RESOLVED colour, not the offered one:
+        // TabGroup.Color coerces a value with no preset, so a group already
+        // wearing the default that is offered one would otherwise pass this
+        // guard, set nothing, raise no INPC, and still announce a change.
         var sameColor = color.DescendantNodes().OfType<IfStatementSyntax>()
-            .Single(i => i.Condition.ToString() == "group.Color == color");
+            .Single(i => i.Condition.ToString()
+                == "group.Color == TabColorPalette.EnsureGroupColor(color)");
         var colorSet = color.DescendantNodes().OfType<AssignmentExpressionSyntax>()
             .Single(a => a.Left.ToString() == "group.Color");
         var colorRaise = color.Calls("GroupChangedFromCommand?.Invoke").Single();

--- a/windows/Ghostty.Tests/Wiring/VerticalTabGroupCommandsWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/VerticalTabGroupCommandsWiringTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Xunit;
 
@@ -397,9 +398,19 @@ public class VerticalTabGroupCommandsWiringTests
         // TabGroup.Color coerces a value with no preset, so a group already
         // wearing the default that is offered one would otherwise pass this
         // guard, set nothing, raise no INPC, and still announce a change.
-        var sameColor = color.DescendantNodes().OfType<IfStatementSyntax>()
-            .Single(i => i.Condition.ToString()
-                == "group.Color == TabColorPalette.EnsureGroupColor(color)");
+        // Read as nodes, not as spelling: `EnsureGroupColor(color) == group.Color`
+        // is the same rule and string equality would fail it.
+        var sameColor = Assert.Single(
+            color.DescendantNodes().OfType<IfStatementSyntax>(),
+            i => i.Condition is BinaryExpressionSyntax cmp
+                 && cmp.IsKind(SyntaxKind.EqualsExpression)
+                 && new[] { cmp.Left.ToString(), cmp.Right.ToString() }
+                        .Order(System.StringComparer.Ordinal)
+                        .SequenceEqual(new[]
+                        {
+                            "TabColorPalette.EnsureGroupColor(color)",
+                            "group.Color",
+                        }.Order(System.StringComparer.Ordinal)));
         var colorSet = color.DescendantNodes().OfType<AssignmentExpressionSyntax>()
             .Single(a => a.Left.ToString() == "group.Color");
         var colorRaise = color.Calls("GroupChangedFromCommand?.Invoke").Single();

--- a/windows/Ghostty/Input/PaneActionRouter.cs
+++ b/windows/Ghostty/Input/PaneActionRouter.cs
@@ -680,7 +680,13 @@ internal sealed class PaneActionRouter
     public void RequestColorGroup(TabGroup group, TabColor color)
     {
         if (!_tabs.Groups.Contains(group)) return;
-        if (group.Color == color) return;
+        // Compared after resolution, because the setter resolves: a group
+        // already wearing the default that is handed a colour with no preset
+        // is asked for no change at all. Comparing the OFFERED value let that
+        // through, and the announcement below then told a screen reader the
+        // colour had changed while nothing repainted, because the model
+        // correctly raised no INPC.
+        if (group.Color == TabColorPalette.EnsureGroupColor(color)) return;
         group.Color = color;
         GroupChangedFromCommand?.Invoke(this, new(GroupCommandKind.Colored, group, null, 0));
     }

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1140,7 +1140,10 @@ public sealed partial class MainWindow : Window
         {
             var anchor = _tabManager.ActiveTab is { } tab ? _tabHost.TabElement(tab) : null;
             if (anchor is null) return;
-            var picker = new TabColorPalettePicker(group.Color);
+            // The strip's group-colour route, the twin of the context menu's.
+            // Both open the picker for a group, so both refuse None: a group
+            // has no "no color" state (see TabGroup.Color).
+            var picker = new TabColorPalettePicker(group.Color, allowNone: false);
             var pickerFlyout = new Flyout
             {
                 Content = picker,

--- a/windows/Ghostty/Tabs/TabColorPalettePicker.xaml
+++ b/windows/Ghostty/Tabs/TabColorPalettePicker.xaml
@@ -134,6 +134,11 @@
             point below folds that flat sequence back into 2x5, and a test ties
             it to the row width rather than to this literal.
 
+            2x5 is the TAB picker. A group picker skips the None swatch, so its
+            flat sequence is nine long, still wraps at five, and reads 5 + 4
+            with Orange moved up a row. The grid is a claim about the full
+            palette, not about every picker built from it.
+
             A GridView rather than the Buttons SnapZonePicker uses, or a
             RadioButtons group: the applied colour has to reach a client as a
             selected item and not only as a drawn ring, and a radio group checks

--- a/windows/Ghostty/Tabs/TabColorPalettePicker.xaml.cs
+++ b/windows/Ghostty/Tabs/TabColorPalettePicker.xaml.cs
@@ -67,7 +67,18 @@ internal sealed partial class TabColorPalettePicker : UserControl
     /// </summary>
     private bool _openedFocus;
 
-    public TabColorPalettePicker(TabColor initial)
+    /// <summary>
+    /// A tab admits <see cref="TabColor.None"/> -- it is how a tint is
+    /// cleared -- so that is the default.
+    /// </summary>
+    public TabColorPalettePicker(TabColor initial) : this(initial, allowNone: true) { }
+
+    /// <param name="allowNone">
+    /// Whether the None swatch is offered. False for a group: a group has no
+    /// "no color" state, and offering None let the UI ask for a value the
+    /// model refuses, which read to the user as a swatch that does nothing.
+    /// </param>
+    public TabColorPalettePicker(TabColor initial, bool allowNone)
     {
         InitializeComponent();
 
@@ -77,7 +88,7 @@ internal sealed partial class TabColorPalettePicker : UserControl
         // tree (see the XAML), and LabeledBy would point into nothing.
         AutomationProperties.SetName(Swatches, PaletteLabel.Text);
 
-        BuildSwatches(initial);
+        BuildSwatches(initial, allowNone);
 
         Loaded += (_, _) =>
         {
@@ -91,7 +102,7 @@ internal sealed partial class TabColorPalettePicker : UserControl
         };
     }
 
-    private void BuildSwatches(TabColor initial)
+    private void BuildSwatches(TabColor initial, bool allowNone)
     {
         // TabColorPalette.PaletteRows is the macOS-derived layout, kept in
         // Ghostty.Core so platform divergence stays in one file. Flattening
@@ -100,6 +111,11 @@ internal sealed partial class TabColorPalettePicker : UserControl
         {
             foreach (var color in row)
             {
+                // Skipped rather than disabled: a disabled first swatch is
+                // still a tab stop the keyboard lands on, and the row would
+                // open with a hole where the palette's first entry belongs.
+                if (color == TabColor.None && !allowNone) continue;
+
                 var swatch = BuildSwatch(color);
                 _colors[swatch] = color;
                 Swatches.Items.Add(swatch);

--- a/windows/Ghostty/Tabs/TabColorPalettePicker.xaml.cs
+++ b/windows/Ghostty/Tabs/TabColorPalettePicker.xaml.cs
@@ -67,16 +67,15 @@ internal sealed partial class TabColorPalettePicker : UserControl
     /// </summary>
     private bool _openedFocus;
 
-    /// <summary>
-    /// A tab admits <see cref="TabColor.None"/> -- it is how a tint is
-    /// cleared -- so that is the default.
-    /// </summary>
-    public TabColorPalettePicker(TabColor initial) : this(initial, allowNone: true) { }
-
     /// <param name="allowNone">
     /// Whether the None swatch is offered. False for a group: a group has no
     /// "no color" state, and offering None let the UI ask for a value the
     /// model refuses, which read to the user as a swatch that does nothing.
+    ///
+    /// No single-argument overload defaulting this to true, deliberately.
+    /// Every caller has to decide, because the permissive answer is the one
+    /// that was wrong, and a defaulted parameter is how a fourth entry point
+    /// would get it without anyone thinking about it.
     /// </param>
     public TabColorPalettePicker(TabColor initial, bool allowNone)
     {
@@ -86,6 +85,11 @@ internal sealed partial class TabColorPalettePicker : UserControl
         // name from the visible heading rather than repeating the string.
         // Set rather than LabeledBy: the heading is out of the automation
         // tree (see the XAML), and LabeledBy would point into nothing.
+        //
+        // The heading reads "Tab Color", which is wrong for the group picker:
+        // a screen reader would announce a tab while the user recolours a
+        // group. The control knows which it is, so it says so.
+        if (!allowNone) PaletteLabel.Text = "Group Color";
         AutomationProperties.SetName(Swatches, PaletteLabel.Text);
 
         BuildSwatches(initial, allowNone);
@@ -107,6 +111,12 @@ internal sealed partial class TabColorPalettePicker : UserControl
         // TabColorPalette.PaletteRows is the macOS-derived layout, kept in
         // Ghostty.Core so platform divergence stays in one file. Flattening
         // it here and letting the panel wrap keeps that ordering authoritative.
+        //
+        // That equivalence holds for the TAB picker only. Dropping None
+        // shortens the flat sequence to nine, and the panel still wraps at
+        // five, so the group picker reads 5 + 4 and Orange moves up a row --
+        // the macOS 2x5 grid is a claim about the full palette, not about
+        // every picker built from it.
         foreach (var row in TabColorPalette.PaletteRows)
         {
             foreach (var color in row)
@@ -124,9 +134,12 @@ internal sealed partial class TabColorPalettePicker : UserControl
             }
         }
 
-        // Only reachable if TabColor gains a member PaletteRows does not
-        // list. Opening on None misreports the tab by one swatch; opening
-        // with nothing selected and nothing focused strands the keyboard.
+        // Reachable two ways: a TabColor that PaletteRows does not list, or
+        // None on a picker that skipped it. Opening on the wrong swatch
+        // misreports by one; opening with nothing selected and nothing
+        // focused strands the keyboard, which is worse. Items[0] is the
+        // palette's first offered colour, which for a group is
+        // DefaultGroupColor -- the value the model would have coerced to.
         Swatches.SelectedItem ??= Swatches.Items[0];
     }
 
@@ -177,7 +190,9 @@ internal sealed partial class TabColorPalettePicker : UserControl
         }
         else
         {
-            var drawing = TabColorPalette.Colors[color];
+            // Border, not Colors[...]: same opaque preset, but through the one
+            // door that refuses an unpaintable value by name.
+            var drawing = TabColorPalette.Border(color);
             ellipse.Fill = new SolidColorBrush(
                 Windows.UI.Color.FromArgb(255, drawing.R, drawing.G, drawing.B));
             tile.Children.Add(ellipse);

--- a/windows/Ghostty/Tabs/TabContextMenuBuilder.cs
+++ b/windows/Ghostty/Tabs/TabContextMenuBuilder.cs
@@ -272,7 +272,10 @@ internal static class TabContextMenuBuilder
         {
             var target = flyout.Target as FrameworkElement;
             if (target is null) return;
-            ShowColorPicker(target, group.Color, c => requestColorGroup(group, c));
+            // allowNone: a group has no "no color" state, so None is not
+            // offered here -- see TabGroup.Color.
+            ShowColorPicker(target, group.Color, c => requestColorGroup(group, c),
+                allowNone: false);
         };
         flyout.Items.Add(color);
 
@@ -306,15 +309,15 @@ internal static class TabContextMenuBuilder
     }
 
     private static void ShowColorPicker(FrameworkElement anchor, TabModel tab)
-        => ShowColorPicker(anchor, tab.Color, color => tab.Color = color);
+        => ShowColorPicker(anchor, tab.Color, color => tab.Color = color, allowNone: true);
 
     private static void ShowColorPicker(
-        FrameworkElement anchor, TabColor initial, Action<TabColor> apply)
+        FrameworkElement anchor, TabColor initial, Action<TabColor> apply, bool allowNone)
     {
         // Build the secondary flyout fresh each invocation. Cheap, and
         // avoids any stale selection-ring state from the previous
         // right-click.
-        var picker = new TabColorPalettePicker(initial);
+        var picker = new TabColorPalettePicker(initial, allowNone);
         var subFlyout = new Flyout
         {
             Content = picker,

--- a/windows/Ghostty/Tabs/TabOverviewControl.xaml.cs
+++ b/windows/Ghostty/Tabs/TabOverviewControl.xaml.cs
@@ -200,7 +200,9 @@ internal sealed partial class TabOverviewControl : UserControl
         };
         if (tab.Color != TabColor.None)
         {
-            var c = TabColorPalette.Colors[tab.Color];
+            // Border, not Colors[...]: same opaque preset, but through the one
+            // door that refuses an unpaintable value by name.
+            var c = TabColorPalette.Border(tab.Color);
             dot.Fill = new SolidColorBrush(Color.FromArgb(0xFF, c.R, c.G, c.B));
         }
         Grid.SetColumn(dot, 0);


### PR DESCRIPTION
Closes #894.

`TabGroup.Color` is documented as having no "no color" state, and eight paint sites rely on it — chip swatch and ink, run label, vertical header row, and the switcher's card, ring and dot all index the palette with no guard. The colour picker renders `PaletteRows`, which leads with `None`, and it is opened for a group from two places. The rule now lives on the **model**: the setter resolves, so the unguarded indexing downstream is guaranteed rather than assumed.

## The invariant is "has a preset", not "is not None"

That distinction is the whole fix, and an earlier revision of this PR got it wrong by guarding `None` alone.

`GroupSession.Color` is a plain `TabColor` and the session context defines **no string converter**, so it round-trips as a *number* — and `System.Text.Json` does not check that a numeric enum is a defined member. A hand-edited session, or one written by a build with an extra swatch, replays a `(TabColor)42` through `RestoreGroup` on every launch and lands in the same mid-paint crash under a different integer, on the one path whose own doc promises it *"repairs, never crashes, on corrupt saved state"*. `EnsureGroupColor` is `Colors.ContainsKey(...)`, which is also self-evidently total.

**Consequence, chosen deliberately:** coercing at the model means the value is *persisted* coerced, so a session from a future build with an extra swatch comes back as the default and is saved that way. That is a repair for a corrupt value and a downgrade loss for a forward one. Keeping the raw value and coercing at the paint boundary would preserve the colour and give up the property every paint site depends on. One lineage, no downgrade story: the invariant is worth more than the swatch.

## Two corrections to the report

- **The switcher's `:172` is not an unguarded tab site.** `var colored = tab.Color != TabColor.None;` sits two lines above it. Every tab site is guarded; every group site is unguarded *by design*.
- **The picker itself was never at risk** — it branches on `None` before indexing.

There are also **two** writers, not three: `PaneActionRouter.RequestColorGroup` (which both pickers funnel through) and `TabManager.RestoreGroup`. The pickers are two *construction* sites sharing one writer, and the shared one is what got overlooked — it change-detected on the **offered** value while the model resolved, so a no-op write announced a colour change to a screen reader while nothing repainted.

## Guards

The picker gains an `allowNone` parameter with **no defaulted overload** — every caller decides, because the permissive answer is the one that was wrong.

Watched red, each against the mutation it exists to catch:

| mutation | test that went red |
|---|---|
| `EnsureGroupColor` back to guarding `None` only | 2 of `TabGroupColorTests`, incl. the restore path |
| router compares the offered value | `RenameAndColorRequests_GuardBeforeSet_BeforeRaise` |
| group menu / MainWindow back to `allowNone: true` | the two call-site guards |
| picker's skip loses `&& !allowNone` | `ThePicker_SkipsTheNoneSwatch_OnlyWhenItWasToldTo` |
| picker's skip rewritten as `\|\|` | same |
| `bool allowNone = true` default reintroduced | `ThePicker_TakesTheFlagFromItsOnlyConstructor` |
| MainWindow's picker argument renamed | `EveryPickerBuiltForAGroup_IsBuiltWithoutNone` |

The last three exist because review found earlier versions of those guards were unsound. `EveryPickerBuiltForAGroup` scanned three hardcoded files and filtered on the text `"group"` with no non-empty assertion — it asserted on exactly one line, and only because a lambda parameter happened to be spelled that way; it sweeps `AllShellSources()` and pins the count now. The skip assertion was moved off string equality and, in doing so, stopped pinning the **operator**: `&&` and `||` are both a `BinaryExpressionSyntax`, so `||` would have passed while silently removing the None swatch from the *tab* picker, making a tint impossible to clear.

The original crash reproduces exactly, as `KeyNotFoundException: The given key 'None' was not present in the dictionary`, when the coercion is removed — the issue had only traced it in source.

**3266** pass in `Ghostty.Tests`, and `Ghostty.csproj` builds with 0 errors.

## Recorded, not changed

Dropping `None` shortens the flat sequence to nine while the panel still wraps at five, so the group picker reads 5 + 4 with Orange moved up a row. The macOS 2×5 grid is a claim about the full palette, not about every picker built from it; the XAML comment and `WrapPoint_MatchesPaletteRowWidth` now say which.

## Not covered

There is no seam op for group colour, so the UI half has a Roslyn guard and no harness-level oracle.
