### PR TITLE
demo: the gate stops depending on how the build was invoked

### DIFF
--- a/windows/Directory.Build.props
+++ b/windows/Directory.Build.props
@@ -4,38 +4,21 @@
     the Core demo logic) and for Release only when explicitly opted in with
     `-p:Demo=true`. Public Release builds define no DEMO symbol, so every file
     wrapped in `#if DEMO` compiles to nothing and ships zero demo bytes.
+
+    The gate itself is NOT here. It lives in Directory.Build.targets, beside
+    the test seam's identically shaped one, because Configuration is still
+    empty in this file: Microsoft.Common.props imports it before defaulting
+    Configuration to Debug, so a condition on '$(Configuration)' here matched
+    only when the value arrived as a global property. Visual Studio and
+    anything passing `-c` supplied one; `just build-win` and `just test-win`
+    do not, so DEMO went undefined for every just recipe and for the signoff
+    ladder, and three test classes compiled to nothing while the ladder
+    reported green.
+
+    Ghostty.csproj reads DemoEnabled from ItemGroup conditions and still sees
+    it from there: MSBuild evaluates every property, trailing imports
+    included, before it evaluates any item.
   -->
-  <PropertyGroup>
-    <!-- One source of truth for "is demo mode on?" so the DEMO constant and the
-         csproj Page/Compile/None conditions can't drift, and so a future
-         constant that merely contains the substring "DEMO" can't false-match. -->
-    <DemoEnabled Condition="'$(Demo)' == 'true' or '$(Configuration)' == 'Debug' or '$(Configuration)' == ''">true</DemoEnabled>
-    <DefineConstants Condition="'$(DemoEnabled)' == 'true'">$(DefineConstants);DEMO</DefineConstants>
-
-    <!--
-      The empty test is the whole fix, and it is not a belt-and-braces extra.
-      Microsoft.Common.props imports this file BEFORE it defaults Configuration
-      to Debug, so Configuration is empty here unless it arrived as a global
-      property (`-c Debug`, or Visual Studio). Without the empty case a bare
-      `dotnet build` left DemoEnabled unset and defined no DEMO, so whether
-      demo code was compiled at all depended on how a developer happened to
-      invoke the build, and it could rot behind a gate nothing was opening.
-      Empty here means Debug: it is the value Microsoft.Common.props is about
-      to assign, so this reads the configuration the build will actually use.
-
-      Deliberately NOT moved to Directory.Build.targets, which is where the
-      test seam's identically shaped gate lives. TESTSEAM is only a compiler
-      constant, and property evaluation still precedes CoreCompile, so a
-      .targets file is early enough for it. DemoEnabled is read by ItemGroup
-      conditions in Ghostty.csproj (they strip Demo\**\*.cs and
-      DemoOverlay.xaml from a non-demo build), and those evaluate with the
-      csproj body, long before Microsoft.Common.targets imports
-      Directory.Build.targets at the end. Setting it there would leave those
-      conditions reading an empty value: the constant would be defined while
-      the files it guards were excluded, which is a build error rather than a
-      silent gate, but a confusing one.
-    -->
-  </PropertyGroup>
   <!--
     'dotnet build' resolves AppxMSBuildToolsPath to the SDK directory which
     lacks the PRI/Appx task DLLs. These ship with Visual Studio Build Tools.

--- a/windows/Directory.Build.props
+++ b/windows/Directory.Build.props
@@ -9,21 +9,31 @@
     <!-- One source of truth for "is demo mode on?" so the DEMO constant and the
          csproj Page/Compile/None conditions can't drift, and so a future
          constant that merely contains the substring "DEMO" can't false-match. -->
-    <DemoEnabled Condition="'$(Demo)' == 'true' or '$(Configuration)' == 'Debug'">true</DemoEnabled>
+    <DemoEnabled Condition="'$(Demo)' == 'true' or '$(Configuration)' == 'Debug' or '$(Configuration)' == ''">true</DemoEnabled>
     <DefineConstants Condition="'$(DemoEnabled)' == 'true'">$(DefineConstants);DEMO</DefineConstants>
 
     <!--
