### PR TITLE
harness: a backdrop stage that a harness can park under the window and paint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ windows/scripts/layout-switch/
 windows/scripts/vtabs-layout-switch/
 windows/scripts/vtabs-morph/
 windows/scripts/vtabs-switcher/
+windows/scripts/backdrop-stage-selftest/
 
 # Gallery tooling scratch renders (WARP PPMs and PNGs diffed during
 # shader bring-up; never something we want committed).

--- a/justfile
+++ b/justfile
@@ -383,6 +383,19 @@ fuzz-list:
 fuzz-selftest:
     pwsh -NoProfile -File windows/scripts/fuzz-suite.ps1 -SelfTest; exit ($LASTEXITCODE ?? 1)
 
+# Prove the backdrop stage (windows/scripts/lib/BackdropStage) is an
+# instrument: it comes up where it was told, never takes the foreground,
+# paints every catalogued scene so the screen reads it back, moves, survives
+# a refused op, and exits 0 on quit. Builds the stage on first use. Launches
+# no Wintty and sets no wallpaper, so it is safe with a Wintty open; it does
+# put a small topmost window on screen for about ten seconds.
+#
+# Exit codes: 0 sound, 1 not sound or could not start. No 2: this judges the
+# instrument, never the product.
+[windows]
+backdrop-stage-selftest:
+    pwsh -NoProfile -File windows/scripts/backdrop-stage-selftest.ps1; exit ($LASTEXITCODE ?? 1)
+
 # Manual recovery after a harness crashed with system state (High Contrast,
 # desktop colour, app theme) left behind: restores from the snapshot the
 # env-guard library takes, and throws if the read-back does not match it.

--- a/windows/scripts/README.md
+++ b/windows/scripts/README.md
@@ -195,6 +195,33 @@ switch's own amplitude) and how the retargeted version was verified: after
 the fix, no post-switch box is wider than the struck strip's own band.
 Point it at a `layout-switch-filmstrip.ps1` out dir and a leg tag.
 
+## Scenery
+
+`lib/backdrop-stage.ps1` plus `lib/BackdropStage/` is the shared backdrop: a
+window a harness parks UNDER the one it is measuring and paints a named scene
+on. Use it whenever the question depends on what is behind the chrome, which
+for a translucent material is every question.
+
+The scene goes to two places because the materials look at two things:
+crystal and frosted show or blur the **window behind**, solid is Mica and
+samples the **desktop wallpaper**. `Set-BackdropScene -Wallpaper` paints the
+stage AND sets the same PNG as the wallpaper. A harness that passes it owns
+putting the wallpaper back (`Get-DesktopWallpaper` before, `Set-DesktopWallpaper`
+in a `finally`); `lib/env-guard.ps1`'s snapshot covers the registry side for
+`just env-restore` after a crash.
+
+- `Start-BackdropStage -X -Y -W -H` builds the tool on first use (not in
+  `Ghostty.sln`, like WindowCapture) and launches it at a device-pixel rect,
+  TOPMOST and non-activating. Place the window under test TOPMOST afterwards
+  and it lands above the stage.
+- `Get-BackdropScenes` is the catalogue: black, white, grey, brand, sunrise,
+  photo, editor, checker, each generated from its name and a seed.
+- `Get-ScreenPixel` reads one device pixel: read the stage's own margin before
+  photographing, so the scene on screen is the one asked for.
+
+`just backdrop-stage-selftest` proves the instrument against the screen. It
+launches no Wintty and is safe with one open.
+
 ## Process policy
 
 `lib/wintty-process.ps1` holds the rule:

--- a/windows/scripts/README.md
+++ b/windows/scripts/README.md
@@ -206,18 +206,27 @@ The scene goes to two places because the materials look at two things:
 crystal and frosted show or blur the **window behind**, solid is Mica and
 samples the **desktop wallpaper**. `Set-BackdropScene -Wallpaper` paints the
 stage AND sets the same PNG as the wallpaper. A harness that passes it owns
-putting the wallpaper back (`Get-DesktopWallpaper` before, `Set-DesktopWallpaper`
-in a `finally`); `lib/env-guard.ps1`'s snapshot covers the registry side for
-`just env-restore` after a crash.
+putting the wallpaper back: `$before = Get-DesktopWallpaper` first and
+`Set-DesktopWallpaper -Snapshot $before` in a `finally`, which restores the
+user's own style and tiling and reads the registry back. `lib/env-guard.ps1`'s
+snapshot covers the registry side for `just env-restore` after a crash, but a
+registry restore does not repaint the desktop: after a crashed `-Wallpaper`
+run, re-run `Set-DesktopWallpaper` (or log off) to see the old wallpaper
+again. Only a single static image is captured; a slideshow, Spotlight or
+per-monitor wallpaper comes back as its current image.
 
 - `Start-BackdropStage -X -Y -W -H` builds the tool on first use (not in
   `Ghostty.sln`, like WindowCapture) and launches it at a device-pixel rect,
   TOPMOST and non-activating. Place the window under test TOPMOST afterwards
   and it lands above the stage.
 - `Get-BackdropScenes` is the catalogue: black, white, grey, brand, sunrise,
-  photo, editor, checker, each generated from its name and a seed.
+  photo, editor, checker, each generated from its name, size and seed.
 - `Get-ScreenPixel` reads one device pixel: read the stage's own margin before
-  photographing, so the scene on screen is the one asked for.
+  photographing, so the scene on screen is the one asked for, and ask
+  `Get-WindowPidAt` first so the pixel is known to be the stage's.
+- The stage closes itself when the shell that launched it dies, so a
+  Ctrl+C cannot leave a window that has no taskbar entry and cannot be
+  focused for Alt+F4.
 
 `just backdrop-stage-selftest` proves the instrument against the screen. It
 launches no Wintty and is safe with one open.

--- a/windows/scripts/backdrop-stage-selftest.ps1
+++ b/windows/scripts/backdrop-stage-selftest.ps1
@@ -3,16 +3,21 @@
     Prove the backdrop stage is an instrument before a matrix trusts it.
 
     What is checked, against the screen rather than the stage's own answer:
