### PR TITLE
build: a Release build refuses a gate it was not asked to open

### DIFF
--- a/windows/Directory.Build.targets
+++ b/windows/Directory.Build.targets
@@ -50,4 +50,53 @@
     <DemoEnabled Condition="'$(Demo)' == 'true' or '$(Configuration)' == 'Debug'">true</DemoEnabled>
     <DefineConstants Condition="'$(DemoEnabled)' == 'true'">$(DefineConstants);DEMO</DefineConstants>
   </PropertyGroup>
+
+  <!--
+    Both gates above were guarded in one direction only: every check asserted
+    the property is WRITTEN correctly here, and nothing asserted that a
+    shipping build does not carry what the gate excludes. Measured on #926's
+    branch, `dotnet build -c Release /p:DemoEnabled=true` produced a Release
+    binary carrying the demo overlay with the gate's own guard green, and
+    TESTSEAM has the identical exposure (issue #927).
+
+    A test cannot close that. Neither test project references the app, so
+    nothing in a test run can see whether Wintty.dll carries the seam. This
+    can: it is evaluated in every project under windows/, the app included,
+    against the RESOLVED property rather than the file that usually sets it.
+
+    The documented opt-ins stay open, and they are the only way through:
+    `-p:TestSeam=true` and `-p:Demo=true` set $(TestSeam)/$(Demo) as globals,
+    which is what separates "a human asked for this build" from "something set
+    the internal property". A build that takes either is one nobody should
+    install, which is what the seam's own comment already says.
+  -->
+  <!--
+    BeforeBuild, not CoreCompile. CoreCompile is skipped when the project is
+    up to date, so hooking it produced a guard that silently did not run on
+    every incremental build, and an incremental build still emits a binary
+    from a compile that may have happened under the leak. BeforeBuild carries
+    no Inputs/Outputs and runs on every invocation.
+  -->
+  <Target Name="RefuseAGateLeakIntoARelease"
+          BeforeTargets="BeforeBuild"
+          Condition="'$(Configuration)' == 'Release'">
+    <Error Condition="'$(TestSeamEnabled)' == 'true' and '$(TestSeam)' != 'true'"
+           Code="WINTTY0001"
+           Text="TestSeamEnabled is true in a Release build of $(MSBuildProjectName) without the -p:TestSeam=true opt-in, so this build would ship the in-process test seam: a named pipe whose send-text op hands arbitrary bytes to a live shell. Something set TestSeamEnabled outside windows/Directory.Build.targets. Pass -p:TestSeam=true if a driveable Release build is genuinely wanted (and do not install it)." />
+    <Error Condition="'$(DemoEnabled)' == 'true' and '$(Demo)' != 'true'"
+           Code="WINTTY0002"
+           Text="DemoEnabled is true in a Release build of $(MSBuildProjectName) without the -p:Demo=true opt-in, so this build would ship demo mode. Something set DemoEnabled outside windows/Directory.Build.targets. Pass -p:Demo=true if that is intended." />
+  </Target>
+
+  <!--
+    Companion constants for the runtime half of the same rule. A test asserting
+    "a Release build carries no demo types" is correct until someone takes the
+    documented opt-in, at which point it would fail a legitimate build. These
+    say which builds asked for it, so the assertion can exempt itself rather
+    than being deleted the first time it is inconvenient.
+  -->
+  <PropertyGroup>
+    <DefineConstants Condition="'$(TestSeam)' == 'true'">$(DefineConstants);TESTSEAM_OPTIN</DefineConstants>
+    <DefineConstants Condition="'$(Demo)' == 'true'">$(DefineConstants);DEMO_OPTIN</DefineConstants>
+  </PropertyGroup>
 </Project>

--- a/windows/Directory.Build.targets
+++ b/windows/Directory.Build.targets
@@ -64,39 +64,74 @@
     can: it is evaluated in every project under windows/, the app included,
     against the RESOLVED property rather than the file that usually sets it.
 
-    The documented opt-ins stay open, and they are the only way through:
-    `-p:TestSeam=true` and `-p:Demo=true` set $(TestSeam)/$(Demo) as globals,
-    which is what separates "a human asked for this build" from "something set
-    the internal property". A build that takes either is one nobody should
-    install, which is what the seam's own comment already says.
-  -->
-  <!--
-    BeforeBuild, not CoreCompile. CoreCompile is skipped when the project is
-    up to date, so hooking it produced a guard that silently did not run on
-    every incremental build, and an incremental build still emits a binary
-    from a compile that may have happened under the leak. BeforeBuild carries
-    no Inputs/Outputs and runs on every invocation.
-  -->
-  <Target Name="RefuseAGateLeakIntoARelease"
-          BeforeTargets="BeforeBuild"
-          Condition="'$(Configuration)' == 'Release'">
-    <Error Condition="'$(TestSeamEnabled)' == 'true' and '$(TestSeam)' != 'true'"
-           Code="WINTTY0001"
-           Text="TestSeamEnabled is true in a Release build of $(MSBuildProjectName) without the -p:TestSeam=true opt-in, so this build would ship the in-process test seam: a named pipe whose send-text op hands arbitrary bytes to a live shell. Something set TestSeamEnabled outside windows/Directory.Build.targets. Pass -p:TestSeam=true if a driveable Release build is genuinely wanted (and do not install it)." />
-    <Error Condition="'$(DemoEnabled)' == 'true' and '$(Demo)' != 'true'"
-           Code="WINTTY0002"
-           Text="DemoEnabled is true in a Release build of $(MSBuildProjectName) without the -p:Demo=true opt-in, so this build would ship demo mode. Something set DemoEnabled outside windows/Directory.Build.targets. Pass -p:Demo=true if that is intended." />
-  </Target>
+    The documented opt-ins stay open and are the only way through, but the
+    test has to be that the opt-in arrived as a GLOBAL property, not merely
+    that $(TestSeam)/$(Demo) reads true. MSBuild lifts environment variables
+    into the property namespace, and this file is imported after the project
+    body, so a bare `$env:Demo='true'` or a `<Demo>true</Demo>` in any csproj,
+    in Directory.Build.props, or in a tier patch would otherwise open the gate
+    AND silence the guard in one stroke: the same class of accident the guard
+    exists to catch, one step removed.
 
+    _DemoOptInIsGlobal below is how that is told apart, and the trick is worth
+    explaining because it reads like a typo. A global property cannot be
+    reassigned from a project file: MSBuild accepts the assignment and ignores
+    it. A local or environment-derived one can. So the probe assigns a
+    sentinel and then asks whether the value survived. If it did, only a
+    command line could have set it.
+
+    That is stricter than the docs promised: the environment-variable route is
+    refused for a legitimate opt-in too. Deliberate. An opt-in that ships the
+    seam should be explicit per invocation, not inherited from a shell.
+  -->
   <!--
     Companion constants for the runtime half of the same rule. A test asserting
     "a Release build carries no demo types" is correct until someone takes the
     documented opt-in, at which point it would fail a legitimate build. These
     say which builds asked for it, so the assertion can exempt itself rather
     than being deleted the first time it is inconvenient.
+
+    Before the probe below, because the probe spends $(TestSeam)/$(Demo).
   -->
   <PropertyGroup>
     <DefineConstants Condition="'$(TestSeam)' == 'true'">$(DefineConstants);TESTSEAM_OPTIN</DefineConstants>
     <DefineConstants Condition="'$(Demo)' == 'true'">$(DefineConstants);DEMO_OPTIN</DefineConstants>
   </PropertyGroup>
+
+  <!--
+    Was the opt-in a command line, or something the build inherited? See the
+    long note above. Order inside each pair is load-bearing: the sentinel is
+    written first, and the flag then reads whether it stuck. This is the last
+    thing in the file that reads $(TestSeam) or $(Demo), because after it they
+    no longer say what they said.
+  -->
+  <PropertyGroup>
+    <TestSeam Condition="'$(TestSeam)' == 'true'">not-a-global</TestSeam>
+    <_TestSeamOptInIsGlobal Condition="'$(TestSeam)' == 'true'">true</_TestSeamOptInIsGlobal>
+    <Demo Condition="'$(Demo)' == 'true'">not-a-global</Demo>
+    <_DemoOptInIsGlobal Condition="'$(Demo)' == 'true'">true</_DemoOptInIsGlobal>
+  </PropertyGroup>
+
+  <!--
+    BeforeBuild AND CoreCompile. CoreCompile alone is skipped when the project
+    is up to date, so hooking only it produced a guard that silently did not
+    run on any incremental build, while that build still emits a binary from a
+    compile that may have happened under the leak. BeforeBuild alone is
+    bypassed by an explicit `-t:Compile`. Both costs nothing: whichever runs
+    first fails the build.
+
+    The configuration test is "not Debug" rather than "is Release" so a
+    configuration nobody has added yet inherits the guarded side, and so it
+    matches the #if !DEBUG the runtime half uses.
+  -->
+  <Target Name="RefuseAGateLeakIntoARelease"
+          BeforeTargets="BeforeBuild;CoreCompile"
+          Condition="'$(Configuration)' != 'Debug'">
+    <Error Condition="'$(TestSeamEnabled)' == 'true' and '$(_TestSeamOptInIsGlobal)' != 'true'"
+           Code="WINTTY0001"
+           Text="TestSeamEnabled is true in a $(Configuration) build of $(MSBuildProjectName) without a command-line -p:TestSeam=true, so this build would ship the in-process test seam: a named pipe whose send-text op hands arbitrary bytes to a live shell. Something set TestSeamEnabled, or set TestSeam somewhere other than the command line (a csproj, Directory.Build.props, or the environment). Pass -p:TestSeam=true if a driveable non-Debug build is genuinely wanted, and do not install it." />
+    <Error Condition="'$(DemoEnabled)' == 'true' and '$(_DemoOptInIsGlobal)' != 'true'"
+           Code="WINTTY0002"
+           Text="DemoEnabled is true in a $(Configuration) build of $(MSBuildProjectName) without a command-line -p:Demo=true, so this build would ship demo mode. Something set DemoEnabled, or set Demo somewhere other than the command line (a csproj, Directory.Build.props, or the environment). Pass -p:Demo=true if that is intended." />
+  </Target>
 </Project>

--- a/windows/Ghostty.Tests/Demo/ShippingBuildGateTests.cs
+++ b/windows/Ghostty.Tests/Demo/ShippingBuildGateTests.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Linq;
+using Xunit;
+
+namespace Ghostty.Tests.Demo;
+
+/// <summary>
+/// The negative direction of the DEMO and TESTSEAM gates (issue #927).
+///
+/// Every other check on these gates asserts the property is WRITTEN correctly
+/// in windows/Directory.Build.targets. None asserted that a shipping build
+/// does not carry what the gate excludes, so a value set from anywhere else
+/// turned the gate off with every guard still green:
+///
+///   dotnet build Ghostty.csproj -c Release /p:DemoEnabled=true
+///     -> DEMO defined, DemoOverlay.xaml back in Page, DemoGateTests passing
+///
+/// The primary guard against that is the RefuseAGateLeakIntoARelease target,
+/// which fails the build itself and reaches the app project these tests
+/// cannot: neither test project references Ghostty.csproj, so nothing here
+/// can see whether Wintty.dll carries the seam.
+///
+/// This is the second line, and it covers a route the target cannot see: a
+/// `DefineConstants;DEMO` written directly into a project file never sets
+/// DemoEnabled, so the build-time error never fires, and only the compiled
+/// result gives it away.
+///
+/// Scoped to the configurations where the claim is true. In Debug both
+/// constants are supposed to be present, and under the documented opt-ins
+/// (-p:Demo=true / -p:TestSeam=true, which define DEMO_OPTIN / TESTSEAM_OPTIN)
+/// a Release build carrying them is exactly what was asked for.
+/// </summary>
+public class ShippingBuildGateTests
+{
+#if !DEBUG && !DEMO_OPTIN
+    [Fact]
+    public void A_shipping_build_carries_no_demo_code()
+    {
+#if DEMO
+        Assert.Fail(
+            "DEMO is defined in a Release build that did not pass -p:Demo=true. "
+            + "Demo sources are compiled into a binary users install. Check for a "
+            + "DefineConstants or DemoEnabled set outside windows/Directory.Build.targets.");
+#endif
+
+        // The constant is only half of it: the gate also strips the sources,
+        // and a build that defined neither but compiled them anyway would
+        // still ship demo code. Ghostty.Core is the half these tests can
+        // reach, and it is where the demo logic lives.
+        var core = typeof(Ghostty.Core.Tabs.TabModel).Assembly;
+        Assert.Null(core.GetType("Ghostty.Core.Demo.DemoScriptParser", throwOnError: false));
+        Assert.Null(core.GetType("Ghostty.Core.Demo.DemoActions", throwOnError: false));
+    }
+#endif
+
+#if !DEBUG && !TESTSEAM_OPTIN
+    [Fact]
+    public void A_shipping_build_carries_no_test_seam()
+    {
+#if TESTSEAM
+        Assert.Fail(
+            "TESTSEAM is defined in a Release build that did not pass "
+            + "-p:TestSeam=true. The seam is a named pipe whose send-text op hands "
+            + "arbitrary bytes to a live shell, so a build carrying it must not be "
+            + "installed. Check for a DefineConstants or TestSeamEnabled set outside "
+            + "windows/Directory.Build.targets.");
+#endif
+        // Deliberately no reflection half. The seam lives in the app assembly
+        // and no test project references it, so this leg speaks only for the
+        // constant reaching a project under windows/ -- which is the shared
+        // property, and therefore evidence about the app only insofar as the
+        // property is shared. RefuseAGateLeakIntoARelease is what actually
+        // binds Ghostty.csproj, and it binds it at build time.
+        Assert.True(true);
+    }
+#endif
+
+    /// <summary>
+    /// The opt-in constants have to keep existing, or both facts above
+    /// silently stop running: they are wrapped in <c>#if !DEMO_OPTIN</c> and
+    /// <c>#if !TESTSEAM_OPTIN</c>, so a constant that is never defined leaves
+    /// them permanently on rather than permanently off, but a constant that is
+    /// RENAMED in the build file leaves the opt-in builds failing a test they
+    /// should be exempt from.
+    ///
+    /// Read from the build file rather than from this assembly's constants,
+    /// for the same reason the primary gate guard is: a `#if DEMO_OPTIN`
+    /// assertion cannot see a misspelling, because a misspelled constant is
+    /// simply never defined and the assertion compiles to nothing.
+    /// </summary>
+    [Fact]
+    public void Each_gate_has_an_opt_in_constant_keyed_to_its_own_opt_in()
+    {
+        var asm = System.Reflection.Assembly.GetExecutingAssembly();
+        using var stream = asm.GetManifestResourceStream(
+            "Ghostty.Tests.Build.Directory.Build.targets")!;
+        var doc = System.Xml.Linq.XDocument.Load(stream);
+
+        AssertOptIn(doc, "'$(Demo)' == 'true'", "DEMO_OPTIN");
+        AssertOptIn(doc, "'$(TestSeam)' == 'true'", "TESTSEAM_OPTIN");
+    }
+
+    private static void AssertOptIn(
+        System.Xml.Linq.XDocument doc, string condition, string constant)
+    {
+        var define = Assert.Single(
+            doc.Descendants(),
+            e => e.Name.LocalName == "DefineConstants"
+                 && e.Attribute("Condition")?.Value == condition);
+
+        // As a token, not a substring. DefineConstants is a semicolon list and
+        // `Contains("DEMO_OPTIN")` is satisfied by "DEMO_OPTIN_TYPO", so the
+        // substring form passes the exact rename it exists to catch.
+        var defined = define.Value.Split(';', StringSplitOptions.RemoveEmptyEntries)
+            .Select(s => s.Trim());
+        Assert.Contains(constant, defined);
+    }
+}

--- a/windows/Ghostty.Tests/Demo/ShippingBuildGateTests.cs
+++ b/windows/Ghostty.Tests/Demo/ShippingBuildGateTests.cs
@@ -47,9 +47,23 @@ public class ShippingBuildGateTests
         // and a build that defined neither but compiled them anyway would
         // still ship demo code. Ghostty.Core is the half these tests can
         // reach, and it is where the demo logic lives.
+        //
+        // The whole namespace, not a list of names. A hand-maintained list is
+        // how the eighth demo type ships while the scan reports clean, which
+        // is the warning Ghostty.Tests.csproj already gives twice about its
+        // own source globs. GetTypes() rather than GetType(name) because the
+        // claim is "nothing here", which a lookup cannot make; Ghostty.Core is
+        // plain net10.0 with no optional dependencies for it to trip over.
         var core = typeof(Ghostty.Core.Tabs.TabModel).Assembly;
-        Assert.Null(core.GetType("Ghostty.Core.Demo.DemoScriptParser", throwOnError: false));
-        Assert.Null(core.GetType("Ghostty.Core.Demo.DemoActions", throwOnError: false));
+        var demoTypes = core.GetTypes()
+            .Where(t => t.Namespace?.StartsWith("Ghostty.Core.Demo", StringComparison.Ordinal) == true)
+            .Select(t => t.FullName)
+            .ToList();
+
+        Assert.True(
+            demoTypes.Count == 0,
+            "a shipping build carries Ghostty.Core.Demo types: "
+            + string.Join(", ", demoTypes));
     }
 #endif
 
