### PR TITLE
build: windows does not compile, and the ladder had no reason to notice

### DIFF
--- a/justfile
+++ b/justfile
@@ -176,8 +176,19 @@ run-win-release: build-dll-release build-win-release
 # stalling a signoff. Added after a proven FakeTransport pipe deadlock hung
 # the whole Ghostty.Tests host at zero CPU; the pipe-buffer fix removed that
 # hang, and blame-hang turns any future one into evidence.
+#
+# The APP is built first, and that is not redundant. Neither test project
+# references Ghostty.csproj -- that is a deliberate boundary, and it is why
+# ShippingBuildGateTests cannot open Wintty.dll -- so `dotnet test` alone never
+# compiles the shell. A change that breaks only the app therefore left this leg
+# green, which is not a theory: #921 merged a file that did not compile, with a
+# signoff PASS recorded against it, because the ladder's only Windows leg had no
+# reason to build the project the mistake was in. The whole solution is built
+# rather than the one project, so a new project cannot join the tree and be
+# missed the same way.
 [windows]
 test-win:
+    dotnet build windows/Ghostty.sln /p:Platform=x64
     dotnet test windows/Ghostty.Tests/Ghostty.Tests.csproj /p:Platform=x64 --blame-hang --blame-hang-timeout 5m
     dotnet test windows/Ghostty.Tests.Windows/Ghostty.Tests.Windows.csproj /p:Platform=x64 --blame-hang --blame-hang-timeout 5m
 

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -1585,7 +1585,8 @@ internal sealed partial class TabHost : UserControl, ITabHost
     /// The element one horizontal slot renders as, or null while the strip
     /// has not built it. A chip counts: it is the folded run's only slot,
     /// so its own ends are the run's ends.
-    /// </summary>    private FrameworkElement? SlotElement(TabStripProjection.HorizontalRow row)
+    /// </summary>
+    private FrameworkElement? SlotElement(TabStripProjection.HorizontalRow row)
         => row switch
         {
             TabStripProjection.HorizontalRow.Chip { Group: { } group }


### PR DESCRIPTION
`origin/windows` does not compile.

## The break

#921 merged a `windows/Ghostty/Tabs/TabHost.xaml.cs` in which a doc comment swallowed the declaration under it:

```csharp
    /// </summary>    private FrameworkElement? SlotElement(TabStripProjection.HorizontalRow row)
        => row switch { ... };
```

`///` runs to the end of its line, so `SlotElement` is never declared and the expression body that follows attaches to the method above it — which already has a block body. `CS8057`, in `Ghostty.csproj`.

The line was joined by a scripted comment move during #921's second review round. That is the small half.

## Why signoff passed anyway

`just signoff`'s only Windows leg is `just test-win`, which is two `dotnet test` invocations against `Ghostty.Tests` and `Ghostty.Tests.Windows`. **Neither references `Ghostty.csproj`.**

That boundary is deliberate — it is exactly why `ShippingBuildGateTests` cannot open `Wintty.dll` and says so — but the consequence is that the ladder never compiles the shell. A change that breaks only the app leaves every leg green and records a PASS.

That is what happened: signoff PASSed on `1ff69f80ce`, and the break surfaced only when the next PR tried to rebase onto `windows`.

## Fix

`test-win` builds the solution before running the suites. The whole solution rather than the one project, so a project added later cannot join the tree and be missed the same way. It costs one incremental build on a leg that already compiles most of the same graph.

| | before | after |
|---|---|---|
| `just test-win` with the joined line | 3350 passed, exit 0 | **exit 1, CS8057** |
| `just test-win` on the fix | — | 3350 passed, exit 0 |

## Related

#929 tracks the other half of this ladder's blindness: it never builds or tests in Release, so the `#if !DEBUG` facts and `RefuseAGateLeakIntoARelease`'s own conditions are unenforced here too. Same shape — a leg that cannot see the configuration or the project the defect lives in.
