### PR TITLE
win32: a failed coordinate conversion stops passing for a measurement

### DIFF
--- a/windows/Ghostty.Tests/Wiring/Win32CoordinateFailureWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/Win32CoordinateFailureWiringTests.cs
@@ -1,63 +1,136 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Xunit;
 
 namespace Ghostty.Tests.Wiring;
 
 /// <summary>
-/// Win32 coordinate conversions whose failure is indistinguishable from
-/// success: they signal through the return value and leave the point or rect
-/// they were handed untouched, so a discarded BOOL turns unconverted input
-/// into confidently-wrong output. <c>ClientToScreen</c> is the one that bit
-/// us (issue #896) -- client coordinates returned labelled as screen ones,
-/// at two seam sites that decide which pixels a harness samples.
+/// Win32 calls whose failure is indistinguishable from success: they signal
+/// through the return value and leave the point or rect they were handed
+/// untouched, so a discarded result turns unconverted input into confidently
+/// wrong output. <c>ClientToScreen</c> is the one that bit us (issue #896):
+/// client coordinates returned labelled as screen ones, at two seam sites
+/// that decide which pixels a harness samples.
 ///
-/// A corpus rule rather than three named lines, because the defect was that
-/// a fourth call site existed and nobody was looking for it.
+/// A corpus rule rather than named lines, because the defect was that another
+/// call site existed and nobody was looking for it.
+///
+/// Matching is on the callee's SIMPLE NAME, not on a <c>PInvoke.</c> prefix.
+/// This codebase uses two Win32 idioms -- CsWin32's generated <c>PInvoke</c>
+/// class and hand-rolled <c>[LibraryImport]</c> partials -- and a rule that
+/// saw only the first would have been blind to
+/// <c>TrayIconService.ShowContextMenu</c>, which discarded a
+/// <c>GetCursorPos</c> and fed the untouched point straight to
+/// <c>TrackPopupMenu</c>. That is the same defect this file exists for, in a
+/// spelling the first version of this rule could not see.
+///
+/// KNOWN BLIND SPOT: <see cref="ShellSource.AllShellSources"/> parses with
+/// DEMO, DEBUG and TESTSEAM defined and, unlike <see cref="ShellSource.Load"/>,
+/// does not refuse a tree with regions it cannot see. A call inside an
+/// <c>#else</c> or <c>#if !DEBUG</c> would therefore be invisible here. No
+/// such region exists in the shell today (every conditional is a bare
+/// <c>#if</c> on one of those three symbols), which is why this is recorded
+/// rather than solved; the day one appears, this rule needs a text-level
+/// companion, as <see cref="ShellSource.ParseForCorpusScan"/> spells out.
 /// </summary>
 public class Win32CoordinateFailureWiringTests
 {
     /// <summary>
-    /// Calls that report failure ONLY through their return value. Deliberately
-    /// not every PInvoke: a call whose out-parameter is checked anyway, or
-    /// whose failure is visible, does not need this rule and adding it here
-    /// would make the guard noisy enough to be suppressed.
+    /// Calls of this shape that the corpus actually makes. Each must match at
+    /// least one call site: a rule enforcing nothing is worse than no rule,
+    /// because it reads as coverage.
     /// </summary>
-    private static readonly string[] Silent =
+    private static readonly string[] Enforced =
     {
-        "PInvoke.ClientToScreen",
-        "PInvoke.ScreenToClient",
-        "PInvoke.GetWindowRect",
-        "PInvoke.GetClientRect",
-        "PInvoke.MapWindowPoints",
+        "ClientToScreen",
+        "GetWindowRect",
+        "GetCursorPos",
+        "GetWindowPlacement",
+        "GetMonitorInfo",
+        "GetMonitorInfoW",
+    };
+
+    /// <summary>
+    /// Same shape, not used here yet. Listed so the rule is already in force
+    /// the day one appears, and kept separate from <see cref="Enforced"/> so
+    /// their absence cannot be mistaken for coverage.
+    /// </summary>
+    private static readonly string[] Forward =
+    {
+        "ScreenToClient",
+        "GetClientRect",
+        "MapWindowPoints",
+    };
+
+    /// <summary>
+    /// The callee's simple name, receiver ignored: <c>PInvoke.GetCursorPos</c>
+    /// and a bare <c>GetCursorPos</c> are the same API and the same hazard.
+    /// </summary>
+    private static string? SimpleName(InvocationExpressionSyntax call) => call.Expression switch
+    {
+        IdentifierNameSyntax id => id.Identifier.ValueText,
+        MemberAccessExpressionSyntax member => member.Name.Identifier.ValueText,
+        _ => null,
+    };
+
+    /// <summary>
+    /// Whether the result is thrown away. Three unambiguous forms; a fourth
+    /// (<c>var ok = Call(); // never read</c>) needs a semantic model and is
+    /// not covered, so what this proves is that the value was CONSUMED, not
+    /// that it was acted on. A lambda body is not treated as a discard either,
+    /// because whether the delegate returns the bool cannot be told from
+    /// syntax alone.
+    /// </summary>
+    private static bool ResultIsDiscarded(InvocationExpressionSyntax call) => call.Parent switch
+    {
+        // Call();
+        ExpressionStatementSyntax => true,
+
+        // _ = Call();  -- an assignment, but to nothing.
+        AssignmentExpressionSyntax assign
+            when assign.IsKind(SyntaxKind.SimpleAssignmentExpression)
+                 && assign.Left is IdentifierNameSyntax { Identifier.ValueText: "_" } => true,
+
+        // void Member() => Call();  -- an expression body on a void-returning
+        // member consumes nothing. A non-void one returns it to its caller.
+        ArrowExpressionClauseSyntax arrow
+            when arrow.Parent is MethodDeclarationSyntax { ReturnType: PredefinedTypeSyntax rt }
+                 && rt.Keyword.IsKind(SyntaxKind.VoidKeyword) => true,
+
+        _ => false,
     };
 
     [Fact]
     public void NoSilentCoordinateConversion_HasItsFailureDiscarded()
     {
+        var watched = Enforced.Concat(Forward).ToHashSet();
         var discarded = new List<string>();
-        var seen = 0;
+        var hits = watched.ToDictionary(n => n, _ => 0);
 
         foreach (var (resource, root) in ShellSource.AllShellSources())
         {
             foreach (var call in root.DescendantNodes().OfType<InvocationExpressionSyntax>())
             {
-                if (!Silent.Contains(call.CalleeText())) continue;
-                seen++;
+                if (SimpleName(call) is not { } name || !watched.Contains(name)) continue;
+                hits[name]++;
 
-                // A bare expression statement is the whole defect: the BOOL
-                // is computed and dropped. Anywhere else -- an `if (!...)`,
-                // an assignment, a return -- something reads it.
-                if (call.Parent is ExpressionStatementSyntax)
+                if (ResultIsDiscarded(call))
                     discarded.Add($"{resource}: {call}");
             }
         }
 
-        // Load-bearing: this rule is worthless the day the callee spelling
-        // changes and the scan quietly matches nothing.
-        Assert.True(seen > 0, "found no calls to scan: " + string.Join(", ", Silent));
+        // Per name, not in aggregate. A single total hides a rule that stopped
+        // matching: five names finding nothing while the sixth finds four
+        // still leaves the count comfortably positive.
+        var silent = Enforced.Where(n => hits[n] == 0).ToList();
+        Assert.True(
+            silent.Count == 0,
+            "these calls are declared enforced but match no call site, so their rule "
+                + "proves nothing -- either the corpus stopped making them (move them to "
+                + $"Forward) or the match stopped working: {string.Join(", ", silent)}");
 
         Assert.True(
             discarded.Count == 0,

--- a/windows/Ghostty.Tests/Wiring/Win32CoordinateFailureWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/Win32CoordinateFailureWiringTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -50,7 +51,11 @@ public class Win32CoordinateFailureWiringTests
         "GetCursorPos",
         "GetWindowPlacement",
         "GetMonitorInfo",
-        "GetMonitorInfoW",
+        // Fills a caller-supplied buffer and reports only through the return.
+        // A discarded failure reads as "high contrast off" / "no screen
+        // reader", which is the confidently-wrong answer in the one subsystem
+        // where being wrong is an accessibility defect.
+        "SystemParametersInfo",
     };
 
     /// <summary>
@@ -68,13 +73,30 @@ public class Win32CoordinateFailureWiringTests
     /// <summary>
     /// The callee's simple name, receiver ignored: <c>PInvoke.GetCursorPos</c>
     /// and a bare <c>GetCursorPos</c> are the same API and the same hazard.
+    /// The member-binding arm is the <c>x?.Call()</c> form -- unreachable for
+    /// static P/Invokes today, but <c>SyntaxQueries.CalleeText</c> in this same
+    /// assembly already handles it, so forgetting it here would be this file
+    /// re-learning the lesson it exists to teach.
+    ///
+    /// A trailing W or A is dropped, so a hand-rolled <c>GetMonitorInfoW</c>
+    /// and CsWin32's <c>GetMonitorInfo</c> are one API rather than two entries
+    /// that both have to keep matching. Nothing watched here legitimately ends
+    /// in W or A.
     /// </summary>
-    private static string? SimpleName(InvocationExpressionSyntax call) => call.Expression switch
+    private static string? SimpleName(InvocationExpressionSyntax call)
     {
-        IdentifierNameSyntax id => id.Identifier.ValueText,
-        MemberAccessExpressionSyntax member => member.Name.Identifier.ValueText,
-        _ => null,
-    };
+        var raw = call.Expression switch
+        {
+            IdentifierNameSyntax id => id.Identifier.ValueText,
+            MemberAccessExpressionSyntax member => member.Name.Identifier.ValueText,
+            MemberBindingExpressionSyntax bind => bind.Name.Identifier.ValueText,
+            _ => null,
+        };
+        if (raw is null) return null;
+        return raw.Length > 1 && (raw[^1] == 'W' || raw[^1] == 'A')
+            ? raw[..^1]
+            : raw;
+    }
 
     /// <summary>
     /// Whether the result is thrown away. Three unambiguous forms; a fourth
@@ -94,11 +116,27 @@ public class Win32CoordinateFailureWiringTests
             when assign.IsKind(SyntaxKind.SimpleAssignmentExpression)
                  && assign.Left is IdentifierNameSyntax { Identifier.ValueText: "_" } => true,
 
-        // void Member() => Call();  -- an expression body on a void-returning
-        // member consumes nothing. A non-void one returns it to its caller.
-        ArrowExpressionClauseSyntax arrow
-            when arrow.Parent is MethodDeclarationSyntax { ReturnType: PredefinedTypeSyntax rt }
-                 && rt.Keyword.IsKind(SyntaxKind.VoidKeyword) => true,
+        // var _ = Call();  -- syntactically unambiguous intent to discard.
+        // `var ok = Call();` with ok never read is the case that genuinely
+        // needs a semantic model; this one does not.
+        EqualsValueClauseSyntax { Parent: VariableDeclaratorSyntax { Identifier.ValueText: "_" } } => true,
+
+        // Member() => Call();  on anything void-returning consumes nothing.
+        // A non-void member returns it to its caller, so only void counts.
+        // Methods, local functions and property/indexer setters all have this
+        // shape; an accessor has no return type of its own, and a set/init
+        // accessor is void by definition.
+        ArrowExpressionClauseSyntax arrow => arrow.Parent switch
+        {
+            MethodDeclarationSyntax { ReturnType: PredefinedTypeSyntax m }
+                when m.Keyword.IsKind(SyntaxKind.VoidKeyword) => true,
+            LocalFunctionStatementSyntax { ReturnType: PredefinedTypeSyntax l }
+                when l.Keyword.IsKind(SyntaxKind.VoidKeyword) => true,
+            AccessorDeclarationSyntax acc
+                when acc.IsKind(SyntaxKind.SetAccessorDeclaration)
+                     || acc.IsKind(SyntaxKind.InitAccessorDeclaration) => true,
+            _ => false,
+        },
 
         _ => false,
     };