@@ -87,17 +101,79 @@ public class ShippingBuildGateTests
     /// for the same reason the primary gate guard is: a `#if DEMO_OPTIN`
     /// assertion cannot see a misspelling, because a misspelled constant is
     /// simply never defined and the assertion compiles to nothing.
+    ///
+    /// It catches a rename in the BUILD FILE, which is the likely direction.
+    /// It cannot cross-check the literal in this file's own `#if !DEMO_OPTIN`
+    /// wrappers; nothing can, short of a run with the opt-in taken.
     /// </summary>
     [Fact]
     public void Each_gate_has_an_opt_in_constant_keyed_to_its_own_opt_in()
     {
+        var doc = BuildTargets();
+        AssertOptIn(doc, "'$(Demo)' == 'true'", "DEMO_OPTIN");
+        AssertOptIn(doc, "'$(TestSeam)' == 'true'", "TESTSEAM_OPTIN");
+    }
+
+    /// <summary>
+    /// The build-time refusal, read as text so it is checkable from a DEBUG
+    /// run.
+    ///
+    /// It has to be. The target only evaluates its conditions when
+    /// Configuration is not Debug, and the signoff ladder's windows-tests leg
+    /// is `just test-win`, which passes no -c and is therefore Debug. Without
+    /// this, an inverted condition in either Error would reach `windows`
+    /// green and only surface in the tiered build's Release cells, which run
+    /// against a pin that lags. That is the guard-that-does-not-run shape
+    /// this whole change is about, one level up from where it started.
+    /// </summary>
+    [Fact]
+    public void The_build_time_refusal_still_refuses_both_gates()
+    {
+        var doc = BuildTargets();
+
+        var target = Assert.Single(
+            doc.Descendants(),
+            e => e.Name.LocalName == "Target"
+                 && (string?)e.Attribute("Name") == "RefuseAGateLeakIntoARelease");
+
+        // Runs at all, and on a hook that is not skipped for an up-to-date
+        // project. CoreCompile alone was exactly that bug.
+        var before = (string?)target.Attribute("BeforeTargets") ?? string.Empty;
+        Assert.Contains("BeforeBuild", before, StringComparison.Ordinal);
+
+        // Guards every configuration that is not Debug, rather than naming
+        // Release, so a configuration nobody has added yet is on the guarded
+        // side.
+        Assert.Equal("'$(Configuration)' != 'Debug'", (string?)target.Attribute("Condition"));
+
+        AssertRefusal(target, "WINTTY0001", "TestSeamEnabled", "_TestSeamOptInIsGlobal");
+        AssertRefusal(target, "WINTTY0002", "DemoEnabled", "_DemoOptInIsGlobal");
+    }
+
+    /// <summary>
+    /// One Error, asserted on its polarity. `'$(X)' != 'true'` inverted to
+    /// `== 'true'` turns the refusal into a rubber stamp, and the two halves
+    /// have opposite senses, so both are spelled out rather than matched
+    /// loosely.
+    /// </summary>
+    private static void AssertRefusal(
+        System.Xml.Linq.XElement target, string code, string gate, string optInFlag)
+    {
+        var error = Assert.Single(
+            target.Descendants(),
+            e => e.Name.LocalName == "Error" && (string?)e.Attribute("Code") == code);
+
+        Assert.Equal(
+            $"'$({gate})' == 'true' and '$({optInFlag})' != 'true'",
+            (string?)error.Attribute("Condition"));
+    }
+
+    private static System.Xml.Linq.XDocument BuildTargets()
+    {
         var asm = System.Reflection.Assembly.GetExecutingAssembly();
         using var stream = asm.GetManifestResourceStream(
             "Ghostty.Tests.Build.Directory.Build.targets")!;
-        var doc = System.Xml.Linq.XDocument.Load(stream);
-
-        AssertOptIn(doc, "'$(Demo)' == 'true'", "DEMO_OPTIN");
-        AssertOptIn(doc, "'$(TestSeam)' == 'true'", "TESTSEAM_OPTIN");
+        return System.Xml.Linq.XDocument.Load(stream);
     }
 
     private static void AssertOptIn(

--- a/windows/Ghostty.Tests/Wiring/TestSeamWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TestSeamWiringTests.cs
@@ -406,13 +406,21 @@ public class TestSeamWiringTests
         Assert.DoesNotContain("Release", condition!, StringComparison.Ordinal);
 
         // And the symbol is defined only when that property says so.
+        //
+        // Selected by CONDITION, not by value. Selecting on "the value
+        // mentions TESTSEAM" matched a second element the moment
+        // TESTSEAM_OPTIN arrived, and the file legitimately has more than one
+        // constant in that family; the gate this test is about is the one
+        // keyed off TestSeamEnabled.
         var define = Assert.Single(
             doc.Descendants(),
             e => e.Name.LocalName == "DefineConstants"
-                 && e.Value.Contains("TESTSEAM", StringComparison.Ordinal));
+                 && (e.Attribute("Condition")?.Value
+                        .Contains("TestSeamEnabled", StringComparison.Ordinal) ?? false));
         Assert.Equal(
             "'$(TestSeamEnabled)' == 'true'",
             define.Attribute("Condition")?.Value);
