### PR TITLE
harness: the contrast oracle's two rect helpers stop sharing a name

### DIFF
--- a/windows/scripts/contrast-oracle.ps1
+++ b/windows/scripts/contrast-oracle.ps1
@@ -822,14 +822,25 @@ function Find-SwitcherHost {
     return $null
 }
 
-# Whether one rect sits inside another, and whether two overlap at all.
-# UIA hands back .X/.Y/.Width/.Height; the seam hands back .x/.y/.w/.h.
-function Test-RectInside($Inner, $Outer) {
+# Whether a UIA rect sits inside, or overlaps, a rect the SEAM reported.
+#
+# Named for the seam on purpose. The UIA-to-UIA containment test one screen
+# up is called Test-RectInside, and a second function of that name here
+# silently replaced it for the whole file: PowerShell defines functions as
+# it reads them, so by the time anything is called the later one is the one
+# in scope, and Test-Samplable -- the gate on EVERY ink sample -- started
+# asking this version about two UIA rects. Property lookup is
+# case-insensitive, so `.x` found `.X` and the comparison looked sane, while
+# `.w` found nothing at all and came back null: `Inner.X + Inner.Width -le
+# Outer.X + $null` is false for any element with width, so every surface in
+# both strips reported "no visible, unclipped run" and the oracle exited 1
+# on a whole table of NOT MEASURED. Two shapes of rect want two names.
+function Test-InsideSeamRect($Inner, $Outer) {
     return ($Inner.X -ge $Outer.x) -and ($Inner.Y -ge $Outer.y) -and
            (($Inner.X + $Inner.Width) -le ($Outer.x + $Outer.w)) -and
            (($Inner.Y + $Inner.Height) -le ($Outer.y + $Outer.h))
 }
-function Test-RectOverlaps($A, $B) {
+function Test-OverlapsSeamRect($A, $B) {
     return ($A.X -lt ($B.x + $B.w)) -and (($A.X + $A.Width) -gt $B.x) -and
            ($A.Y -lt ($B.y + $B.h)) -and (($A.Y + $A.Height) -gt $B.y)
 }
@@ -871,8 +882,8 @@ function Get-SwitcherTileRect($Session) {
     }
     foreach ($run in (Get-TextRuns $el)) {
         $r = $run.Current.BoundingRectangle
-        if (-not (Test-RectInside $r $lit[0].card)) { continue }
-        if ($null -ne $lit[0].preview -and (Test-RectOverlaps $r $lit[0].preview)) { continue }
+        if (-not (Test-InsideSeamRect $r $lit[0].card)) { continue }
+        if ($null -ne $lit[0].preview -and (Test-OverlapsSeamRect $r $lit[0].preview)) { continue }
         return $r
     }
     return $null


### PR DESCRIPTION
#923 added a containment test for the rects the `switcher-cells` seam op reports, and put it in `contrast-oracle.ps1` beside one that already existed for UIA's rects — under the same name.

PowerShell defines functions as it reads them, so by the time anything is *called* the later definition is the one in scope. `Test-Samplable`, which gates **every ink sample in both strips**, started asking the seam version about two UIA rects:

```powershell
function Test-RectInside($Inner, $Outer, [double]$Slack = 1.0) { ... }   # line 380, UIA
...
function Test-RectInside($Inner, $Outer) { ... }                          # line 827, seam
```

Property lookup is case-insensitive, so `.x` found `.X` and the comparison looked sane. `.w` found nothing — the property is `Width` — and came back `$null`. `Inner.X + Inner.Width -le Outer.X + $null` is false for any element that has width, so containment failed for everything and the 1px slack the real helper takes went with it.

The result: every strip surface reported *"no visible, unclipped Text run"* and the oracle exited 1 on a table of NOT MEASURED. I saw that table on #923's own verification run and wrote it off as run-to-run instability, which it was not.

Renamed for the shape of rect each takes — `Test-InsideSeamRect` / `Test-OverlapsSeamRect`. Two shapes want two names.

## Proof

Two runs against a build of `01dc5a8509` with the rename:

- Strip surfaces are **measured again**. The NOT MEASURED entries that remain say *"no dominant background: the largest cluster is N% of the region, under the 20% floor"* — a sampling limit — rather than *"exposes no visible, unclipped Text run"*, which was the shadowing.
- The failures that come back are the real contrast numbers already filed as #936: `vtab-close-glyph-inactive` 2.09, `vtab-group-title` 4.10, `vtab-group-count` 2.83, `htab-title-inactive` 2.40, and the rest of that cluster. The oracle still exits 2 on `windows` for that reason; this change is about it *measuring*, not about it being green.
- `switcher-tile-text` passes in all four legs on both runs but one: run 1 had `nocfg` at 1.00:1, run 2 had all four green. That is the popup's 1.2s self-dismissal race the leg already retries for, slightly widened by the seam round trip #923 added between the cycle and the shutter — noted in that code's own comment. Not addressed here.

`just signoff` PASS on `045d84076b`.

## Not fixed here

`fuzz-suite.ps1` runs five free integrity checks on every invocation and none of them would have caught this. A sixth — no script may define the same function name twice — is the guard that stops it recurring, and it belongs with that runner's numbering, prose and self-test fixtures rather than inside a rename. Filed separately.