@@ -138,5 +176,51 @@ public class Win32CoordinateFailureWiringTests
                 + "leave their point/rect untouched when they fail -- so a discarded "
                 + "result is unconverted coordinates reported as converted:\n  "
                 + string.Join("\n  ", discarded));
+    }
+
+    /// <summary>
+    /// The tripwire for the blind spot named above.
+    ///
+    /// <see cref="ShellSource.AllShellSources"/> parses with DEMO, DEBUG and
+    /// TESTSEAM defined, so an <c>#else</c>, <c>#elif</c> or <c>#if !</c>
+    /// region is invisible to the sweep and a call inside one would be
+    /// reported as covered. Recording that in a doc comment is not a guard --
+    /// nothing announces the day it stops being hypothetical, which is round
+    /// one's finding (a site nobody was looking for) wearing different
+    /// clothes. This is the text-level companion
+    /// <see cref="ShellSource.ParseForCorpusScan"/> says such a caller owes.
+    /// </summary>
+    [Fact]
+    public void NoShellSource_HidesCodeFromTheCorpusSweep()
+    {
+        var hidden = new List<string>();
+        var scanned = 0;
+
+        foreach (var (tail, text) in ShellSource.AllUnder("Ghostty.Tests.Interop.Sources.Ghostty."))
+        {
+            scanned++;
+            var lines = text.Split('\n');
+            for (var i = 0; i < lines.Length; i++)
+            {
+                var line = lines[i].TrimStart();
+                if (line.StartsWith("#else", StringComparison.Ordinal)
+                    || line.StartsWith("#elif", StringComparison.Ordinal)
+                    || line.StartsWith("#if !", StringComparison.Ordinal))
+                {
+                    hidden.Add($"{tail}:{i + 1}: {line.TrimEnd()}");
+                }
+            }
+        }
+
+        Assert.True(scanned > 0, "the shell-source sweep found no files to read");
+        Assert.True(
+            hidden.Count == 0,
+            "these conditional regions are invisible to every scan built on "
+                + "AllShellSources, which parses with DEMO, DEBUG and TESTSEAM defined "
+                + "and keeps the opposite branch as disabled trivia. A Win32 call "
+                + "discarded inside one would be reported as covered. Either restructure "
+                + "so the code is not hidden, or give the affected rules a text-level "
+                + "companion and exempt the file here deliberately:\n  "
+                + string.Join("\n  ", hidden));
     }
 }