-    the window comes up where it was told to and never takes the foreground;
-    every scene in the catalogue paints something that reads back as that
-    scene (a solid is its colour, a checker is black-or-white, a gradient and
-    a photograph vary between two points, the editor's gutter is its grey);
-    a place moves it and the pixels follow; quit ends the process with 0.
+    the window comes up where it was told to and never takes the foreground,
+    not at launch and not after any place; every scene in the catalogue
+    paints something that reads back as that scene (a solid is its colour, a
+    checker is black-or-white, a gradient and a photograph vary between two
+    points, the editor's band is its grey); a place to a rect DISJOINT from
+    the first moves the pixels with it; a place bigger than every monitor
+    together is honoured; a refused op does not kill it; quit exits 0.
+
+    Every pixel read is preceded by asking Windows whose window is at that
+    point. A foreign window over the stage is reported as an occlusion, not
+    scored as a wrong colour. Scenes are regenerated on every run: a cached
+    picture from last time would make the generator's checks vacuous.
 
     Launches no Wintty, sets no wallpaper, and is safe to run with anything
-    else open: the stage is topmost while it is up, so the pixels it is
-    judged on are its own unless another topmost window sits on the same
-    spot, which is reported rather than scored.
+    else open.
 
     Exit 0 when the instrument is sound, 1 when it is not or could not be
     started. There is no 2: this measures the instrument, never the product.
@@ -22,12 +27,6 @@ param(
 )
 . (Join-Path $PSScriptRoot 'lib/backdrop-stage.ps1')
 $ErrorActionPreference = 'Stop'
-
-trap {
-    Write-Host "STAGE_SELFTEST_FAIL: $_" -ForegroundColor Red
-    if ($null -ne $script:stage) { try { Stop-BackdropStage $script:stage } catch { } }
-    exit 1
-}
 
 New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
 [void][StageWin]::SetProcessDpiAwarenessContext([IntPtr](-4))
@@ -40,90 +39,115 @@ function Add-Check([string]$Name, [bool]$Pass, [string]$Detail) {
     if (-not $Pass) { throw "${Name}: $Detail" }
 }
 
-$X = 140; $Y = 140; $W = 480; $H = 320
-$foregroundBefore = [StageWin]::GetForegroundWindow()
-$script:stage = Start-BackdropStage -X $X -Y $Y -W $W -H $H
+# A pixel the stage owns, or an occlusion reported by name.
+function Read-StagePixel([int]$X, [int]$Y) {
+    $owner = Get-WindowPidAt -X $X -Y $Y
+    if ($owner -ne [uint32]$script:stage.Proc.Id) {
+        $who = try { (Get-Process -Id $owner -ErrorAction Stop).ProcessName } catch { '?' }
+        throw "OCCLUDED: the point $X,$Y belongs to pid $owner ($who), not the stage; nothing was measured there"
+    }
+    return Get-ScreenPixel -X $X -Y $Y
+}
 
-$q = Invoke-BackdropStage $script:stage @{ op = 'query' }
-Add-Check 'placed-where-told' ($q.x -eq $X -and $q.y -eq $Y -and $q.w -eq $W -and $q.h -eq $H) `
-    ("asked {0},{1} {2}x{3} got {4},{5} {6}x{7}" -f $X, $Y, $W, $H, $q.x, $q.y, $q.w, $q.h)
-Add-Check 'hwnd-reported' ($q.hwnd -eq $script:stage.Hwnd64) "READY said $($script:stage.Hwnd64), query says $($q.hwnd)"
+function Assert-NotForeground([string]$After) {
+    $fg = [StageWin]::GetForegroundWindow().ToInt64()
+    Add-Check "never-activates-$After" ($fg -ne $script:stage.Hwnd64) "foreground $fg, stage $($script:stage.Hwnd64)"
+}
 
-$fgNow = [StageWin]::GetForegroundWindow()
-Add-Check 'never-activates' ($fgNow.ToInt64() -ne $script:stage.Hwnd64) `
-    ("foreground before {0}, now {1}, stage {2}" -f $foregroundBefore.ToInt64(), $fgNow.ToInt64(), $script:stage.Hwnd64)
+$script:stage = $null
+$exitCode = 1
+try {
+    $X = 140; $Y = 140; $W = 480; $H = 320
+    $script:stage = Start-BackdropStage -X $X -Y $Y -W $W -H $H
 
-Start-Sleep -Milliseconds 300
-$sceneDir = Join-Path $OutDir 'scenes'
-$cx = $X + [int]($W / 2); $cy = $Y + [int]($H / 2)
-foreach ($scene in (Get-BackdropScenes).Values) {
-    $png = Set-BackdropScene -Stage $script:stage -Scene $scene -SceneDir $sceneDir -Width 960 -Height 540
-    Start-Sleep -Milliseconds 120
-    $centre = Get-ScreenPixel -X $cx -Y $cy
-    switch ($scene.Kind) {
-        'solid' {
-            Add-Check "scene-$($scene.Name)" (Test-PixelNear $centre $scene.Color 3) "centre $($centre.Hex) expected $($scene.Color)"
-        }
-        default {
-            switch ($scene.Name) {
-                'checker' {
-                    $p2 = Get-ScreenPixel -X ($cx + 3) -Y $cy
-                    $bw = { param($p) (Test-PixelNear $p '#000000' 40) -or (Test-PixelNear $p '#FFFFFF' 40) }
-                    Add-Check 'scene-checker' ((& $bw $centre) -and (& $bw $p2)) "centre $($centre.Hex), +3px $($p2.Hex): both must be near black or white"
-                }
-                'editor' {
-                    # The minimap band on the right is the one text-free
-                    # surface in the scene (the gutter carries line numbers,
-                    # and a sample there reads a glyph's anti-aliasing).
-                    $band = Get-ScreenPixel -X ($X + $W - 6) -Y ($Y + 40)
-                    Add-Check 'scene-editor' (Test-PixelNear $band '#F8F8F8' 6) "minimap band $($band.Hex) expected #F8F8F8"
-                }
-                default {
-                    $top = Get-ScreenPixel -X $cx -Y ($Y + 8)
-                    $bot = Get-ScreenPixel -X $cx -Y ($Y + $H - 8)
-                    $gap = [Math]::Abs($top.R - $bot.R) + [Math]::Abs($top.G - $bot.G) + [Math]::Abs($top.B - $bot.B)
-                    Add-Check "scene-$($scene.Name)" ($gap -gt 40) "top $($top.Hex) bottom $($bot.Hex) differ by $gap (needs > 40)"
+    $q = Invoke-BackdropStage $script:stage @{ op = 'query' }
+    Add-Check 'placed-where-told' ($q.x -eq $X -and $q.y -eq $Y -and $q.w -eq $W -and $q.h -eq $H) `
+        ("asked {0},{1} {2}x{3} got {4},{5} {6}x{7}" -f $X, $Y, $W, $H, $q.x, $q.y, $q.w, $q.h)
+    Add-Check 'hwnd-reported' ($q.hwnd -eq $script:stage.Hwnd64) "READY said $($script:stage.Hwnd64), query says $($q.hwnd)"
+    Assert-NotForeground 'launch'
+
+    $sceneDir = Join-Path $OutDir 'scenes'
+    Remove-Item $sceneDir -Recurse -Force -ErrorAction SilentlyContinue
+    $cx = $X + [int]($W / 2); $cy = $Y + [int]($H / 2)
+    foreach ($scene in (Get-BackdropScenes).Values) {
+        $png = Set-BackdropScene -Stage $script:stage -Scene $scene -SceneDir $sceneDir -Width 960 -Height 540
+        $centre = Read-StagePixel $cx $cy
+        switch ($scene.Kind) {
+            'solid' {
+                Add-Check "scene-$($scene.Name)" (Test-PixelNear $centre $scene.Color 3) "centre $($centre.Hex) expected $($scene.Color)"
+            }
+            default {
+                switch ($scene.Name) {
+                    'checker' {
+                        $p2 = Read-StagePixel ($cx + 3) $cy
+                        $bw = { param($p) (Test-PixelNear $p '#000000' 40) -or (Test-PixelNear $p '#FFFFFF' 40) }
+                        Add-Check 'scene-checker' ((& $bw $centre) -and (& $bw $p2)) "centre $($centre.Hex), +3px $($p2.Hex): both must be near black or white"
+                    }
+                    'editor' {
+                        # The minimap band on the right is the one text-free
+                        # surface in the scene (the gutter carries line numbers,
+                        # and a sample there reads a glyph's anti-aliasing).
+                        $band = Read-StagePixel ($X + $W - 6) ($Y + 40)
+                        Add-Check 'scene-editor' (Test-PixelNear $band '#F8F8F8' 6) "minimap band $($band.Hex) expected #F8F8F8"
+                    }
+                    default {
+                        $top = Read-StagePixel $cx ($Y + 8)
+                        $bot = Read-StagePixel $cx ($Y + $H - 8)
+                        $gap = [Math]::Abs($top.R - $bot.R) + [Math]::Abs($top.G - $bot.G) + [Math]::Abs($top.B - $bot.B)
+                        Add-Check "scene-$($scene.Name)" ($gap -gt 40) "top $($top.Hex) bottom $($bot.Hex) differ by $gap (needs > 40)"
+                    }
                 }
             }
         }
+        Add-Check "png-$($scene.Name)" (Test-Path -LiteralPath $png) $png
     }
-    Add-Check "png-$($scene.Name)" (Test-Path -LiteralPath $png) $png
+
+    # Move it to a rect that shares no pixel with the first, paint a colour
+    # no earlier scene left behind, and read the new centre: a place that
+    # silently did nothing cannot pass this.
+    $X2 = $X + $W + 40; $Y2 = 200; $W2 = 300; $H2 = 200
+    $q2 = Invoke-BackdropStage $script:stage @{ op = 'place'; x = $X2; y = $Y2; w = $W2; h = $H2 }
+    Add-Check 'place-moves' ($q2.x -eq $X2 -and $q2.y -eq $Y2 -and $q2.w -eq $W2 -and $q2.h -eq $H2) `
+        ("asked {0},{1} {2}x{3} got {4},{5} {6}x{7}" -f $X2, $Y2, $W2, $H2, $q2.x, $q2.y, $q2.w, $q2.h)
+    Assert-NotForeground 'place'
+    [void](Invoke-BackdropStage $script:stage @{ op = 'solid'; color = '#0067C0' })
+    $moved = Read-StagePixel ($X2 + [int]($W2 / 2)) ($Y2 + [int]($H2 / 2))
+    Add-Check 'pixels-follow' (Test-PixelNear $moved '#0067C0' 3) "new centre $($moved.Hex) expected #0067C0"
+
+    # Bigger than every monitor together. A harness grows the stage past the
+    # window under test on every side, and a window that fills the screen
+    # needs a stage that overhangs it; Windows clamps a window to the monitor
+    # unless the stage overrides WM_GETMINMAXINFO, and this is the check.
+    $vs = Get-VirtualScreenRect
+    $bigX = $vs.X - 200; $bigY = $vs.Y - 200; $bigW = $vs.W + 400; $bigH = $vs.H + 400
+    $q3 = Invoke-BackdropStage $script:stage @{ op = 'place'; x = $bigX; y = $bigY; w = $bigW; h = $bigH }
+    Add-Check 'bigger-than-screen' ($q3.x -eq $bigX -and $q3.y -eq $bigY -and $q3.w -eq $bigW -and $q3.h -eq $bigH) `
+        ("virtual screen {0}x{1}; asked {2},{3} {4}x{5} got {6},{7} {8}x{9}" -f $vs.W, $vs.H, $bigX, $bigY, $bigW, $bigH, $q3.x, $q3.y, $q3.w, $q3.h)
+    Assert-NotForeground 'oversize'
+    [void](Invoke-BackdropStage $script:stage @{ op = 'place'; x = $X2; y = $Y2; w = $W2; h = $H2 })
+
+    # Refusals are answered, not crashed on.
+    $refused = $false
+    try { [void](Invoke-BackdropStage $script:stage @{ op = 'image'; path = 'C:\no\such\file.png'; mode = 'stretch' }) }
+    catch { $refused = "$_" -like '*no such image*' }
+    Add-Check 'refuses-missing-image' $refused 'image op with a missing path is refused with a reason'
+    Add-Check 'survives-refusal' (-not $script:stage.Proc.HasExited) 'the stage is still up after a refused op'
+
+    Stop-BackdropStage $script:stage
+    $code = $script:stage.Proc.ExitCode
+    Add-Check 'quit-exits-zero' ($code -eq 0) "exit code $code"
+    $script:stage = $null
+
+    [pscustomobject]@{ checks = $checks } | ConvertTo-Json -Depth 4 | Set-Content (Join-Path $OutDir 'result.json') -Encoding utf8
+    Write-Host "backdrop-stage: $($checks.Count) checks passed"
+    $exitCode = 0
 }
-
-# Move it and read the moved pixels: the last scene painted was the checker,
-# so the new centre must still be black-or-white.
-$X2 = 260; $Y2 = 200; $W2 = 300; $H2 = 200
-$q2 = Invoke-BackdropStage $script:stage @{ op = 'place'; x = $X2; y = $Y2; w = $W2; h = $H2 }
-Add-Check 'place-moves' ($q2.x -eq $X2 -and $q2.y -eq $Y2 -and $q2.w -eq $W2 -and $q2.h -eq $H2) `
-    ("asked {0},{1} {2}x{3} got {4},{5} {6}x{7}" -f $X2, $Y2, $W2, $H2, $q2.x, $q2.y, $q2.w, $q2.h)
-Start-Sleep -Milliseconds 120
-$moved = Get-ScreenPixel -X ($X2 + [int]($W2 / 2)) -Y ($Y2 + [int]($H2 / 2))
-Add-Check 'pixels-follow' ((Test-PixelNear $moved '#000000' 40) -or (Test-PixelNear $moved '#FFFFFF' 40)) "new centre $($moved.Hex)"
-
-# Bigger than every monitor together. A harness grows the stage past the
-# window under test on every side, and a window that fills the screen needs
-# a stage that overhangs it; Windows clamps a window to the monitor unless
-# the stage overrides WM_GETMINMAXINFO, and this is the check that it does.
-$vs = Get-VirtualScreenRect
-$bigX = $vs.X - 200; $bigY = $vs.Y - 200; $bigW = $vs.W + 400; $bigH = $vs.H + 400
-$q3 = Invoke-BackdropStage $script:stage @{ op = 'place'; x = $bigX; y = $bigY; w = $bigW; h = $bigH }
-Add-Check 'bigger-than-screen' ($q3.x -eq $bigX -and $q3.y -eq $bigY -and $q3.w -eq $bigW -and $q3.h -eq $bigH) `
-    ("virtual screen {0}x{1}; asked {2},{3} {4}x{5} got {6},{7} {8}x{9}" -f $vs.W, $vs.H, $bigX, $bigY, $bigW, $bigH, $q3.x, $q3.y, $q3.w, $q3.h)
-[void](Invoke-BackdropStage $script:stage @{ op = 'place'; x = $X2; y = $Y2; w = $W2; h = $H2 })
-
-# Refusals are answered, not crashed on.
-$refused = $false
-try { [void](Invoke-BackdropStage $script:stage @{ op = 'image'; path = 'C:\no\such\file.png'; mode = 'stretch' }) }
-catch { $refused = "$_" -like '*no such image*' }
-Add-Check 'refuses-missing-image' $refused 'image op with a missing path is refused with a reason'
-$alive = -not $script:stage.Proc.HasExited
-Add-Check 'survives-refusal' $alive 'the stage is still up after a refused op'
-
-Stop-BackdropStage $script:stage
-$code = $script:stage.Proc.ExitCode
-Add-Check 'quit-exits-zero' ($code -eq 0) "exit code $code"
-$script:stage = $null
-
-[pscustomobject]@{ checks = $checks } | ConvertTo-Json -Depth 4 | Set-Content (Join-Path $OutDir 'result.json') -Encoding utf8
-Write-Host "backdrop-stage: $($checks.Count) checks passed"
-exit 0
+catch {
+    Write-Host "STAGE_SELFTEST_FAIL: $_" -ForegroundColor Red
+}
+finally {
+    # Every exit path, a throw and a Ctrl+C included, takes the stage down:
+    # its window has no taskbar entry and cannot be focused for Alt+F4.
+    if ($null -ne $script:stage) { try { Stop-BackdropStage $script:stage } catch { } }
+}
+exit $exitCode

--- a/windows/scripts/backdrop-stage-selftest.ps1
+++ b/windows/scripts/backdrop-stage-selftest.ps1
@@ -1,0 +1,129 @@
+#requires -Version 7
+<#
+    Prove the backdrop stage is an instrument before a matrix trusts it.
+
+    What is checked, against the screen rather than the stage's own answer:
+    the window comes up where it was told to and never takes the foreground;
+    every scene in the catalogue paints something that reads back as that
+    scene (a solid is its colour, a checker is black-or-white, a gradient and
+    a photograph vary between two points, the editor's gutter is its grey);
+    a place moves it and the pixels follow; quit ends the process with 0.
+
+    Launches no Wintty, sets no wallpaper, and is safe to run with anything
+    else open: the stage is topmost while it is up, so the pixels it is
+    judged on are its own unless another topmost window sits on the same
+    spot, which is reported rather than scored.
+
+    Exit 0 when the instrument is sound, 1 when it is not or could not be
+    started. There is no 2: this measures the instrument, never the product.
+#>
+param(
+    [string]$OutDir = (Join-Path $PSScriptRoot 'backdrop-stage-selftest')
+)
+. (Join-Path $PSScriptRoot 'lib/backdrop-stage.ps1')
+$ErrorActionPreference = 'Stop'
+
+trap {
+    Write-Host "STAGE_SELFTEST_FAIL: $_" -ForegroundColor Red
+    if ($null -ne $script:stage) { try { Stop-BackdropStage $script:stage } catch { } }
+    exit 1
+}
+
+New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+[void][StageWin]::SetProcessDpiAwarenessContext([IntPtr](-4))
+
+$checks = [System.Collections.Generic.List[object]]::new()
+function Add-Check([string]$Name, [bool]$Pass, [string]$Detail) {
+    $checks.Add([pscustomobject]@{ check = $Name; pass = $Pass; detail = $Detail })
+    $mark = if ($Pass) { 'ok  ' } else { 'FAIL' }
+    Write-Host ("  {0} {1,-28} {2}" -f $mark, $Name, $Detail)
+    if (-not $Pass) { throw "${Name}: $Detail" }
+}
+
+$X = 140; $Y = 140; $W = 480; $H = 320
+$foregroundBefore = [StageWin]::GetForegroundWindow()
+$script:stage = Start-BackdropStage -X $X -Y $Y -W $W -H $H
+
+$q = Invoke-BackdropStage $script:stage @{ op = 'query' }
+Add-Check 'placed-where-told' ($q.x -eq $X -and $q.y -eq $Y -and $q.w -eq $W -and $q.h -eq $H) `
+    ("asked {0},{1} {2}x{3} got {4},{5} {6}x{7}" -f $X, $Y, $W, $H, $q.x, $q.y, $q.w, $q.h)
+Add-Check 'hwnd-reported' ($q.hwnd -eq $script:stage.Hwnd64) "READY said $($script:stage.Hwnd64), query says $($q.hwnd)"
+
+$fgNow = [StageWin]::GetForegroundWindow()
+Add-Check 'never-activates' ($fgNow.ToInt64() -ne $script:stage.Hwnd64) `
+    ("foreground before {0}, now {1}, stage {2}" -f $foregroundBefore.ToInt64(), $fgNow.ToInt64(), $script:stage.Hwnd64)
+
+Start-Sleep -Milliseconds 300
+$sceneDir = Join-Path $OutDir 'scenes'
+$cx = $X + [int]($W / 2); $cy = $Y + [int]($H / 2)
+foreach ($scene in (Get-BackdropScenes).Values) {
+    $png = Set-BackdropScene -Stage $script:stage -Scene $scene -SceneDir $sceneDir -Width 960 -Height 540
+    Start-Sleep -Milliseconds 120
+    $centre = Get-ScreenPixel -X $cx -Y $cy
+    switch ($scene.Kind) {
+        'solid' {
+            Add-Check "scene-$($scene.Name)" (Test-PixelNear $centre $scene.Color 3) "centre $($centre.Hex) expected $($scene.Color)"
+        }
+        default {
+            switch ($scene.Name) {
+                'checker' {
+                    $p2 = Get-ScreenPixel -X ($cx + 3) -Y $cy
+                    $bw = { param($p) (Test-PixelNear $p '#000000' 40) -or (Test-PixelNear $p '#FFFFFF' 40) }
+                    Add-Check 'scene-checker' ((& $bw $centre) -and (& $bw $p2)) "centre $($centre.Hex), +3px $($p2.Hex): both must be near black or white"
+                }
+                'editor' {
+                    # The minimap band on the right is the one text-free
+                    # surface in the scene (the gutter carries line numbers,
+                    # and a sample there reads a glyph's anti-aliasing).
+                    $band = Get-ScreenPixel -X ($X + $W - 6) -Y ($Y + 40)
+                    Add-Check 'scene-editor' (Test-PixelNear $band '#F8F8F8' 6) "minimap band $($band.Hex) expected #F8F8F8"
+                }
+                default {
+                    $top = Get-ScreenPixel -X $cx -Y ($Y + 8)
+                    $bot = Get-ScreenPixel -X $cx -Y ($Y + $H - 8)
+                    $gap = [Math]::Abs($top.R - $bot.R) + [Math]::Abs($top.G - $bot.G) + [Math]::Abs($top.B - $bot.B)
+                    Add-Check "scene-$($scene.Name)" ($gap -gt 40) "top $($top.Hex) bottom $($bot.Hex) differ by $gap (needs > 40)"
+                }
+            }
+        }
+    }
+    Add-Check "png-$($scene.Name)" (Test-Path -LiteralPath $png) $png
+}
+
+# Move it and read the moved pixels: the last scene painted was the checker,
+# so the new centre must still be black-or-white.
+$X2 = 260; $Y2 = 200; $W2 = 300; $H2 = 200
+$q2 = Invoke-BackdropStage $script:stage @{ op = 'place'; x = $X2; y = $Y2; w = $W2; h = $H2 }
+Add-Check 'place-moves' ($q2.x -eq $X2 -and $q2.y -eq $Y2 -and $q2.w -eq $W2 -and $q2.h -eq $H2) `
+    ("asked {0},{1} {2}x{3} got {4},{5} {6}x{7}" -f $X2, $Y2, $W2, $H2, $q2.x, $q2.y, $q2.w, $q2.h)
+Start-Sleep -Milliseconds 120
+$moved = Get-ScreenPixel -X ($X2 + [int]($W2 / 2)) -Y ($Y2 + [int]($H2 / 2))
+Add-Check 'pixels-follow' ((Test-PixelNear $moved '#000000' 40) -or (Test-PixelNear $moved '#FFFFFF' 40)) "new centre $($moved.Hex)"
+
+# Bigger than every monitor together. A harness grows the stage past the
+# window under test on every side, and a window that fills the screen needs
+# a stage that overhangs it; Windows clamps a window to the monitor unless
+# the stage overrides WM_GETMINMAXINFO, and this is the check that it does.
+$vs = Get-VirtualScreenRect
+$bigX = $vs.X - 200; $bigY = $vs.Y - 200; $bigW = $vs.W + 400; $bigH = $vs.H + 400
+$q3 = Invoke-BackdropStage $script:stage @{ op = 'place'; x = $bigX; y = $bigY; w = $bigW; h = $bigH }
+Add-Check 'bigger-than-screen' ($q3.x -eq $bigX -and $q3.y -eq $bigY -and $q3.w -eq $bigW -and $q3.h -eq $bigH) `
+    ("virtual screen {0}x{1}; asked {2},{3} {4}x{5} got {6},{7} {8}x{9}" -f $vs.W, $vs.H, $bigX, $bigY, $bigW, $bigH, $q3.x, $q3.y, $q3.w, $q3.h)
+[void](Invoke-BackdropStage $script:stage @{ op = 'place'; x = $X2; y = $Y2; w = $W2; h = $H2 })
+
+# Refusals are answered, not crashed on.
+$refused = $false
+try { [void](Invoke-BackdropStage $script:stage @{ op = 'image'; path = 'C:\no\such\file.png'; mode = 'stretch' }) }
+catch { $refused = "$_" -like '*no such image*' }
+Add-Check 'refuses-missing-image' $refused 'image op with a missing path is refused with a reason'
+$alive = -not $script:stage.Proc.HasExited
+Add-Check 'survives-refusal' $alive 'the stage is still up after a refused op'
+
+Stop-BackdropStage $script:stage
+$code = $script:stage.Proc.ExitCode
+Add-Check 'quit-exits-zero' ($code -eq 0) "exit code $code"
+$script:stage = $null
+
+[pscustomobject]@{ checks = $checks } | ConvertTo-Json -Depth 4 | Set-Content (Join-Path $OutDir 'result.json') -Encoding utf8
+Write-Host "backdrop-stage: $($checks.Count) checks passed"
+exit 0

--- a/windows/scripts/fuzz-suite.ps1
+++ b/windows/scripts/fuzz-suite.ps1
@@ -268,6 +268,7 @@ $NotInSuite = [ordered]@{
     'seam-cdb.ps1'                  = 'needs cdb on PATH and takes a full dump at a fail-fast. Exits 0 with a dump path, 1 when the dump never appeared - so a crash that IS reproduced and a debugger that never fired look alike to an aggregator'
     'seam-crash-dump.ps1'           = 'writes WER LocalDumps registry state (snapshot, set, restore) and needs to be the only thing holding the process, since WER does not run under a debugger. Its exits are inverted for this suite''s purpose: 2 means the app SURVIVED and there was no crash to dump, which the runner would file as a product finding'
     'layout-motion-profile.ps1'     = 'an analysis tool, not a harness: it reads a layout-switch-filmstrip run that has already happened (-RunDir and -Tag, no -ExePath) and prints what moved, when and where. It launches nothing and returns no verdict; the change-box column is for a human reading a filmstrip that already failed'
+    'backdrop-stage-selftest.ps1'   = 'measures an instrument, not the product: it proves lib/BackdropStage paints the scene it was told to and never takes the foreground. Launches no Wintty, takes no -ExePath, and has no findings exit'
 }
 
 # The one form every check compares a script path in: the path relative to this

--- a/windows/scripts/lib/BackdropStage/BackdropStage.csproj
+++ b/windows/scripts/lib/BackdropStage/BackdropStage.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    The scenery: a window a harness parks UNDER the one it is measuring and
+    paints whatever a user might have behind a terminal. Deliberately NOT in
+    Ghostty.sln, the same arrangement WindowCapture has: backdrop-stage.ps1
+    builds it on demand.
+
+    WinForms rather than WinUI because the whole job is "own an HWND, paint
+    a bitmap into it, never take focus". A WinUI window brings its own
+    backdrop, activation and packaging, the three things this must not have.
+  -->
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
+    <Platforms>x64</Platforms>
+    <PlatformTarget>x64</PlatformTarget>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>false</SelfContained>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <AssemblyName>BackdropStage</AssemblyName>
+    <RootNamespace>BackdropStage</RootNamespace>
+  </PropertyGroup>
+
+</Project>

--- a/windows/scripts/lib/BackdropStage/Program.cs
+++ b/windows/scripts/lib/BackdropStage/Program.cs
@@ -16,9 +16,10 @@ namespace BackdropStage;
 /// It follows the test seam's shape on purpose: one named pipe, one JSON
 /// line per request, one line back, the pipe named after a session token in
 /// the environment (WINTTY_BACKDROP_STAGE, 32 hex characters),
-/// CurrentUserOnly, and every ack sent AFTER the paint has landed, so a
-/// driver that photographs on the ack photographs the scene it asked for.
-/// Nothing here can reach the app under test.
+/// CurrentUserOnly, and every ack sent AFTER the paint has landed AND the
+/// compositor has presented it (DwmFlush), so a driver that photographs on
+/// the ack photographs the scene it asked for. Nothing here can reach the
+/// app under test.
 ///
 /// It never activates (WS_EX_NOACTIVATE, ShowWithoutActivation): a harness
 /// measuring an activated window must not have its subject deactivated by
@@ -29,7 +30,8 @@ namespace BackdropStage;
 /// Protocol: {"op":"place","x","y","w","h"} in device pixels,
 /// {"op":"solid","color":"#RRGGBB"}, {"op":"image","path","mode":"stretch|tile"},
 /// {"op":"query"}, {"op":"quit"}. Every response carries ok, op, hwnd, pid,
-/// the window rect and the scene.
+/// the window rect and the scene, all read on the UI thread in the same
+/// turn as the mutation they describe.
 ///
 /// Exit codes: 0 after quit, 2 on an internal failure, 120 when the token is
 /// missing or malformed (incoda's "usage" code, so a wrapper can tell a
@@ -56,11 +58,37 @@ internal static class Program
         try
         {
             ApplicationConfiguration.Initialize();
+            // Without this, an exception thrown on the UI thread outside an
+            // Invoke (a GDI+ decode that only fails at DrawImage time, for
+            // one) goes to WinForms' ThreadException dialog: a modal box
+            // parked topmost on the desktop under test, the ack never sent,
+            // the driver hung until its kill. Thrown, it lands in the catch
+            // below and leaves as STAGE_FAIL with a 2.
+            Application.SetUnhandledExceptionMode(UnhandledExceptionMode.ThrowException);
             var stage = new StageForm(
                 ArgInt(args, "--x", 0), ArgInt(args, "--y", 0),
                 ArgInt(args, "--w", 800), ArgInt(args, "--h", 600));
             var pipeName = PipeNamePrefix + token;
-            var server = new Thread(() => Serve(stage, pipeName)) { IsBackground = true };
+            var server = new Thread(() => Serve(stage, pipeName))
+            {
+                IsBackground = true, Name = "backdrop-pipe",
+            };
+            // A borderless, non-activating, topmost tool window has no
+            // taskbar entry, no Alt-Tab slot and cannot be focused for
+            // Alt+F4: a driver that dies after READY (a Ctrl+C, a throw
+            // before its own cleanup) would leave it on the desktop until
+            // someone finds it in Task Manager. So the stage follows its
+            // driver down: --parent names the pid to watch.
+            var parent = ArgInt(args, "--parent", 0);
+            if (parent > 0)
+            {
+                new Thread(() =>
+                {
+                    try { System.Diagnostics.Process.GetProcessById(parent).WaitForExit(); }
+                    catch (ArgumentException) { /* already gone */ }
+                    CloseStage(stage);
+                }) { IsBackground = true, Name = "backdrop-parent-watch" }.Start();
+            }
             stage.Shown += (_, _) =>
             {
                 server.Start();
@@ -102,26 +130,32 @@ internal static class Program
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {
-                // Something already owns this token's name. Going quiet is the
-                // seam's answer too: the driver's connect times out and says so.
+                // Something already owns this token's name. The seam goes
+                // quiet here because it is the product; a stage has no
+                // reason to stay on the desktop with nobody able to reach
+                // it, so it says why and takes its window down.
                 Console.Error.WriteLine($"STAGE_FAIL pipe name taken: {ex.Message}");
+                CloseStage(stage);
                 return;
             }
             try
             {
                 pipe.WaitForConnection();
-                using var reader = new StreamReader(pipe, new UTF8Encoding(false));
-                using var writer = new StreamWriter(pipe, new UTF8Encoding(false))
+                var reader = new BoundedLineReader(pipe, MaxRequestBytes);
+                var writer = new StreamWriter(pipe, new UTF8Encoding(false), leaveOpen: true)
                 {
                     AutoFlush = true, NewLine = "\n",
                 };
                 while (pipe.IsConnected && !stage.IsDisposed)
                 {
-                    var line = reader.ReadLine();
-                    if (line is null) break;
-                    if (line.Length > MaxRequestBytes)
+                    var (status, line) = reader.ReadLine();
+                    if (status == LineStatus.Eof) break;
+                    if (status == LineStatus.TooLong)
                     {
-                        writer.WriteLine(Error("parse", "request too long"));
+                        // No resyncing after this: the rest of the oversized
+                        // line is bytes of unknown shape. Say so once and
+                        // drop the connection; the accept loop takes the next.
+                        writer.WriteLine(Error("parse", $"request exceeds {MaxRequestBytes} bytes"));
                         break;
                     }
                     if (string.IsNullOrWhiteSpace(line)) continue;
@@ -129,7 +163,11 @@ internal static class Program
                     writer.WriteLine(response);
                     if (quit)
                     {
-                        stage.BeginInvoke(stage.Close);
+                        // The ack has to reach the client before the handle
+                        // goes: DisconnectNamedPipe discards unread bytes,
+                        // Dispose on a drained pipe does not.
+                        pipe.WaitForPipeDrain();
+                        CloseStage(stage);
                         return;
                     }
                 }
@@ -140,8 +178,57 @@ internal static class Program
             }
             finally
             {
-                try { if (pipe.IsConnected) pipe.Disconnect(); } catch { }
+                // Dispose, not Disconnect: Disconnect throws away anything the
+                // client has not read yet, which on this path is the last
+                // response sent. Closing the handle delivers it.
                 pipe.Dispose();
+            }
+        }
+    }
+
+    private static void CloseStage(StageForm stage)
+    {
+        try { if (!stage.IsDisposed) stage.BeginInvoke(stage.Close); }
+        catch (InvalidOperationException) { /* already gone */ }
+    }
+
+    private enum LineStatus { Ok, Eof, TooLong }
+
+    /// <summary>
+    /// Reads newline-delimited UTF-8 requests off the pipe with a hard
+    /// ceiling on one line, enforced on the bytes as they arrive. The
+    /// seam's reader exists for the same reason: StreamReader.ReadLine has
+    /// no ceiling and buffers until it sees a newline, so a check on the
+    /// finished string is a check after the memory was already spent.
+    /// </summary>
+    private sealed class BoundedLineReader(Stream stream, int maxBytes)
+    {
+        private readonly byte[] _chunk = new byte[4096];
+        private readonly MemoryStream _line = new();
+        private int _next;
+        private int _filled;
+
+        public (LineStatus Status, string Line) ReadLine()
+        {
+            _line.SetLength(0);
+            while (true)
+            {
+                if (_next == _filled)
+                {
+                    _filled = stream.Read(_chunk, 0, _chunk.Length);
+                    _next = 0;
+                    if (_filled == 0) return (LineStatus.Eof, string.Empty);
+                }
+                var newline = Array.IndexOf(_chunk, (byte)'\n', _next, _filled - _next);
+                var take = (newline >= 0 ? newline : _filled) - _next;
+                if (_line.Length + take > maxBytes) return (LineStatus.TooLong, string.Empty);
+                _line.Write(_chunk, _next, take);
+                _next += take;
+                if (newline < 0) continue;
+                _next++;
+                var bytes = _line.GetBuffer().AsSpan(0, (int)_line.Length);
+                if (bytes.Length > 0 && bytes[^1] == (byte)'\r') bytes = bytes[..^1];
+                return (LineStatus.Ok, Encoding.UTF8.GetString(bytes));
             }
         }
     }
@@ -163,11 +250,13 @@ internal static class Program
 
             try
             {
-                // Every mutation runs on the UI thread and Refresh() is
-                // synchronous, so by the time Invoke returns the pixels are on
-                // screen and the ack below is not a promise.
-                string? failure = null;
-                stage.Invoke(() =>
+                // Every mutation AND the response describing it run on the UI
+                // thread in one turn: Refresh() is synchronous and DwmFlush
+                // waits for the present, so by the time Invoke returns the
+                // pixels are on screen and the hwnd, rect and scene in the
+                // reply are the ones that were painted, not a later read
+                // from a thread that must not touch the control anyway.
+                var response = (string)stage.Invoke(() =>
                 {
                     switch (op)
                     {
@@ -186,12 +275,11 @@ internal static class Program
                         case "quit":
                             break;
                         default:
-                            failure = $"unknown op '{op}'";
-                            break;
+                            return Error(op, $"unknown op '{op}'");
                     }
+                    return Ok(stage, op);
                 });
-                if (failure is not null) return (Error(op, failure), false);
-                return (Ok(stage, op), op == "quit");
+                return (response, op == "quit" && response.StartsWith("{\"ok\":true", StringComparison.Ordinal));
             }
             catch (Exception ex)
             {
@@ -200,6 +288,7 @@ internal static class Program
         }
     }
 
+    /// <summary>UI thread only: reads the handle and the rect.</summary>
     private static string Ok(StageForm stage, string op)
     {
         var rect = stage.ScreenRect();
@@ -222,7 +311,18 @@ internal static class Program
     }
 
     private static string Error(string op, string message)
-        => JsonSerializer.Serialize(new { ok = false, op, error = message });
+    {
+        using var stream = new MemoryStream();
+        using (var json = new Utf8JsonWriter(stream))
+        {
+            json.WriteStartObject();
+            json.WriteBoolean("ok", false);
+            json.WriteString("op", op);
+            json.WriteString("error", message);
+            json.WriteEndObject();
+        }
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
 
     private static int ArgInt(string[] args, string name, int fallback)
     {
@@ -256,8 +356,10 @@ internal sealed class StageForm : Form
 
     [DllImport("user32.dll", SetLastError = true)]
     private static extern bool SetWindowPos(IntPtr h, IntPtr after, int x, int y, int w, int hh, uint flags);
-    [DllImport("user32.dll")]
+    [DllImport("user32.dll", SetLastError = true)]
     private static extern bool GetWindowRect(IntPtr h, out RECT r);
+    [DllImport("dwmapi.dll")]
+    private static extern int DwmFlush();
 
     [StructLayout(LayoutKind.Sequential)]
     public struct RECT { public int Left, Top, Right, Bottom; }
@@ -273,7 +375,9 @@ internal sealed class StageForm : Form
     private Color _solid = Color.Black;
     private Image? _image;
     private string _mode = "stretch";
-    private readonly int _x, _y, _w, _h;
+    // The last rect asked for, so a handle recreation lands on it and not
+    // on the launch rect.
+    private int _x, _y, _w, _h;
 
     public string SceneDescription { get; private set; } = "solid #000000";
 
@@ -286,8 +390,11 @@ internal sealed class StageForm : Form
         StartPosition = FormStartPosition.Manual;
         // TopMost via SetWindowPos below rather than the property, so the
         // placement and the z-order land in one call with SWP_NOACTIVATE.
+        // No double buffering: a flat surface that is only ever photographed
+        // has no flicker to hide, and a back buffer the size of a stage that
+        // overhangs every monitor is memory for nothing.
         SetStyle(ControlStyles.AllPaintingInWmPaint | ControlStyles.UserPaint
-                 | ControlStyles.OptimizedDoubleBuffer | ControlStyles.ResizeRedraw, true);
+                 | ControlStyles.ResizeRedraw, true);
     }
 
     protected override bool ShowWithoutActivation => true;
@@ -306,6 +413,17 @@ internal sealed class StageForm : Form
     {
         base.OnHandleCreated(e);
         Place(_x, _y, _w, _h);
+    }
+
+    /// <summary>
+    /// The harness owns the rect, in device pixels. Under PerMonitorV2
+    /// WinForms would otherwise apply the OS's suggested rectangle when the
+    /// window's centre crosses to a monitor of a different DPI, rescaling a
+    /// stage that was deliberately placed to straddle them.
+    /// </summary>
+    protected override void OnDpiChanged(DpiChangedEventArgs e)
+    {
+        e.Cancel = true;
     }
 
     /// <summary>
@@ -338,12 +456,14 @@ internal sealed class StageForm : Form
         if (!SetWindowPos(Handle, HWND_TOPMOST, x, y, w, h, SWP_NOACTIVATE | SWP_SHOWWINDOW))
             throw new InvalidOperationException(
                 $"SetWindowPos failed ({Marshal.GetLastWin32Error()})");
-        Refresh();
+        _x = x; _y = y; _w = w; _h = h;
+        Present();
     }
 
     public RECT ScreenRect()
     {
-        GetWindowRect(Handle, out var r);
+        if (!GetWindowRect(Handle, out var r))
+            throw new InvalidOperationException($"GetWindowRect failed ({Marshal.GetLastWin32Error()})");
         return r;
     }
 
@@ -353,22 +473,39 @@ internal sealed class StageForm : Form
         _image?.Dispose();
         _image = null;
         SceneDescription = $"solid {hex}";
-        Refresh();
+        Present();
     }
 
     public void SetImage(string path, string mode)
     {
-        if (!File.Exists(path)) throw new FileNotFoundException("no such image", path);
         if (mode is not ("stretch" or "tile"))
             throw new ArgumentException($"unknown mode '{mode}'");
-        // Copied out of the file so nothing holds it open afterwards.
-        var bytes = File.ReadAllBytes(path);
-        var loaded = Image.FromStream(new MemoryStream(bytes));
+        var full = Path.GetFullPath(path);
+        if (!File.Exists(full)) throw new FileNotFoundException("no such image", full);
+        // Decoded fully and detached from its bytes: GDI+ otherwise decodes
+        // lazily off the stream it was given, and a stream someone later
+        // wraps in a using would break the paint.
+        Image loaded;
+        using (var source = Image.FromStream(new MemoryStream(File.ReadAllBytes(full))))
+            loaded = new Bitmap(source);
         _image?.Dispose();
         _image = loaded;
         _mode = mode;
-        SceneDescription = $"image {mode} {path}";
+        SceneDescription = $"image {mode} {full}";
+        Present();
+    }
+
+    /// <summary>
+    /// Paint now and wait for the compositor to show it. Refresh() returns
+    /// when WM_PAINT has, which puts the pixels in the window's redirection
+    /// surface; a screen grab can still see the previous frame until DWM
+    /// presents. DwmFlush blocks until that next present, which is what
+    /// makes the ack a promise about the screen and not about a buffer.
+    /// </summary>
+    private void Present()
+    {
         Refresh();
+        _ = DwmFlush();
     }
 
     protected override void OnPaint(PaintEventArgs e)
@@ -384,6 +521,12 @@ internal sealed class StageForm : Form
         }
         g.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.HighQualityBicubic;
         g.DrawImage(_image, ClientRectangle);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing) { _image?.Dispose(); _image = null; }
+        base.Dispose(disposing);
     }
 
     private static Color ParseColor(string hex)

--- a/windows/scripts/lib/BackdropStage/Program.cs
+++ b/windows/scripts/lib/BackdropStage/Program.cs
@@ -1,0 +1,396 @@
+using System.IO.Pipes;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
+
+namespace BackdropStage;
+
+/// <summary>
+/// A window that stands in for "whatever is behind the terminal".
+///
+/// A contrast measurement taken in front of whatever the developer happened
+/// to have open is a measurement of that developer's desktop. This process
+/// gives a harness a backdrop it chooses, can move, and can repaint between
+/// photographs, so the scene behind the chrome is a named input to the run.
+///
+/// It follows the test seam's shape on purpose: one named pipe, one JSON
+/// line per request, one line back, the pipe named after a session token in
+/// the environment (WINTTY_BACKDROP_STAGE, 32 hex characters),
+/// CurrentUserOnly, and every ack sent AFTER the paint has landed, so a
+/// driver that photographs on the ack photographs the scene it asked for.
+/// Nothing here can reach the app under test.
+///
+/// It never activates (WS_EX_NOACTIVATE, ShowWithoutActivation): a harness
+/// measuring an activated window must not have its subject deactivated by
+/// its own scenery. TOPMOST, so it sits above every ordinary window; the
+/// harness places the window under test TOPMOST afterwards, which lands it
+/// above this one.
+///
+/// Protocol: {"op":"place","x","y","w","h"} in device pixels,
+/// {"op":"solid","color":"#RRGGBB"}, {"op":"image","path","mode":"stretch|tile"},
+/// {"op":"query"}, {"op":"quit"}. Every response carries ok, op, hwnd, pid,
+/// the window rect and the scene.
+///
+/// Exit codes: 0 after quit, 2 on an internal failure, 120 when the token is
+/// missing or malformed (incoda's "usage" code, so a wrapper can tell a
+/// refusal from a crash).
+/// </summary>
+internal static class Program
+{
+    private const string EnvVar = "WINTTY_BACKDROP_STAGE";
+    private const string PipeNamePrefix = "wintty-backdrop-stage-";
+    private const int TokenLength = 32;
+    private const int MaxRequestBytes = 16 * 1024;
+
+    [STAThread]
+    private static int Main(string[] args)
+    {
+        var token = Environment.GetEnvironmentVariable(EnvVar);
+        if (!IsSessionToken(token))
+        {
+            Console.Error.WriteLine(
+                $"STAGE_REFUSED {EnvVar} must hold a {TokenLength}-character hex session token");
+            return 120;
+        }
+
+        try
+        {
+            ApplicationConfiguration.Initialize();
+            var stage = new StageForm(
+                ArgInt(args, "--x", 0), ArgInt(args, "--y", 0),
+                ArgInt(args, "--w", 800), ArgInt(args, "--h", 600));
+            var pipeName = PipeNamePrefix + token;
+            var server = new Thread(() => Serve(stage, pipeName)) { IsBackground = true };
+            stage.Shown += (_, _) =>
+            {
+                server.Start();
+                // READY is the driver's cue that the HWND exists and the pipe
+                // is about to be listening. Printed from the UI thread after
+                // Shown so the handle in it is a real, visible window.
+                Console.Out.WriteLine($"READY {stage.Handle.ToInt64()} {Environment.ProcessId}");
+                Console.Out.Flush();
+            };
+            Application.Run(stage);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"STAGE_FAIL {ex.GetType().Name}: {ex.Message}");
+            return 2;
+        }
+    }
+
+    private static bool IsSessionToken(string? value)
+    {
+        if (value is null || value.Length != TokenLength) return false;
+        foreach (var c in value)
+            if (!char.IsAsciiHexDigit(c)) return false;
+        return true;
+    }
+
+    private static void Serve(StageForm stage, string pipeName)
+    {
+        while (!stage.IsDisposed)
+        {
+            NamedPipeServerStream pipe;
+            try
+            {
+                pipe = new NamedPipeServerStream(
+                    pipeName, PipeDirection.InOut, maxNumberOfServerInstances: 1,
+                    PipeTransmissionMode.Byte,
+                    PipeOptions.Asynchronous | PipeOptions.CurrentUserOnly);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                // Something already owns this token's name. Going quiet is the
+                // seam's answer too: the driver's connect times out and says so.
+                Console.Error.WriteLine($"STAGE_FAIL pipe name taken: {ex.Message}");
+                return;
+            }
+            try
+            {
+                pipe.WaitForConnection();
+                using var reader = new StreamReader(pipe, new UTF8Encoding(false));
+                using var writer = new StreamWriter(pipe, new UTF8Encoding(false))
+                {
+                    AutoFlush = true, NewLine = "\n",
+                };
+                while (pipe.IsConnected && !stage.IsDisposed)
+                {
+                    var line = reader.ReadLine();
+                    if (line is null) break;
+                    if (line.Length > MaxRequestBytes)
+                    {
+                        writer.WriteLine(Error("parse", "request too long"));
+                        break;
+                    }
+                    if (string.IsNullOrWhiteSpace(line)) continue;
+                    var (response, quit) = Execute(stage, line);
+                    writer.WriteLine(response);
+                    if (quit)
+                    {
+                        stage.BeginInvoke(stage.Close);
+                        return;
+                    }
+                }
+            }
+            catch (Exception ex) when (ex is IOException or ObjectDisposedException)
+            {
+                // The client hung up mid-line; accept the next one.
+            }
+            finally
+            {
+                try { if (pipe.IsConnected) pipe.Disconnect(); } catch { }
+                pipe.Dispose();
+            }
+        }
+    }
+
+    private static (string Response, bool Quit) Execute(StageForm stage, string line)
+    {
+        JsonDocument doc;
+        try { doc = JsonDocument.Parse(line); }
+        catch (JsonException ex) { return (Error("parse", ex.Message), false); }
+
+        using (doc)
+        {
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object
+                || !root.TryGetProperty("op", out var opEl)
+                || opEl.ValueKind != JsonValueKind.String)
+                return (Error("parse", "request needs a string 'op'"), false);
+            var op = opEl.GetString()!;
+
+            try
+            {
+                // Every mutation runs on the UI thread and Refresh() is
+                // synchronous, so by the time Invoke returns the pixels are on
+                // screen and the ack below is not a promise.
+                string? failure = null;
+                stage.Invoke(() =>
+                {
+                    switch (op)
+                    {
+                        case "place":
+                            stage.Place(ArgInt(root, "x"), ArgInt(root, "y"),
+                                        ArgInt(root, "w"), ArgInt(root, "h"));
+                            break;
+                        case "solid":
+                            stage.SetSolid(ArgString(root, "color") ?? "#000000");
+                            break;
+                        case "image":
+                            stage.SetImage(ArgString(root, "path") ?? "",
+                                           ArgString(root, "mode") ?? "stretch");
+                            break;
+                        case "query":
+                        case "quit":
+                            break;
+                        default:
+                            failure = $"unknown op '{op}'";
+                            break;
+                    }
+                });
+                if (failure is not null) return (Error(op, failure), false);
+                return (Ok(stage, op), op == "quit");
+            }
+            catch (Exception ex)
+            {
+                return (Error(op, ex.InnerException?.Message ?? ex.Message), false);
+            }
+        }
+    }
+
+    private static string Ok(StageForm stage, string op)
+    {
+        var rect = stage.ScreenRect();
+        using var stream = new MemoryStream();
+        using (var json = new Utf8JsonWriter(stream))
+        {
+            json.WriteStartObject();
+            json.WriteBoolean("ok", true);
+            json.WriteString("op", op);
+            json.WriteNumber("hwnd", stage.Handle.ToInt64());
+            json.WriteNumber("pid", Environment.ProcessId);
+            json.WriteNumber("x", rect.Left);
+            json.WriteNumber("y", rect.Top);
+            json.WriteNumber("w", rect.Right - rect.Left);
+            json.WriteNumber("h", rect.Bottom - rect.Top);
+            json.WriteString("scene", stage.SceneDescription);
+            json.WriteEndObject();
+        }
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    private static string Error(string op, string message)
+        => JsonSerializer.Serialize(new { ok = false, op, error = message });
+
+    private static int ArgInt(string[] args, string name, int fallback)
+    {
+        for (int i = 0; i + 1 < args.Length; i++)
+            if (args[i] == name && int.TryParse(args[i + 1], out var v)) return v;
+        return fallback;
+    }
+
+    private static int ArgInt(JsonElement args, string name)
+        => args.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.Number
+            ? v.GetInt32() : throw new ArgumentException($"'{name}' is required");
+
+    private static string? ArgString(JsonElement args, string name)
+        => args.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.String
+            ? v.GetString() : null;
+}
+
+/// <summary>
+/// The window itself: a borderless, non-activating, topmost surface that
+/// paints one scene. Solid or image; the image is copied out of its file at
+/// load so the file is never held open (a harness regenerates scenes in
+/// place between runs).
+/// </summary>
+internal sealed class StageForm : Form
+{
+    private const int WS_EX_NOACTIVATE = 0x08000000;
+    private const int WS_EX_TOOLWINDOW = 0x00000080;
+    private const uint SWP_NOACTIVATE = 0x0010;
+    private const uint SWP_SHOWWINDOW = 0x0040;
+    private static readonly IntPtr HWND_TOPMOST = new(-1);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern bool SetWindowPos(IntPtr h, IntPtr after, int x, int y, int w, int hh, uint flags);
+    [DllImport("user32.dll")]
+    private static extern bool GetWindowRect(IntPtr h, out RECT r);
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RECT { public int Left, Top, Right, Bottom; }
+    [StructLayout(LayoutKind.Sequential)]
+    private struct POINT { public int X, Y; }
+    [StructLayout(LayoutKind.Sequential)]
+    private struct MINMAXINFO
+    {
+        public POINT ptReserved, ptMaxSize, ptMaxPosition, ptMinTrackSize, ptMaxTrackSize;
+    }
+    private const int WM_GETMINMAXINFO = 0x0024;
+
+    private Color _solid = Color.Black;
+    private Image? _image;
+    private string _mode = "stretch";
+    private readonly int _x, _y, _w, _h;
+
+    public string SceneDescription { get; private set; } = "solid #000000";
+
+    public StageForm(int x, int y, int w, int h)
+    {
+        _x = x; _y = y; _w = w; _h = h;
+        Text = "Wintty Backdrop Stage";
+        FormBorderStyle = FormBorderStyle.None;
+        ShowInTaskbar = false;
+        StartPosition = FormStartPosition.Manual;
+        // TopMost via SetWindowPos below rather than the property, so the
+        // placement and the z-order land in one call with SWP_NOACTIVATE.
+        SetStyle(ControlStyles.AllPaintingInWmPaint | ControlStyles.UserPaint
+                 | ControlStyles.OptimizedDoubleBuffer | ControlStyles.ResizeRedraw, true);
+    }
+
+    protected override bool ShowWithoutActivation => true;
+
+    protected override CreateParams CreateParams
+    {
+        get
+        {
+            var cp = base.CreateParams;
+            cp.ExStyle |= WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW;
+            return cp;
+        }
+    }
+
+    protected override void OnHandleCreated(EventArgs e)
+    {
+        base.OnHandleCreated(e);
+        Place(_x, _y, _w, _h);
+    }
+
+    /// <summary>
+    /// The stage must be able to be BIGGER than the monitor: a harness
+    /// grows it past the window under test on every side so a translucent
+    /// frame at the window's edge still has scene behind it, and a window
+    /// under test that fills the screen needs a stage that overhangs it.
+    /// Windows answers WM_GETMINMAXINFO with the monitor's size as the
+    /// maximum tracking size and SetWindowPos honours it, so without this
+    /// override a place larger than the screen is silently clamped, and the
+    /// query would report a rect the caller never asked for.
+    /// </summary>
+    protected override void WndProc(ref Message m)
+    {
+        if (m.Msg == WM_GETMINMAXINFO)
+        {
+            base.WndProc(ref m);
+            var info = Marshal.PtrToStructure<MINMAXINFO>(m.LParam);
+            info.ptMaxTrackSize = new POINT { X = 32000, Y = 32000 };
+            info.ptMaxSize = info.ptMaxTrackSize;
+            Marshal.StructureToPtr(info, m.LParam, false);
+            return;
+        }
+        base.WndProc(ref m);
+    }
+
+    public void Place(int x, int y, int w, int h)
+    {
+        if (w < 1 || h < 1) throw new ArgumentException("w and h must be positive");
+        if (!SetWindowPos(Handle, HWND_TOPMOST, x, y, w, h, SWP_NOACTIVATE | SWP_SHOWWINDOW))
+            throw new InvalidOperationException(
+                $"SetWindowPos failed ({Marshal.GetLastWin32Error()})");
+        Refresh();
+    }
+
+    public RECT ScreenRect()
+    {
+        GetWindowRect(Handle, out var r);
+        return r;
+    }
+
+    public void SetSolid(string hex)
+    {
+        _solid = ParseColor(hex);
+        _image?.Dispose();
+        _image = null;
+        SceneDescription = $"solid {hex}";
+        Refresh();
+    }
+
+    public void SetImage(string path, string mode)
+    {
+        if (!File.Exists(path)) throw new FileNotFoundException("no such image", path);
+        if (mode is not ("stretch" or "tile"))
+            throw new ArgumentException($"unknown mode '{mode}'");
+        // Copied out of the file so nothing holds it open afterwards.
+        var bytes = File.ReadAllBytes(path);
+        var loaded = Image.FromStream(new MemoryStream(bytes));
+        _image?.Dispose();
+        _image = loaded;
+        _mode = mode;
+        SceneDescription = $"image {mode} {path}";
+        Refresh();
+    }
+
+    protected override void OnPaint(PaintEventArgs e)
+    {
+        var g = e.Graphics;
+        g.Clear(_solid);
+        if (_image is null) return;
+        if (_mode == "tile")
+        {
+            using var brush = new TextureBrush(_image);
+            g.FillRectangle(brush, ClientRectangle);
+            return;
+        }
+        g.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.HighQualityBicubic;
+        g.DrawImage(_image, ClientRectangle);
+    }
+
+    private static Color ParseColor(string hex)
+    {
+        var s = hex.TrimStart('#');
+        if (s.Length != 6 || !int.TryParse(s, System.Globalization.NumberStyles.HexNumber, null, out var rgb))
+            throw new ArgumentException($"colour must be #RRGGBB, got '{hex}'");
+        return Color.FromArgb((rgb >> 16) & 0xFF, (rgb >> 8) & 0xFF, rgb & 0xFF);
+    }
+}

--- a/windows/scripts/lib/backdrop-stage.ps1
+++ b/windows/scripts/lib/backdrop-stage.ps1
@@ -11,8 +11,8 @@
     whatever wallpaper the developer has. So a scene is one PNG applied
     twice: painted on the stage, and set as the wallpaper.
 
-    Scenes are generated, not shipped: each is reproducible from its name
-    and a seed, and "photo" is procedural rather than a file to carry.
+    Scenes are generated, not shipped: each is reproducible from its name,
+    size and seed, and "photo" is procedural rather than a file to carry.
 
     Dot-source it:
 
@@ -22,9 +22,14 @@
         Stop-BackdropStage $stage
 
     The wallpaper is machine state. A caller that passes -Wallpaper owns
-    putting it back: Get-DesktopWallpaper before, Set-DesktopWallpaper in a
-    finally; lib/env-guard.ps1's snapshot covers the registry side for
-    `just env-restore` after a crash.
+    putting it back: `$before = Get-DesktopWallpaper` first and
+    `Set-DesktopWallpaper -Snapshot $before` in a finally, which reads the
+    registry back and throws if it disagrees. lib/env-guard.ps1's snapshot
+    covers the registry side for `just env-restore` after a crash, but a
+    registry restore does not repaint the desktop: after a crashed
+    -Wallpaper run, re-run Set-DesktopWallpaper (or log off) to see the old
+    wallpaper again. Only a single static image is captured; a slideshow,
+    Spotlight or per-monitor wallpaper comes back as its current image.
 #>
 
 Add-Type -AssemblyName System.Drawing
@@ -56,11 +61,19 @@ Add-Type -TypeDefinition @'
 using System;
 using System.Runtime.InteropServices;
 public static class StageWin {
+    [StructLayout(LayoutKind.Sequential)] public struct POINT { public int X, Y; }
     [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
     [DllImport("user32.dll")] public static extern int GetSystemMetrics(int index);
     [DllImport("user32.dll")] public static extern bool SetProcessDpiAwarenessContext(IntPtr value);
+    [DllImport("user32.dll")] static extern IntPtr WindowFromPoint(POINT p);
+    [DllImport("user32.dll")] static extern uint GetWindowThreadProcessId(IntPtr h, out uint pid);
     [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
     public static extern bool SystemParametersInfo(uint uiAction, uint uiParam, string pvParam, uint fWinIni);
+    // Whose pixels are at a point: the proof a caller needs that a pixel it
+    // is about to read belongs to the stage and not to whatever is on top.
+    public static uint PidAt(int x, int y) {
+        uint pid; GetWindowThreadProcessId(WindowFromPoint(new POINT { X = x, Y = y }), out pid); return pid;
+    }
 }
 '@
 }
@@ -84,7 +97,9 @@ function New-BackdropStageToken {
 }
 
 # Launch the stage at a device-pixel rect and connect its pipe. Returns the
-# session every other function here takes.
+# session every other function here takes. A launch that gets as far as a
+# window and no further is killed here, not left for the operator: the
+# stage's window has no taskbar entry and cannot be focused for Alt+F4.
 function Start-BackdropStage {
     param(
         [Parameter(Mandatory)][int]$X,
@@ -95,41 +110,47 @@ function Start-BackdropStage {
     )
     $exe = Assert-BackdropStageReady
     $token = New-BackdropStageToken
-    $orig = if (Test-Path Env:WINTTY_BACKDROP_STAGE) { $env:WINTTY_BACKDROP_STAGE } else { $null }
-    $env:WINTTY_BACKDROP_STAGE = $token
 
     $psi = [System.Diagnostics.ProcessStartInfo]::new()
     $psi.FileName = $exe
-    foreach ($a in @('--x', $X, '--y', $Y, '--w', $W, '--h', $H)) { $psi.ArgumentList.Add([string]$a) }
+    # --parent: the stage closes itself when this shell dies, so a Ctrl+C or
+    # a throw before the caller's own cleanup cannot orphan it.
+    foreach ($a in @('--x', $X, '--y', $Y, '--w', $W, '--h', $H, '--parent', $PID)) { $psi.ArgumentList.Add([string]$a) }
+    # The token goes to the child alone. Setting it on this process would
+    # hand it to every process launched afterwards, the app under test
+    # included.
+    $psi.Environment['WINTTY_BACKDROP_STAGE'] = $token
     $psi.RedirectStandardOutput = $true
     $psi.RedirectStandardError = $true
     $psi.UseShellExecute = $false
     $proc = [System.Diagnostics.Process]::Start($psi)
 
-    # READY <hwnd> <pid> is printed after the window is shown; a process that
-    # exits first has printed why on stderr.
-    $ready = $proc.StandardOutput.ReadLine()
-    if ($ready -notlike 'READY *') {
-        $err = $proc.StandardError.ReadToEnd()
-        if ($null -ne $orig) { $env:WINTTY_BACKDROP_STAGE = $orig } else { Remove-Item Env:WINTTY_BACKDROP_STAGE -ErrorAction SilentlyContinue }
-        throw "HARNESS: the backdrop stage did not come up: '$ready' $err"
+    try {
+        # READY <hwnd> <pid> is printed after the window is shown; a process
+        # that exits first has printed why on stderr.
+        $ready = $proc.StandardOutput.ReadLine()
+        if ($ready -notlike 'READY *') {
+            $err = $proc.StandardError.ReadToEnd()
+            throw "HARNESS: the backdrop stage did not come up: '$ready' $err"
+        }
+        $parts = $ready.Split(' ')
+        $session = @{ Proc = $proc; Token = $token; Hwnd64 = [int64]$parts[1] }
+        $pipe = [System.IO.Pipes.NamedPipeClientStream]::new(
+            '.', "wintty-backdrop-stage-$token",
+            [System.IO.Pipes.PipeDirection]::InOut,
+            [System.IO.Pipes.PipeOptions]::CurrentUserOnly)
+        $pipe.Connect($TimeoutSeconds * 1000)
+        $session.Pipe = $pipe
+        $session.Reader = [System.IO.StreamReader]::new($pipe)
+        $session.Writer = [System.IO.StreamWriter]::new($pipe, [System.Text.UTF8Encoding]::new($false))
+        $session.Writer.AutoFlush = $true
+        $session.Writer.NewLine = "`n"
+        return $session
     }
-    $parts = $ready.Split(' ')
-    $session = @{
-        Proc = $proc; Token = $token; OrigToken = $orig
-        Hwnd64 = [int64]$parts[1]
+    catch {
+        try { if (-not $proc.HasExited) { $proc.Kill($true) } } catch { }
+        throw
     }
-    $pipe = [System.IO.Pipes.NamedPipeClientStream]::new(
-        '.', "wintty-backdrop-stage-$token",
-        [System.IO.Pipes.PipeDirection]::InOut,
-        [System.IO.Pipes.PipeOptions]::CurrentUserOnly)
-    $pipe.Connect($TimeoutSeconds * 1000)
-    $session.Pipe = $pipe
-    $session.Reader = [System.IO.StreamReader]::new($pipe)
-    $session.Writer = [System.IO.StreamWriter]::new($pipe, [System.Text.UTF8Encoding]::new($false))
-    $session.Writer.AutoFlush = $true
-    $session.Writer.NewLine = "`n"
-    return $session
 }
 
 # One request, one response. A refusal from the stage is a HARNESS failure,
@@ -153,8 +174,6 @@ function Stop-BackdropStage {
     try { if (-not $Stage.Proc.HasExited) { [void](Invoke-BackdropStage $Stage @{ op = 'quit' }) } } catch { }
     foreach ($k in 'Writer', 'Reader', 'Pipe') { if ($Stage[$k]) { try { $Stage[$k].Dispose() } catch { } } }
     if (-not $Stage.Proc.WaitForExit(5000)) { try { $Stage.Proc.Kill($true) } catch { } }
-    if ($null -ne $Stage.OrigToken) { $env:WINTTY_BACKDROP_STAGE = $Stage.OrigToken }
-    else { Remove-Item Env:WINTTY_BACKDROP_STAGE -ErrorAction SilentlyContinue }
 }
 
 # ---- scenes ----------------------------------------------------------------
@@ -167,17 +186,17 @@ function Stop-BackdropStage {
 # acrylic blurs into grey and crystal shows raw.
 function Get-BackdropScenes {
     return [ordered]@{
-        black   = [pscustomobject]@{ Name = 'black';   Kind = 'solid'; Color = '#000000'; What = 'flat black' }
-        white   = [pscustomobject]@{ Name = 'white';   Kind = 'solid'; Color = '#FFFFFF'; What = 'flat white' }
-        grey    = [pscustomobject]@{ Name = 'grey';    Kind = 'solid'; Color = '#808080'; What = 'flat mid grey, the tone chrome most often lands near' }
-        brand   = [pscustomobject]@{ Name = 'brand';   Kind = 'solid'; Color = '#0067C0'; What = 'a saturated accent blue, the default Windows accent' }
+        black   = [pscustomobject]@{ Name = 'black';   Kind = 'solid'; Mode = 'stretch'; Color = '#000000'; What = 'flat black' }
+        white   = [pscustomobject]@{ Name = 'white';   Kind = 'solid'; Mode = 'stretch'; Color = '#FFFFFF'; What = 'flat white' }
+        grey    = [pscustomobject]@{ Name = 'grey';    Kind = 'solid'; Mode = 'stretch'; Color = '#808080'; What = 'flat mid grey, the tone chrome most often lands near' }
+        brand   = [pscustomobject]@{ Name = 'brand';   Kind = 'solid'; Mode = 'stretch'; Color = '#0067C0'; What = 'a saturated accent blue, the default Windows accent' }
         sunrise = [pscustomobject]@{ Name = 'sunrise'; Kind = 'image'; Mode = 'stretch'; Color = $null; What = 'a soft vertical gradient, night navy to pale gold' }
         photo   = [pscustomobject]@{ Name = 'photo';   Kind = 'image'; Mode = 'stretch'; Color = $null; What = 'a procedural busy photograph: overlapping colour, lines, small high-contrast marks' }
         editor  = [pscustomobject]@{ Name = 'editor';  Kind = 'image'; Mode = 'stretch'; Color = $null; What = 'a light code editor: white ground, grey gutter, coloured tokens' }
         # Tiled, not stretched: a stretch resamples the squares and turns the
         # boundaries grey, which is the acrylic blur the scene exists to be
         # measured against, manufactured by the instrument instead.
-        checker = [pscustomobject]@{ Name = 'checker'; Kind = 'image'; Mode = 'tile';    Color = $null; What = 'an 8px black and white checkerboard: acrylic blurs it to grey, crystal shows it raw' }
+        checker = [pscustomobject]@{ Name = 'checker'; Kind = 'image'; Mode = 'tile';    Color = $null; What = 'a black and white checkerboard of 4px squares: acrylic blurs it to grey, crystal shows it raw' }
     }
 }
 
@@ -185,7 +204,7 @@ function ConvertTo-DrawingColor([string]$Hex) {
     return [System.Drawing.ColorTranslator]::FromHtml($Hex)
 }
 
-# Render one scene to a PNG. Deterministic for a (name, seed, size), so a
+# Render one scene to a PNG. Deterministic for a (name, size, seed), so a
 # matrix row can be re-run against the same backdrop it was measured on.
 function New-BackdropSceneImage {
     param(
@@ -283,9 +302,13 @@ function New-BackdropSceneImage {
                 $font.Dispose()
             }
             'checker' {
-                # HatchStyle.LargeCheckerBoard is an 8px checker in the
-                # image's own pixels. The scene is applied tiled so those are
-                # 8 device pixels on screen whatever the stage's size.
+                # HatchStyle.LargeCheckerBoard: 4px squares, 8px period, in the
+                # image's own pixels. Applied tiled so those are device pixels
+                # whatever the stage's size. No anti-aliasing: with it the
+                # image's outer ring is half-alpha, and tiled that becomes a
+                # grey seam at every tile boundary, the very grey the scene
+                # must not contain.
+                $g.SmoothingMode = [System.Drawing.Drawing2D.SmoothingMode]::None
                 $brush = [System.Drawing.Drawing2D.HatchBrush]::new(
                     [System.Drawing.Drawing2D.HatchStyle]::LargeCheckerBoard,
                     [System.Drawing.Color]::Black, [System.Drawing.Color]::White)
@@ -302,8 +325,9 @@ function New-BackdropSceneImage {
 }
 
 # Apply a scene to the stage, and optionally to the wallpaper. Generates the
-# PNG on first use under $SceneDir. Returns the PNG path either way, so the
-# report can point at what was behind the window.
+# PNG on first use under $SceneDir, keyed by name, size and seed so a run
+# with a different seed never reads the previous run's picture. Returns the
+# PNG path either way, so the report can point at what was behind the window.
 function Set-BackdropScene {
     param(
         [Parameter(Mandatory)]$Stage,
@@ -314,7 +338,10 @@ function Set-BackdropScene {
         [int]$Width = 1920,
         [int]$Height = 1080
     )
-    $png = Join-Path $SceneDir "$($Scene.Name).png"
+    # Absolute, because the path is handed to two other processes (the stage
+    # and Explorer) that resolve relative paths against their own cwd.
+    $SceneDir = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($SceneDir)
+    $png = Join-Path $SceneDir ('{0}-{1}x{2}-{3}.png' -f $Scene.Name, $Width, $Height, $Seed)
     if (-not (Test-Path -LiteralPath $png)) {
         [void](New-BackdropSceneImage -Name $Scene.Name -Path $png -Width $Width -Height $Height -Seed $Seed)
     }
@@ -329,12 +356,12 @@ function Set-BackdropScene {
 
 # ---- wallpaper ---------------------------------------------------------------
 
-$script:DesktopKey = 'HKCU:\Control Panel\Desktop'
+$script:BackdropDesktopKey = 'HKCU:\Control Panel\Desktop'
 $script:SPI_SETDESKWALLPAPER = 0x0014
 $script:SPIF_UPDATEINIFILE_SENDCHANGE = 0x0003
 
 function Get-DesktopWallpaper {
-    $item = Get-ItemProperty -LiteralPath $script:DesktopKey
+    $item = Get-ItemProperty -LiteralPath $script:BackdropDesktopKey
     return @{
         Path  = [string]$item.WallPaper
         Style = [string]$item.WallpaperStyle
@@ -342,21 +369,32 @@ function Get-DesktopWallpaper {
     }
 }
 
-# Style 10 is "Fill". An empty -Path clears the wallpaper to the desktop
-# colour, which is what a restore needs when the snapshot had none.
+# Set a wallpaper, or put one back from a Get-DesktopWallpaper snapshot with
+# -Snapshot, which carries the user's own style and tiling. Style 10 is
+# "Fill". An empty path clears the wallpaper to the desktop colour, which is
+# what a restore needs when the snapshot had none. The registry is read back
+# afterwards and a disagreement throws: a restore that "probably worked" is
+# what the env guard's incidents had.
 function Set-DesktopWallpaper {
     param(
-        [Parameter(Mandatory)][AllowEmptyString()][string]$Path,
-        [string]$Style = '10',
-        [string]$Tile = '0'
+        [Parameter(ParameterSetName = 'Path', Mandatory)][AllowEmptyString()][string]$Path,
+        [Parameter(ParameterSetName = 'Path')][string]$Style = '10',
+        [Parameter(ParameterSetName = 'Path')][string]$Tile = '0',
+        [Parameter(ParameterSetName = 'Snapshot', Mandatory)][hashtable]$Snapshot
     )
+    if ($PSCmdlet.ParameterSetName -eq 'Snapshot') { $Path = $Snapshot.Path; $Style = $Snapshot.Style; $Tile = $Snapshot.Tile }
     if ($Path -and -not (Test-Path -LiteralPath $Path)) { throw "HARNESS: wallpaper file not found: $Path" }
-    Set-ItemProperty -LiteralPath $script:DesktopKey -Name 'WallpaperStyle' -Value $Style
-    Set-ItemProperty -LiteralPath $script:DesktopKey -Name 'TileWallpaper' -Value $Tile
+    Set-ItemProperty -LiteralPath $script:BackdropDesktopKey -Name 'WallpaperStyle' -Value $Style
+    Set-ItemProperty -LiteralPath $script:BackdropDesktopKey -Name 'TileWallpaper' -Value $Tile
     $ok = [StageWin]::SystemParametersInfo(
         $script:SPI_SETDESKWALLPAPER, 0, $Path, $script:SPIF_UPDATEINIFILE_SENDCHANGE)
     if (-not $ok) {
         throw ("HARNESS: SPI_SETDESKWALLPAPER failed (Win32 {0})" -f [System.Runtime.InteropServices.Marshal]::GetLastWin32Error())
+    }
+    $now = Get-DesktopWallpaper
+    if ($now.Path -ne $Path -or $now.Style -ne $Style -or $now.Tile -ne $Tile) {
+        throw ("HARNESS: the wallpaper did not read back: asked '{0}' style {1} tile {2}, registry says '{3}' style {4} tile {5}" -f
+            $Path, $Style, $Tile, $now.Path, $now.Style, $now.Tile)
     }
 }
 
@@ -364,7 +402,8 @@ function Set-DesktopWallpaper {
 
 # Read one screen pixel in device coordinates. The stage's own margin, read
 # through this, is how a caller proves the scene it asked for is the scene
-# on screen before it photographs anything.
+# on screen before it photographs anything; pair it with Get-WindowPidAt so
+# the pixel is known to be the stage's and not a window over it.
 function Get-ScreenPixel {
     param([Parameter(Mandatory)][int]$X, [Parameter(Mandatory)][int]$Y)
     $bmp = [System.Drawing.Bitmap]::new(1, 1)
@@ -375,6 +414,11 @@ function Get-ScreenPixel {
         return @{ R = [int]$c.R; G = [int]$c.G; B = [int]$c.B; Hex = ('#{0:X2}{1:X2}{2:X2}' -f $c.R, $c.G, $c.B) }
     }
     finally { $g.Dispose(); $bmp.Dispose() }
+}
+
+function Get-WindowPidAt {
+    param([Parameter(Mandatory)][int]$X, [Parameter(Mandatory)][int]$Y)
+    return [StageWin]::PidAt($X, $Y)
 }
 
 function Test-PixelNear {

--- a/windows/scripts/lib/backdrop-stage.ps1
+++ b/windows/scripts/lib/backdrop-stage.ps1
@@ -1,0 +1,386 @@
+#requires -Version 7
+<#
+    The scenery driver: launch lib/BackdropStage under the window a harness is
+    measuring, paint a named scene on it, and put the same scene on the
+    desktop wallpaper.
+
+    Why both. crystal is DWM transparency and shows the window behind;
+    frosted is acrylic and blurs the window behind; solid is Mica, which
+    samples the DESKTOP WALLPAPER and ignores windows entirely. A stage alone
+    measures two materials against a chosen backdrop and the third against
+    whatever wallpaper the developer has. So a scene is one PNG applied
+    twice: painted on the stage, and set as the wallpaper.
+
+    Scenes are generated, not shipped: each is reproducible from its name
+    and a seed, and "photo" is procedural rather than a file to carry.
+
+    Dot-source it:
+
+        . (Join-Path $PSScriptRoot 'lib/backdrop-stage.ps1')
+        $stage = Start-BackdropStage -X 0 -Y 0 -W 1600 -H 1100
+        $png = Set-BackdropScene -Stage $stage -Scene (Get-BackdropScenes)['photo'] -SceneDir $dir -Wallpaper
+        Stop-BackdropStage $stage
+
+    The wallpaper is machine state. A caller that passes -Wallpaper owns
+    putting it back: Get-DesktopWallpaper before, Set-DesktopWallpaper in a
+    finally; lib/env-guard.ps1's snapshot covers the registry side for
+    `just env-restore` after a crash.
+#>
+
+Add-Type -AssemblyName System.Drawing
+
+$script:BackdropStageRoot = Join-Path $PSScriptRoot 'BackdropStage'
+$script:BackdropStageExe = Join-Path $script:BackdropStageRoot `
+    'bin\Release\net10.0-windows10.0.19041.0\win-x64\BackdropStage.exe'
+
+# Build on demand, once. Same arrangement as WindowCapture: the tool is not
+# in Ghostty.sln, so the harness that needs it is the honest owner of the
+# build.
+function Assert-BackdropStageReady {
+    param([switch]$Force)
+    if (-not $Force -and (Test-Path -LiteralPath $script:BackdropStageExe)) {
+        return $script:BackdropStageExe
+    }
+    Write-Host 'backdrop-stage: building BackdropStage.exe (first use)'
+    $log = & dotnet build (Join-Path $script:BackdropStageRoot 'BackdropStage.csproj') `
+        -c Release 2>&1
+    if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $script:BackdropStageExe)) {
+        $log | Select-Object -Last 20 | ForEach-Object { Write-Host $_ }
+        throw 'HARNESS: BackdropStage.exe could not be built'
+    }
+    return $script:BackdropStageExe
+}
+
+if (-not ('StageWin' -as [type])) {
+Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+public static class StageWin {
+    [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
+    [DllImport("user32.dll")] public static extern int GetSystemMetrics(int index);
+    [DllImport("user32.dll")] public static extern bool SetProcessDpiAwarenessContext(IntPtr value);
+    [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    public static extern bool SystemParametersInfo(uint uiAction, uint uiParam, string pvParam, uint fWinIni);
+}
+'@
+}
+
+# The whole virtual screen in device pixels (SM_XVIRTUALSCREEN and friends),
+# for a caller that wants a stage overhanging every monitor at once.
+function Get-VirtualScreenRect {
+    return @{
+        X = [StageWin]::GetSystemMetrics(76); Y = [StageWin]::GetSystemMetrics(77)
+        W = [StageWin]::GetSystemMetrics(78); H = [StageWin]::GetSystemMetrics(79)
+    }
+}
+
+# 128 bits of hex, the shape the stage accepts. Its own function rather than
+# seam-client's New-SeamToken so a caller that only wants scenery does not
+# have to load the seam client.
+function New-BackdropStageToken {
+    $bytes = [byte[]]::new(16)
+    [System.Security.Cryptography.RandomNumberGenerator]::Fill($bytes)
+    return [System.Convert]::ToHexString($bytes).ToLowerInvariant()
+}
+
+# Launch the stage at a device-pixel rect and connect its pipe. Returns the
+# session every other function here takes.
+function Start-BackdropStage {
+    param(
+        [Parameter(Mandatory)][int]$X,
+        [Parameter(Mandatory)][int]$Y,
+        [Parameter(Mandatory)][int]$W,
+        [Parameter(Mandatory)][int]$H,
+        [int]$TimeoutSeconds = 30
+    )
+    $exe = Assert-BackdropStageReady
+    $token = New-BackdropStageToken
+    $orig = if (Test-Path Env:WINTTY_BACKDROP_STAGE) { $env:WINTTY_BACKDROP_STAGE } else { $null }
+    $env:WINTTY_BACKDROP_STAGE = $token
+
+    $psi = [System.Diagnostics.ProcessStartInfo]::new()
+    $psi.FileName = $exe
+    foreach ($a in @('--x', $X, '--y', $Y, '--w', $W, '--h', $H)) { $psi.ArgumentList.Add([string]$a) }
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError = $true
+    $psi.UseShellExecute = $false
+    $proc = [System.Diagnostics.Process]::Start($psi)
+
+    # READY <hwnd> <pid> is printed after the window is shown; a process that
+    # exits first has printed why on stderr.
+    $ready = $proc.StandardOutput.ReadLine()
+    if ($ready -notlike 'READY *') {
+        $err = $proc.StandardError.ReadToEnd()
+        if ($null -ne $orig) { $env:WINTTY_BACKDROP_STAGE = $orig } else { Remove-Item Env:WINTTY_BACKDROP_STAGE -ErrorAction SilentlyContinue }
+        throw "HARNESS: the backdrop stage did not come up: '$ready' $err"
+    }
+    $parts = $ready.Split(' ')
+    $session = @{
+        Proc = $proc; Token = $token; OrigToken = $orig
+        Hwnd64 = [int64]$parts[1]
+    }
+    $pipe = [System.IO.Pipes.NamedPipeClientStream]::new(
+        '.', "wintty-backdrop-stage-$token",
+        [System.IO.Pipes.PipeDirection]::InOut,
+        [System.IO.Pipes.PipeOptions]::CurrentUserOnly)
+    $pipe.Connect($TimeoutSeconds * 1000)
+    $session.Pipe = $pipe
+    $session.Reader = [System.IO.StreamReader]::new($pipe)
+    $session.Writer = [System.IO.StreamWriter]::new($pipe, [System.Text.UTF8Encoding]::new($false))
+    $session.Writer.AutoFlush = $true
+    $session.Writer.NewLine = "`n"
+    return $session
+}
+
+# One request, one response. A refusal from the stage is a HARNESS failure,
+# never a product finding: the stage is the instrument, not the subject.
+function Invoke-BackdropStage {
+    param([Parameter(Mandatory)]$Stage, [Parameter(Mandatory)][hashtable]$Command)
+    if ($Stage.Proc.HasExited) {
+        throw ("HARNESS: the backdrop stage exited (code {0}) before '{1}'" -f
+            $Stage.Proc.ExitCode, $Command['op'])
+    }
+    $Stage.Writer.WriteLine(($Command | ConvertTo-Json -Compress -Depth 4))
+    $line = $Stage.Reader.ReadLine()
+    if ($null -eq $line) { throw ("HARNESS: the backdrop stage closed the pipe during '{0}'" -f $Command['op']) }
+    $response = $line | ConvertFrom-Json
+    if (-not $response.ok) { throw ("HARNESS: backdrop stage {0} -> {1}" -f $Command['op'], $response.error) }
+    return $response
+}
+
+function Stop-BackdropStage {
+    param([Parameter(Mandatory)]$Stage)
+    try { if (-not $Stage.Proc.HasExited) { [void](Invoke-BackdropStage $Stage @{ op = 'quit' }) } } catch { }
+    foreach ($k in 'Writer', 'Reader', 'Pipe') { if ($Stage[$k]) { try { $Stage[$k].Dispose() } catch { } } }
+    if (-not $Stage.Proc.WaitForExit(5000)) { try { $Stage.Proc.Kill($true) } catch { } }
+    if ($null -ne $Stage.OrigToken) { $env:WINTTY_BACKDROP_STAGE = $Stage.OrigToken }
+    else { Remove-Item Env:WINTTY_BACKDROP_STAGE -ErrorAction SilentlyContinue }
+}
+
+# ---- scenes ----------------------------------------------------------------
+
+# The catalogue, in the order a matrix runs them. Each is what a user might
+# plausibly have behind a terminal, and the set spans the cases that break
+# translucent chrome differently: flat extremes, a mid grey that sits near
+# every "chrome" tone, a saturated brand colour, a soft gradient, a busy
+# photograph, a light editor full of text, and a high-frequency pattern that
+# acrylic blurs into grey and crystal shows raw.
+function Get-BackdropScenes {
+    return [ordered]@{
+        black   = [pscustomobject]@{ Name = 'black';   Kind = 'solid'; Color = '#000000'; What = 'flat black' }
+        white   = [pscustomobject]@{ Name = 'white';   Kind = 'solid'; Color = '#FFFFFF'; What = 'flat white' }
+        grey    = [pscustomobject]@{ Name = 'grey';    Kind = 'solid'; Color = '#808080'; What = 'flat mid grey, the tone chrome most often lands near' }
+        brand   = [pscustomobject]@{ Name = 'brand';   Kind = 'solid'; Color = '#0067C0'; What = 'a saturated accent blue, the default Windows accent' }
+        sunrise = [pscustomobject]@{ Name = 'sunrise'; Kind = 'image'; Mode = 'stretch'; Color = $null; What = 'a soft vertical gradient, night navy to pale gold' }
+        photo   = [pscustomobject]@{ Name = 'photo';   Kind = 'image'; Mode = 'stretch'; Color = $null; What = 'a procedural busy photograph: overlapping colour, lines, small high-contrast marks' }
+        editor  = [pscustomobject]@{ Name = 'editor';  Kind = 'image'; Mode = 'stretch'; Color = $null; What = 'a light code editor: white ground, grey gutter, coloured tokens' }
+        # Tiled, not stretched: a stretch resamples the squares and turns the
+        # boundaries grey, which is the acrylic blur the scene exists to be
+        # measured against, manufactured by the instrument instead.
+        checker = [pscustomobject]@{ Name = 'checker'; Kind = 'image'; Mode = 'tile';    Color = $null; What = 'an 8px black and white checkerboard: acrylic blurs it to grey, crystal shows it raw' }
+    }
+}
+
+function ConvertTo-DrawingColor([string]$Hex) {
+    return [System.Drawing.ColorTranslator]::FromHtml($Hex)
+}
+
+# Render one scene to a PNG. Deterministic for a (name, seed, size), so a
+# matrix row can be re-run against the same backdrop it was measured on.
+function New-BackdropSceneImage {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$Path,
+        [int]$Width = 1920,
+        [int]$Height = 1080,
+        [int]$Seed = 1337
+    )
+    $scenes = Get-BackdropScenes
+    if (-not $scenes.Contains($Name)) { throw "HARNESS: unknown scene '$Name'" }
+    $scene = $scenes[$Name]
+    $bmp = [System.Drawing.Bitmap]::new($Width, $Height)
+    $g = [System.Drawing.Graphics]::FromImage($bmp)
+    try {
+        $g.SmoothingMode = [System.Drawing.Drawing2D.SmoothingMode]::AntiAlias
+        switch ($Name) {
+            { $scene.Kind -eq 'solid' } {
+                $g.Clear((ConvertTo-DrawingColor $scene.Color))
+            }
+            'sunrise' {
+                # Early-sunrise colours, dark sky at the top and a pale gold
+                # horizon at the bottom.
+                $brush = [System.Drawing.Drawing2D.LinearGradientBrush]::new(
+                    [System.Drawing.Point]::new(0, 0), [System.Drawing.Point]::new(0, $Height),
+                    [System.Drawing.Color]::Black, [System.Drawing.Color]::White)
+                $blend = [System.Drawing.Drawing2D.ColorBlend]::new(4)
+                $blend.Colors = @(
+                    (ConvertTo-DrawingColor '#1C2541'), (ConvertTo-DrawingColor '#F28482'),
+                    (ConvertTo-DrawingColor '#FFB385'), (ConvertTo-DrawingColor '#FFE8A3'))
+                $blend.Positions = [single[]]@(0.0, 0.45, 0.75, 1.0)
+                $brush.InterpolationColors = $blend
+                $g.FillRectangle($brush, 0, 0, $Width, $Height)
+                $brush.Dispose()
+            }
+            'photo' {
+                $rng = [System.Random]::new($Seed)
+                $g.Clear((ConvertTo-DrawingColor '#5B6B4F'))
+                for ($i = 0; $i -lt 220; $i++) {
+                    $c = [System.Drawing.Color]::FromArgb(150, $rng.Next(256), $rng.Next(256), $rng.Next(256))
+                    $b = [System.Drawing.SolidBrush]::new($c)
+                    $w = $rng.Next(40, 520); $h = $rng.Next(40, 520)
+                    $g.FillEllipse($b, $rng.Next(-200, $Width), $rng.Next(-200, $Height), $w, $h)
+                    $b.Dispose()
+                }
+                for ($i = 0; $i -lt 120; $i++) {
+                    $c = [System.Drawing.Color]::FromArgb(220, $rng.Next(256), $rng.Next(256), $rng.Next(256))
+                    $p = [System.Drawing.Pen]::new($c, $rng.Next(1, 6))
+                    $g.DrawLine($p, $rng.Next($Width), $rng.Next($Height), $rng.Next($Width), $rng.Next($Height))
+                    $p.Dispose()
+                }
+                # Small marks in the two extremes, the detail a blur has to
+                # average away and a transparent frame shows as noise.
+                foreach ($c in @([System.Drawing.Color]::White, [System.Drawing.Color]::Black)) {
+                    $b = [System.Drawing.SolidBrush]::new($c)
+                    for ($i = 0; $i -lt 400; $i++) {
+                        $g.FillRectangle($b, $rng.Next($Width), $rng.Next($Height), $rng.Next(2, 9), $rng.Next(2, 9))
+                    }
+                    $b.Dispose()
+                }
+            }
+            'editor' {
+                $rng = [System.Random]::new($Seed)
+                $g.Clear([System.Drawing.Color]::White)
+                $gutter = [int]($Width * 0.025)
+                $g.FillRectangle([System.Drawing.SolidBrush]::new((ConvertTo-DrawingColor '#F3F3F3')), 0, 0, $gutter, $Height)
+                $g.FillRectangle([System.Drawing.SolidBrush]::new((ConvertTo-DrawingColor '#F8F8F8')), $Width - [int]($Width * 0.06), 0, [int]($Width * 0.06), $Height)
+                $font = [System.Drawing.Font]::new('Consolas', [single]($Height / 60.0), [System.Drawing.GraphicsUnit]::Pixel)
+                $tokens = @(
+                    @('#0000FF', 'const'), @('#0000FF', 'return'), @('#0000FF', 'if'), @('#0000FF', 'fn'),
+                    @('#A31515', '"text"'), @('#A31515', "'c'"), @('#008000', '// note'),
+                    @('#1F1F1F', 'value'), @('#1F1F1F', 'buffer.len'), @('#1F1F1F', '= 0;'), @('#1F1F1F', '(x, y)'),
+                    @('#795E26', 'render'), @('#267F99', 'Widget'), @('#098658', '4096'))
+                $lineH = [single]($Height / 40.0)
+                $y = [single]($lineH * 0.5)
+                $line = 1
+                while ($y -lt $Height) {
+                    $x = [single]($gutter + 12)
+                    $indent = $rng.Next(0, 4)
+                    $x += $indent * $lineH * 2
+                    $numBrush = [System.Drawing.SolidBrush]::new((ConvertTo-DrawingColor '#9A9A9A'))
+                    $g.DrawString([string]$line, $font, $numBrush, [single]4, $y)
+                    $numBrush.Dispose()
+                    $n = $rng.Next(2, 8)
+                    for ($i = 0; $i -lt $n; $i++) {
+                        $t = $tokens[$rng.Next($tokens.Count)]
+                        $b = [System.Drawing.SolidBrush]::new((ConvertTo-DrawingColor $t[0]))
+                        $g.DrawString($t[1], $font, $b, $x, $y)
+                        $x += $g.MeasureString($t[1] + ' ', $font).Width
+                        $b.Dispose()
+                    }
+                    $y += $lineH
+                    $line++
+                }
+                $font.Dispose()
+            }
+            'checker' {
+                # HatchStyle.LargeCheckerBoard is an 8px checker in the
+                # image's own pixels. The scene is applied tiled so those are
+                # 8 device pixels on screen whatever the stage's size.
+                $brush = [System.Drawing.Drawing2D.HatchBrush]::new(
+                    [System.Drawing.Drawing2D.HatchStyle]::LargeCheckerBoard,
+                    [System.Drawing.Color]::Black, [System.Drawing.Color]::White)
+                $g.FillRectangle($brush, 0, 0, $Width, $Height)
+                $brush.Dispose()
+            }
+        }
+    }
+    finally { $g.Dispose() }
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $Path) | Out-Null
+    $bmp.Save($Path, [System.Drawing.Imaging.ImageFormat]::Png)
+    $bmp.Dispose()
+    return $Path
+}
+
+# Apply a scene to the stage, and optionally to the wallpaper. Generates the
+# PNG on first use under $SceneDir. Returns the PNG path either way, so the
+# report can point at what was behind the window.
+function Set-BackdropScene {
+    param(
+        [Parameter(Mandatory)]$Stage,
+        [Parameter(Mandatory)]$Scene,
+        [Parameter(Mandatory)][string]$SceneDir,
+        [switch]$Wallpaper,
+        [int]$Seed = 1337,
+        [int]$Width = 1920,
+        [int]$Height = 1080
+    )
+    $png = Join-Path $SceneDir "$($Scene.Name).png"
+    if (-not (Test-Path -LiteralPath $png)) {
+        [void](New-BackdropSceneImage -Name $Scene.Name -Path $png -Width $Width -Height $Height -Seed $Seed)
+    }
+    if ($Scene.Kind -eq 'solid') {
+        [void](Invoke-BackdropStage $Stage @{ op = 'solid'; color = $Scene.Color })
+    } else {
+        [void](Invoke-BackdropStage $Stage @{ op = 'image'; path = $png; mode = $Scene.Mode })
+    }
+    if ($Wallpaper) { Set-DesktopWallpaper -Path $png }
+    return $png
+}
+
+# ---- wallpaper ---------------------------------------------------------------
+
+$script:DesktopKey = 'HKCU:\Control Panel\Desktop'
+$script:SPI_SETDESKWALLPAPER = 0x0014
+$script:SPIF_UPDATEINIFILE_SENDCHANGE = 0x0003
+
+function Get-DesktopWallpaper {
+    $item = Get-ItemProperty -LiteralPath $script:DesktopKey
+    return @{
+        Path  = [string]$item.WallPaper
+        Style = [string]$item.WallpaperStyle
+        Tile  = [string]$item.TileWallpaper
+    }
+}
+
+# Style 10 is "Fill". An empty -Path clears the wallpaper to the desktop
+# colour, which is what a restore needs when the snapshot had none.
+function Set-DesktopWallpaper {
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Path,
+        [string]$Style = '10',
+        [string]$Tile = '0'
+    )
+    if ($Path -and -not (Test-Path -LiteralPath $Path)) { throw "HARNESS: wallpaper file not found: $Path" }
+    Set-ItemProperty -LiteralPath $script:DesktopKey -Name 'WallpaperStyle' -Value $Style
+    Set-ItemProperty -LiteralPath $script:DesktopKey -Name 'TileWallpaper' -Value $Tile
+    $ok = [StageWin]::SystemParametersInfo(
+        $script:SPI_SETDESKWALLPAPER, 0, $Path, $script:SPIF_UPDATEINIFILE_SENDCHANGE)
+    if (-not $ok) {
+        throw ("HARNESS: SPI_SETDESKWALLPAPER failed (Win32 {0})" -f [System.Runtime.InteropServices.Marshal]::GetLastWin32Error())
+    }
+}
+
+# ---- one pixel -------------------------------------------------------------
+
+# Read one screen pixel in device coordinates. The stage's own margin, read
+# through this, is how a caller proves the scene it asked for is the scene
+# on screen before it photographs anything.
+function Get-ScreenPixel {
+    param([Parameter(Mandatory)][int]$X, [Parameter(Mandatory)][int]$Y)
+    $bmp = [System.Drawing.Bitmap]::new(1, 1)
+    $g = [System.Drawing.Graphics]::FromImage($bmp)
+    try {
+        $g.CopyFromScreen($X, $Y, 0, 0, $bmp.Size)
+        $c = $bmp.GetPixel(0, 0)
+        return @{ R = [int]$c.R; G = [int]$c.G; B = [int]$c.B; Hex = ('#{0:X2}{1:X2}{2:X2}' -f $c.R, $c.G, $c.B) }
+    }
+    finally { $g.Dispose(); $bmp.Dispose() }
+}
+
+function Test-PixelNear {
+    param([Parameter(Mandatory)]$Pixel, [Parameter(Mandatory)][string]$Hex, [int]$Tolerance = 3)
+    $c = ConvertTo-DrawingColor $Hex
+    return ([Math]::Abs($Pixel.R - $c.R) -le $Tolerance) -and
+           ([Math]::Abs($Pixel.G - $c.G) -le $Tolerance) -and
+           ([Math]::Abs($Pixel.B - $c.B) -le $Tolerance)
+}


### PR DESCRIPTION
First of two PRs for #937, the theme matrix. This one is the scenery: a window a harness parks under the one it is measuring and paints whatever a user might have behind a terminal. The matrix harness itself follows in a second PR stacked on this one.

## Why a stage window and the wallpaper both

The three window materials look at three different things. `crystal` is DWM transparency and shows the window behind. `frosted` is acrylic and blurs the window behind. `solid` is Mica, which samples the desktop wallpaper and the theme colour and ignores windows entirely. A harness that parks a window behind Wintty measures two materials against a chosen backdrop and the third against whatever wallpaper the developer has. So a scene is one PNG applied twice: painted on the stage, and set as the wallpaper. `Set-BackdropScene -Wallpaper` does both; the caller owns putting the wallpaper back, and the existing env-guard snapshot covers the registry side for `just env-restore` after a crash.

## What is in here

- `windows/scripts/lib/BackdropStage/`: a WinForms exe, built on first use and deliberately not in `Ghostty.sln`, the same arrangement as `WindowCapture`. It follows the test seam's shape: a 32-hex session token in `WINTTY_BACKDROP_STAGE`, a pipe named after it, `CurrentUserOnly`, one JSON line per request, and every ack sent after `Refresh()` so a driver photographs the scene it asked for. Ops: `place`, `solid`, `image` (stretch or tile), `query`, `quit`; `--parent` makes it close when its driver dies. `WS_EX_NOACTIVATE` and `ShowWithoutActivation`, so it never takes focus from the window under test; TOPMOST via `SetWindowPos` with `SWP_NOACTIVATE`, so it sits above every ordinary window and under a window placed TOPMOST after it.
- `windows/scripts/lib/backdrop-stage.ps1`: the driver, the scene catalogue and the generators. Eight scenes, each reproducible from its name and a seed: black, white, grey, brand, sunrise, photo, editor, checker. `photo` is procedural so the repo ships no image. `checker` is applied tiled rather than stretched, because a stretch resamples an 8px checker into grey boundaries, which is the acrylic blur the scene exists to be measured against, manufactured by the instrument instead. Wallpaper helpers go through `SPI_SETDESKWALLPAPER`. `Get-ScreenPixel` reads one device pixel, which is how a caller proves the scene on screen is the one it asked for before photographing anything.
- `windows/scripts/backdrop-stage-selftest.ps1` and `just backdrop-stage-selftest`: proves the instrument against the screen, not against the stage's own answer. Placement, no activation, every scene reading back as itself, a move, a refusal that does not kill it, exit 0 on quit. Classified in `fuzz-suite.ps1` as not in the suite (it measures an instrument, launches no Wintty, has no findings exit).
- `windows/scripts/README.md`: a Scenery section beside Filming motion.

The stage can be larger than the screen. Windows answers `WM_GETMINMAXINFO` with the monitor as the maximum tracking size and `SetWindowPos` honours it, so a place larger than the screen was silently clamped; the stage overrides that message, and the selftest places it 400px past the whole virtual screen on every side and reads the size back.

## Verified

`just backdrop-stage-selftest` under the incoda lane: 27 checks green after the review round (the first run's log is in the first comment, the review round in the second). The first two runs failed for reasons that were the selftest's, not the stage's, and both fixes are in: the editor check sampled a line-number glyph in the gutter and now samples the text-free minimap band; the checker check exposed the stretch resampling above and the scene is now tiled. `just fuzz-list` passes the manifest integrity checks with the new classification.

The wallpaper path was exercised by hand under the lane: read the current wallpaper, set the brand scene, read it back, restore, read it back again; all three reads are in the first comment. Against a real matrix run it is PR 2's job.

Size-override: one instrument arriving whole. The exe, its driver, the scene generators and the selftest that proves them are one unit; a stage without scenes has nothing to paint, and a stage without its selftest would merge unproven. About 1200 countable lines after the review round, of which roughly a third are the comments this directory's README asks every harness to carry.

## Not in this PR

The matrix harness, its recipes, and the incoda wrapping. Promoting the contrast oracle's UIA locators into `lib/` (noted in #937 as a follow-up).

Closes nothing. Part of #937.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
