### PR TITLE
docs: the heavy job lane is mandatory, and AGENTS.md says so

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,10 +58,10 @@ Always pass `--repo deblasis/wintty`. Never open anything against
 
 ## Heavy job lane (mandatory on the development machine)
 
-The machine this fork is developed on cannot run two heavy jobs at once:
-concurrent memory-heavy builds have taken it down with no warning, and two
-GUI harness runs corrupt each other by fighting over focus, the foreground
-window and the desktop. Every session, in every worktree, routes heavy jobs
+A development machine cannot run two heavy jobs at once: concurrent
+memory-heavy builds have taken one down with no warning, and two GUI harness
+runs corrupt each other by fighting over focus, the foreground window and
+the desktop. Every session, in every worktree, routes heavy jobs
 through one named lane with [incoda](https://github.com/deblasis/incoda),
 queue key `wintty` (shared with `wintty-release`, which builds the same
 thing):
@@ -74,28 +74,40 @@ incoda watch  --queue wintty     # live view
 
 Run under the lane, always:
 
-- `zig build` in any form that links libghostty (`just build-dll`,
-  `just build-dll-release`, `zig build test`), and `just test-win`
+- `zig build` in any form that links libghostty: `just build-dll`,
+  `just build-dll-release`, `just test` and `just test-full`, `just test-win`,
+  and `just run-win`, whose build half is one of those whatever it is run for
 - every GUI harness: `just fuzz`, `just search-fuzz`, `just frame-style-fuzz`,
-  `just shader-notice-fuzz`, `just splash-race`, anything under
-  `windows/scripts/` that launches a window, and `just run-win` when it is
-  part of a test. `just theme-matrix` takes the lane itself.
+  `just shader-notice-fuzz`, `just splash-race`, and anything under
+  `windows/scripts/` that launches a window. The theme matrix recipe (#941)
+  takes the lane itself.
 - any test that is timing-sensitive enough to fail on a loaded machine
 
 The rules that matter:
 
-- Never bypass the lane: no "just this once" outside it, no second heavy job
-  in another terminal while one is queued. The lane binds only what is routed
-  through it, so a single bypass reintroduces exactly the collision it exists
-  to stop.
+- Never bypass the lane: no "just this once" outside it, no detached
+  background job, no second heavy job in another terminal while one is
+  queued, and never two heavy jobs at once even if both would probably fit.
+  The lane binds only what is routed through it, so a single bypass
+  reintroduces exactly the collision it exists to stop.
+- `run` passes the child's exit status through unchanged, which is why the
+  justfile's `; exit ($LASTEXITCODE ?? 1)` idiom still means what it says
+  under the lane. `--wait` defaults to 30 minutes; when it elapses `run`
+  exits 121 and the command never ran, so a 121 is a queue timeout, not a
+  build failure. `--wait 0` fails immediately instead of queueing.
 - If the lane makes you wait longer than about ten minutes, say so to the
   user: `incoda status` names the pid, the command and the directory holding
   it. Do not wait half an hour in silence and do not go around it.
 - `incoda force-release` is a human decision, never an agent's. It refuses
-  while a live holder exists for a reason.
+  while a live holder exists for a reason; thinking you need it is something
+  to tell the user, not something to do.
 - `--reason` every time. With several sessions sharing a lane, "which
   worktree is that and why" is the first question anyone asks, and `status`
   can only answer if you said.
 - `run` releases on exit, including a crash: the lock is an OS file lock, so
   a killed holder frees the lane on its own.
+- The working directory does not matter and neither does the worktree; every
+  session using key `wintty` shares one lane. Never set `INCODA_DIR` per
+  checkout: it is machine-level, and setting it in one place splits the lane
+  in two while both halves look healthy.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,3 +55,47 @@ work no PR reviewed may ride along unnamed or unacknowledged.
 
 Always pass `--repo deblasis/wintty`. Never open anything against
 `ghostty-org/ghostty`.
+
+## Heavy job lane (mandatory on the development machine)
+
+The machine this fork is developed on cannot run two heavy jobs at once:
+concurrent memory-heavy builds have taken it down with no warning, and two
+GUI harness runs corrupt each other by fighting over focus, the foreground
+window and the desktop. Every session, in every worktree, routes heavy jobs
+through one named lane with [incoda](https://github.com/deblasis/incoda),
+queue key `wintty` (shared with `wintty-release`, which builds the same
+thing):
+
+```
+incoda run --queue wintty --reason "what this is" -- <cmd...>
+incoda status --queue wintty     # who holds it, from which folder, who waits
+incoda watch  --queue wintty     # live view
+```
+
+Run under the lane, always:
+
+- `zig build` in any form that links libghostty (`just build-dll`,
+  `just build-dll-release`, `zig build test`), and `just test-win`
+- every GUI harness: `just fuzz`, `just search-fuzz`, `just frame-style-fuzz`,
+  `just shader-notice-fuzz`, `just splash-race`, anything under
+  `windows/scripts/` that launches a window, and `just run-win` when it is
+  part of a test. `just theme-matrix` takes the lane itself.
+- any test that is timing-sensitive enough to fail on a loaded machine
+
+The rules that matter:
+
+- Never bypass the lane: no "just this once" outside it, no second heavy job
+  in another terminal while one is queued. The lane binds only what is routed
+  through it, so a single bypass reintroduces exactly the collision it exists
+  to stop.
+- If the lane makes you wait longer than about ten minutes, say so to the
+  user: `incoda status` names the pid, the command and the directory holding
+  it. Do not wait half an hour in silence and do not go around it.
+- `incoda force-release` is a human decision, never an agent's. It refuses
+  while a live holder exists for a reason.
+- `--reason` every time. With several sessions sharing a lane, "which
+  worktree is that and why" is the first question anyone asks, and `status`
+  can only answer if you said.
+- `run` releases on exit, including a crash: the lock is an OS file lock, so
+  a killed holder frees the lane on its own.
+


### PR DESCRIPTION
Every GUI harness under `windows/scripts` takes the foreground and refuses to share a desktop, and a libghostty build is exactly the memory-heavy job that has taken the development machine down when two ran at once. The lane that serialises them (incoda, queue key `wintty`, shared with the release repo) was documented only in incoda's own repository, so an agent reading `AGENTS.md` had no way to know the rule existed; #937's harness work found this out by grepping for it.

This adds the rule to `AGENTS.md`: what goes under the lane in this repo (any linking `zig build`, `just test-win`, every GUI harness), the three commands, and the rules that matter, including that `force-release` is never an agent's decision and that a wait past about ten minutes gets surfaced to the user rather than sat through. Wording is this fork's, not a paste of incoda's block: the key is filled in and the list names this repo's recipes.

Docs only. Part of #937.

🤖 Generated with [Claude Code](https://claude.com/claude-code)