--- a/windows/Ghostty.Tests/Wiring/Win32CoordinateFailureWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/Win32CoordinateFailureWiringTests.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// Win32 coordinate conversions whose failure is indistinguishable from
+/// success: they signal through the return value and leave the point or rect
+/// they were handed untouched, so a discarded BOOL turns unconverted input
+/// into confidently-wrong output. <c>ClientToScreen</c> is the one that bit
+/// us (issue #896) -- client coordinates returned labelled as screen ones,
+/// at two seam sites that decide which pixels a harness samples.
+///
+/// A corpus rule rather than three named lines, because the defect was that
+/// a fourth call site existed and nobody was looking for it.
+/// </summary>
+public class Win32CoordinateFailureWiringTests
+{
+    /// <summary>
+    /// Calls that report failure ONLY through their return value. Deliberately
+    /// not every PInvoke: a call whose out-parameter is checked anyway, or
+    /// whose failure is visible, does not need this rule and adding it here
+    /// would make the guard noisy enough to be suppressed.
+    /// </summary>
+    private static readonly string[] Silent =
+    {
+        "PInvoke.ClientToScreen",
+        "PInvoke.ScreenToClient",
+        "PInvoke.GetWindowRect",
+        "PInvoke.GetClientRect",
+        "PInvoke.MapWindowPoints",
+    };
+
+    [Fact]
+    public void NoSilentCoordinateConversion_HasItsFailureDiscarded()
+    {
+        var discarded = new List<string>();
+        var seen = 0;
+
+        foreach (var (resource, root) in ShellSource.AllShellSources())
+        {
+            foreach (var call in root.DescendantNodes().OfType<InvocationExpressionSyntax>())
+            {
+                if (!Silent.Contains(call.CalleeText())) continue;
+                seen++;
+
+                // A bare expression statement is the whole defect: the BOOL
+                // is computed and dropped. Anywhere else -- an `if (!...)`,
+                // an assignment, a return -- something reads it.
+                if (call.Parent is ExpressionStatementSyntax)
+                    discarded.Add($"{resource}: {call}");
+            }
+        }
+
+        // Load-bearing: this rule is worthless the day the callee spelling
+        // changes and the scan quietly matches nothing.
+        Assert.True(seen > 0, "found no calls to scan: " + string.Join(", ", Silent));
+
+        Assert.True(
+            discarded.Count == 0,
+            "these Win32 calls signal failure only through their return value, and "
+                + "leave their point/rect untouched when they fail -- so a discarded "
+                + "result is unconverted coordinates reported as converted:\n  "
+                + string.Join("\n  ", discarded));
+    }
+}