+        Assert.Contains("TESTSEAM", define.Value, StringComparison.Ordinal);
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #927.

Both gates under `windows/` were guarded in one direction only. Every check asserted the property is *written* correctly in `Directory.Build.targets`; nothing asserted that a shipping build does not carry what the gate excludes:

```
dotnet build Ghostty.csproj -c Release /p:DemoEnabled=true
  -> DEMO defined, DemoOverlay.xaml back in Page, the gate's own guard green
```

`TESTSEAM` had the identical exposure, and that one is worse than a feature leak: the seam is a named pipe whose `send-text` op hands arbitrary bytes to a live shell.

## A test cannot close this, so the primary guard is the build

Neither test project references the app, so nothing in a test run can see whether `Wintty.dll` carries the seam. The guard is a build-time refusal in `Directory.Build.targets` — imported by every project under `windows/`, the app included — evaluated against the **resolved** property rather than the file that usually sets it. The documented opt-ins stay open and become the only way through: `-p:Demo=true` / `-p:TestSeam=true` arrive as globals, which is what separates *"a human asked for this build"* from *"something set the internal property"*.

| build | result |
|---|---|
| `Release /p:DemoEnabled=true` | **FAILS** `WINTTY0002` |
| `Release /p:TestSeamEnabled=true` | **FAILS** `WINTTY0001` |
| `Release -p:Demo=true` | succeeds |
| `Release -p:TestSeam=true` | succeeds |
| `Release` (plain) | succeeds |
| `Debug` (plain) | succeeds |
| bare `dotnet build` | succeeds |