-      NOTE: Configuration is still empty here. Microsoft.Common.props imports
-      this file before it defaults Configuration to Debug, so the condition
-      above only matches when Configuration arrives as a global property
-      (`-c Debug`, or Visual Studio). A bare `dotnet build` leaves DemoEnabled
-      unset and defines no DEMO, which is not what the comment above expects.
-      Left alone here: changing it changes what a Debug build contains, which
-      is a decision of its own rather than part of the seam work.
+      The empty test is the whole fix, and it is not a belt-and-braces extra.
+      Microsoft.Common.props imports this file BEFORE it defaults Configuration
+      to Debug, so Configuration is empty here unless it arrived as a global
+      property (`-c Debug`, or Visual Studio). Without the empty case a bare
+      `dotnet build` left DemoEnabled unset and defined no DEMO, so whether
+      demo code was compiled at all depended on how a developer happened to
+      invoke the build, and it could rot behind a gate nothing was opening.
+      Empty here means Debug: it is the value Microsoft.Common.props is about
+      to assign, so this reads the configuration the build will actually use.
 
-      The test seam's own gate is the same shape but cannot afford that
-      ambiguity, so it lives in Directory.Build.targets, which is imported
-      after Configuration is settled. See the comment there.
+      Deliberately NOT moved to Directory.Build.targets, which is where the
+      test seam's identically shaped gate lives. TESTSEAM is only a compiler
+      constant, and property evaluation still precedes CoreCompile, so a
+      .targets file is early enough for it. DemoEnabled is read by ItemGroup
+      conditions in Ghostty.csproj (they strip Demo\**\*.cs and
+      DemoOverlay.xaml from a non-demo build), and those evaluate with the
+      csproj body, long before Microsoft.Common.targets imports
+      Directory.Build.targets at the end. Setting it there would leave those
+      conditions reading an empty value: the constant would be defined while
+      the files it guards were excluded, which is a build error rather than a
+      silent gate, but a confusing one.
     -->
   </PropertyGroup>
   <!--

--- a/windows/Directory.Build.props
+++ b/windows/Directory.Build.props
@@ -5,6 +5,12 @@
     `-p:Demo=true`. Public Release builds define no DEMO symbol, so every file
     wrapped in `#if DEMO` compiles to nothing and ships zero demo bytes.
 
+    DO NOT EDIT THE FIRST FOUR LINES OF THIS FILE. The tiered build's
+    0011-windows__Directory.Build.props.patch anchors its hunk on `<Project>`
+    plus the three comment lines above, and materialize applies it with no
+    fuzz, so rewording them breaks every tier that carries the patch. This
+    paragraph and everything below it are safe to change.
+
     The gate itself is NOT here. It lives in Directory.Build.targets, beside
     the test seam's identically shaped one, because Configuration is still
     empty in this file: Microsoft.Common.props imports it before defaulting
@@ -51,8 +57,10 @@
     from anywhere, which is why KeybindListWinUiAbiTests scans source instead.
 
     Kept last in the file on purpose: the tiered build patches this props file
-    with a hunk anchored on the opening tag, and materialize applies it with
-    no fuzz, so anything inserted at the top breaks every tier that uses it.
+    with a hunk anchored on the first FOUR lines (the opening tag plus the
+    three comment lines under it, not the tag alone), and materialize applies
+    it with no fuzz, so anything inserted at the top, or any rewording of
+    those lines, breaks every tier that uses it.
   -->
   <PropertyGroup>
     <WarningsAsErrors>$(WarningsAsErrors);CsWinRT1028</WarningsAsErrors>

--- a/windows/Directory.Build.targets
+++ b/windows/Directory.Build.targets
@@ -26,4 +26,28 @@
     <TestSeamEnabled Condition="'$(TestSeam)' == 'true' or '$(Configuration)' == 'Debug'">true</TestSeamEnabled>
     <DefineConstants Condition="'$(TestSeamEnabled)' == 'true'">$(DefineConstants);TESTSEAM</DefineConstants>
   </PropertyGroup>
