### PR TITLE
harness: the theme matrix, every theme against polarity, material, layout and backdrop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ windows/scripts/vtabs-layout-switch/
 windows/scripts/vtabs-morph/
 windows/scripts/vtabs-switcher/
 windows/scripts/backdrop-stage-selftest/
+windows/scripts/theme-matrix/
 
 # Gallery tooling scratch renders (WARP PPMs and PNGs diffed during
 # shader bring-up; never something we want committed).

--- a/justfile
+++ b/justfile
@@ -298,14 +298,21 @@ frame-style-fuzz args="": _no-wintty-running build-dll build-win
 # Every axis takes one value, a comma list, or all. Pass args through, e.g.
 #   just theme-matrix "-Theme wintty-dark -Polarity dark -Layout vertical"
 #   just theme-matrix "-Theme all -App solid -Frame inherit -Scene black,photo"
+#   just theme-matrix "-Theme 'Catppuccin Mocha,Nord' -App crystal"
 #   just theme-matrix "-NoFlip"    never touch the desktop theme
+# A theme list with a space in it is ONE inner single-quoted string with the
+# commas inside, as in the third line. The recipe body is PowerShell:
+# `"Catppuccin Mocha",Nord` there would be an array that reaches the harness
+# as two arguments, the second of which lands on -Polarity, and a `\"` is
+# not an escape at all. The args cross the lane inside double quotes, so a
+# double quote or a `$` is what cannot be passed.
 #
 # Exit codes: 0 clean, 2 findings, 1 could not run or a surface went unmeasured.
 #
 # Run the theme matrix (#937) under the incoda lane against the Debug build.
 [windows]
 theme-matrix args="":
-    $inc = (Get-Command incoda -ErrorAction SilentlyContinue)?.Source ?? (Join-Path $env:LOCALAPPDATA 'Programs\incoda\incoda.exe'); & $inc run --queue wintty --reason "theme matrix (#937)" -- just _theme-matrix-in-lane '{{args}}'; exit ($LASTEXITCODE ?? 1)
+    $inc = (Get-Command incoda -ErrorAction SilentlyContinue)?.Source ?? (Join-Path $env:LOCALAPPDATA 'Programs\incoda\incoda.exe'); & $inc run --queue wintty --reason "theme matrix (#937)" -- just _theme-matrix-in-lane "{{args}}"; exit ($LASTEXITCODE ?? 1)
 
 [windows]
 _theme-matrix-in-lane args="": _no-wintty-running build-dll build-win
@@ -328,7 +335,7 @@ theme-matrix-plan args="":
 # Rebuild matrix.md from a theme-matrix run that already happened.
 [windows]
 theme-matrix-report run="windows/scripts/theme-matrix":
-    pwsh -NoProfile -File windows/scripts/theme-matrix-report.ps1 -RunDir {{run}}; exit ($LASTEXITCODE ?? 1)
+    pwsh -NoProfile -File windows/scripts/theme-matrix-report.ps1 -RunDir "{{run}}"; exit ($LASTEXITCODE ?? 1)
 
 # Real windows and real input, so it needs an interactive desktop and holds
 # the foreground for the duration - about 43 minutes budgeted for everything,

--- a/justfile
+++ b/justfile
@@ -279,6 +279,57 @@ frame-style-fuzz args="": _no-wintty-running build-dll build-win
         -ExePath windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Wintty.exe \
         -OutDir windows/scripts/frame-style-fuzz {{args}}; exit ($LASTEXITCODE ?? 1)
 
+# The theme matrix (#937): every selected theme against desktop polarity,
+# app and frame material, tab layout and a backdrop scene behind the window,
+# measured in rendered pixels against lib/contrast.ps1's floors. Hours for the
+# curated set, a day and more for `-Theme all`; a red run is the expected
+# outcome and windows/scripts/theme-matrix/matrix.md is the deliverable.
+#
+# It goes through the incoda lane, and the lane is taken BEFORE the builds:
+# this harness flips the desktop theme and the wallpaper and puts a topmost
+# stage on screen, so nothing else may own the desktop while it runs, and a
+# build started outside the lane while another lane holder ran would be the
+# collision the lane exists to stop. Hence two recipes: this one only takes
+# the lane, the private one below it does the work inside.
+#
+# incoda is looked up on PATH and then in its installer's location, because
+# the agent shell this was written under had the latter and not the former.
+#
+# Every axis takes one value, a comma list, or all. Pass args through, e.g.
+#   just theme-matrix "-Theme wintty-dark -Polarity dark -Layout vertical"
+#   just theme-matrix "-Theme all -App solid -Frame inherit -Scene black,photo"
+#   just theme-matrix "-NoFlip"    never touch the desktop theme
+#
+# Exit codes: 0 clean, 2 findings, 1 could not run or a surface went unmeasured.
+#
+# Run the theme matrix (#937) under the incoda lane against the Debug build.
+[windows]
+theme-matrix args="":
+    $inc = (Get-Command incoda -ErrorAction SilentlyContinue)?.Source ?? (Join-Path $env:LOCALAPPDATA 'Programs\incoda\incoda.exe'); & $inc run --queue wintty --reason "theme matrix (#937)" -- just _theme-matrix-in-lane '{{args}}'; exit ($LASTEXITCODE ?? 1)
+
+[windows]
+_theme-matrix-in-lane args="": _no-wintty-running build-dll build-win
+    pwsh -NoProfile -File windows/scripts/theme-matrix.ps1 \
+        -ExePath windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Wintty.exe \
+        -OutDir windows/scripts/theme-matrix {{args}}; exit ($LASTEXITCODE ?? 1)
+
+# No lane, no build, no desktop, same args as theme-matrix.
+#
+# Print the processes a theme-matrix filter selects and their cost; launch nothing.
+[windows]
+theme-matrix-plan args="":
+    pwsh -NoProfile -File windows/scripts/theme-matrix.ps1 -DryRun \
+        -ExePath windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Wintty.exe \
+        -OutDir windows/scripts/theme-matrix {{args}}; exit ($LASTEXITCODE ?? 1)
+
+# The harness writes matrix.md itself; this is for a run dir kept from
+# earlier. Paste the result into #937.
+#
+# Rebuild matrix.md from a theme-matrix run that already happened.
+[windows]
+theme-matrix-report run="windows/scripts/theme-matrix":
+    pwsh -NoProfile -File windows/scripts/theme-matrix-report.ps1 -RunDir {{run}}; exit ($LASTEXITCODE ?? 1)
+
 # Real windows and real input, so it needs an interactive desktop and holds
 # the foreground for the duration - about 43 minutes budgeted for everything,
 # 7 for `-Tag smoke` (measured 5). Each harness is killed if it overruns its
@@ -392,6 +443,8 @@ fuzz-selftest:
 #
 # Exit codes: 0 sound, 1 not sound or could not start. No 2: this judges the
 # instrument, never the product.
+#
+# Prove the backdrop stage paints what it is told and never takes focus.
 [windows]
 backdrop-stage-selftest:
     pwsh -NoProfile -File windows/scripts/backdrop-stage-selftest.ps1; exit ($LASTEXITCODE ?? 1)