--- a/windows/Ghostty/Branding/SystemMenuPopup.cs
+++ b/windows/Ghostty/Branding/SystemMenuPopup.cs
@@ -51,7 +51,12 @@ internal static class SystemMenuPopup
         var clientPoint = new System.Drawing.Point(
             (int)(bottomLeftDip.X * scale),
             (int)(bottomLeftDip.Y * scale));
-        PInvoke.ClientToScreen(hwnd, ref clientPoint);
+        // Checked, the way ShowForWindow already checks GetWindowRect below:
+        // a discarded failure leaves clientPoint in CLIENT coordinates and
+        // the menu opens somewhere else on screen. The realistic failure is
+        // a window that has gone away, where TrackPopupMenu has nothing to
+        // anchor to either.
+        if (!PInvoke.ClientToScreen(hwnd, ref clientPoint)) return;
 
         Track(hwnd, clientPoint.X, clientPoint.Y);
     }

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -334,8 +334,13 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
             // The panel's offset is in DIPs relative to the window content; the
             // window's client origin is already in physical screen pixels, so
             // only the former is scaled.
+            // A discarded failure here leaves the point at (0,0), and the
+            // geometry then claims the terminal viewport sits at the screen
+            // origin -- a plausible rectangle, so IsUsable accepts it and a
+            // screen reader is told where the text is with confidence.
             var client = new System.Drawing.Point(0, 0);