+
+  <!--
+    The demo-mode gate, here for the same reason and in the same shape.
+
+    It used to live in Directory.Build.props, where Configuration is still
+    empty, so it matched only when the value arrived as a global property.
+    Visual Studio and anything passing `-c` supplied one; `just build-win` and
+    `just test-win` pass only /p:Platform=x64, so DEMO went undefined for every
+    just recipe and therefore for the signoff ladder's windows-tests leg.
+    Three test classes compiled to nothing and the ladder called that green.
+
+    One source of truth for "is demo mode on?" so the DEMO constant and the
+    csproj Page/Compile/None conditions cannot drift, and so a future constant
+    that merely contains the substring "DEMO" cannot false-match.
+
+    Ghostty.csproj reads DemoEnabled from static ItemGroup conditions (they
+    strip Demo\**\*.cs and DemoOverlay.xaml from a non-demo build) and sees it
+    from here: MSBuild evaluates every property, trailing imports included,
+    before it evaluates any item.
+  -->
+  <PropertyGroup>
+    <DemoEnabled Condition="'$(Demo)' == 'true' or '$(Configuration)' == 'Debug'">true</DemoEnabled>
+    <DefineConstants Condition="'$(DemoEnabled)' == 'true'">$(DefineConstants);DEMO</DefineConstants>
+  </PropertyGroup>
 </Project>

--- a/windows/Ghostty.Tests/Demo/DemoGateTests.cs
+++ b/windows/Ghostty.Tests/Demo/DemoGateTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Linq;
+using Xunit;
+
+namespace Ghostty.Tests.Demo;
+
+/// <summary>
+/// The demo gate, asserted from inside the gate.
+///
+/// `DemoEnabled` is computed in windows/Directory.Build.props, where
+/// Configuration is still empty because Microsoft.Common.props imports that
+/// file before it defaults Configuration to Debug. For a long time the
+/// condition read only `'$(Configuration)' == 'Debug'`, so DEMO was defined
+/// from Visual Studio and from anything passing `-c`, and NOT from a bare
+/// `dotnet build` -- which is what every `just` recipe issues, `test-win`
+/// included, and therefore what the signoff ladder ran. Three test classes
+/// compiled to nothing and the ladder called that green.
+///
+/// This file is deliberately NOT wrapped in `#if DEMO`. A self-gated test
+/// vanishes with the thing it is testing, which is exactly the failure being
+/// guarded against: the whole point is to fail loudly when the constant is
+/// absent, not to disappear alongside it.
+/// </summary>
+public class DemoGateTests
+{
+    [Fact]
+    public void The_DEMO_constant_reaches_this_assembly()
+    {
+#if DEMO
+        Assert.True(true);
+#else
+        Assert.Fail(
+            "DEMO is not defined for this build, so the demo tests compiled to "
+            + "nothing and every other assertion about demo behaviour is vacuous. "
+            + "Check DemoEnabled in windows/Directory.Build.props: Configuration is "
+            + "empty there for a bare `dotnet build`, so the condition has to admit "
+            + "the empty case as well as 'Debug'.");
+#endif
+    }
+
+    [Fact]
+    public void The_gate_reaches_Ghostty_Core_too()
+    {
+        // A constant defined only for the test assembly would leave the code
+        // under test compiled out while these tests still ran -- green, and
+        // measuring nothing. Directory.Build.props sits above every project
+        // under windows/, so the Core demo types are the check that it did.
+        var core = typeof(Ghostty.Core.Tabs.TabModel).Assembly;
+        var demoTypes = core.GetTypes()
+            .Where(t => t.Namespace == "Ghostty.Core.Demo")
+            .Select(t => t.Name)
+            .ToList();
+
+        Assert.True(
+            demoTypes.Count > 0,
+            "Ghostty.Core carries no Ghostty.Core.Demo types, so DEMO was not "
+            + "defined when Core was compiled. If the constant test above passed, "
+            + "the gate reaches the test assembly but not Core, and something has "
+            + "scoped DemoEnabled below windows/. If it failed too, the gate is "
+            + "off everywhere and its message is the one to read.");
+    }
+}

--- a/windows/Ghostty.Tests/Demo/DemoGateTests.cs
+++ b/windows/Ghostty.Tests/Demo/DemoGateTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using Xunit;
 
 namespace Ghostty.Tests.Demo;
@@ -61,11 +60,16 @@ public class DemoGateTests
         Assert.Contains("'$(Demo)' == 'true'", condition!, StringComparison.Ordinal);
         Assert.DoesNotContain("Release", condition!, StringComparison.Ordinal);
 