Plain incremental builds, verified on two projects.

**It hooks `BeforeBuild`, not `CoreCompile`.** The first version hooked `CoreCompile`, which is *skipped when the project is up to date* — so the guard silently did not run on any incremental build, while that build still emits a binary from a compile that may have happened under the leak. A guard that quietly doesn't run is the failure mode this repo keeps meeting; it took ten minutes to reproduce here.

## The runtime half covers a route the build half structurally cannot

A `DefineConstants;DEMO` written straight into a project file never sets `DemoEnabled`, so no error fires and only the compiled result gives it away. `ShippingBuildGateTests` asserts — in Release, without the opt-in — that `DEMO` and `TESTSEAM` are undefined and that `Ghostty.Core` carries no `Ghostty.Core.Demo` types.

The seam leg deliberately has **no reflection half**, and says so: the seam lives in an assembly no test project references, so that leg speaks only for the shared property reaching a project under `windows/`. `RefuseAGateLeakIntoARelease` is what actually binds `Ghostty.csproj`, and it binds it at build time.

`DEMO_OPTIN` / `TESTSEAM_OPTIN` exist so those facts can exempt a legitimate opt-in build rather than being deleted the first time one is run.

## Two guards caught something while being written

Which is the argument for having both:

- **`TestSeamWiringTests` went red** the moment `TESTSEAM_OPTIN` arrived, because it selected its `DefineConstants` by *"the value mentions TESTSEAM"*. It selects by **condition** now, keyed to `TestSeamEnabled` — the gate it is actually about.
- **The opt-in pairing check false-passed on its own mutation.** It asserted `Contains("DEMO_OPTIN")` over the raw `DefineConstants` text, which `"DEMO_OPTIN_TYPO"` satisfies — the substring trap, in the test written to catch a rename. It splits the semicolon list and compares tokens.