--- a/windows/scripts/README.md
+++ b/windows/scripts/README.md
@@ -235,10 +235,20 @@ launches no Wintty and is safe with one open.
 
 `theme-matrix.ps1` (#937) is the one harness here that SETS machine state:
 it flips the desktop light/dark theme and the wallpaper while it runs, and
-puts everything back through the env guard's snapshot and read-back. That
-is why it is not in the suite and why `just theme-matrix` takes the incoda
-lane before it builds. `-NoFlip` keeps the read-only policy every other
-harness has.
+puts everything back in its `finally`: the wallpaper through the API that
+applies one, the polarity through the broadcast, then the env guard's
+restore and read-back. A restore that fails is the run's exit code (1),
+whatever it measured. That is why it is not in the suite and why
+`just theme-matrix` takes the incoda lane before it builds. `-NoFlip` keeps
+the read-only policy every other harness has.
+
+After a hard kill (a `taskkill`, the lane's own timeout) the `finally`
+never ran, and the manual recovery is: end `BackdropStage.exe` if it is
+still up, `just env-restore` for the registry, then toggle the desktop
+light/dark setting once by hand and re-apply the wallpaper, because a
+registry restore alone repaints neither. The snapshot the run took is also
+kept as `env-before.json` in its output dir, since the well-known one is
+overwritten by whatever harness runs next.
 
 Every axis (theme, polarity, app, frame, layout, scene) takes one value, a
 comma list, or `all`; `just theme-matrix-plan` prints what a filter selects

--- a/windows/scripts/README.md
+++ b/windows/scripts/README.md
@@ -231,6 +231,27 @@ per-monitor wallpaper comes back as its current image.
 `just backdrop-stage-selftest` proves the instrument against the screen. It
 launches no Wintty and is safe with one open.
 
+## The theme matrix
+
+`theme-matrix.ps1` (#937) is the one harness here that SETS machine state:
+it flips the desktop light/dark theme and the wallpaper while it runs, and
+puts everything back through the env guard's snapshot and read-back. That
+is why it is not in the suite and why `just theme-matrix` takes the incoda
+lane before it builds. `-NoFlip` keeps the read-only policy every other
+harness has.
+
+Every axis (theme, polarity, app, frame, layout, scene) takes one value, a
+comma list, or `all`; `just theme-matrix-plan` prints what a filter selects
+and what it would cost without touching anything. Themes go into the config
+as absolute paths under a staged copy of the catalogue, because a bare name
+that resolves to nothing falls back silently (#877); each process then
+proves the theme reached the glass by comparing the terminal ground it
+photographs with the theme file's own `background`, and a process whose
+ground is not the theme's is reported unmeasured rather than scored.
+
+The run leaves `result.json`, `shots/`, `scenes/` and `matrix.md`; the
+markdown is what gets pasted into #937, one comment per run.
+
 ## Process policy
 
 `lib/wintty-process.ps1` holds the rule:

--- a/windows/scripts/fuzz-suite.ps1
+++ b/windows/scripts/fuzz-suite.ps1
@@ -269,6 +269,13 @@ $NotInSuite = [ordered]@{
     'seam-crash-dump.ps1'           = 'writes WER LocalDumps registry state (snapshot, set, restore) and needs to be the only thing holding the process, since WER does not run under a debugger. Its exits are inverted for this suite''s purpose: 2 means the app SURVIVED and there was no crash to dump, which the runner would file as a product finding'
     'layout-motion-profile.ps1'     = 'an analysis tool, not a harness: it reads a layout-switch-filmstrip run that has already happened (-RunDir and -Tag, no -ExePath) and prints what moved, when and where. It launches nothing and returns no verdict; the change-box column is for a human reading a filmstrip that already failed'
     'backdrop-stage-selftest.ps1'   = 'measures an instrument, not the product: it proves lib/BackdropStage paints the scene it was told to and never takes the foreground. Launches no Wintty, takes no -ExePath, and has no findings exit'
+    # The theme matrix is exploratory and long: hours for the curated set, a
+    # day and more for the catalogue, and it flips the desktop theme and the
+    # wallpaper while it runs, which no other harness here does. Its red run
+    # is the expected outcome and the matrix.md it leaves is the deliverable
+    # (#937), so aggregating its exit into a suite verdict would say nothing.
+    'theme-matrix.ps1'              = 'hours long by design and it sets the desktop theme and wallpaper; run it on its own through `just theme-matrix`, under the incoda lane, and read its matrix.md (#937)'
+    'theme-matrix-report.ps1'       = 'an analysis tool: it reads a theme-matrix run that has already happened (-RunDir, no -ExePath) and writes matrix.md. Launches nothing and returns no verdict'
 }
 
 # The one form every check compares a script path in: the path relative to this

--- a/windows/scripts/theme-matrix-report.ps1
+++ b/windows/scripts/theme-matrix-report.ps1
@@ -21,9 +21,12 @@ if (-not $OutFile) { $OutFile = Join-Path $RunDir 'matrix.md' }
 $r = Get-Content -LiteralPath $resultPath -Raw | ConvertFrom-Json
 
 $rows = @($r.rows); $findings = @($r.findings); $unmeasured = @($r.unmeasured); $deltas = @($r.deltas)
-# Invariant, round-trip: the machine's own culture read the ISO date with
-# its day and month swapped.
+# Every number in the markdown goes through this. PowerShell's -f follows
+# the machine's culture, and on a comma-decimal desktop "4,50" in a ratio
+# column is a different number to every reader of #937.
 $inv = [System.Globalization.CultureInfo]::InvariantCulture
+function N2($v) { return ([double]$v).ToString('0.00', $inv) }
+# Invariant, round-trip, so the culture cannot reorder the fields.
 $started = [datetime]::Parse($r.startedUtc, $inv, [System.Globalization.DateTimeStyles]::RoundtripKind)
 $finished = [datetime]::Parse($r.finishedUtc, $inv, [System.Globalization.DateTimeStyles]::RoundtripKind)
 $md = [System.Text.StringBuilder]::new()
@@ -31,9 +34,10 @@ function L([string]$s = '') { [void]$md.AppendLine($s) }
 
 L "## theme matrix run $($started.ToString('yyyy-MM-dd HH:mm')) UTC"
 L
-L ("build ``{0}``, {1} min, {2} rows, **{3} finding(s)**, {4} unmeasured{5}" -f
-    $r.buildSha, [Math]::Round(($finished - $started).TotalMinutes, 1), $rows.Count, $findings.Count, $unmeasured.Count,
-    $(if ($r.fatal) { ", RUN FAILED: $($r.fatal)" } else { '' }))
+L ("build ``{0}``, {1} min, {2} rows, **{3} finding(s)**, {4} unmeasured{5}{6}" -f
+    $r.buildSha, ($finished - $started).TotalMinutes.ToString('0.0', $inv), $rows.Count, $findings.Count, $unmeasured.Count,
+    $(if ($r.fatal) { ", RUN FAILED: $($r.fatal)" } else { '' }),
+    $(if (@($r.restoreErrors).Count -gt 0) { ", **RESTORE FAILED**: " + (@($r.restoreErrors) -join '; ') } else { '' }))
 L
 L ("desktop was **{0}** with wallpaper ``{1}``{2}; filters: theme={3} polarity={4} app={5} frame={6} layout={7} scene={8}{9}{10}" -f
     $r.machine.polarityBefore, $r.machine.wallpaperBefore, $(if ($r.machine.noFlip) { ' (no flip)' } else { '' }),
@@ -66,7 +70,7 @@ foreach ($polarity in $r.axes.polarities) {
             $judged = @($inCell | Where-Object { $_.class -ne 'field' })
             $worst = $(if ($judged.Count -gt 0) { ($judged | Measure-Object -Property ratio -Minimum).Minimum } else { $null })
             $fails = @($inCell | Where-Object { -not $_.pass }).Count
-            $text = $(if ($null -ne $worst) { '{0:N2}' -f $worst } else { 'field' })
+            $text = $(if ($null -ne $worst) { N2 $worst } else { 'field' })
             if ($fails -gt 0) { $text = "**$text** ($fails)" }
             if ($missing -gt 0) { $text += ' ?' }
             $line += " $text |"
@@ -87,8 +91,8 @@ if ($deltas.Count -gt 0) {
         if ($d.Count -eq 0) { continue }
         $vt = @($d | Where-Object delta -eq 'strip-vs-terminal' | Measure-Object -Property ratio -Average).Average
         $vs = @($d | Where-Object delta -eq 'strip-vs-scene')
-        $vsText = $(if ($vs.Count -gt 0) { '{0:N2}' -f ($vs | Measure-Object -Property ratio -Average).Average } else { '-' })
-        L ('| {0} | {1} | {2:N2} | {3} | {4} |' -f $polarity, $col, $vt, $vsText, $d.Count)
+        $vsText = $(if ($vs.Count -gt 0) { N2 ($vs | Measure-Object -Property ratio -Average).Average } else { '-' })
+        L ('| {0} | {1} | {2} | {3} | {4} |' -f $polarity, $col, (N2 $vt), $vsText, $d.Count)
     } }
 }
 
@@ -99,8 +103,8 @@ if ($findings.Count -gt 0) {
     L '| desktop | theme | app/frame | layout | scene | surface | ratio | floor | ink on ground |'
     L '|---|---|---|---|---|---|---:|---:|---|'
     foreach ($f in ($findings | Sort-Object polarity, theme, app, frame, layout, scene, surface)) {
-        L ('| {0} | {1} | {2}/{3} | {4} | {5} | {6} | {7:N2} | {8} | {9} on {10} |' -f
-            $f.polarity, $f.theme, $f.app, $f.frame, $f.layout, $f.scene, $f.surface, $f.ratio, $f.min, $f.fg, $f.bg)
+        L ('| {0} | {1} | {2}/{3} | {4} | {5} | {6} | {7} | {8} | {9} on {10} |' -f
+            $f.polarity, $f.theme, $f.app, $f.frame, $f.layout, $f.scene, $f.surface, (N2 $f.ratio), ([double]$f.min).ToString($inv), $f.fg, $f.bg)
     }
 }
 

--- a/windows/scripts/theme-matrix-report.ps1
+++ b/windows/scripts/theme-matrix-report.ps1
@@ -1,0 +1,118 @@
+#requires -Version 7
+<#
+    Turn a theme-matrix.ps1 run into the markdown that gets pasted into #937.
+
+    The matrix cell is the WORST judged ratio across every layout and scene
+    the cell was photographed in, so a green cell is green everywhere it was
+    looked at. A cell with an unmeasured surface shows a ? beside its number:
+    a number nothing is known about is not a pass.
+
+    Reads <RunDir>/result.json, writes <RunDir>/matrix.md, prints the path.
+    Exit 0 when written, 1 when there is no result to read.
+#>
+param(
+    [Parameter(Mandatory)][string]$RunDir,
+    [string]$OutFile = ''
+)
+$ErrorActionPreference = 'Stop'
+$resultPath = Join-Path $RunDir 'result.json'
+if (-not (Test-Path -LiteralPath $resultPath)) { Write-Host "no result.json under $RunDir"; exit 1 }
+if (-not $OutFile) { $OutFile = Join-Path $RunDir 'matrix.md' }
+$r = Get-Content -LiteralPath $resultPath -Raw | ConvertFrom-Json
+
+$rows = @($r.rows); $findings = @($r.findings); $unmeasured = @($r.unmeasured); $deltas = @($r.deltas)
+# Invariant, round-trip: the machine's own culture read the ISO date with
+# its day and month swapped.
+$inv = [System.Globalization.CultureInfo]::InvariantCulture
+$started = [datetime]::Parse($r.startedUtc, $inv, [System.Globalization.DateTimeStyles]::RoundtripKind)
+$finished = [datetime]::Parse($r.finishedUtc, $inv, [System.Globalization.DateTimeStyles]::RoundtripKind)
+$md = [System.Text.StringBuilder]::new()
+function L([string]$s = '') { [void]$md.AppendLine($s) }
+
+L "## theme matrix run $($started.ToString('yyyy-MM-dd HH:mm')) UTC"
+L
+L ("build ``{0}``, {1} min, {2} rows, **{3} finding(s)**, {4} unmeasured{5}" -f
+    $r.buildSha, [Math]::Round(($finished - $started).TotalMinutes, 1), $rows.Count, $findings.Count, $unmeasured.Count,
+    $(if ($r.fatal) { ", RUN FAILED: $($r.fatal)" } else { '' }))
+L
+L ("desktop was **{0}** with wallpaper ``{1}``{2}; filters: theme={3} polarity={4} app={5} frame={6} layout={7} scene={8}{9}{10}" -f
+    $r.machine.polarityBefore, $r.machine.wallpaperBefore, $(if ($r.machine.noFlip) { ' (no flip)' } else { '' }),
+    ($r.filters.theme -join ','), ($r.filters.polarity -join ','), ($r.filters.app -join ','), ($r.filters.frame -join ','),
+    ($r.filters.layout -join ','), ($r.filters.scene -join ','),
+    $(if ($r.filters.maxCells -gt 0) { " maxCells=$($r.filters.maxCells)" } else { '' }),
+    $(if ($r.filters.mutate -ne 'none') { " **MUTATED ($($r.filters.mutate))**" } else { '' }))
+if (@($r.axes.skippedThemes).Count -gt 0) { L; L ("not in the catalogue, skipped: {0}" -f (@($r.axes.skippedThemes) -join ', ')) }
+L
+L "Cell = worst judged ratio over layouts x scenes (text >= 4.5, glyph >= 3.0, field <= 1.05). Bold = a failure in the cell; ? = a surface went unmeasured."
+
+$columns = @()
+foreach ($a in $r.axes.apps) { foreach ($f in $r.axes.frames) { $columns += "$a/$f" } }
+
+foreach ($polarity in $r.axes.polarities) {
+    L
+    L "### desktop $polarity"
+    L
+    L ('| theme | ' + ($columns -join ' | ') + ' |')
+    L ('|---|' + (($columns | ForEach-Object { '---:' }) -join '|') + '|')
+    foreach ($theme in $r.axes.themes) {
+        $line = "| $theme |"
+        foreach ($col in $columns) {
+            $app, $frame = $col -split '/'
+            $inCell = @($rows | Where-Object { $_.polarity -eq $polarity -and $_.theme -eq $theme -and $_.app -eq $app -and $_.frame -eq $frame })
+            $missing = @($unmeasured | Where-Object { $_.polarity -eq $polarity -and $_.theme -eq $theme -and $_.app -eq $app -and $_.frame -eq $frame }).Count
+            if ($inCell.Count -eq 0) { $line += $(if ($missing -gt 0) { ' ? |' } else { ' - |' }); continue }
+            # Worst = the lowest text/glyph ratio; a field failure is reported
+            # by its count since its scale runs the other way.
+            $judged = @($inCell | Where-Object { $_.class -ne 'field' })
+            $worst = $(if ($judged.Count -gt 0) { ($judged | Measure-Object -Property ratio -Minimum).Minimum } else { $null })
+            $fails = @($inCell | Where-Object { -not $_.pass }).Count
+            $text = $(if ($null -ne $worst) { '{0:N2}' -f $worst } else { 'field' })
+            if ($fails -gt 0) { $text = "**$text** ($fails)" }
+            if ($missing -gt 0) { $text += ' ?' }
+            $line += " $text |"
+        }
+        L $line
+    }
+}
+
+if ($deltas.Count -gt 0) {
+    L
+    L "### materials, measured (#897): mean ratio of the strip ground against the terminal and against the scene"
+    L
+    L '| desktop | app/frame | strip vs terminal | strip vs scene | n |'
+    L '|---|---|---:|---:|---:|'
+    foreach ($polarity in $r.axes.polarities) { foreach ($col in $columns) {
+        $app, $frame = $col -split '/'
+        $d = @($deltas | Where-Object { $_.polarity -eq $polarity -and $_.app -eq $app -and $_.frame -eq $frame })
+        if ($d.Count -eq 0) { continue }
+        $vt = @($d | Where-Object delta -eq 'strip-vs-terminal' | Measure-Object -Property ratio -Average).Average
+        $vs = @($d | Where-Object delta -eq 'strip-vs-scene')
+        $vsText = $(if ($vs.Count -gt 0) { '{0:N2}' -f ($vs | Measure-Object -Property ratio -Average).Average } else { '-' })
+        L ('| {0} | {1} | {2:N2} | {3} | {4} |' -f $polarity, $col, $vt, $vsText, $d.Count)
+    } }
+}
+
+if ($findings.Count -gt 0) {
+    L
+    L "### findings ($($findings.Count))"
+    L
+    L '| desktop | theme | app/frame | layout | scene | surface | ratio | floor | ink on ground |'
+    L '|---|---|---|---|---|---|---:|---:|---|'
+    foreach ($f in ($findings | Sort-Object polarity, theme, app, frame, layout, scene, surface)) {
+        L ('| {0} | {1} | {2}/{3} | {4} | {5} | {6} | {7:N2} | {8} | {9} on {10} |' -f
+            $f.polarity, $f.theme, $f.app, $f.frame, $f.layout, $f.scene, $f.surface, $f.ratio, $f.min, $f.fg, $f.bg)
+    }
+}
+
+if ($unmeasured.Count -gt 0) {
+    L
+    L ('<details><summary>unmeasured ({0})</summary>' -f $unmeasured.Count)
+    L
+    foreach ($u in $unmeasured) { L ('- {0} / {1} / {2}/{3} / {4} / {5} / {6}: {7}' -f $u.polarity, $u.theme, $u.app, $u.frame, $u.layout, $u.scene, $u.surface, $u.why) }
+    L
+    L '</details>'
+}
+
+[IO.File]::WriteAllText($OutFile, $md.ToString())
+Write-Host $OutFile
+exit 0

--- a/windows/scripts/theme-matrix.ps1
+++ b/windows/scripts/theme-matrix.ps1
@@ -1,0 +1,663 @@
+#requires -Version 7
+<#
+    The theme matrix (#937): every selected theme against desktop polarity,
+    app material, frame material, tab layout and a backdrop scene, measured
+    in RENDERED PIXELS and judged by the floors in lib/contrast.ps1.
+
+    Why. contrast-oracle.ps1 guards four configs on whatever polarity the
+    desktop is in; frame-style-fuzz.ps1 sweeps materials against the
+    developer's own wallpaper. Neither answers the question a user has: with
+    MY theme, in MY desktop mode, with the material I picked, in front of MY
+    wallpaper and windows, is the chrome readable? That is a matrix, and this
+    is it. It is exploratory by design: a red run is the expected outcome and
+    the matrix.md it leaves is the deliverable, posted to #937.
+
+    Axes. Every one takes one value, a comma list, or `all`:
+      -Theme     names, `curated` (the built-in pair + 14 catalogue names),
+                 or `all` (the whole staged catalogue)
+      -Polarity  light | dark        the DESKTOP setting, flipped by this
+                                     harness under a snapshot (see below)
+      -App       solid | frosted | crystal        background-style
+      -Frame     inherit | solid | frosted | crystal   frame-style; inherit
+                                     writes no line, which is the product's
+                                     "Match backdrop"
+      -Layout    horizontal | vertical           vertical-tabs, toggled in
+                                     process through the seam
+      -Scene     names from lib/backdrop-stage.ps1's catalogue
+
+    frosted and crystal cells carry background-opacity (-Opacity, 0.85):
+    the product flattens crystal to solid at 1.0, so without it a crystal
+    cell would measure Mica and call it crystal. solid cells set none.
+
+    One process per (polarity, theme, app, frame). Inside it the scene is
+    changed on the stage AND the wallpaper (Mica reads the wallpaper, acrylic
+    and crystal read the stage), the change is verified on the stage's own
+    margin before anything is photographed, and each layout is captured once
+    per scene.
+
+    The desktop is machine state, and this is the first harness here that
+    SETS it. It runs the polarity the desktop is already in first, flips to
+    the other, and puts everything back: polarity, wallpaper, and the env
+    guard's snapshot with its read-back. -NoFlip keeps the read-only policy
+    every other harness has, and reports the skipped polarity as unmeasured.
+    High Contrast pins every material solid, so the run refuses under it
+    rather than measure the pin.
+
+    Themes are given to the config as ABSOLUTE PATHS under a staging copy of
+    the catalogue: a name resolves against the XDG root the seam session
+    isolates, and a name that resolves to nothing falls back silently to the
+    compile-time default (#877, #878). Each process then proves the theme
+    reached the glass by comparing the terminal ground it photographs with
+    the theme file's own `background`; a process whose ground is not the
+    theme's is reported unmeasured, never scored.
+
+    Anti-vacuity: -Mutate terminal launches every cell with an illegible
+    pair and the run must go red.
+
+    Exit 0 clean, 2 findings, 1 the harness could not run or a surface went
+    unmeasured. Findings outrank unmeasured, as in the oracle.
+#>
+param(
+    [Parameter(Mandatory)][string]$ExePath,
+    [Parameter(Mandatory)][string]$OutDir,
+    [string[]]$Theme = @('curated'),
+    [string[]]$Polarity = @('all'),
+    [string[]]$App = @('all'),
+    [string[]]$Frame = @('all'),
+    [string[]]$Layout = @('all'),
+    [string[]]$Scene = @('all'),
+    # background-opacity for the frosted and crystal cells. The product
+    # flattens crystal to solid at opacity 1.0 (MainWindow.ApplyBackdropStyle:
+    # a fully opaque window has nothing to reveal), so a crystal cell without
+    # this would measure Mica and call it crystal. solid cells never set it.
+    [double]$Opacity = 0.85,
+    [switch]$NoFlip,
+    [switch]$DryRun,
+    [ValidateSet('none', 'terminal')][string]$Mutate = 'none',
+    # Where the shipped catalogue is read from. Default: the first that exists
+    # of zig-out/share/ghostty/themes (a -Demit-themes build), the user's
+    # wintty themes, the user's ghostty themes.
+    [string]$ThemesDir = '',
+    [int]$Seed = 1337,
+    # Stop after this many processes, for a smoke. 0 is no cap.
+    [int]$MaxCells = 0
+)
+
+. (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
+. (Join-Path $PSScriptRoot 'lib/seam-client.ps1')
+. (Join-Path $PSScriptRoot 'lib/contrast.ps1')
+. (Join-Path $PSScriptRoot 'lib/backdrop-stage.ps1')
+. (Join-Path $PSScriptRoot 'lib/env-guard.ps1')
+$ErrorActionPreference = 'Stop'
+
+Add-Type -AssemblyName UIAutomationClient
+Add-Type -AssemblyName UIAutomationTypes
+$UIA = [System.Windows.Automation.AutomationElement]
+$TREE = [System.Windows.Automation.TreeScope]::Descendants
+$CTRL = [System.Windows.Automation.ControlType]
+
+if (-not ('MatrixWin' -as [type])) {
+Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+public static class MatrixWin {
+    [StructLayout(LayoutKind.Sequential)] public struct POINT { public int X, Y; }
+    [DllImport("user32.dll")] static extern IntPtr WindowFromPoint(POINT p);
+    [DllImport("user32.dll")] static extern IntPtr GetForegroundWindow();
+    [DllImport("user32.dll")] static extern uint GetWindowThreadProcessId(IntPtr h, out uint pid);
+    [DllImport("user32.dll")] static extern bool SetWindowPos(IntPtr h, IntPtr after, int x, int y, int w, int hh, uint flags);
+    [DllImport("user32.dll")] static extern bool SetForegroundWindow(IntPtr h);
+    static readonly IntPtr HWND_TOPMOST = new IntPtr(-1);
+    // Placed and raised without activating; a separate best-effort activate
+    // because the chrome paints an inactive window differently.
+    public static bool PlaceOnTop(IntPtr h, int x, int y, int w, int hh) { return SetWindowPos(h, HWND_TOPMOST, x, y, w, hh, 0x0010); }
+    public static bool TryActivate(IntPtr h) { return SetForegroundWindow(h); }
+    public static uint PidAt(int x, int y) { uint pid; GetWindowThreadProcessId(WindowFromPoint(new POINT { X = x, Y = y }), out pid); return pid; }
+    public static uint ForegroundPid() { uint pid; GetWindowThreadProcessId(GetForegroundWindow(), out pid); return pid; }
+}
+'@
+}
+
+# ---- axes ------------------------------------------------------------------
+
+$AllApps = @('solid', 'frosted', 'crystal')
+$AllFrames = @('inherit', 'solid', 'frosted', 'crystal')
+$AllLayouts = @('horizontal', 'vertical')
+$AllPolarities = @('light', 'dark')
+$CuratedThemes = @(
+    'wintty-light', 'wintty-dark',
+    'Catppuccin Latte', 'Catppuccin Mocha', 'Gruvbox Light', 'Gruvbox Dark',
+    'Nord Light', 'Nord', 'One Half Light', 'One Half Dark',
+    'Rose Pine Dawn', 'Rose Pine', 'GitHub Light Default', 'GitHub Dark',
+    'Zenburn', 'Dracula')
+
+# One value, a comma list, or all: `just` hands the whole -X argument over as
+# one string, so "a,b" has to mean two values here.
+function Resolve-Axis([string[]]$Given, [string[]]$All, [string]$Name) {
+    $values = @($Given | ForEach-Object { $_ -split ',' } | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+    if ($values -contains 'all') { return @($All) }
+    foreach ($v in $values) {
+        if ($All -notcontains $v) { throw "HARNESS: -$Name '$v' is not one of: $($All -join ', '), all" }
+    }
+    return @($values | Select-Object -Unique)
+}
+
+$apps = Resolve-Axis $App $AllApps 'App'
+$frames = Resolve-Axis $Frame $AllFrames 'Frame'
+$layouts = Resolve-Axis $Layout $AllLayouts 'Layout'
+$polarities = Resolve-Axis $Polarity $AllPolarities 'Polarity'
+$sceneCatalogue = Get-BackdropScenes
+$scenes = @(Resolve-Axis $Scene @($sceneCatalogue.Keys) 'Scene' | ForEach-Object { $sceneCatalogue[$_] })
+
+# ---- theme staging -----------------------------------------------------------
+
+# The built-in halves, read out of the zig source at run time so a palette
+# edit reaches this harness by itself (contrast-oracle.ps1 does the same).
+function Get-BuiltinTheme([string]$Half) {
+    $path = (Resolve-Path (Join-Path $PSScriptRoot '..\..\src\config\wintty_theme.zig') -ErrorAction SilentlyContinue)?.Path
+    if (-not $path) { throw "HARNESS: cannot find src/config/wintty_theme.zig from $PSScriptRoot" }
+    $body = [System.Collections.Generic.List[string]]::new(); $inside = $false
+    foreach ($line in (Get-Content $path)) {
+        if ($line -match "^pub const $Half\s*:") { $inside = $true; continue }
+        if (-not $inside) { continue }
+        if ($line.Trim() -eq ';') { break }
+        $t = $line.Trim()
+        if ($t.StartsWith('\\')) { $v = $t.Substring(2).Trim(); if ($v) { [void]$body.Add($v) } }
+    }
+    if ($body.Count -lt 20) { throw "HARNESS: parsed only $($body.Count) lines of the built-in '$Half' half; the source shape changed" }
+    return ($body -join "`n")
+}
+
+if (-not $ThemesDir) {
+    foreach ($candidate in @(
+        (Join-Path $PSScriptRoot '..\..\zig-out\share\ghostty\themes'),
+        (Join-Path $env:APPDATA 'wintty\themes'),
+        (Join-Path $env:APPDATA 'Ghostty\themes'))) {
+        if ((Test-Path -LiteralPath $candidate) -and @(Get-ChildItem -LiteralPath $candidate -File).Count -gt 0) { $ThemesDir = (Resolve-Path $candidate).Path; break }
+    }
+}
+$runStamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+$stageRoot = Join-Path $env:TEMP "wintty-theme-matrix-$runStamp"
+$stagedThemes = Join-Path $stageRoot 'themes'
+New-Item -ItemType Directory -Force -Path $stagedThemes | Out-Null
+if ($ThemesDir) { Get-ChildItem -LiteralPath $ThemesDir -File | Copy-Item -Destination $stagedThemes }
+[IO.File]::WriteAllText((Join-Path $stagedThemes 'wintty-light'), (Get-BuiltinTheme 'light') + "`n")
+[IO.File]::WriteAllText((Join-Path $stagedThemes 'wintty-dark'), (Get-BuiltinTheme 'dark') + "`n")
+$catalogue = @(Get-ChildItem -LiteralPath $stagedThemes -File | Select-Object -ExpandProperty Name | Sort-Object)
+
+$themeValues = @($Theme | ForEach-Object { $_ -split ',' } | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+$themes = [System.Collections.Generic.List[string]]::new()
+$skippedThemes = [System.Collections.Generic.List[string]]::new()
+foreach ($t in $themeValues) {
+    $want = switch ($t) { 'all' { $catalogue } 'curated' { $CuratedThemes } default { @($t) } }
+    foreach ($name in $want) {
+        if ($catalogue -contains $name) { if ($themes -notcontains $name) { $themes.Add($name) } }
+        else { $skippedThemes.Add($name) }
+    }
+}
+if ($themes.Count -eq 0) { throw "HARNESS: no selected theme exists in the staged catalogue ($($catalogue.Count) names from '$ThemesDir')" }
+
+# The colour the theme says its ground is, so a process can prove the theme
+# it was given is the theme on the glass.
+function Get-ThemeBackground([string]$Name) {
+    foreach ($line in (Get-Content (Join-Path $stagedThemes $Name))) {
+        if ($line -match '^\s*background\s*=\s*#?([0-9A-Fa-f]{6})\s*$') { return '#' + $Matches[1].ToUpperInvariant() }
+    }
+    return $null
+}
+
+# ---- the plan ----------------------------------------------------------------
+
+$current = if ([int](Get-ItemProperty -LiteralPath $script:PersonalizeKey -ErrorAction SilentlyContinue).AppsUseLightTheme -eq 0) { 'dark' } else { 'light' }
+# Current polarity first, so a -NoFlip run and the first half of a flipping
+# run measure the same thing.
+$polarityOrder = @(@($polarities | Where-Object { $_ -eq $current }) + @($polarities | Where-Object { $_ -ne $current }))
+
+$cells = [System.Collections.Generic.List[object]]::new()
+foreach ($p in $polarityOrder) { foreach ($t in $themes) { foreach ($a in $apps) { foreach ($f in $frames) {
+    $cells.Add([pscustomobject]@{ Polarity = $p; Theme = $t; App = $a; Frame = $f
+        Id = ('{0}/{1}/{2}-{3}' -f $p, $t, $a, $f) })
+} } } }
+if ($MaxCells -gt 0 -and $cells.Count -gt $MaxCells) { $cells = [System.Collections.Generic.List[object]]@($cells | Select-Object -First $MaxCells) }
+$captures = $cells.Count * $scenes.Count * $layouts.Count
+$estimateMin = [Math]::Round(($cells.Count * 9 + $captures * 2.4 + ($polarityOrder.Count - 1) * 10) / 60.0, 1)
+
+Write-Host ("theme-matrix: {0} processes, {1} captures, ~{2} min; polarity now {3}, order {4}{5}" -f
+    $cells.Count, $captures, $estimateMin, $current, ($polarityOrder -join ' then '), $(if ($NoFlip) { ' (no flip)' } else { '' }))
+Write-Host ("  themes {0}: {1}{2}" -f $themes.Count, (($themes | Select-Object -First 16) -join ', '), $(if ($themes.Count -gt 16) { ', ...' } else { '' }))
+if ($skippedThemes.Count -gt 0) { Write-Host ("  not in catalogue, skipped: {0}" -f ($skippedThemes -join ', ')) -ForegroundColor Yellow }
+Write-Host ("  app {0}; frame {1}; layout {2}; scene {3}" -f ($apps -join ','), ($frames -join ','), ($layouts -join ','), (($scenes | ForEach-Object Name) -join ','))
+if ($DryRun) {
+    foreach ($c in $cells) { Write-Host ("  {0}" -f $c.Id) }
+    Remove-Item $stageRoot -Recurse -Force -ErrorAction SilentlyContinue
+    exit 0
+}
+
+# ---- refusals before anything moves ----------------------------------------
+
+if (-not (Test-Path -LiteralPath $ExePath)) { Write-Host "HARVEST_MISS: missing exe: $ExePath"; exit 1 }
+if (((Get-HighContrastFlags) -band 1) -ne 0) {
+    Write-Host 'HARNESS: High Contrast is on, which pins every material solid; nothing here would measure a material. Refusing.' -ForegroundColor Red
+    exit 1
+}
+New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots'), (Join-Path $OutDir 'scenes') | Out-Null
+[void][SeamWin]::SetProcessDpiAwarenessContext([IntPtr](-4))
+
+# ---- measurement -------------------------------------------------------------
+
+$WinX = 160; $WinY = 120; $WinW = 1500; $WinH = 950
+$Margin = 120
+$script:Rows = [System.Collections.Generic.List[object]]::new()
+$script:Findings = [System.Collections.Generic.List[object]]::new()
+$script:Unmeasured = [System.Collections.Generic.List[object]]::new()
+$script:Deltas = [System.Collections.Generic.List[object]]::new()
+$script:Cell = $null; $script:LayoutName = ''; $script:SceneName = ''; $script:Shot = ''
+$script:MainHwnd64 = 0; $script:ProcId = 0
+
+function Add-Row([string]$Surface, [string]$Class, [double]$Ratio, [string]$Fg, [string]$Bg, [string]$Note) {
+    $rule = Get-ContrastRule $Class
+    $pass = Test-ContrastPasses $Ratio $Class
+    $row = [pscustomobject][ordered]@{
+        polarity = $script:Cell.Polarity; theme = $script:Cell.Theme; app = $script:Cell.App; frame = $script:Cell.Frame
+        layout = $script:LayoutName; scene = $script:SceneName; surface = $Surface; class = $Class
+        ratio = [Math]::Round($Ratio, 2); min = $rule.Min; rule = $rule.Source; fg = $Fg; bg = $Bg; pass = $pass; note = $Note; shot = $script:Shot
+    }
+    $script:Rows.Add($row)
+    if (-not $pass) { $script:Findings.Add($row) }
+    Write-Host ("    {0} {1,-22} {2,6:N2}:1  {3} on {4}" -f $(if ($pass) { 'ok  ' } else { 'FAIL' }), $Surface, $Ratio, $Fg, $Bg)
+}
+
+# Not a pass: nothing is known, and the run leaves with 1 for it.
+function Add-Unmeasured([string]$Surface, [string]$Why) {
+    $script:Unmeasured.Add([pscustomobject][ordered]@{
+        polarity = $script:Cell.Polarity; theme = $script:Cell.Theme; app = $script:Cell.App; frame = $script:Cell.Frame
+        layout = $script:LayoutName; scene = $script:SceneName; surface = $Surface; why = $Why; shot = $script:Shot })
+    Write-Host ("    ??   {0,-22} not measured: {1}" -f $Surface, $Why) -ForegroundColor Yellow
+}
+
+# Recorded, never judged: the distances #897 and #878 keep asking for.
+function Add-Delta([string]$Name, $A, $B) {
+    $ratio = [ContrastMath]::Ratio($A.BgR, $A.BgG, $A.BgB, $B.BgR, $B.BgG, $B.BgB)
+    $script:Deltas.Add([pscustomobject][ordered]@{
+        polarity = $script:Cell.Polarity; theme = $script:Cell.Theme; app = $script:Cell.App; frame = $script:Cell.Frame
+        layout = $script:LayoutName; scene = $script:SceneName; delta = $Name; ratio = [Math]::Round($ratio, 2); a = $A.BgHex; b = $B.BgHex })
+    Write-Host ("    ..   {0,-22} {1,6:N2}:1  {2} vs {3}" -f $Name, $ratio, $A.BgHex, $B.BgHex)
+}
+
+function Get-UiaRoot { return $UIA::FromHandle([SeamWin]::P($script:MainHwnd64)) }
+function Find-ById([string]$Id, [int]$ms = 3000) {
+    $cond = New-Object System.Windows.Automation.PropertyCondition($UIA::AutomationIdProperty, $Id)
+    $dl = (Get-Date).AddMilliseconds($ms)
+    while ((Get-Date) -lt $dl) {
+        $el = (Get-UiaRoot).FindFirst($TREE, $cond)
+        if ($null -ne $el) { return $el }
+        Start-Sleep -Milliseconds 120
+    }
+    return $null
+}
+function Get-Kids($el, $ControlType) {
+    if ($null -eq $el) { return @() }
+    $cond = New-Object System.Windows.Automation.PropertyCondition($UIA::ControlTypeProperty, $ControlType)
+    return @($el.FindAll($TREE, $cond) | Where-Object {
+        $r = $_.Current.BoundingRectangle
+        $off = try { $_.Current.IsOffscreen } catch { $true }
+        -not [double]::IsNaN($r.X) -and $r.Width -gt 2 -and $r.Height -gt 2 -and -not $off })
+}
+function Test-Selected($el) {
+    try { return $el.GetCurrentPattern([System.Windows.Automation.SelectionItemPattern]::Pattern).Current.IsSelected } catch { return $false }
+}
+# The title is the run that SAYS the title, not the leftmost run: a pin
+# glyph or an icon sits before it (contrast-oracle.ps1 learned this).
+function Get-TitleRun($el) {
+    return @(Get-Kids $el $CTRL::Text | Where-Object { $_.Current.Name -eq $el.Current.Name }) | Select-Object -First 1
+}
+
+# The strip's tabs, either layout: El, Selected, Rect, Close (which may be
+# null: a row can hide its close button until hovered, and a tab without
+# one is still a tab). The seeded state has no groups and no pins, so every
+# item that says a title is a tab.
+function Get-StripTabs([string]$LayoutName) {
+    if ($LayoutName -eq 'vertical') {
+        $nav = Find-ById 'NavView'
+        if ($null -eq $nav) { throw 'HARVEST_MISS: no NavView' }
+        $items = @(Get-Kids $nav $CTRL::ListItem | Where-Object { $_.Current.ItemStatus -notmatch 'Pinned' })
+    } else {
+        $tv = Find-ById 'TabViewControl'
+        if ($null -eq $tv) { throw 'HARVEST_MISS: no TabViewControl' }
+        $items = @(Get-Kids $tv $CTRL::TabItem)
+    }
+    return @($items | Where-Object { $_.Current.Name } | ForEach-Object {
+        $close = @(Get-Kids $_ $CTRL::Button) | Select-Object -First 1
+        [pscustomobject]@{ El = $_; Selected = (Test-Selected $_); Rect = $_.Current.BoundingRectangle; Close = $close; Name = $_.Current.Name }
+    } | Sort-Object { $_.Rect.Y * 10000 + $_.Rect.X })
+}
+
+function New-Capture {
+    $rc = [SeamWin]::RectOf($script:MainHwnd64)
+    if ($null -eq $rc) { throw 'HARVEST_MISS: degenerate window rect' }
+    for ($gx = 1; $gx -le 6; $gx++) { for ($gy = 1; $gy -le 6; $gy++) {
+        $px = [int]($rc.L + $rc.W * $gx / 7.0); $py = [int]($rc.T + $rc.Hh * $gy / 7.0)
+        $owner = [MatrixWin]::PidAt($px, $py)
+        if ($owner -ne $script:ProcId) { throw "OCCLUDED: $px,$py inside the window belongs to pid $owner, not $($script:ProcId); nothing measured" }
+    } }
+    $bmp = [System.Drawing.Bitmap]::new($rc.W, $rc.Hh)
+    $g = [System.Drawing.Graphics]::FromImage($bmp)
+    $g.CopyFromScreen($rc.L, $rc.T, 0, 0, $bmp.Size); $g.Dispose()
+    $script:Shot = ('{0}-{1}-{2}-{3}-{4}-{5}.png' -f $script:Cell.Polarity, ($script:Cell.Theme -replace '[^A-Za-z0-9]', '_'), $script:Cell.App, $script:Cell.Frame, $script:SceneName, $script:LayoutName)
+    $bmp.Save((Join-Path $OutDir "shots\$($script:Shot)"))
+    return [pscustomobject]@{ Bmp = $bmp; L = $rc.L; T = $rc.T; W = $rc.W; H = $rc.Hh; Activated = ([MatrixWin]::ForegroundPid() -eq $script:ProcId) }
+}
+
+function ConvertTo-Local($Cap, $Rect, [int]$Inset = 1) {
+    if ($null -eq $Rect -or [double]::IsNaN($Rect.X)) { return $null }
+    $x = [int][Math]::Round($Rect.X) - $Cap.L + $Inset; $y = [int][Math]::Round($Rect.Y) - $Cap.T + $Inset
+    $w = [int][Math]::Round($Rect.Width) - 2 * $Inset; $h = [int][Math]::Round($Rect.Height) - 2 * $Inset
+    if ($x -lt 0) { $w += $x; $x = 0 }; if ($y -lt 0) { $h += $y; $y = 0 }
+    if ($x + $w -gt $Cap.W) { $w = $Cap.W - $x }; if ($y + $h -gt $Cap.H) { $h = $Cap.H - $y }
+    if ($w -le 2 -or $h -le 2) { return $null }
+    return @{ X = $x; Y = $y; W = $w; H = $h }
+}
+function Sample($Cap, $Rect, [int]$Inset = 1) {
+    $l = ConvertTo-Local $Cap $Rect $Inset
+    if ($null -eq $l) { return $null }
+    return [ContrastSampler]::Region($Cap.Bmp, $l.X, $l.Y, $l.W, $l.H)
+}
+function Measure-Ink([string]$Surface, [string]$Class, $Cap, $Rect, [int]$Inset = 1, [string]$Note = '') {
+    $s = Sample $Cap $Rect $Inset
+    if ($null -eq $s) { Add-Unmeasured $Surface 'no usable rect in the capture'; return $null }
+    if (-not $s.Ok) { Add-Unmeasured $Surface $s.Why; return $null }
+    Add-Row $Surface $Class $s.Ratio $s.FgHex $s.BgHex $Note
+    return $s
+}
+function New-Rect([double]$X, [double]$Y, [double]$W, [double]$H) { return New-Object System.Windows.Rect($X, $Y, $W, $H) }
+
+# One photograph, five judged surfaces and three deltas.
+function Measure-Capture($Cap, [string]$LayoutName, [string]$ThemeBg, $SceneGround, [bool]$GroundIsPicture = $false) {
+    $tabs = Get-StripTabs $LayoutName
+    $active = @($tabs | Where-Object Selected) | Select-Object -First 1
+    $idle = @($tabs | Where-Object { -not $_.Selected }) | Select-Object -First 1
+
+    # The terminal's ground, read from a band low and to the right where no
+    # prompt reaches, clear of the DWM border band. Judged first, because it
+    # decides whether the theme is on the glass at all.
+    $ground = Sample $Cap (New-Rect ($Cap.L + $Cap.W - 220) ($Cap.T + $Cap.H - 160) 48 48) 0
+    if ($null -eq $ground -or -not $ground.Ok) { Add-Unmeasured 'terminal-ground' 'the terminal band could not be sampled'; return }
+    # $ThemeBg is what the ground should read: the theme's own value on an
+    # opaque terminal, the theme blended with the scene on a translucent one
+    # over a flat scene, and null over an image scene at opacity below 1,
+    # where the ground is the picture and nothing can be proven from it.
+    if ($ThemeBg) {
+        $expect = ConvertTo-DrawingColor $ThemeBg
+        $off = [Math]::Abs($ground.BgR - $expect.R) + [Math]::Abs($ground.BgG - $expect.G) + [Math]::Abs($ground.BgB - $expect.B)
+        # Wide, because the compositor's blend and the sampler's bucketing
+        # both move the number; the compile-time default (#282C34) a silent
+        # fallback lands on is dozens of counts per channel away from any
+        # theme this is likely to be run with.
+        if ($off -gt 60) {
+            Add-Unmeasured 'theme-on-glass' ("the terminal ground is {0}, it should read {1}: the theme did not reach the glass, so nothing here is scored" -f $ground.BgHex, $ThemeBg)
+            return
+        }
+    }
+
+    if ($null -eq $active) { Add-Unmeasured 'tab-title-active' 'no tab reports itself selected'; Add-Unmeasured 'tab-close-active' 'no tab reports itself selected'; Add-Unmeasured 'tab-field' 'no tab reports itself selected' }
+    else {
+        $t = Get-TitleRun $active.El
+        if ($null -eq $t) { Add-Unmeasured 'tab-title-active' 'the selected tab exposes no Text run saying its title' }
+        else { [void](Measure-Ink 'tab-title-active' 'text' $Cap $t.Current.BoundingRectangle 1 "tab '$($active.Name)'") }
+        if ($null -eq $active.Close) { Add-Unmeasured 'tab-close-active' 'the selected tab exposes no close Button' }
+        else { [void](Measure-Ink 'tab-close-active' 'glyph' $Cap $active.Close.Current.BoundingRectangle 2 'the close X') }
+        # The active tab is the field: its fill must BE the terminal ground.
+        # A slice clear of the ink: the top band of a horizontal tab, the
+        # trailing end of a vertical row (where contrast-oracle reads it).
+        $r = $active.Rect
+        $slice = if ($LayoutName -eq 'vertical') { New-Rect ($r.X + $r.Width - [Math]::Max(6.0, $r.Width * 0.12) - 2) ($r.Y + 3) ([Math]::Max(6.0, $r.Width * 0.12)) ([Math]::Max(6.0, $r.Height - 6)) }
+                 else { New-Rect ($r.X + 14) ($r.Y + 3) ([Math]::Max(6.0, $r.Width - 28)) 4.0 }
+        $fill = Sample $Cap $slice 0
+        if ($null -eq $fill -or -not $fill.Ok) { Add-Unmeasured 'tab-field' 'the fill slice could not be sampled' }
+        else { Add-Row 'tab-field' 'field' ([ContrastMath]::Ratio($fill.BgR, $fill.BgG, $fill.BgB, $ground.BgR, $ground.BgG, $ground.BgB)) $fill.BgHex $ground.BgHex 'the active tab fill against the terminal it must match' }
+    }
+
+    $strip = $null
+    if ($null -eq $idle) { Add-Unmeasured 'tab-title-inactive' 'no unselected tab' }
+    else {
+        $t = Get-TitleRun $idle.El
+        if ($null -eq $t) { Add-Unmeasured 'tab-title-inactive' 'the unselected tab exposes no Text run saying its title' }
+        else { $strip = Measure-Ink 'tab-title-inactive' 'text' $Cap $t.Current.BoundingRectangle 1 "tab '$($idle.Name)'" }
+    }
+
+    # The shell prompt against its ground: of the bands walked down the top
+    # of the surface, the one with the MOST contrast in it. The first band
+    # with ink would do on an opaque terminal, but a translucent one over a
+    # busy scene has "ink" in every band, and the prompt is the one where the
+    # real glyphs beat the scene's own variance.
+    $left = if ($LayoutName -eq 'vertical') { ($tabs | ForEach-Object { $_.Rect.X + $_.Rect.Width } | Measure-Object -Maximum).Maximum + 12 } else { $Cap.L + 12 }
+    $top = if ($LayoutName -eq 'vertical') { $Cap.T + 44 } else { ($tabs | ForEach-Object { $_.Rect.Y + $_.Rect.Height } | Measure-Object -Maximum).Maximum + 12 }
+    #
+    # Over a picture, through a translucent terminal, there is no flat
+    # ground for the prompt to be read against: the band with the prompt is
+    # the one the sampler refuses (no dominant cluster), and the band it
+    # accepts is one with no prompt in it, which scored a legible prompt as
+    # 1.3:1. Judging text on a busy ground needs a local metric this harness
+    # does not have (noted in #937), so it is reported as not measured.
+    $best = $null
+    if ($GroundIsPicture) {
+        Add-Unmeasured 'terminal-fg-on-bg' 'the terminal is translucent over a picture; text on a busy ground needs a local metric this harness does not have'
+        $best = 'skipped'
+    }
+    for ($step = 0; $step -lt 6 -and $best -isnot [string]; $step++) {
+        $s = Sample $Cap (New-Rect $left ($top + $step * 40.0) ([Math]::Min(520.0, ($Cap.L + $Cap.W - 12) - $left)) 40.0) 0
+        if ($null -ne $s -and $s.Ok -and $s.FgCount -gt 0 -and ($null -eq $best -or $s.Ratio -gt $best.Ratio)) { $best = $s }
+    }
+    if ($best -is [string]) { }
+    elseif ($null -ne $best) { Add-Row 'terminal-fg-on-bg' 'text' $best.Ratio $best.FgHex $best.BgHex 'the shell prompt against the terminal ground' }
+    else { Add-Unmeasured 'terminal-fg-on-bg' 'every sampled band on the terminal surface is flat' }
+
+    # The deltas. The strip ground is the inactive tab's plurality colour,
+    # which is the chrome as it rendered under this material.
+    if ($null -ne $strip) {
+        Add-Delta 'strip-vs-terminal' $strip $ground
+        if ($null -ne $SceneGround) { Add-Delta 'strip-vs-scene' $strip $SceneGround }
+    }
+}
+
+# ---- desktop polarity --------------------------------------------------------
+
+function Get-DesktopPolarity {
+    $v = (Get-ItemProperty -LiteralPath $script:PersonalizeKey -ErrorAction SilentlyContinue).AppsUseLightTheme
+    return $(if ($null -ne $v -and [int]$v -eq 0) { 'dark' } else { 'light' })
+}
+# Both Personalize values and the broadcast Settings sends, then a read-back.
+# Explorer, DWM and UISettings all pick the change up from the broadcast, and
+# the app launched afterwards reads the system value fresh.
+function Set-DesktopPolarity([string]$P) {
+    $v = $(if ($P -eq 'light') { 1 } else { 0 })
+    Set-ItemProperty -LiteralPath $script:PersonalizeKey -Name 'AppsUseLightTheme' -Value $v -Type DWord
+    Set-ItemProperty -LiteralPath $script:PersonalizeKey -Name 'SystemUsesLightTheme' -Value $v -Type DWord
+    Send-SettingChange 'ImmersiveColorSet'
+    Start-Sleep -Seconds 4
+    if ((Get-DesktopPolarity) -ne $P) { throw "HARNESS: the desktop polarity did not read back as $P" }
+}
+
+# ---- run ---------------------------------------------------------------------
+
+$startedUtc = (Get-Date).ToUniversalTime().ToString('o')
+$snapshotPath = Save-EnvSnapshot
+$wallpaperBefore = Get-DesktopWallpaper
+$polarityBefore = Get-DesktopPolarity
+$stage = $null
+$cellVerdicts = [System.Collections.Generic.List[object]]::new()
+$fatal = ''
+$titles = @('alpha', 'bravo', 'charlie')
+$sceneDir = Join-Path $OutDir 'scenes'
+$marginPoint = @{ X = $WinX - [int]($Margin / 2); Y = $WinY + [int]($WinH / 2) }
+
+try {
+    $stage = Start-BackdropStage -X ($WinX - $Margin) -Y ($WinY - $Margin) -W ($WinW + 2 * $Margin) -H ($WinH + 2 * $Margin)
+    $activePolarity = $polarityBefore
+    foreach ($cell in $cells) {
+        if ($cell.Polarity -ne $activePolarity) {
+            if ($NoFlip) {
+                $script:Cell = $cell; $script:LayoutName = '*'; $script:SceneName = '*'; $script:Shot = ''
+                Add-Unmeasured 'cell' "-NoFlip: the desktop is $activePolarity and this cell needs $($cell.Polarity)"
+                continue
+            }
+            Write-Host ("=== flipping the desktop to {0} ===" -f $cell.Polarity) -ForegroundColor Cyan
+            Set-DesktopPolarity $cell.Polarity
+            $activePolarity = $cell.Polarity
+            # The flip recreates the stage's window underneath WinForms; the
+            # placement is re-asserted so it is topmost again before the
+            # next window under test is placed above it.
+            [void](Invoke-BackdropStage $stage @{ op = 'place'; x = ($WinX - $Margin); y = ($WinY - $Margin); w = ($WinW + 2 * $Margin); h = ($WinH + 2 * $Margin) })
+        }
+        $script:Cell = $cell
+        Write-Host ""
+        Write-Host ("=== {0} ===" -f $cell.Id) -ForegroundColor Cyan
+        $firstLayout = $layouts[0]
+        $themePath = Join-Path $stagedThemes $cell.Theme
+        $config = @(
+            'windows-single-instance = false', 'window-save-state = never', 'windows-settings-ui = true',
+            ('vertical-tabs = ' + $(if ($firstLayout -eq 'vertical') { 'true' } else { 'false' })),
+            'vertical-tabs-hover-expand = false', 'vertical-tabs-pinned = true',
+            "theme = $themePath",
+            "background-style = $($cell.App)")
+        if ($cell.Frame -ne 'inherit') { $config += "frame-style = $($cell.Frame)" }
+        if ($cell.App -ne 'solid') { $config += ('background-opacity = {0}' -f $Opacity.ToString('F2', [System.Globalization.CultureInfo]::InvariantCulture)) }
+        $themeBg = Get-ThemeBackground $cell.Theme
+        if ($Mutate -eq 'terminal') { $config += 'background = #808080', 'foreground = #858585'; $themeBg = '#808080' }
+        $translucent = ($cell.App -ne 'solid') -or ($cell.Frame -in @('frosted', 'crystal'))
+
+        $s = $null; $cellErr = ''
+        try {
+            $s = Start-SeamSession -ExePath $ExePath -ConfigText ($config -join "`n")
+            $script:MainHwnd64 = $s.Hwnd64; $script:ProcId = [uint32]$s.Proc.Id
+            $hwnd = [SeamWin]::P($script:MainHwnd64)
+            [void][MatrixWin]::PlaceOnTop($hwnd, $WinX, $WinY, $WinW, $WinH)
+            [void][MatrixWin]::TryActivate($hwnd)
+            [void](Invoke-SeamCommand $s @{ op = 'seed-tabs'; count = 3; titles = $titles })
+            [void](Invoke-SeamCommand $s @{ op = 'select'; index = 1 })
+            Start-Sleep -Seconds 3
+
+            # $sc, not $scene: the loop variable would be the typed [string[]]
+            # -Scene parameter, and assigning the scene object to it coerces
+            # the object to strings and loses its Name.
+            foreach ($sc in $scenes) {
+                $script:SceneName = $sc.Name
+                [void](Set-BackdropScene -Stage $stage -Scene $sc -SceneDir $sceneDir -Wallpaper -Seed $Seed)
+                Start-Sleep -Milliseconds $(if ($translucent) { 1800 } else { 500 })
+                # The scene is proven on the stage's own margin before the
+                # shutter: the pixel there must belong to the stage, and for a
+                # flat scene must be its colour.
+                # The stage can lose its topmost standing: a polarity flip
+                # makes WinForms recreate its window, and the developer's
+                # own terminal was found sitting over the margin right after
+                # one. Re-asserting the placement puts it back on top; three
+                # beats and it is a real occlusion, refused rather than
+                # measured through.
+                $owner = 0
+                for ($attempt = 1; $attempt -le 3; $attempt++) {
+                    $owner = [MatrixWin]::PidAt($marginPoint.X, $marginPoint.Y)
+                    if ($owner -eq [uint32]$stage.Proc.Id) { break }
+                    [void](Invoke-BackdropStage $stage @{ op = 'place'; x = ($WinX - $Margin); y = ($WinY - $Margin); w = ($WinW + 2 * $Margin); h = ($WinH + 2 * $Margin) })
+                    [void][MatrixWin]::PlaceOnTop($hwnd, $WinX, $WinY, $WinW, $WinH)
+                    Start-Sleep -Milliseconds 800
+                }
+                $marginPx = Get-ScreenPixel -X $marginPoint.X -Y $marginPoint.Y
+                if ($owner -ne [uint32]$stage.Proc.Id) { throw "OCCLUDED: the stage margin at $($marginPoint.X),$($marginPoint.Y) belongs to pid $owner, not the stage" }
+                if ($sc.Kind -eq 'solid' -and -not (Test-PixelNear $marginPx $sc.Color 3)) { throw "HARNESS: the stage margin reads $($marginPx.Hex), not the $($sc.Name) scene's $($sc.Color)" }
+                $sceneGround = $(if ($sc.Kind -eq 'solid') { [pscustomobject]@{ BgR = $marginPx.R; BgG = $marginPx.G; BgB = $marginPx.B; BgHex = $marginPx.Hex } } else { $null })
+                # What the terminal ground should read under this cell's
+                # opacity: the theme itself when opaque, the theme blended
+                # with a flat scene when not, nothing provable over a picture.
+                $expectBg = $themeBg
+                if ($cell.App -ne 'solid' -and $themeBg) {
+                    if ($sc.Kind -eq 'solid') {
+                        $tc = ConvertTo-DrawingColor $themeBg
+                        $expectBg = '#{0:X2}{1:X2}{2:X2}' -f [int][Math]::Round($tc.R * $Opacity + $marginPx.R * (1 - $Opacity)),
+                            [int][Math]::Round($tc.G * $Opacity + $marginPx.G * (1 - $Opacity)),
+                            [int][Math]::Round($tc.B * $Opacity + $marginPx.B * (1 - $Opacity))
+                    } else { $expectBg = $null }
+                }
+
+                foreach ($layoutName in $layouts) {
+                    $script:LayoutName = $layoutName
+                    $wantVertical = ($layoutName -eq 'vertical')
+                    $state = Invoke-SeamCommand $s @{ op = 'get-state' }
+                    for ($try = 0; $try -lt 3 -and ([bool]$state.state.vertical -ne $wantVertical); $try++) {
+                        $state = Invoke-SeamCommand $s @{ op = 'toggle-layout' }
+                        if ([bool]$state.state.vertical -ne $wantVertical) { Start-Sleep -Milliseconds 900 }
+                    }
+                    if ([bool]$state.state.vertical -ne $wantVertical) {
+                        $script:Shot = ''
+                        Add-Unmeasured 'layout' "the layout toggle acked three times and the window stayed $(if ($state.state.vertical) { 'vertical' } else { 'horizontal' })"
+                        continue
+                    }
+                    Start-Sleep -Milliseconds 700
+                    Write-Host ("-- {0} / {1}" -f $sc.Name, $layoutName)
+                    $cap = New-Capture
+                    try { Measure-Capture $cap $layoutName $expectBg $sceneGround ($cell.App -ne 'solid' -and $sc.Kind -ne 'solid') }
+                    finally { $cap.Bmp.Dispose() }
+                }
+            }
+        }
+        catch {
+            $cellErr = "$($_.Exception.Message)"
+            Write-Host ("CELL FAILED {0}: {1}" -f $cell.Id, $cellErr) -ForegroundColor Red
+            # The frame, because a binding error names a parameter and not
+            # the call that bound it.
+            Write-Host ("  at " + (($_.ScriptStackTrace -split "`n" | Select-Object -First 3) -join "`n  at ")) -ForegroundColor DarkGray
+            $script:Shot = ''
+            Add-Unmeasured 'cell' $cellErr
+        }
+        finally {
+            if ($null -ne $s) { Stop-SeamSession $s }
+        }
+        $cellVerdicts.Add([pscustomobject]@{ id = $cell.Id; error = $cellErr })
+    }
+}
+catch {
+    $fatal = "$($_.Exception.Message)"
+    Write-Host "RUN FAILED: $fatal" -ForegroundColor Red
+}
+finally {
+    # Everything back, in the order that makes the read-back true: the
+    # wallpaper through the API that actually applies one, the polarity
+    # through the broadcast, then the env guard's own restore and read-back.
+    if ($null -ne $stage) { try { Stop-BackdropStage $stage } catch { } }
+    try { Set-DesktopWallpaper -Path $wallpaperBefore.Path -Style $wallpaperBefore.Style -Tile $wallpaperBefore.Tile } catch { Write-Host "RESTORE: wallpaper: $_" -ForegroundColor Red }
+    try { if ((Get-DesktopPolarity) -ne $polarityBefore) { Set-DesktopPolarity $polarityBefore } } catch { Write-Host "RESTORE: polarity: $_" -ForegroundColor Red }
+    try { Restore-EnvSnapshot -Path $snapshotPath } catch { Write-Host "RESTORE: env guard: $_ (run 'just env-restore')" -ForegroundColor Red }
+    Remove-Item $stageRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# ---- report ------------------------------------------------------------------
+
+$buildSha = try { (git -C $PSScriptRoot rev-parse --short HEAD 2>$null) } catch { '' }
+$result = [ordered]@{
+    harness = 'theme-matrix.ps1'
+    issue = 937
+    exe = (Resolve-Path $ExePath).Path
+    buildSha = "$buildSha"
+    startedUtc = $startedUtc
+    finishedUtc = (Get-Date).ToUniversalTime().ToString('o')
+    machine = [ordered]@{ polarityBefore = $polarityBefore; wallpaperBefore = $wallpaperBefore.Path; noFlip = [bool]$NoFlip; screen = (Get-VirtualScreenRect) }
+    filters = [ordered]@{ theme = $Theme; polarity = $Polarity; app = $App; frame = $Frame; layout = $Layout; scene = $Scene; opacity = $Opacity; maxCells = $MaxCells; mutate = $Mutate }
+    axes = [ordered]@{ themes = @($themes); skippedThemes = @($skippedThemes); polarities = @($polarityOrder); apps = @($apps); frames = @($frames); layouts = @($layouts); scenes = @($scenes | ForEach-Object Name); themesDir = $ThemesDir }
+    thresholds = [ordered]@{
+        text = @{ min = $script:CONTRAST_TEXT_AA; sense = '>=' }; glyph = @{ min = $script:CONTRAST_NONTEXT; sense = '>=' }
+        field = @{ min = $script:CONTRAST_FIELD_SAME; sense = '<=' } }
+    cells = $cellVerdicts
+    rows = $script:Rows
+    deltas = $script:Deltas
+    findings = $script:Findings
+    unmeasured = $script:Unmeasured
+    fatal = $fatal
+}
+$result | ConvertTo-Json -Depth 6 | Set-Content (Join-Path $OutDir 'result.json') -Encoding utf8
+& (Join-Path $PSScriptRoot 'theme-matrix-report.ps1') -RunDir $OutDir | Out-Null
+
+Write-Host ""
+Write-Host ("theme-matrix: {0} rows, {1} findings, {2} unmeasured, {3} deltas -> {4}" -f
+    $script:Rows.Count, $script:Findings.Count, $script:Unmeasured.Count, $script:Deltas.Count, (Join-Path $OutDir 'matrix.md'))
+if ($script:Findings.Count -gt 0) { exit 2 }
+if ($fatal -or $script:Unmeasured.Count -gt 0 -or $script:Rows.Count -eq 0) { exit 1 }
+exit 0

--- a/windows/scripts/theme-matrix.ps1
+++ b/windows/scripts/theme-matrix.ps1
@@ -185,18 +185,6 @@ if ($ThemesDir) { Get-ChildItem -LiteralPath $ThemesDir -File | Copy-Item -Desti
 [IO.File]::WriteAllText((Join-Path $stagedThemes 'wintty-dark'), (Get-BuiltinTheme 'dark') + "`n")
 $catalogue = @(Get-ChildItem -LiteralPath $stagedThemes -File | Select-Object -ExpandProperty Name | Sort-Object)
 
-$themeValues = @($Theme | ForEach-Object { $_ -split ',' } | ForEach-Object { $_.Trim() } | Where-Object { $_ })
-$themes = [System.Collections.Generic.List[string]]::new()
-$skippedThemes = [System.Collections.Generic.List[string]]::new()
-foreach ($t in $themeValues) {
-    $want = switch ($t) { 'all' { $catalogue } 'curated' { $CuratedThemes } default { @($t) } }
-    foreach ($name in $want) {
-        if ($catalogue -contains $name) { if ($themes -notcontains $name) { $themes.Add($name) } }
-        else { $skippedThemes.Add($name) }
-    }
-}
-if ($themes.Count -eq 0) { throw "HARNESS: no selected theme exists in the staged catalogue ($($catalogue.Count) names from '$ThemesDir')" }
-
 # The colour the theme says its ground is, so a process can prove the theme
 # it was given is the theme on the glass.
 function Get-ThemeBackground([string]$Name) {
@@ -206,9 +194,34 @@ function Get-ThemeBackground([string]$Name) {
     return $null
 }
 
+$themeValues = @($Theme | ForEach-Object { $_ -split ',' } | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+$themes = [System.Collections.Generic.List[string]]::new()
+$skippedThemes = [System.Collections.Generic.List[string]]::new()
+foreach ($t in $themeValues) {
+    $want = switch ($t) { 'all' { $catalogue } 'curated' { $CuratedThemes } default { @($t) } }
+    foreach ($name in $want) {
+        if ($catalogue -notcontains $name) { $skippedThemes.Add($name); continue }
+        # A theme with no background line cannot be proven on the glass, and
+        # scoring it would be exactly the silent fallback the proof exists
+        # to catch; it is skipped and named rather than measured blind.
+        if ($null -eq (Get-ThemeBackground $name)) { $skippedThemes.Add("$name (no background line)"); continue }
+        if ($themes -notcontains $name) { $themes.Add($name) }
+    }
+}
+if ($themes.Count -eq 0) { throw "HARNESS: no selected theme exists in the staged catalogue ($($catalogue.Count) names from '$ThemesDir')" }
+
+# ---- desktop polarity --------------------------------------------------------
+
+# One reader, used by the plan and by the run, so the two cannot disagree
+# on what a missing value means.
+function Get-DesktopPolarity {
+    $v = (Get-ItemProperty -LiteralPath $script:PersonalizeKey -ErrorAction SilentlyContinue).AppsUseLightTheme
+    return $(if ($null -ne $v -and [int]$v -eq 0) { 'dark' } else { 'light' })
+}
+
 # ---- the plan ----------------------------------------------------------------
 
-$current = if ([int](Get-ItemProperty -LiteralPath $script:PersonalizeKey -ErrorAction SilentlyContinue).AppsUseLightTheme -eq 0) { 'dark' } else { 'light' }
+$current = Get-DesktopPolarity
 # Current polarity first, so a -NoFlip run and the first half of a flipping
 # run measure the same thing.
 $polarityOrder = @(@($polarities | Where-Object { $_ -eq $current }) + @($polarities | Where-Object { $_ -ne $current }))
@@ -251,7 +264,7 @@ $script:Rows = [System.Collections.Generic.List[object]]::new()
 $script:Findings = [System.Collections.Generic.List[object]]::new()
 $script:Unmeasured = [System.Collections.Generic.List[object]]::new()
 $script:Deltas = [System.Collections.Generic.List[object]]::new()
-$script:Cell = $null; $script:LayoutName = ''; $script:SceneName = ''; $script:Shot = ''
+$script:Cell = $null; $script:LayoutName = ''; $script:SceneName = ''; $script:Shot = ''; $script:Activated = $false
 $script:MainHwnd64 = 0; $script:ProcId = 0
 
 function Add-Row([string]$Surface, [string]$Class, [double]$Ratio, [string]$Fg, [string]$Bg, [string]$Note) {
@@ -261,6 +274,9 @@ function Add-Row([string]$Surface, [string]$Class, [double]$Ratio, [string]$Fg, 
         polarity = $script:Cell.Polarity; theme = $script:Cell.Theme; app = $script:Cell.App; frame = $script:Cell.Frame
         layout = $script:LayoutName; scene = $script:SceneName; surface = $Surface; class = $Class
         ratio = [Math]::Round($Ratio, 2); min = $rule.Min; rule = $rule.Source; fg = $Fg; bg = $Bg; pass = $pass; note = $Note; shot = $script:Shot
+        # The chrome paints an inactive window differently, so each number
+        # says which state it was read in (the oracle records the same).
+        activated = $script:Activated
     }
     $script:Rows.Add($row)
     if (-not $pass) { $script:Findings.Add($row) }
@@ -371,8 +387,53 @@ function Measure-Ink([string]$Surface, [string]$Class, $Cap, $Rect, [int]$Inset 
 }
 function New-Rect([double]$X, [double]$Y, [double]$W, [double]$H) { return New-Object System.Windows.Rect($X, $Y, $W, $H) }
 
+# The ground the theme should produce, and the rule it is held to.
+#   exact    an opaque terminal: the theme's own background, within 60 counts
+#            summed over the channels (compositor dither and the sampler's
+#            bucketing both move the number; the compile-time default a
+#            silent fallback lands on, #282C34, is far from most themes,
+#            though not from One Half Dark, whose background it IS, so for
+#            that one theme the proof cannot tell the fallback apart)
+#   blend    crystal over a flat scene: theme*opacity + scene*(1-opacity),
+#            same budget, since crystal is plain alpha over the stage
+#   segment  frosted over a flat scene: acrylic adds its own tint and
+#            luminosity to the scene before the alpha, so the exact blend
+#            is not predictable; what is, is that the ground lies on the
+#            line between the theme and the scene, nearer the theme. The
+#            ground must be within 25 counts of that segment and at least
+#            half way toward the theme, which still refuses a fallback
+#            palette that is nowhere near the line.
+function New-GlassExpectation([string]$Mode, [string]$ThemeHex, $SceneRgb, [double]$Alpha) {
+    return [pscustomobject]@{ Mode = $Mode; Theme = (ConvertTo-DrawingColor $ThemeHex); Scene = $SceneRgb; Alpha = $Alpha; ThemeHex = $ThemeHex }
+}
+function Test-ThemeOnGlass($Ground, $Expect) {
+    $t = $Expect.Theme
+    switch ($Expect.Mode) {
+        'segment' {
+            $s = $Expect.Scene
+            $dx = $t.R - $s.BgR; $dy = $t.G - $s.BgG; $dz = $t.B - $s.BgB
+            $len2 = $dx * $dx + $dy * $dy + $dz * $dz
+            if ($len2 -lt 1) { $Expect = New-GlassExpectation 'exact' $Expect.ThemeHex $null 1.0; break }
+            $gx = $Ground.BgR - $s.BgR; $gy = $Ground.BgG - $s.BgG; $gz = $Ground.BgB - $s.BgB
+            $u = ($gx * $dx + $gy * $dy + $gz * $dz) / $len2
+            $px = $s.BgR + $u * $dx; $py = $s.BgG + $u * $dy; $pz = $s.BgB + $u * $dz
+            $dist = [Math]::Sqrt(($Ground.BgR - $px) * ($Ground.BgR - $px) + ($Ground.BgG - $py) * ($Ground.BgG - $py) + ($Ground.BgB - $pz) * ($Ground.BgB - $pz))
+            if ($u -ge 0.5 -and $u -le 1.15 -and $dist -le 25) { return $null }
+            return ("the terminal ground is {0}, which is not on the line from the {1} scene to the theme's {2} (blend {3:N2}, off the line by {4:N0})" -f $Ground.BgHex, $s.BgHex, $Expect.ThemeHex, $u, $dist)
+        }
+    }
+    $r = $t.R; $g = $t.G; $b = $t.B
+    if ($Expect.Mode -eq 'blend') {
+        $a = $Expect.Alpha; $s = $Expect.Scene
+        $r = $t.R * $a + $s.BgR * (1 - $a); $g = $t.G * $a + $s.BgG * (1 - $a); $b = $t.B * $a + $s.BgB * (1 - $a)
+    }
+    $off = [Math]::Abs($Ground.BgR - $r) + [Math]::Abs($Ground.BgG - $g) + [Math]::Abs($Ground.BgB - $b)
+    if ($off -le 60) { return $null }
+    return ("the terminal ground is {0}, it should read about #{1:X2}{2:X2}{3:X2}" -f $Ground.BgHex, [int][Math]::Round($r), [int][Math]::Round($g), [int][Math]::Round($b))
+}
+
 # One photograph, five judged surfaces and three deltas.
-function Measure-Capture($Cap, [string]$LayoutName, [string]$ThemeBg, $SceneGround, [bool]$GroundIsPicture = $false) {
+function Measure-Capture($Cap, [string]$LayoutName, $Expect, $SceneGround, [bool]$GroundIsPicture = $false) {
     $tabs = Get-StripTabs $LayoutName
     $active = @($tabs | Where-Object Selected) | Select-Object -First 1
     $idle = @($tabs | Where-Object { -not $_.Selected }) | Select-Object -First 1
@@ -382,21 +443,13 @@ function Measure-Capture($Cap, [string]$LayoutName, [string]$ThemeBg, $SceneGrou
     # decides whether the theme is on the glass at all.
     $ground = Sample $Cap (New-Rect ($Cap.L + $Cap.W - 220) ($Cap.T + $Cap.H - 160) 48 48) 0
     if ($null -eq $ground -or -not $ground.Ok) { Add-Unmeasured 'terminal-ground' 'the terminal band could not be sampled'; return }
-    # $ThemeBg is what the ground should read: the theme's own value on an
-    # opaque terminal, the theme blended with the scene on a translucent one
-    # over a flat scene, and null over an image scene at opacity below 1,
-    # where the ground is the picture and nothing can be proven from it.
-    if ($ThemeBg) {
-        $expect = ConvertTo-DrawingColor $ThemeBg
-        $off = [Math]::Abs($ground.BgR - $expect.R) + [Math]::Abs($ground.BgG - $expect.G) + [Math]::Abs($ground.BgB - $expect.B)
-        # Wide, because the compositor's blend and the sampler's bucketing
-        # both move the number; the compile-time default (#282C34) a silent
-        # fallback lands on is dozens of counts per channel away from any
-        # theme this is likely to be run with.
-        if ($off -gt 60) {
-            Add-Unmeasured 'theme-on-glass' ("the terminal ground is {0}, it should read {1}: the theme did not reach the glass, so nothing here is scored" -f $ground.BgHex, $ThemeBg)
-            return
-        }
+    # Is the theme on the glass? $Expect says what the ground should be and
+    # how strictly: null means nothing can be proven (a picture behind a
+    # translucent terminal), and the check refuses the capture rather than
+    # scoring a fallback palette as the theme.
+    if ($null -ne $Expect) {
+        $why = Test-ThemeOnGlass $ground $Expect
+        if ($why) { Add-Unmeasured 'theme-on-glass' ($why + ': the theme did not reach the glass, so nothing here is scored'); return }
     }
 
     if ($null -eq $active) { Add-Unmeasured 'tab-title-active' 'no tab reports itself selected'; Add-Unmeasured 'tab-close-active' 'no tab reports itself selected'; Add-Unmeasured 'tab-field' 'no tab reports itself selected' }
@@ -430,6 +483,7 @@ function Measure-Capture($Cap, [string]$LayoutName, [string]$ThemeBg, $SceneGrou
     # with ink would do on an opaque terminal, but a translucent one over a
     # busy scene has "ink" in every band, and the prompt is the one where the
     # real glyphs beat the scene's own variance.
+    if ($tabs.Count -eq 0) { Add-Unmeasured 'terminal-fg-on-bg' 'no tab was located, so there is nothing to anchor the terminal band on'; return }
     $left = if ($LayoutName -eq 'vertical') { ($tabs | ForEach-Object { $_.Rect.X + $_.Rect.Width } | Measure-Object -Maximum).Maximum + 12 } else { $Cap.L + 12 }
     $top = if ($LayoutName -eq 'vertical') { $Cap.T + 44 } else { ($tabs | ForEach-Object { $_.Rect.Y + $_.Rect.Height } | Measure-Object -Maximum).Maximum + 12 }
     #
@@ -460,12 +514,6 @@ function Measure-Capture($Cap, [string]$LayoutName, [string]$ThemeBg, $SceneGrou
     }
 }
 
-# ---- desktop polarity --------------------------------------------------------
-
-function Get-DesktopPolarity {
-    $v = (Get-ItemProperty -LiteralPath $script:PersonalizeKey -ErrorAction SilentlyContinue).AppsUseLightTheme
-    return $(if ($null -ne $v -and [int]$v -eq 0) { 'dark' } else { 'light' })
-}
 # Both Personalize values and the broadcast Settings sends, then a read-back.
 # Explorer, DWM and UISettings all pick the change up from the broadcast, and
 # the app launched afterwards reads the system value fresh.
@@ -482,11 +530,17 @@ function Set-DesktopPolarity([string]$P) {
 
 $startedUtc = (Get-Date).ToUniversalTime().ToString('o')
 $snapshotPath = Save-EnvSnapshot
+# A copy the next harness cannot overwrite: the well-known snapshot is
+# replaced by whoever runs next, and after a kill mid-flip that would be a
+# snapshot of the flipped desktop.
+Copy-Item -LiteralPath $snapshotPath -Destination (Join-Path $OutDir 'env-before.json') -Force
 $wallpaperBefore = Get-DesktopWallpaper
 $polarityBefore = Get-DesktopPolarity
 $stage = $null
 $cellVerdicts = [System.Collections.Generic.List[object]]::new()
 $fatal = ''
+$restoreErrors = [System.Collections.Generic.List[string]]::new()
+$occludedInARow = 0
 $titles = @('alpha', 'bravo', 'charlie')
 $sceneDir = Join-Path $OutDir 'scenes'
 $marginPoint = @{ X = $WinX - [int]($Margin / 2); Y = $WinY + [int]($WinH / 2) }
@@ -494,37 +548,38 @@ $marginPoint = @{ X = $WinX - [int]($Margin / 2); Y = $WinY + [int]($WinH / 2) }
 try {
     $stage = Start-BackdropStage -X ($WinX - $Margin) -Y ($WinY - $Margin) -W ($WinW + 2 * $Margin) -H ($WinH + 2 * $Margin)
     $activePolarity = $polarityBefore
-    foreach ($cell in $cells) {
-        if ($cell.Polarity -ne $activePolarity) {
+    foreach ($plan in $cells) {
+        if ($plan.Polarity -ne $activePolarity) {
             if ($NoFlip) {
-                $script:Cell = $cell; $script:LayoutName = '*'; $script:SceneName = '*'; $script:Shot = ''
-                Add-Unmeasured 'cell' "-NoFlip: the desktop is $activePolarity and this cell needs $($cell.Polarity)"
+                $script:Cell = $plan; $script:LayoutName = '*'; $script:SceneName = '*'; $script:Shot = ''
+                Add-Unmeasured 'cell' "-NoFlip: the desktop is $activePolarity and this cell needs $($plan.Polarity)"
+                $cellVerdicts.Add([pscustomobject]@{ id = $plan.Id; error = 'skipped: -NoFlip' })
                 continue
             }
-            Write-Host ("=== flipping the desktop to {0} ===" -f $cell.Polarity) -ForegroundColor Cyan
-            Set-DesktopPolarity $cell.Polarity
-            $activePolarity = $cell.Polarity
+            Write-Host ("=== flipping the desktop to {0} ===" -f $plan.Polarity) -ForegroundColor Cyan
+            Set-DesktopPolarity $plan.Polarity
+            $activePolarity = $plan.Polarity
             # The flip recreates the stage's window underneath WinForms; the
             # placement is re-asserted so it is topmost again before the
             # next window under test is placed above it.
             [void](Invoke-BackdropStage $stage @{ op = 'place'; x = ($WinX - $Margin); y = ($WinY - $Margin); w = ($WinW + 2 * $Margin); h = ($WinH + 2 * $Margin) })
         }
-        $script:Cell = $cell
+        $script:Cell = $plan
         Write-Host ""
-        Write-Host ("=== {0} ===" -f $cell.Id) -ForegroundColor Cyan
+        Write-Host ("=== {0} ===" -f $plan.Id) -ForegroundColor Cyan
         $firstLayout = $layouts[0]
-        $themePath = Join-Path $stagedThemes $cell.Theme
+        $themePath = Join-Path $stagedThemes $plan.Theme
         $config = @(
             'windows-single-instance = false', 'window-save-state = never', 'windows-settings-ui = true',
             ('vertical-tabs = ' + $(if ($firstLayout -eq 'vertical') { 'true' } else { 'false' })),
             'vertical-tabs-hover-expand = false', 'vertical-tabs-pinned = true',
             "theme = $themePath",
-            "background-style = $($cell.App)")
-        if ($cell.Frame -ne 'inherit') { $config += "frame-style = $($cell.Frame)" }
-        if ($cell.App -ne 'solid') { $config += ('background-opacity = {0}' -f $Opacity.ToString('F2', [System.Globalization.CultureInfo]::InvariantCulture)) }
-        $themeBg = Get-ThemeBackground $cell.Theme
+            "background-style = $($plan.App)")
+        if ($plan.Frame -ne 'inherit') { $config += "frame-style = $($plan.Frame)" }
+        if ($plan.App -ne 'solid') { $config += ('background-opacity = {0}' -f $Opacity.ToString('F2', [System.Globalization.CultureInfo]::InvariantCulture)) }
+        $themeBg = Get-ThemeBackground $plan.Theme
         if ($Mutate -eq 'terminal') { $config += 'background = #808080', 'foreground = #858585'; $themeBg = '#808080' }
-        $translucent = ($cell.App -ne 'solid') -or ($cell.Frame -in @('frosted', 'crystal'))
+        $translucent = ($plan.App -ne 'solid') -or ($plan.Frame -in @('frosted', 'crystal'))
 
         $s = $null; $cellErr = ''
         try {
@@ -566,21 +621,17 @@ try {
                 if ($sc.Kind -eq 'solid' -and -not (Test-PixelNear $marginPx $sc.Color 3)) { throw "HARNESS: the stage margin reads $($marginPx.Hex), not the $($sc.Name) scene's $($sc.Color)" }
                 $sceneGround = $(if ($sc.Kind -eq 'solid') { [pscustomobject]@{ BgR = $marginPx.R; BgG = $marginPx.G; BgB = $marginPx.B; BgHex = $marginPx.Hex } } else { $null })
                 # What the terminal ground should read under this cell's
-                # opacity: the theme itself when opaque, the theme blended
-                # with a flat scene when not, nothing provable over a picture.
-                $expectBg = $themeBg
-                if ($cell.App -ne 'solid' -and $themeBg) {
-                    if ($sc.Kind -eq 'solid') {
-                        $tc = ConvertTo-DrawingColor $themeBg
-                        $expectBg = '#{0:X2}{1:X2}{2:X2}' -f [int][Math]::Round($tc.R * $Opacity + $marginPx.R * (1 - $Opacity)),
-                            [int][Math]::Round($tc.G * $Opacity + $marginPx.G * (1 - $Opacity)),
-                            [int][Math]::Round($tc.B * $Opacity + $marginPx.B * (1 - $Opacity))
-                    } else { $expectBg = $null }
-                }
+                # material (see New-GlassExpectation): exact when opaque, a
+                # blend or a segment over a flat scene, nothing provable over
+                # a picture.
+                $expect = $(if ($plan.App -eq 'solid') { New-GlassExpectation 'exact' $themeBg $null 1.0 }
+                    elseif ($null -eq $sceneGround) { $null }
+                    elseif ($plan.App -eq 'crystal') { New-GlassExpectation 'blend' $themeBg $sceneGround $Opacity }
+                    else { New-GlassExpectation 'segment' $themeBg $sceneGround $Opacity })
 
-                foreach ($layoutName in $layouts) {
-                    $script:LayoutName = $layoutName
-                    $wantVertical = ($layoutName -eq 'vertical')
+                foreach ($ln in $layouts) {
+                    $script:LayoutName = $ln
+                    $wantVertical = ($ln -eq 'vertical')
                     $state = Invoke-SeamCommand $s @{ op = 'get-state' }
                     for ($try = 0; $try -lt 3 -and ([bool]$state.state.vertical -ne $wantVertical); $try++) {
                         $state = Invoke-SeamCommand $s @{ op = 'toggle-layout' }
@@ -592,16 +643,17 @@ try {
                         continue
                     }
                     Start-Sleep -Milliseconds 700
-                    Write-Host ("-- {0} / {1}" -f $sc.Name, $layoutName)
+                    Write-Host ("-- {0} / {1}" -f $sc.Name, $ln)
                     $cap = New-Capture
-                    try { Measure-Capture $cap $layoutName $expectBg $sceneGround ($cell.App -ne 'solid' -and $sc.Kind -ne 'solid') }
+                    $script:Activated = $cap.Activated
+                    try { Measure-Capture $cap $ln $expect $sceneGround ($plan.App -ne 'solid' -and $sc.Kind -ne 'solid') }
                     finally { $cap.Bmp.Dispose() }
                 }
             }
         }
         catch {
             $cellErr = "$($_.Exception.Message)"
-            Write-Host ("CELL FAILED {0}: {1}" -f $cell.Id, $cellErr) -ForegroundColor Red
+            Write-Host ("CELL FAILED {0}: {1}" -f $plan.Id, $cellErr) -ForegroundColor Red
             # The frame, because a binding error names a parameter and not
             # the call that bound it.
             Write-Host ("  at " + (($_.ScriptStackTrace -split "`n" | Select-Object -First 3) -join "`n  at ")) -ForegroundColor DarkGray
@@ -611,7 +663,12 @@ try {
         finally {
             if ($null -ne $s) { Stop-SeamSession $s }
         }
-        $cellVerdicts.Add([pscustomobject]@{ id = $cell.Id; error = $cellErr })
+        $cellVerdicts.Add([pscustomobject]@{ id = $plan.Id; error = $cellErr })
+        # A window parked over the stage fails every cell the same way; three
+        # in a row is a desk problem, not a matrix, and hours of exit-1 noise
+        # would say nothing more than this does.
+        $occludedInARow = $(if ($cellErr -like 'OCCLUDED*') { $occludedInARow + 1 } else { 0 })
+        if ($occludedInARow -ge 3) { throw "three cells in a row were occluded; something is parked over the stage, stopping ($cellErr)" }
     }
 }
 catch {
@@ -622,10 +679,14 @@ finally {
     # Everything back, in the order that makes the read-back true: the
     # wallpaper through the API that actually applies one, the polarity
     # through the broadcast, then the env guard's own restore and read-back.
+    # A restore that fails is recorded, and it decides the exit code below:
+    # a machine left in the other polarity or wearing a scene is the one
+    # thing that must never look green.
     if ($null -ne $stage) { try { Stop-BackdropStage $stage } catch { } }
-    try { Set-DesktopWallpaper -Path $wallpaperBefore.Path -Style $wallpaperBefore.Style -Tile $wallpaperBefore.Tile } catch { Write-Host "RESTORE: wallpaper: $_" -ForegroundColor Red }
-    try { if ((Get-DesktopPolarity) -ne $polarityBefore) { Set-DesktopPolarity $polarityBefore } } catch { Write-Host "RESTORE: polarity: $_" -ForegroundColor Red }
-    try { Restore-EnvSnapshot -Path $snapshotPath } catch { Write-Host "RESTORE: env guard: $_ (run 'just env-restore')" -ForegroundColor Red }
+    try { Set-DesktopWallpaper -Snapshot $wallpaperBefore } catch { $restoreErrors.Add("wallpaper: $_") }
+    try { if ((Get-DesktopPolarity) -ne $polarityBefore) { Set-DesktopPolarity $polarityBefore } } catch { $restoreErrors.Add("polarity: $_") }
+    try { Restore-EnvSnapshot -Path $snapshotPath } catch { $restoreErrors.Add("env guard: $_ (run 'just env-restore')") }
+    foreach ($e in $restoreErrors) { Write-Host "RESTORE FAILED: $e" -ForegroundColor Red }
     Remove-Item $stageRoot -Recurse -Force -ErrorAction SilentlyContinue
 }
 
@@ -651,13 +712,20 @@ $result = [ordered]@{
     findings = $script:Findings
     unmeasured = $script:Unmeasured
     fatal = $fatal
+    restoreErrors = @($restoreErrors)
 }
 $result | ConvertTo-Json -Depth 6 | Set-Content (Join-Path $OutDir 'result.json') -Encoding utf8
-& (Join-Path $PSScriptRoot 'theme-matrix-report.ps1') -RunDir $OutDir | Out-Null
+# The renderer is not the verdict: a failure in it is printed, and the exit
+# code below still comes from the measurements.
+try { & (Join-Path $PSScriptRoot 'theme-matrix-report.ps1') -RunDir $OutDir | Out-Null }
+catch { Write-Host "REPORT: matrix.md could not be written: $_ (result.json is there; run 'just theme-matrix-report')" -ForegroundColor Red }
 
 Write-Host ""
 Write-Host ("theme-matrix: {0} rows, {1} findings, {2} unmeasured, {3} deltas -> {4}" -f
     $script:Rows.Count, $script:Findings.Count, $script:Unmeasured.Count, $script:Deltas.Count, (Join-Path $OutDir 'matrix.md'))
+# A failed restore outranks everything: the operator has to act on the
+# machine before the findings mean anything.
+if ($restoreErrors.Count -gt 0) { exit 1 }
 if ($script:Findings.Count -gt 0) { exit 2 }
 if ($fatal -or $script:Unmeasured.Count -gt 0 -or $script:Rows.Count -eq 0) { exit 1 }
 exit 0


### PR DESCRIPTION
Second of two PRs for #937, stacked on #940 (the backdrop stage). This is the matrix itself: every selected theme against desktop polarity, app material, frame material, tab layout and a backdrop scene, measured in rendered pixels and judged by the floors already in `lib/contrast.ps1`.

## Shape

One process per (polarity, theme, app, frame). Inside it the harness seeds three tabs through the seam, selects the middle one, and for each scene paints the stage under the window AND sets the same PNG as the wallpaper (Mica reads the wallpaper, acrylic and crystal read the stage), proves the scene on the stage's own margin before the shutter, then photographs each layout once, toggling through the seam and verifying the toggle. Five judged surfaces per photograph: active tab title, inactive tab title, active close glyph, the terminal's prompt against its ground, and the active tab fill against the terminal under the field rule. Three recorded deltas: strip ground vs terminal, strip ground vs scene, and the numbers #897 asks for come out of those.

Every axis takes one value, a comma list, or `all`, so "wintty-dark on a dark desktop with vertical tabs" is one command and the whole catalogue is another. `just theme-matrix-plan` prints what a filter selects and what it costs without touching anything: the curated set over all axes is 384 processes and about five hours across both polarities; `-Theme all` at one material is about the same.

## The first harness that sets machine state

It runs the polarity the desktop is in first, flips to the other, and puts everything back: the wallpaper through the API that actually applies one, the polarity through the broadcast Settings sends, then the env guard's own restore and read-back. `-NoFlip` keeps the read-only policy every other harness has and reports the skipped polarity as unmeasured. Under High Contrast it refuses to run rather than measure the pin. Because of all that, `just theme-matrix` takes the incoda lane BEFORE the builds (two recipes, the outer one only takes the lane), and the harness is classified out of the fuzz suite: hours long by design, a red run is the expected outcome, and its `matrix.md` is the deliverable.

## Themes reach the glass or the cell is not scored

Themes go into the config as absolute paths under a staged copy of the catalogue, because a bare name that resolves to nothing falls back silently to the compile-time default (#877, #878). That is not trusted either: each photograph compares the terminal ground it reads with the theme file's own `background`, and a process whose ground is not the theme's is reported unmeasured rather than scored. `-Mutate terminal` launches every cell with an illegible pair and the run must go red.

## What is in here

- `windows/scripts/theme-matrix.ps1`: the harness.
- `windows/scripts/theme-matrix-report.ps1`: `result.json` to `matrix.md`, the cell being the worst judged ratio over every layout and scene, bold with a count when anything in it failed, `?` when a surface went unmeasured, plus the materials table, the findings and the unmeasured list.
- `just theme-matrix`, `just _theme-matrix-in-lane`, `just theme-matrix-plan`, `just theme-matrix-report`.
- Suite classification for both scripts, a README section, the output dir ignored.

## Verified

Smoke under the incoda lane against this clone's Debug build, two cells with a polarity flip (`-Theme wintty-dark -App crystal -Frame inherit -Scene black,photo -MaxCells 2`): 34 rows, 7 findings, 6 unmeasured, 10 deltas, and the desktop theme and wallpaper read back exactly as before. The matrix.md is in the first comment. `just theme-matrix-plan` was exercised with the default, a single-cell filter, `-Theme all` with comma lists, and a bad value (refused by name). `just fuzz-list` passes the manifest integrity checks with both scripts classified.

What the smoke already says, recorded here and not fixed here:

- Crystal is only crystal below opacity 1.0; at 1.0 the product flattens it to Mica. The first smoke measured "crystal" reading `#F3F3F3` over both a black and a busy scene, which is how `-Opacity` (0.85, frosted and crystal cells only) came to exist.
- Under crystal over a black scene on a light desktop, the horizontal strip's inactive title is black ink on a see-through black strip: 1.00:1. The ink is chosen for the desktop, the ground is whatever is behind the window. That is #884's root cause A with the material axis added.
- The active tab as the field (#918) cannot hold under a translucent app material by construction: the tab fill is the opaque theme ground while the pane beside it is a blend, 1.29:1 against a 1.05 bound on every translucent capture.
- Text on a translucent terminal over a picture has no flat ground to be judged against; the sampler either refuses the band (no dominant cluster) or scores a promptless band. It is reported unmeasured with the reason, and a local metric for busy grounds is a follow-up in #937.

Three harness bugs were caught by the smoke and are fixed in this diff: a scene loop variable that shared its name with the typed `-Scene` parameter (PowerShell coerced the scene object to strings), the same shape for `-Layout`, and the stage losing its topmost standing across a polarity flip (WinForms recreates its window; the placement is now re-asserted after a flip and before each scene).

## Not in this PR

Fixing anything the matrix finds. Promoting the contrast oracle's UIA locators into `lib/` (this harness carries a smaller copy of them, noted in #937 as a follow-up). Installing the incoda rule into `AGENTS.md`.

Part of #937.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