-        // And the symbol is defined only when that property says so.
+        // And the symbol is defined only when that property says so. The
+        // condition is pinned exactly, the way TestSeamWiringTests pins the
+        // seam's: selecting on "contains DemoEnabled" and then asserting only
+        // that the value mentions DEMO accepts an INVERTED gate
+        // (`'$(DemoEnabled)' != 'true'`), which is the rule backwards.
         var define = Assert.Single(
             doc.Descendants(),
             e => e.Name.LocalName == "DefineConstants"
                  && (e.Attribute("Condition")?.Value.Contains("DemoEnabled", StringComparison.Ordinal) ?? false));
+        Assert.Equal("'$(DemoEnabled)' == 'true'", define.Attribute("Condition")?.Value);
         Assert.Contains("DEMO", define.Value, StringComparison.Ordinal);
     }
 

--- a/windows/Ghostty.Tests/Demo/DemoGateTests.cs
+++ b/windows/Ghostty.Tests/Demo/DemoGateTests.cs
@@ -5,58 +5,102 @@ using Xunit;
 namespace Ghostty.Tests.Demo;
 
 /// <summary>
-/// The demo gate, asserted from inside the gate.
+/// The demo gate.
 ///
-/// `DemoEnabled` is computed in windows/Directory.Build.props, where
-/// Configuration is still empty because Microsoft.Common.props imports that
-/// file before it defaults Configuration to Debug. For a long time the
-/// condition read only `'$(Configuration)' == 'Debug'`, so DEMO was defined
-/// from Visual Studio and from anything passing `-c`, and NOT from a bare
-/// `dotnet build` -- which is what every `just` recipe issues, `test-win`
-/// included, and therefore what the signoff ladder ran. Three test classes
-/// compiled to nothing and the ladder called that green.
+/// It used to live in <c>windows/Directory.Build.props</c>, where
+/// <c>Configuration</c> is still empty: <c>Microsoft.Common.props</c> imports
+/// that file before it defaults <c>Configuration</c> to <c>Debug</c>. The
+/// condition therefore matched only when the value arrived as a global
+/// property. Visual Studio and anything passing <c>-c</c> supplied one;
+/// <c>just build-win</c> and <c>just test-win</c> pass only
+/// <c>/p:Platform=x64</c>, so DEMO went undefined for every just recipe and
+/// so for the signoff ladder's windows-tests leg. Three test classes compiled
+/// to nothing and the ladder reported green.
 ///