## Watched red

| mutation | outcome |
|---|---|
| `RefuseAGateLeakIntoARelease` removed | `Release /p:DemoEnabled=true` **succeeds** again — the leak the issue measured |
| `DefineConstants;DEMO` added straight to `Ghostty.Core.csproj` | build-time guard correctly **silent** (the property was never set); runtime guard **catches it** |
| `DEMO_OPTIN` renamed to a superstring of itself | pairing test **fails** |

Debug **3296** pass, Release **3272** pass.

## Not covered

The app assembly is still only bound at build time — there is no test that opens `Wintty.dll` and looks for `Ghostty.Testing.TestSeam`, because no test project references it. Closing that would mean either a project reference the test assembly does not want, or a post-build scan of the output, and neither is worth it while the build-time refusal holds.

---

## Review round

The escape hatch was not the one the comment described. `'$(Demo)' != 'true'` is satisfied by a global — and also by an **environment variable** and by a `<Demo>true</Demo>` in any csproj, `Directory.Build.props`, or tier patch, because MSBuild lifts the environment into the property namespace and this file is imported after the project body. A stray `$env:Demo='true'` in a CI shell opened the gate in Release *and* silenced the guard in one stroke.

Told apart by asking whether the opt-in survives reassignment: a global property cannot be reassigned from a project file, a local or environment-derived one can. Stricter than the docs promised, deliberately — an opt-in that ships the seam should be explicit per invocation, not inherited from a shell.