-            PInvoke.ClientToScreen(new Windows.Win32.Foundation.HWND(hwnd), ref client);
+            if (!PInvoke.ClientToScreen(new Windows.Win32.Foundation.HWND(hwnd), ref client))
+                return null;
             var scale = xamlRoot.RasterizationScale;
             var offset = Panel.TransformToVisual(root)
                 .TransformPoint(new Windows.Foundation.Point(0, 0));

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -214,7 +214,10 @@ public sealed partial class MainWindow : Window
 
     /// <summary>
     /// The first switcher tile's pane-preview rect in screen pixels, or null
-    /// when the cycle popup is not up. A pixel oracle cannot locate this
+    /// when the cycle popup is not up, when the preview has no XamlRoot, or
+    /// when the client-to-screen conversion failed -- the last of which is a
+    /// harness miss and not a measurement, which is why it is a null here and
+    /// not a rect. A pixel oracle cannot locate this
     /// surface the way it locates the tile's title: the preview body is a
     /// bare Canvas, which gets no automation peer and so never appears in
     /// the UIA tree. Screen pixels because that is the space a window
@@ -1811,16 +1814,19 @@ public sealed partial class MainWindow : Window
     ///
     /// DPI contract: <c>GetCursorPos</c> returns physical pixel
     /// coordinates in virtual desktop space. <c>DisplayArea.GetFromPoint</c>