-/// This file is deliberately NOT wrapped in `#if DEMO`. A self-gated test
-/// vanishes with the thing it is testing, which is exactly the failure being
-/// guarded against: the whole point is to fail loudly when the constant is
-/// absent, not to disappear alongside it.
+/// The primary guard reads the BUILD FILE, not this assembly's constants, and
+/// that is deliberate. A guard asserting `#if DEMO` here can only speak about
+/// the configuration it was itself compiled in, so it would fail every
+/// Release test run -- and the tiered build runs <c>dotnet test -c Release</c>
+/// across five cells, which the OSS ladder never exercises. A gate whose
+/// guard breaks a configuration the ladder cannot see is the same blind spot
+/// this whole change exists to close, one level up.
+///
+/// Same shape, and the same reasoning, as <c>TestSeamWiringTests</c>'s check
+/// on the seam gate three lines above it in that file.
 /// </summary>
 public class DemoGateTests
 {
+    private static System.Xml.Linq.XDocument BuildTargets()
+    {
+        var asm = System.Reflection.Assembly.GetExecutingAssembly();
+        using var stream = asm.GetManifestResourceStream(
+            "Ghostty.Tests.Build.Directory.Build.targets")!;
+        return System.Xml.Linq.XDocument.Load(stream);
+    }
+
     [Fact]
-    public void The_DEMO_constant_reaches_this_assembly()
+    public void The_demo_gate_reads_a_settled_Configuration()
+    {
+        var doc = BuildTargets();
+
+        // In Directory.Build.targets at all: that is the fix. In
+        // Directory.Build.props the condition below is evaluated against an
+        // empty Configuration and silently never matches.
+        var enabled = Assert.Single(
+            doc.Descendants(), e => e.Name.LocalName == "DemoEnabled");
+
+        var condition = enabled.Attribute("Condition")?.Value;
+        Assert.False(
+            string.IsNullOrWhiteSpace(condition),
+            "DemoEnabled has no Condition, so every build defines DEMO and a "
+            + "public Release ships demo code.");
+
+        // Debug, or an explicit opt-in, and nothing else. A condition that
+        // also admits Release is the gate gone the other way.
+        Assert.Contains("'$(Configuration)' == 'Debug'", condition!, StringComparison.Ordinal);
+        Assert.Contains("'$(Demo)' == 'true'", condition!, StringComparison.Ordinal);
+        Assert.DoesNotContain("Release", condition!, StringComparison.Ordinal);
+
+        // And the symbol is defined only when that property says so.
+        var define = Assert.Single(
+            doc.Descendants(),
+            e => e.Name.LocalName == "DefineConstants"
+                 && (e.Attribute("Condition")?.Value.Contains("DemoEnabled", StringComparison.Ordinal) ?? false));
+        Assert.Contains("DEMO", define.Value, StringComparison.Ordinal);
+    }
+
+#if DEBUG
+    /// <summary>
+    /// The build-file check proves the gate is written correctly; this proves
+    /// it arrived. Scoped to DEBUG because that is the configuration whose
+    /// invariant it states -- in Release both of these SHOULD be absent, and
+    /// asserting them there is what broke the tiered Release test leg.
+    /// </summary>
+    [Fact]
+    public void A_Debug_build_actually_carries_the_constant()
     {
 #if DEMO
+        // Reached only if DEMO survived to this assembly's compile.
         Assert.True(true);
 #else
         Assert.Fail(
-            "DEMO is not defined for this build, so the demo tests compiled to "
-            + "nothing and every other assertion about demo behaviour is vacuous. "
-            + "Check DemoEnabled in windows/Directory.Build.props: Configuration is "
-            + "empty there for a bare `dotnet build`, so the condition has to admit "
-            + "the empty case as well as 'Debug'.");
+            "This is a DEBUG build and DEMO is not defined, so the demo tests "
+            + "compiled to nothing and every assertion about demo behaviour is "
+            + "vacuous. Check DemoEnabled in windows/Directory.Build.targets.");
 #endif
-    }
 
-    [Fact]
-    public void The_gate_reaches_Ghostty_Core_too()
-    {
         // A constant defined only for the test assembly would leave the code
         // under test compiled out while these tests still ran -- green, and
-        // measuring nothing. Directory.Build.props sits above every project
-        // under windows/, so the Core demo types are the check that it did.
+        // measuring nothing. Directory.Build.targets sits above every project
+        // under windows/, so a Core demo type is the check that it did.
+        // GetType rather than GetTypes(): one type loaded, and no
+        // ReflectionTypeLoadException to misreport as a missing gate.
         var core = typeof(Ghostty.Core.Tabs.TabModel).Assembly;
-        var demoTypes = core.GetTypes()
-            .Where(t => t.Namespace == "Ghostty.Core.Demo")
-            .Select(t => t.Name)
-            .ToList();
-
         Assert.True(
-            demoTypes.Count > 0,
-            "Ghostty.Core carries no Ghostty.Core.Demo types, so DEMO was not "
-            + "defined when Core was compiled. If the constant test above passed, "
-            + "the gate reaches the test assembly but not Core, and something has "
-            + "scoped DemoEnabled below windows/. If it failed too, the gate is "
-            + "off everywhere and its message is the one to read.");
+            core.GetType("Ghostty.Core.Demo.DemoScriptParser", throwOnError: false) is not null,
+            "Ghostty.Core carries no Ghostty.Core.Demo.DemoScriptParser, so DEMO "
+            + "reached this assembly but not Core: something has scoped DemoEnabled "
+            + "below windows/.");
     }
+#endif
 }

--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -514,7 +514,9 @@
 
   <!--
     Demo mode files compile only when the DEMO constant is set (see
-    windows/Directory.Build.props). The *.cs are self-gated with #if DEMO, but
+    windows/Directory.Build.targets, NOT the props file beside it: the gate
+    reads $(Configuration), which is still empty while props is being
+    evaluated). The *.cs are self-gated with #if DEMO, but
     the XAML toolchain would still generate a g.cs for DemoOverlay.xaml in a
     non-demo build, leaking the type. Exclude both from non-demo builds so
     public Release binaries carry zero demo bytes.