| build | before | after |
|---|---|---|
| `Release`, `Demo=true` in the **environment** | succeeds | **FAILS** `WINTTY0002` |
| `Release`, `<Demo>true</Demo>` in a csproj | succeeds | **FAILS** `WINTTY0002` |
| `Release -p:Demo=true` (command line) | succeeds | succeeds |

**The refusal is now readable from a Debug run**, which is the only kind this repo's ladder does. `just test-win` passes no `-c`, and the target evaluates its conditions only when the configuration is not Debug — so an inverted `!= 'true'` would have reached `windows` green and surfaced only in the tiered build's Release cells, against a pin that lags. `The_build_time_refusal_still_refuses_both_gates` reads the target out of the embedded build file and pins both `Error` conditions, the hook, and the configuration test.

Three smaller ones:

- `BeforeTargets` regains `CoreCompile` alongside `BeforeBuild`. `BeforeBuild` alone is bypassed by an explicit `-t:Compile`; `CoreCompile` alone was the original bug. Both costs nothing — whichever runs first fails the build.
- The configuration test is `!= 'Debug'` rather than `== 'Release'`, so a configuration nobody has added yet lands on the guarded side, and it agrees with the `#if !DEBUG` the runtime half uses.
- The demo sweep asks about the whole namespace instead of two names. The list was **two of seven**, and a hand-maintained list is how the eighth type ships while the scan reports clean.

Watched red, all three in a **Debug** run: the refusal's polarity inverted, the hook narrowed back to `CoreCompile`, and the configuration test narrowed back to `== 'Release'`.

Debug **3297** pass, Release **3273** pass.

### Filed, not fixed here

- **Release-side materialize break** — `materialize` will throw for sponsor, pro and pro-legacy on the next bump: the `sponsor-update` overlay collides with `windows/Directory.Build.targets`. Not caused by this PR (it is #909's debt), but the fix is a no-fuzz patch anchored on this file, so it should be written *after* this lands.
- **#929** — the signoff ladder never runs Release, so the two `#if !DEBUG` facts and the target's own conditions are unenforced on this repo. Mitigated here by the Debug-readable build-file check; not fixed.