-    /// consumes physical pixels. The two line up without scaling.
+    /// consumes physical pixels. The two line up without scaling. The
+    /// fallback below shares that contract: <c>AppWindow.Position</c> is a
+    /// <c>PointInt32</c> in the same raw physical screen space, which is what
+    /// makes it substitutable for the cursor here.
     /// </summary>
     private Ghostty.Core.Windows.PlacementRect ComputeCursorAnchoredPlacement(MainWindow target)
     {
         // A discarded failure leaves pt at (0,0), which is a real coordinate:
         // the new window would anchor to the corner of the primary monitor
-        // and nothing would say why. Falling back to the source window's own
-        // position keeps the rest of this method honest, since it opens the
-        // new window beside the one that spawned it rather than at a place
-        // the cursor never was.
+        // and nothing would say why. The source window's own position is the
+        // fallback -- Compute offsets by 32 and clamps, so the new window
+        // lands essentially on top of the one that spawned it, on the right
+        // monitor, rather than at a place the cursor never was.
         if (!PInvoke.GetCursorPos(out var pt))
         {
             var origin = AppWindow.Position;
@@ -4370,29 +4376,32 @@ public sealed partial class MainWindow : Window
         var style = (WINDOW_STYLE)PInvoke.GetWindowLong(hwnd, WINDOW_LONG_PTR_INDEX.GWL_STYLE);
         var isMaximized = (style & WINDOW_STYLE.WS_MAXIMIZE) != 0;
         var g = new Ghostty.Core.Session.WindowGeometry { Maximized = isMaximized };
-        var placement = new WINDOWPLACEMENT { length = (uint)Marshal.SizeOf<WINDOWPLACEMENT>() };
-        // A discarded failure leaves rcNormalPosition all zeros, and this
-        // window's restore geometry is then persisted as 0,0,0,0 -- the next
-        // launch un-maximizes into a degenerate window. The AppWindow branch
-        // below is the wrong answer for a maximized window (it saves the
-        // maximized rect as the restored size, which is what rcNormalPosition
-        // exists to avoid), but it is a usable window rather than a broken
-        // one, so a failure falls through to it.
-        if (isMaximized && PInvoke.GetWindowPlacement(hwnd, ref placement))
+        if (isMaximized)
         {
-            var rc = placement.rcNormalPosition;
-            g.X = rc.left;
-            g.Y = rc.top;
-            g.Width = rc.right - rc.left;
-            g.Height = rc.bottom - rc.top;
+            // A discarded failure leaves rcNormalPosition all zeros, and this
+            // window's restore geometry is then persisted as 0,0,0,0 -- the
+            // next launch un-maximizes into a degenerate window. Falling
+            // through to the AppWindow bounds is the wrong answer in the
+            // small way (it saves the maximized rect as the restored size,
+            // which is exactly what rcNormalPosition exists to avoid) and the
+            // right one in the large: a monitor-sized window rather than a
+            // broken one.
+            var placement = new WINDOWPLACEMENT { length = (uint)Marshal.SizeOf<WINDOWPLACEMENT>() };
+            if (PInvoke.GetWindowPlacement(hwnd, ref placement))
+            {
+                var rc = placement.rcNormalPosition;
+                g.X = rc.left;
+                g.Y = rc.top;
+                g.Width = rc.right - rc.left;
+                g.Height = rc.bottom - rc.top;
+                return g;
+            }
         }
-        else
-        {
-            g.X = AppWindow.Position.X;
-            g.Y = AppWindow.Position.Y;
-            g.Width = AppWindow.Size.Width;
-            g.Height = AppWindow.Size.Height;
-        }
+
+        g.X = AppWindow.Position.X;
+        g.Y = AppWindow.Position.Y;
+        g.Width = AppWindow.Size.Width;
+        g.Height = AppWindow.Size.Height;
         return g;
     }
 

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1815,7 +1815,17 @@ public sealed partial class MainWindow : Window
     /// </summary>
     private Ghostty.Core.Windows.PlacementRect ComputeCursorAnchoredPlacement(MainWindow target)
     {
-        PInvoke.GetCursorPos(out var pt);
+        // A discarded failure leaves pt at (0,0), which is a real coordinate:
+        // the new window would anchor to the corner of the primary monitor
+        // and nothing would say why. Falling back to the source window's own
+        // position keeps the rest of this method honest, since it opens the
+        // new window beside the one that spawned it rather than at a place
+        // the cursor never was.
+        if (!PInvoke.GetCursorPos(out var pt))
+        {
+            var origin = AppWindow.Position;
+            pt = new System.Drawing.Point(origin.X, origin.Y);
+        }
 
         var cursorPoint = new Windows.Graphics.PointInt32(pt.X, pt.Y);
         var display = Microsoft.UI.Windowing.DisplayArea.GetFromPoint(
@@ -4360,10 +4370,16 @@ public sealed partial class MainWindow : Window
         var style = (WINDOW_STYLE)PInvoke.GetWindowLong(hwnd, WINDOW_LONG_PTR_INDEX.GWL_STYLE);
         var isMaximized = (style & WINDOW_STYLE.WS_MAXIMIZE) != 0;
         var g = new Ghostty.Core.Session.WindowGeometry { Maximized = isMaximized };
-        if (isMaximized)
+        var placement = new WINDOWPLACEMENT { length = (uint)Marshal.SizeOf<WINDOWPLACEMENT>() };
+        // A discarded failure leaves rcNormalPosition all zeros, and this
+        // window's restore geometry is then persisted as 0,0,0,0 -- the next
+        // launch un-maximizes into a degenerate window. The AppWindow branch
+        // below is the wrong answer for a maximized window (it saves the
+        // maximized rect as the restored size, which is what rcNormalPosition
+        // exists to avoid), but it is a usable window rather than a broken
+        // one, so a failure falls through to it.
+        if (isMaximized && PInvoke.GetWindowPlacement(hwnd, ref placement))
         {
-            var placement = new WINDOWPLACEMENT { length = (uint)Marshal.SizeOf<WINDOWPLACEMENT>() };
-            PInvoke.GetWindowPlacement(hwnd, ref placement);
             var rc = placement.rcNormalPosition;
             g.X = rc.left;
             g.Y = rc.top;

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -170,7 +170,12 @@ public sealed partial class MainWindow : Window
         var scale = source.XamlRoot.RasterizationScale;
         var client = new System.Drawing.Point(
             (int)(origin.X * scale), (int)(origin.Y * scale));
-        PInvoke.ClientToScreen(new HWND(WindowNative.GetWindowHandle(this)), ref client);
+        // On failure ClientToScreen leaves the point untouched, so the
+        // client coordinates would be returned labelled as screen ones and
+        // nothing downstream could tell. For a seam rect that is not a
+        // missed measurement, it is a verdict about the wrong region.
+        if (!PInvoke.ClientToScreen(new HWND(WindowNative.GetWindowHandle(this)), ref client))
+            return null;
         return (client.X, client.Y,
             (int)(rect.Width * scale), (int)(rect.Height * scale));
     }
@@ -228,7 +233,8 @@ public sealed partial class MainWindow : Window
             .TransformPoint(new Windows.Foundation.Point(0, 0));
         var origin = new System.Drawing.Point(
             (int)(topLeft.X * scale), (int)(topLeft.Y * scale));
-        PInvoke.ClientToScreen(new HWND(WindowNative.GetWindowHandle(this)), ref origin);
+        if (!PInvoke.ClientToScreen(new HWND(WindowNative.GetWindowHandle(this)), ref origin))
+            return null;
         return (origin.X, origin.Y,
             (int)(body.ActualWidth * scale), (int)(body.ActualHeight * scale));
     }

--- a/windows/Ghostty/Shell/TrayIconService.cs
+++ b/windows/Ghostty/Shell/TrayIconService.cs
@@ -205,7 +205,12 @@ internal sealed unsafe partial class TrayIconService : IDisposable
             AppendMenuW(menu, MF_STRING, IDM_SHOW, "Show Wintty");
             AppendMenuW(menu, MF_SEPARATOR, 0, null);
             AppendMenuW(menu, MF_STRING, IDM_EXIT, "Exit");
-            GetCursorPos(out var pt);
+            // A discarded failure leaves pt at (0,0) and the menu opens in the
+            // corner of the primary monitor instead of at the cursor. The
+            // documented failure is "the input desktop is not the current
+            // desktop" (a lock or secure-desktop transition), where popping a
+            // menu at all is wrong, so this bails the way SystemMenuPopup does.
+            if (!GetCursorPos(out var pt)) return;
             // TrackPopupMenu requires the owning window to be foreground
             // (see SystemMenuPopup.Track / user32 docs).
             SetForegroundWindow(_messageHwnd);

--- a/windows/Ghostty/Testing/TestSeam.cs
+++ b/windows/Ghostty/Testing/TestSeam.cs
@@ -665,8 +665,14 @@ internal static class TestSeam
                 // is a bare Canvas and gets no automation peer, so the tile's
                 // title is the only thing in the tree. Read while the popup is
                 // up -- it dismisses itself on a 1.2s timer.
+                // Two reasons for null and the message says so, because they
+                // send an investigation in opposite directions: the popup was
+                // never up, or it was up and the client-to-screen conversion
+                // failed. Naming only the first sent a bisect after the popup
+                // lifetime for a coordinate failure.
                 if (window.TestSeamSwitcherPreviewRect() is not { } rect)
-                    return Error(op, "no switcher preview: the cycle popup is not up");
+                    return Error(op, "no switcher preview: either the cycle popup is "
+                        + "not up, or its rect could not be placed on screen");
                 return Json(json =>
                 {
                     json.WriteStartObject();


### PR DESCRIPTION
Closes #896.

`ClientToScreen` signals failure through its return value and leaves the point it was handed **untouched**, so a discarded `BOOL` returns client coordinates labelled as screen ones and nothing downstream can tell.

## Seven sites, not the three the issue named

Four `ClientToScreen`, plus three more of the same shape found during review:

| site | what a dropped failure did |
|---|---|
| `MainWindow.TestSeamToScreenPixels` | a seam rect measured in the wrong space |
| `MainWindow.TestSeamSwitcherPreviewRect` | same |
| `TerminalControl.AccessibilityViewportGeometry` | reported the terminal viewport at the **screen origin** to a screen reader — a plausible rectangle, so `IsUsable` accepted it |
| `SystemMenuPopup.ShowAt` | menu opened somewhere else |
| `TrayIconService.ShowContextMenu` | `GetCursorPos` discarded, untouched point fed to `TrackPopupMenu` |
| `MainWindow.ComputeCursorAnchoredPlacement` | `GetCursorPos` discarded, new window anchored at the screen origin |
| `MainWindow.CaptureGeometry` | `GetWindowPlacement` discarded, restore geometry persisted as `0,0,0,0` |

All seven now return, bail, or fall back. That matches what the codebase already argues: `TabHost.xaml.cs:118-121` says a rect nobody can vouch for is worse than no rect, and `SystemMenuPopup`'s own sibling three lines down already returns when `GetWindowRect` fails.

The two seam sites matter for a different reason than the rest, and the issue put it exactly right: a menu in the wrong place is visible and someone notices, but a seam rect decides *which pixels a harness samples*, so a silent failure there does not produce a miss — it produces a **verdict about the wrong region**.

## The guard matches the API, not the spelling

An earlier revision matched a `PInvoke.` prefix, which made it structurally blind to `TrayIconService` — a hand-rolled `[LibraryImport]`. This codebase uses **both** Win32 idioms, and a rule that sees one of them has a hole the size of the other. Matching is on the callee's simple name, receiver ignored, with a trailing `W`/`A` dropped so a hand-rolled `GetMonitorInfoW` and CsWin32's `GetMonitorInfo` are one API rather than two entries that both have to keep matching.

Watched names are split into **`Enforced`** (each must match at least one call site) and **`Forward`** (same shape, unused here), so an absence cannot be read as coverage. The canary is **per name**: one aggregate count hides a rule that stopped matching, because five names finding nothing while the sixth finds four still leaves the total comfortably positive.

`SystemParametersInfo` is in the enforced set. Both its call sites are accessibility detectors, where a dropped failure reads as "high contrast off" and "no screen reader" — the confidently-wrong answer in the one subsystem where being wrong is an accessibility defect.

**Discard detection** covers a bare `ExpressionStatement`, `_ = Call()`, `var _ = Call()`, and a void-returning expression body (method, local function, or set/init accessor). A lambda body is deliberately *not* a discard: whether the delegate returns the bool cannot be told from syntax. What the rule proves is that the value was **consumed**, not that it was acted on, and the file says so.

## The blind spot is now a tripwire, not a comment

`AllShellSources` parses with `DEMO`/`DEBUG`/`TESTSEAM` defined and, unlike `ShellSource.Load`, does not refuse regions it cannot see — so a call inside an `#else` would be reported as covered. Recording that in a doc comment left nothing to announce the day it stopped being hypothetical, which is this PR's own finding wearing different clothes. A text-level scan now refuses `#else`, `#elif` and `#if !` across the shell corpus, which is the companion rule `ParseForCorpusScan` says such a caller owes.

## Watched red

- `TrayIconService`'s discard restored → caught (the previous guard passed it).
- a `ClientToScreen` rewritten as `_ = ...` → caught.
- an enforced name that matches nothing → per-name canary fires.
- `SystemParametersInfo`'s check removed from `HighContrastDetector` → caught.
- a void expression-bodied discard added → caught (this branch had never been exercised).
- an `#if DEMO` flipped to `#if !DEMO` → tripwire reports it by file and line.

**3252** pass in `Ghostty.Tests`, and `Ghostty.csproj` builds with 0 errors — the wiring tests only *parse* these files, so the app project is what compiles them.

## Surveyed, not changed

`TransformToVisual`/`TransformPoint` are the same family but signal by **throwing**, and every site already wraps them; they are not in the scan list because that is not the silent shape this rule is about. `TrackPopupMenu`'s KB135788 `WM_NULL` workaround is missing at both menu sites, and `SetForegroundWindow`/`AppendMenuW` results are discarded nearby — all pre-existing, all a different failure shape, and folding them in would grow this past what it set out to do.