### PR DESCRIPTION
Closes #898.

`DemoEnabled` was computed in `windows/Directory.Build.props`, where `Configuration` is still empty — `Microsoft.Common.props` imports that file *before* it defaults `Configuration` to `Debug`. The condition therefore matched only when the value arrived as a global property. **The gate now lives in `windows/Directory.Build.targets`**, beside the test seam's identically shaped one, which is imported once `Configuration` has settled.

## It was wider than a stray `dotnet build`

Both `just` recipes are the bare form:

```
build-win:  dotnet build windows/Ghostty.sln /p:Platform=x64
test-win:   dotnet test windows/Ghostty.Tests/... /p:Platform=x64
```

So **every `just` recipe was in the broken case, including the signoff ladder's `windows-tests` leg** — the merge authority while CI is unavailable. Three test classes compiled to nothing and the ladder reported green.

## The drift the issue expected is not there

Turning the gate on adds **25 tests that had never run** — `DemoActionsTests`, `DemoKeysTests`, `DemoScriptParserTests` were excluded whole. All 25 pass. `Ghostty.csproj` builds with **0 errors** once `Demo\**\*.cs` and `DemoOverlay.xaml` compile. Nothing had rotted; the gate was the only thing to repair.

| invocation | `DemoEnabled` | demo sources compiled |
|---|---|---|
| `dotnet build /p:Platform=x64` | `true` | yes |
| `dotnet build -c Debug` | `true` | yes |
| `dotnet build -c Release` | *empty* | no |
| `dotnet publish` (no `-c`) | *empty* | no |
| `dotnet pack` (no `-c`) | *empty* | no |

Release ships zero demo bytes, confirmed by byte-scanning `Wintty.dll` and `Ghostty.Core.dll` for `DemoScriptParser`, `DemoOverlay`, `WINTTY_DEMO` and friends in both ASCII and UTF-16, plus the absence of `DemoOverlay.xbf` and `demo.sample.json` from the output tree.

## A correction, because an earlier revision of this PR asserted the opposite

The first version of this branch kept the gate in props and argued that moving it to `Directory.Build.targets` was impossible, because `Ghostty.csproj` reads `DemoEnabled` in `ItemGroup` conditions that evaluate with the csproj body. **That was wrong.** MSBuild evaluates *every* property — trailing imports included — before it evaluates *any* item, so a property set in `.targets` reaches a static `ItemGroup Condition` in the csproj body fine. Verified with a minimal repro, and then confirmed on the real project with `-getItem:Compile` / `-getItem:Page`: Debug includes the demo sources *and* defines DEMO; Release excludes both.

Moving it is also the better fix, and it is what #898 suggested in the first place: it reads a `Configuration` that has settled rather than inferring that empty means Debug, and it puts the two gates of this shape side by side.

## The guard

`DemoGateTests`'s primary leg reads the **build file** (`XDocument` over the embedded `Directory.Build.targets`), so it is configuration-independent — the same shape `TestSeamWiringTests` uses on the seam gate. That matters: an earlier revision asserted on this assembly's own constants and therefore **failed every Release test run**, and the tiered build runs `dotnet test -c Release` across five cells that the Debug-only signoff ladder never exercises. It would have merged green and broken where the ladder cannot look — the same blind spot this change exists to close.

The runtime confirmation that the constant actually *arrived* is kept, scoped to `#if DEBUG`, because that is the configuration whose invariant it states.

Watched red:

- `#if DEBUG` scoping removed → fails in Release, reproducing the reported breakage.
- `DefineConstants` condition inverted to `!= 'true'` → caught by the configuration-independent leg, in a Release run.

Debug **3277** pass, Release **3251** pass, and the release-side patches still apply cleanly (`git apply --check`), with none touching `Directory.Build.targets`.

## Known limit, filed separately

Nothing asserts the *negative* direction in Release: a `DemoEnabled` forced from outside `Directory.Build.targets` defines DEMO in a shipping build with every guard green. `TestSeamWiringTests` has the identical exposure, so it is the house pattern for both gates rather than something introduced here. #927.
