### PR TITLE
tabs: the pinned band answers its own drag, so a band row can be reordered

### DIFF
--- a/windows/Ghostty.Core/Tabs/TabDragReorder.cs
+++ b/windows/Ghostty.Core/Tabs/TabDragReorder.cs
@@ -90,9 +90,29 @@ public sealed class TabDragReorder
     /// never starts the drag, so a jittering grab stays a click.
     /// </summary>
     public bool Begin(double position)
+        => BeginOnTravel(Math.Abs(position - _pressPosition));
+
+    /// <summary>
+    /// Lift on a travel the CALLER measured, for a grab whose gesture is
+    /// not confined to this machine's axis.
+    ///
+    /// The pinned band is the one such surface: it wraps, so two of its
+    /// squares can share this machine's axis exactly, and a reorder between
+    /// them is pure cross-axis travel. Asked through
+    /// <see cref="Begin(double)"/> that gesture can never lift at all --
+    /// the row the user is dragging sideways sits at an unchanging Y, and
+    /// the press stays a click forever.
+    ///
+    /// The one-axis rule stays the DEFAULT, and deliberately: a body row is
+    /// dragged up and down a list, and admitting sideways travel there
+    /// would turn a hand tremor on a click into a drag. Only a caller that
+    /// knows its surface has a second axis is allowed to say so, and it
+    /// says so by measuring the travel itself.
+    /// </summary>
+    public bool BeginOnTravel(double travelPx)
     {
         if (_phase != TabDragPhase.Pressed) return false;
-        if (Math.Abs(position - _pressPosition) < _startThresholdPx) return false;
+        if (travelPx < _startThresholdPx) return false;
         _phase = TabDragPhase.Dragging;
         return true;
     }

--- a/windows/Ghostty.Core/Tabs/TabPinBand.cs
+++ b/windows/Ghostty.Core/Tabs/TabPinBand.cs
@@ -131,4 +131,65 @@ public static class TabPinBand
         var rows = RowsFor(chipCount, columns);
         return rows == 0 ? 0 : rows * ChipSize + (rows - 1) * ChipGap;
     }
+
+    /// <summary>
+    /// The slot a pointer at <paramref name="x"/>, <paramref name="y"/> in
+    /// band space is asking for: the one whose square is nearest, over
+    /// slots <c>0 .. slotCount - 1</c>.
+    ///
+    /// This is the band's answer to the question the linear drag machine
+    /// cannot be asked. That machine commits on a CROSSING along one axis:
+    /// the dragged row's centre passing a neighbour's centre. Two squares
+    /// sharing a band row share a centre on that axis, so no crossing
+    /// between them can ever be produced -- and worse, a comparison that
+    /// holds for one of them holds for every other square on the row, so
+    /// the strip's drain-the-crossings loop walked the drag all the way to
+    /// slot 0 in a single tick. A wrapping band is two axes, and two axes
+    /// want a hit test rather than a crossing.
+    ///
+    /// Nearest CENTRE rather than strict containment, so the gutters and
+    /// the ragged end of a partial row belong to the square beside them
+    /// instead of answering "nowhere". It carries its own hysteresis for
+    /// free: the answer only changes when the pointer passes the midpoint
+    /// between two squares, which is half a pitch -- far more than the
+    /// 8px the crossing engine spends, and it needs no state to hold.
+    ///
+    /// <paramref name="slotCount"/> is what the caller is asking ABOUT, and
+    /// the two callers differ: a reorder among the pins passes the pin
+    /// count, and a drop from outside the band passes one more, because the
+    /// slot one past the end is a real place for a new pin to land and is
+    /// the slot the drop preview draws.
+    /// </summary>
+    public static int NearestSlot(double x, double y, int columns, int slotCount)
+    {
+        if (columns < 1)
+            throw new ArgumentOutOfRangeException(
+                nameof(columns), columns, "A band has at least one column.");
+        if (slotCount < 1)
+            throw new ArgumentOutOfRangeException(
+                nameof(slotCount), slotCount,
+                "A band with no slots has no slot to name; the caller decides what to do "
+                + "with an empty band before asking.");
+
+        var best = 0;
+        var bestDistance = double.PositiveInfinity;
+        for (int i = 0; i < slotCount; i++)
+        {
+            var (left, top) = OriginOf(i, columns);
+            var dx = x - (left + ChipSize / 2);
+            var dy = y - (top + ChipSize / 2);
+            var distance = dx * dx + dy * dy;
+            // Strictly nearer, so a tie goes to the LOWER slot. Ties are
+            // reachable -- a pointer exactly between two squares is one
+            // pixel of travel, and a rule that picked the higher slot there
+            // would make the same gesture land differently depending on
+            // which way the pointer happened to arrive.
+            if (distance < bestDistance)
+            {
+                bestDistance = distance;
+                best = i;
+            }
+        }
+        return best;
+    }
 }

--- a/windows/Ghostty.Tests/Tabs/TabPinBandTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabPinBandTests.cs
@@ -182,6 +182,79 @@ public class TabPinBandTests
     }
 
     [Fact]
+    public void The_nearest_slot_is_the_square_the_pointer_is_over()
+    {
+        const double pitch = TabPinBand.ChipSize + TabPinBand.ChipGap;
+        // Dead centre of each of four squares on one row.
+        for (int i = 0; i < 4; i++)
+        {
+            var x = i * pitch + TabPinBand.ChipSize / 2;
+            Assert.Equal(i, TabPinBand.NearestSlot(x, TabPinBand.ChipSize / 2, 4, 4));
+        }
+        // ...and the second row, which is the half a crossing engine on one
+        // axis cannot reach at all.
+        Assert.Equal(4, TabPinBand.NearestSlot(
+            TabPinBand.ChipSize / 2, pitch + TabPinBand.ChipSize / 2, 4, 8));
+        Assert.Equal(6, TabPinBand.NearestSlot(
+            2 * pitch + TabPinBand.ChipSize / 2, pitch + TabPinBand.ChipSize / 2, 4, 8));
+    }
+
+    [Fact]
+    public void The_answer_changes_at_the_midpoint_between_two_squares()
+    {
+        // Half a pitch of hysteresis, and it costs no state. The crossing
+        // engine spends 8px and has to remember which way it last went.
+        const double pitch = TabPinBand.ChipSize + TabPinBand.ChipGap;
+        var midpoint = TabPinBand.ChipSize / 2 + pitch / 2;
+        var y = TabPinBand.ChipSize / 2;
+        Assert.Equal(0, TabPinBand.NearestSlot(midpoint - 0.5, y, 4, 4));
+        Assert.Equal(1, TabPinBand.NearestSlot(midpoint + 0.5, y, 4, 4));
+        // A tie goes to the lower slot, so one gesture cannot land two ways
+        // depending on which side the pointer arrived from.
+        Assert.Equal(0, TabPinBand.NearestSlot(midpoint, y, 4, 4));
+    }
+
+    [Fact]
+    public void A_pointer_past_the_end_of_a_row_belongs_to_the_last_square_on_it()
+    {
+        // Nearest centre, not containment: the gutters and the ragged end
+        // of a partial row have to belong to something, or a drop there
+        // reads as "nowhere" and falls through to the list below.
+        const double pitch = TabPinBand.ChipSize + TabPinBand.ChipGap;
+        var y = TabPinBand.ChipSize / 2;
+        // Three pins in a four-column band: well past the third square.
+        Assert.Equal(2, TabPinBand.NearestSlot(3 * pitch + 100, y, 4, 3));
+        // ...and before the first.
+        Assert.Equal(0, TabPinBand.NearestSlot(-100, y, 4, 3));
+        // Below the last row, which is where a pointer on its way out of
+        // the band sits for a frame.
+        Assert.Equal(2, TabPinBand.NearestSlot(2 * pitch + 20, 500, 4, 3));
+    }
+
+    [Fact]
+    public void The_slot_one_past_the_end_is_reachable_only_when_asked_for()
+    {
+        // The difference between a reorder and a drop from outside. Three
+        // pins in a four-column band, pointer over the empty fourth column:
+        // a reorder has nowhere to put it but the third square, and an
+        // insertion has the slot the drop preview is drawing.
+        const double pitch = TabPinBand.ChipSize + TabPinBand.ChipGap;
+        var x = 3 * pitch + TabPinBand.ChipSize / 2;
+        var y = TabPinBand.ChipSize / 2;
+        Assert.Equal(2, TabPinBand.NearestSlot(x, y, 4, slotCount: 3));
+        Assert.Equal(3, TabPinBand.NearestSlot(x, y, 4, slotCount: 4));
+    }
+
+    [Fact]
+    public void A_slotless_band_is_corrupt_state_not_a_hit_test()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => TabPinBand.NearestSlot(0, 0, columns: 4, slotCount: 0));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => TabPinBand.NearestSlot(0, 0, columns: 0, slotCount: 3));
+    }
+
+    [Fact]
     public void A_bandless_column_count_is_corrupt_state_not_a_layout()
     {
         Assert.Throws<ArgumentOutOfRangeException>(

--- a/windows/Ghostty.Tests/Wiring/PinBandDragWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/PinBandDragWiringTests.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// The band drag's arbitration boundary, and the one property that has to
+/// hold across both engines that read it.
+///
+/// A wrapping band and a linear list share one gesture, and they are split
+/// on the machine's own axis: above the shelf's bottom the band answers,
+/// below it the list does. That edge is decided mid-drag, and it is acted
+/// on -- an arriving row is PINNED the moment the band claims a tick. So
+/// the release cannot ask a different question. If it reads a different
+/// edge, every pointer in the gap between the two edges is a row the drag
+/// pinned and the release unpinned again, which is not a rounding error
+/// but a drop landing somewhere the user never aimed.
+///
+/// The specific trap this pins shut: the band panel is inset INSIDE the
+/// shelf, so its rect and the shelf's rect differ by exactly the panel's
+/// top and bottom margins. Reading the panel here looks equivalent and is
+/// not. Wiring guards, not behaviour tests -- which edge a live release
+/// falls on is only observable on an arranged strip.
+/// </summary>
+public class PinBandDragWiringTests
+{
+    private static ShellSource Strip() => ShellSource.Load("Tabs.VerticalTabStrip.xaml.cs");
+
+    /// <summary>
+    /// One edge, both readers. The arbitration that decides to pin and the
+    /// release that decides to keep must call the same helper, or they can
+    /// disagree about the same pointer.
+    /// </summary>
+    [Fact]
+    public void TheBandAndTheRelease_ReadTheSameEdge()
+    {
+        // THREE readers, not two. The arbitration decides to pin, the ghost
+        // promises where, and the release decides to keep -- and the ghost
+        // was the one that got missed the first time round, gated on the
+        // dragged row's centre while the other two read the pointer. They
+        // differ by the grab offset, so there was a band of positions where
+        // the drag pinned a row the preview had refused to promise.
+        foreach (var method in new[] { "BandTargetSlot", "UpdatePinPreview", "DragRelease" })
+            Assert.Single(Strip().Method(method).Calls("ShelfBottomY"));
+
+        // ...and the two that REFUSE do it on the same side of the same
+        // number, asserted as a tree. `>=` and `>` are both
+        // BinaryExpressionSyntax, so a substring cannot tell "at the edge
+        // the band answers" from "at the edge it declines" -- and that one
+        // pixel row is a strip where the drag pins and the release unpins,
+        // which is the disagreement this whole file exists to close.
+        foreach (var method in new[] { "BandTargetSlot", "UpdatePinPreview" })
+        {
+            var refusal = Strip().Method(method)
+                .DescendantNodes().OfType<BinaryExpressionSyntax>()
+                .Single(b => b.IsKind(SyntaxKind.GreaterThanOrEqualExpression)
+                    && b.Right.ToString() == "shelfBottom");
+
+            Assert.Equal("drag.LastPointerY", refusal.Left.ToString());
+        }
+    }
+
+    /// <summary>
+    /// And the release reads it from nowhere else. The panel's own rect is
+    /// the near-miss that was there before: same idea, inset by the
+    /// margins, so it disagreed with the arbitration exactly across the
+    /// two strips the band claims and the panel does not cover.
+    /// </summary>
+    [Fact]
+    public void TheRelease_NeverMeasuresTheBandPanel()
+    {
+        Assert.DoesNotContain(
+            Strip().Method("DragRelease").DescendantNodes().OfType<IdentifierNameSyntax>(),
+            id => id.Identifier.ValueText == "_pinnedPanel");
+    }
+
+    /// <summary>
+    /// The harness has to be able to SEE a pin, or a green leg and a red
+    /// one look alike. A drag into the band changes the tab's pin state and
+    /// the release can change it back, so the pin is half of what the
+    /// gesture produced -- but it is carried on a field that defaults to
+    /// false, and a path that forgets to set it reports a clean "not
+    /// pinned" rather than failing. That is the worst shape a harness can
+    /// have: `drag` skipped it, and the band leg read the default as a
+    /// product bug.
+    ///
+    /// The count is pinned deliberately. Without it a sweep like this goes
+    /// quiet the moment a new drag op is added -- which is exactly when the
+    /// omission would be made again.
+    /// </summary>
+    [Fact]
+    public void EverySeamDragPath_ReportsThePinState()
+    {
+        var drags = Strip().Root.DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .Where(m => m.Identifier.ValueText.StartsWith(
+                "TestSeamDrag", StringComparison.Ordinal))
+            .Where(m => m.ReturnType.ToString().Contains(
+                "TestSeamDragOutcome", StringComparison.Ordinal))
+            .ToList();
+
+        Assert.Equal(5, drags.Count);
+
+        foreach (var drag in drags)
+        {
+            // The receiver is pinned too, not just the member name: any
+            // member called Pinned would otherwise satisfy this, and the
+            // one that matters is the outcome the seam serializes.
+            var report = drag.DescendantNodes()
+                .OfType<AssignmentExpressionSyntax>()
+                .SingleOrDefault(a => a.Left is MemberAccessExpressionSyntax member
+                    && member.Name.Identifier.ValueText == "Pinned"
+                    && member.Expression is IdentifierNameSyntax receiver
+                    && receiver.Identifier.ValueText == "outcome");
+
+            Assert.True(report is not null,
+                $"{drag.Identifier.ValueText} never assigns outcome.Pinned, so it "
+                + "reports every drop as unpinned");
+
+            // WHAT it assigns, not merely that it assigns. `outcome.Pinned
+            // = false` would satisfy an existence check while reproducing
+            // the exact defect this test was written for: a default read
+            // back as a measurement.
+            Assert.Equal("tab.IsPinned", report!.Right.ToString());
+
+            // ...and WHEN. The release is what classifies pin-out, so a
+            // report taken before it measures the gesture's aim rather
+            // than its result -- green test, wrong answer.
+            var release = drag.Calls("DragRelease").Single();
+            Assert.True(
+                report.SpanStart > release.SpanStart,
+                $"{drag.Identifier.ValueText} reports outcome.Pinned before "
+                + "DragRelease, so it records the pre-release state");
+        }
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/PinnedPreviewWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/PinnedPreviewWiringTests.cs
@@ -38,13 +38,15 @@ public class PinnedPreviewWiringTests
 
     /// <summary>
     /// Show means "the drop would pin": the dragged row is still unpinned,
-    /// pins exist, and its center is over the shelf. The pinned arm of the
+    /// pins exist, and the POINTER is over the shelf. The pinned arm of the
     /// gate is the one that goes wrong silently -- once the crossing has
     /// committed, the real icon-only row is in the shelf following the
     /// pointer, and a ghost alongside it promises a slot the real row
     /// already holds. The shelf-bottom comparison is the "over the shelf"
-    /// half of the grammar, in the coordinates the machine judges
-    /// crossings in.
+    /// half of the grammar, and it is asked of the pointer because that is
+    /// what the band's arbitration asks: a gate on the dragged row's centre
+    /// instead disagrees by the grab offset, and disagreement here means a
+    /// pin committed with no promise ever shown.
     /// </summary>
     [Fact]
     public void ThePreview_ShowsOnlyWhileTheDropWouldPin()
@@ -61,7 +63,16 @@ public class PinnedPreviewWiringTests
         Assert.StartsWith(
             "drag.Tab.IsPinned || _manager.PinCount == 0",
             gate.Condition.ToString());
-        Assert.Contains("draggedCenter >= shelfBottom", gate.Condition.ToString());
+        // The POINTER's Y, and nothing else. This used to read
+        // `draggedCenter`, which is the pointer plus the grab offset --
+        // half a row height away from the number BandTargetSlot arbitrates
+        // on. That gap was a band of positions where the drag pinned an
+        // arriving row while this gate refused to promise anything, so the
+        // tab landed somewhere the user was never shown. Naming the
+        // variable here is the point: the promise and the commit have to
+        // be the same reading, not two readings that usually agree.
+        Assert.Contains("drag.LastPointerY >= shelfBottom", gate.Condition.ToString());
+        Assert.DoesNotContain("draggedCenter", gate.Condition.ToString());
         Assert.Contains(
             gate.Statement.DescendantNodesAndSelf().OfType<InvocationExpressionSyntax>(),
             c => c.CalleeText() == "HidePinPreview");
@@ -82,8 +93,20 @@ public class PinnedPreviewWiringTests
             .Single(v => v.Identifier.ValueText == "slot");
         var ask = Assert.IsType<InvocationExpressionSyntax>(slot.Initializer!.Value);
         Assert.Equal("BandSlotRect", ask.CalleeText());
-        // One past the end: the slot the pin about to land will take.
-        Assert.Equal("_manager.PinCount", ask.Arg(0));
+
+        // The ghost and the landing are ONE answer. Both read
+        // BandTargetSlot, so the slot the preview promises cannot differ
+        // from the slot the release commits -- which is what a promise
+        // means. Asserted as the same call the tick's commit fork makes,
+        // not as a spelling: the preview used to name the end slot
+        // unconditionally and was right only because nothing else had an
+        // opinion.
+        Assert.StartsWith("BandTargetSlot(drag)", ask.Arg(0), StringComparison.Ordinal);
+        Assert.Single(Strip().Method("EvaluateDrag").Calls("BandTargetSlot"));
+        // ...and the fallback is the end slot, for the approach: the gate
+        // above is open while the row is still outside the band, and there
+        // the band has no answer to give.
+        Assert.Contains("_manager.PinCount", ask.Arg(0));
 
         // The three named arguments, each pinned to ITS axis. Looking for
         // "slot.X" and "slot.Y" anywhere among the method's arguments is

--- a/windows/Ghostty.Tests/Wiring/VerticalTabGroupDragWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/VerticalTabGroupDragWiringTests.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Xunit;
 
@@ -606,15 +607,52 @@ public class VerticalTabGroupDragWiringTests
             + "fix -- hoisted out it always unpins, inverted it never does.");
 
         // The inZone initializer is the second prong: the ancestors-pin
-        // cannot catch a VALUE-level flip (swapping >=/<= inside inZone's
-        // initializer still passes everything). The initializer must
-        // compare releaseY against BOTH shelf bounds.
-        Assert.Contains("releaseY >= shelfTop && releaseY <= shelfBottom",
-            arm.DescendantNodes()
-               .OfType<VariableDeclaratorSyntax>()
-               .Single(v => v.Identifier.ValueText == "inZone")
-               .Initializer!.Value.ToFullString(),
-            StringComparison.Ordinal);
+        // cannot catch a VALUE-level flip (swapping the comparison inside
+        // inZone's initializer still passes everything).
+        //
+        // ONE bound, and it is the band's. The zone ends where the band
+        // stops claiming the pointer -- ShelfBottomY, the edge
+        // BandTargetSlot arbitrates on -- so the release cannot overturn a
+        // pin the drag already committed. There is deliberately no top
+        // bound: above the shelf the band still answers, so above the
+        // shelf the release must still keep. A second bound here would put
+        // the panel's own margins back in play as a strip where the two
+        // disagree.
+        // Asserted as a TREE, not a substring. The version this replaced
+        // pinned "releaseY >= shelfTop && releaseY <= shelfBottom", which
+        // carried its own connective inside the asserted text; dropping to
+        // one bound and keeping a substring assertion silently gave up the
+        // `&&` between the NaN guard and the comparison. Flip that to `||`
+        // and inZone is permanently true -- pin-out stops working
+        // altogether -- while every substring in sight still matches.
+        var inZoneInit = arm.DescendantNodes()
+            .OfType<VariableDeclaratorSyntax>()
+            .Single(v => v.Identifier.ValueText == "inZone")
+            .Initializer!.Value;
+        var conjunction = Assert.IsType<BinaryExpressionSyntax>(inZoneInit);
+        Assert.True(
+            conjunction.IsKind(SyntaxKind.LogicalAndExpression),
+            "inZone must AND the NaN guard with the bound: under || an "
+            + "unreadable shelf reads as in-zone and the unpin never runs.");
+        Assert.Equal("!double.IsNaN(shelfBottom)", conjunction.Left.ToString());
+
+        // The bound itself, also as a tree: `<` and `>` are both
+        // BinaryExpressionSyntax, so the kind is what separates "below the
+        // shelf keeps the pin" from its exact opposite.
+        var comparison = Assert.IsType<BinaryExpressionSyntax>(conjunction.Right);
+        Assert.True(
+            comparison.IsKind(SyntaxKind.LessThanExpression),
+            "the release is in-zone strictly ABOVE the shelf's bottom.");
+        Assert.Equal("releaseY", comparison.Left.ToString());
+        Assert.Equal("shelfBottom", comparison.Right.ToString());
+        Assert.DoesNotContain("shelfTop", inZoneInit.ToFullString(), StringComparison.Ordinal);
+
+        // ...and that bound is read from the arbitration's own helper, not
+        // re-derived from a rect that merely looks equivalent.
+        var bound = arm.DescendantNodes()
+            .OfType<VariableDeclaratorSyntax>()
+            .Single(v => v.Identifier.ValueText == "shelfBottom");
+        Assert.Equal("ShelfBottomY()", bound.Initializer!.Value.ToString());
 
         // The mid-drag crossing arm PINS only: the gate is the Pin
         // classification, and the Unpin classification hangs off it as an

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -2836,11 +2836,21 @@ internal sealed partial class VerticalTabStrip : UserControl
         // press-time answer is the one that describes where the user aimed.
         public FrameworkElement? PressRow;
         public double PressY;
+        // The press X, for the one gesture that is not confined to the
+        // strip's axis: a reorder inside a band row is pure sideways
+        // travel. See DragMove's lift.
+        public double PressX;
         public double PressBaseCenter;
         // The arranged center the anchor currently assumes; the tick's
         // measurement is only believed when it moves off this.
         public double AssumedCenter;
         public double LastPointerY;
+        // The pointer's X, carried only for the pinned band. Everything
+        // else in this gesture speaks one axis -- the machine's whole
+        // contract is a scalar along it -- and the band is the one surface
+        // that wraps, so it is the one place a second axis has to be
+        // answered. Nothing outside BandTargetSlot reads this.
+        public double LastPointerX;
         public double AnchorY;
         public double LastScrollOffset;
         public double LastAutoscrollSpeed;
@@ -2888,8 +2898,9 @@ internal sealed partial class VerticalTabStrip : UserControl
 
     private void OnDragPointerPressed(object sender, PointerRoutedEventArgs e)
     {
+        var point = e.GetCurrentPoint(this).Position;
         DragPress(e.OriginalSource as DependencyObject, e.Pointer.PointerId,
-            e.GetCurrentPoint(this).Position.Y);
+            point.Y, point.X);
     }
 
     /// <summary>
@@ -2900,7 +2911,7 @@ internal sealed partial class VerticalTabStrip : UserControl
     /// passes the same three values itself and lands here anyway. Everything
     /// from the row resolution down is the one gesture body either way.
     /// </summary>
-    private void DragPress(DependencyObject? source, uint pointerId, double y)
+    private void DragPress(DependencyObject? source, uint pointerId, double y, double x = double.NaN)
     {
         if (_drag is not null)
         {
@@ -2929,7 +2940,7 @@ internal sealed partial class VerticalTabStrip : UserControl
         // exactly as before.
         if (item is VerticalTabGroupHeaderItem { Tag: TabGroup group })
         {
-            ArmGroupDrag(group, item, pointerId, y);
+            ArmGroupDrag(group, item, pointerId, y, x);
             return;
         }
 
@@ -2953,6 +2964,8 @@ internal sealed partial class VerticalTabStrip : UserControl
             PointerId = pointerId,
             PressRow = owned,
             LastPointerY = y,
+            LastPointerX = x,
+            PressX = x,
             PressY = y,
         };
     }
@@ -2966,7 +2979,7 @@ internal sealed partial class VerticalTabStrip : UserControl
     /// prefix contributes no units, so the drag never even offers a
     /// crossing into the zone MoveGroup's clamp would refuse.
     /// </summary>
-    private void ArmGroupDrag(TabGroup group, FrameworkElement header, uint pointerId, double y)
+    private void ArmGroupDrag(TabGroup group, FrameworkElement header, uint pointerId, double y, double x)
     {
         var run = _manager.MembersOf(group);
         if (run.Count == 0) return;
@@ -2991,6 +3004,8 @@ internal sealed partial class VerticalTabStrip : UserControl
             PointerId = pointerId,
             PressRow = header,
             LastPointerY = y,
+            LastPointerX = x,
+            PressX = x,
             PressY = y,
         };
     }
@@ -3010,21 +3025,55 @@ internal sealed partial class VerticalTabStrip : UserControl
 
     private void OnDragPointerMoved(object sender, PointerRoutedEventArgs e)
     {
-        DragMove(e.Pointer.PointerId, e.GetCurrentPoint(this).Position.Y);
+        var point = e.GetCurrentPoint(this).Position;
+        DragMove(e.Pointer.PointerId, point.Y, point.X);
     }
 
-    /// <summary>The move, parameterized the same way as the press.</summary>
-    private void DragMove(uint pointerId, double y)
+    /// <summary>
+    /// The move, parameterized the same way as the press.
+    ///
+    /// <paramref name="x"/> is the band's axis and nothing else's. It does
+    /// NOT reach <see cref="TabDragReorder.Begin"/>: the start threshold is
+    /// deliberately one-axis, so a grab that jitters sideways stays a
+    /// click, and admitting X there would start a drag on a hand tremor.
+    /// </summary>
+    private void DragMove(uint pointerId, double y, double x = double.NaN)
     {
         if (_drag is not { } drag || pointerId != drag.PointerId) return;
 
         if (drag.Machine.Phase == TabDragPhase.Pressed)
         {
-            if (!drag.Machine.Begin(y)) return;
+            // A press on a band square lifts on travel in EITHER direction,
+            // and it has to: the band wraps, so a reorder between two
+            // squares on one row is pure sideways travel at an unchanging
+            // Y, and the one-axis threshold would keep that gesture a click
+            // no matter how far it went.
+            //
+            // Only for a square. A body row keeps the one-axis rule, so a
+            // hand tremor across a click still cannot lift it.
+            // PER-AXIS, not the straight-line distance. A disc of radius
+            // 4 is SMALLER than the +/-4 square the one-axis rule left a
+            // click: 3px of horizontal and 3px of vertical travel is 4.24
+            // away, so a click on a 40px icon with ordinary jitter lifted
+            // -- and a lifted press that ends in the zone keeps its pin and
+            // never activates, because only the click path calls
+            // ActivateFromShelf. Taking the larger of the two axes is the
+            // OR of two one-axis rules: the Y door is exactly what it was,
+            // and X gets a door of the same width rather than the gesture
+            // getting a smaller one overall.
+            var lifted = drag.PressRow is VerticalTabPinnedRow
+                         && !double.IsNaN(x) && !double.IsNaN(drag.PressX)
+                ? drag.Machine.BeginOnTravel(
+                    Math.Max(
+                        Math.Abs(y - drag.PressY),
+                        Math.Abs(x - drag.PressX)))
+                : drag.Machine.Begin(y);
+            if (!lifted) return;
             StartDragVisual(drag);
             if (_drag is null) return; // start refused; the click falls through
         }
 
+        if (!double.IsNaN(x)) drag.LastPointerX = x;
         drag.LastPointerY = y;
         drag.Machine.SampleVelocity(y, Environment.TickCount64);
         drag.Properties?.InsertVector3("pointer", new Vector3(0, (float)y, 0));
@@ -3116,25 +3165,24 @@ internal sealed partial class VerticalTabStrip : UserControl
         if (drag.Tab.IsPinned)
         {
             var releaseY = y;
-            double shelfTop = double.NaN, shelfBottom = double.NaN;
-            try
-            {
-                var origin = _pinnedPanel.TransformToVisual(this)
-                    .TransformPoint(new Windows.Foundation.Point(0, 0));
-                shelfTop = origin.Y;
-                shelfBottom = origin.Y + _pinnedPanel.ActualHeight;
-            }
-            catch (Exception ex) when (IsLayoutReadFailure(ex))
-            {
-                // No honest shelf bounds: NaN fails the IsNaN gate below,
-                // so the release is treated as OUT of the zone and the
-                // unpin arm runs. That polarity is deliberate -- unpin
-                // unless provably in-zone -- and safe to act on without
-                // the bounds, because BodySlotAtY reads the body pairing
-                // and never the shelf's layout.
-            }
-            var inZone = !double.IsNaN(shelfTop)
-                && releaseY >= shelfTop && releaseY <= shelfBottom;
+            // The boundary is the arbitration's own, and there is only one.
+            // The tick loop hands the band every pointer above ShelfBottomY
+            // and pins an arriving row the moment it gets one, so a release
+            // that asked a different edge could only overturn what the drag
+            // had already committed. The panel's rect is that different
+            // edge: it sits inset inside the shelf, which makes its top and
+            // bottom margins exactly the strips where the band pinned a row
+            // and this arm unpinned it again. No top bound either, for the
+            // same reason -- above the shelf the band still answers, so
+            // above the shelf the release must still keep.
+            //
+            // No honest bound reads NaN, which fails the gate and runs the
+            // unpin arm. That polarity is deliberate -- unpin unless
+            // provably in-zone -- and safe to act on without the bounds,
+            // because BodySlotAtY reads the body pairing and never the
+            // shelf's layout.
+            var shelfBottom = ShelfBottomY();
+            var inZone = !double.IsNaN(shelfBottom) && releaseY < shelfBottom;
             if (!inZone)
             {
                 _commitChurn = true;
@@ -4158,7 +4206,49 @@ internal sealed partial class VerticalTabStrip : UserControl
             beforeCenters[i] = RowCenterY(beforeRows[i]);
 
         var committed = false;
-        while (drag.Machine.Evaluate(draggedCenter) is { } crossing)
+        // The band answers for itself while the pointer is over it, and the
+        // crossing engine is not consulted at all on that tick.
+        //
+        // Not an optimisation -- the crossing engine cannot answer here and
+        // is actively wrong when asked. It commits on the dragged centre
+        // passing a NEIGHBOUR'S centre along one axis, and squares sharing a
+        // band row share that centre: no crossing between them can ever be
+        // produced, so a reorder inside a row was impossible. Worse, the
+        // comparison that fires for one square on the row fires for every
+        // square on it, and this loop drains crossings until none is left --
+        // so a drag arriving at the band committed 2->1, re-evaluated
+        // against the identical centre, committed 1->0, and landed at slot 0
+        // whatever the pointer was pointing at.
+        // ...and a PINNED row is never handed to it, band tick or not. The
+        // paragraph above is only half true while the pointer is over the
+        // band: carry a square below the shelf and BandTargetSlot declines,
+        // which hands the crossing engine that same array of equal centres
+        // and it drains three commits in one tick, shuffling the square to
+        // slot 0 exactly as described. Below the shelf a pinned row's
+        // position among body rows means nothing anyway -- it is still in
+        // the band -- and where it ends up is the release's call, which
+        // unpins and places it under the release point. So there is nothing
+        // for a crossing to decide here, and letting it try is the bug.
+        var bandTarget = BandTargetSlot(drag);
+        if (drag.Tab.IsPinned && bandTarget is null)
+        {
+            // No reorder this tick. The tail still runs: the ghost, the
+            // dwell and the glides are all still this gesture's business.
+        }
+        else if (bandTarget is { } bandSlot)
+        {
+            committed = CommitBandTarget(drag, bandSlot, beforeCenters);
+            // CommitBandTarget can cancel the session, and the crossing arm
+            // below returns on its own cancels rather than finishing the
+            // tick. This owes the same: EndDrag has already hidden the
+            // ghost and cleared the ring, and the tail of this method would
+            // re-derive both from a torn-down session -- ShowPinPreview
+            // adds a fresh row to PreviewHost that nothing then owns, and
+            // CountLeakedMotion does not count it, so the oracle reports a
+            // clean gesture while a phantom pin sits on the shelf.
+            if (_drag is null) return;
+        }
+        else while (drag.Machine.Evaluate(draggedCenter) is { } crossing)
         {
             // The machine speaks in visible slots, the manager in tabs;
             // a slot the pairing does not name is refused, never guessed.
@@ -4252,7 +4342,7 @@ internal sealed partial class VerticalTabStrip : UserControl
             }
         }
 
-        UpdatePinPreview(drag, draggedCenter);
+        UpdatePinPreview(drag);
         UpdateJoinDwell(drag, draggedCenter);
     }
 
@@ -4471,29 +4561,129 @@ internal sealed partial class VerticalTabStrip : UserControl
     // -----------------------------------------------------------------
 
     /// <summary>
+    /// Put the dragged tab in band slot <paramref name="target"/>: the
+    /// band's whole commit, and it is ONE move rather than a drained run
+    /// of crossings.
+    ///
+    /// That is the shape the two-axis hit test buys. A crossing engine has
+    /// to walk a drag slot by slot because each step is a comparison
+    /// against one neighbour; the band already knows the answer outright,
+    /// so there is nothing to iterate and no way for the iteration to run
+    /// away. <see cref="TabPinBand.NearestSlot"/> only changes its answer
+    /// at the midpoint between two squares, so a pointer resting on a
+    /// boundary cannot thrash the manager either.
+    ///
+    /// An unpinned tab arriving is pinned first and then placed, the same
+    /// two steps the boundary crossing takes and for the same reason: Move
+    /// alone clamps to the tab's own zone, so a pin has to exist before it
+    /// can be positioned among the pins.
+    ///
+    /// Returns whether anything committed, which is what the caller's
+    /// anchor-adoption rule reads.
+    ///
+    /// Of the three "closed" cancels below, only the last -- the row
+    /// element being gone after the churn -- is live. EvaluateDrag has
+    /// already proved the tab is in the manager, and SetPinned relocates
+    /// rather than removes, so neither IndexOf can return -1. They stay as
+    /// belt-and-braces on a path that mutates manager state mid-gesture,
+    /// but do not read the method as having three failure modes.
+    /// </summary>
+    private bool CommitBandTarget(DragSession drag, int target, double[] beforeCenters)
+    {
+        var wasPinned = drag.Tab.IsPinned;
+        var from = _manager.IndexOf(drag.Tab);
+        if (from < 0) { CancelDrag("closed"); return false; }
+        // The band's slots ARE the manager's pinned prefix, in order, so a
+        // band slot is a manager index directly -- no pairing to walk. The
+        // clamp is the arriving case: a tab that is not pinned yet cannot
+        // land past the end of the prefix it is joining.
+        var managerTo = Math.Min(target, wasPinned ? _manager.PinCount - 1 : _manager.PinCount);
+        if (wasPinned && managerTo == from) return false;
+
+        _commitChurn = true;
+        try
+        {
+            if (!wasPinned)
+            {
+                _manager.SetPinned(drag.Tab, true);
+                from = _manager.IndexOf(drag.Tab);
+                if (from < 0) { CancelDrag("closed"); return false; }
+            }
+            if (from != managerTo) _manager.Move(from, managerTo);
+        }
+        finally { _commitChurn = false; }
+
+        if (!wasPinned)
+        {
+            // The zone moved, so the boundary this gesture aims at repaints
+            // now -- the same exception the crossing path makes for a pin.
+            if (drag.HidesSelectionRow) UpdateSelectionRow();
+            else UpdateRowSeparators(selectionRowVisible: true);
+        }
+        if (RowElementOf(drag.Tab) is null) { CancelDrag("closed"); return false; }
+
+        // Read the truth back rather than trusting the request: Move clamps,
+        // and a target the manager declined must not re-anchor the row to a
+        // slot it never reached.
+        var (_, nowIndex) = DragSlots();
+        var actualSlot = nowIndex.IndexOf(_manager.IndexOf(drag.Tab));
+        if (actualSlot < 0)
+        {
+            DragTrace($"BAND refused ->{target}");
+            return false;
+        }
+        drag.Machine.UpdateIndex(actualSlot);
+        // The anchor re-bases on where the square was BEFORE this move, so
+        // the row keeps following the pointer instead of jumping by the
+        // slot delta. Out of the pre-commit frame the caller measured, and
+        // only when that frame actually holds the slot: a tab arriving from
+        // the list was not in the band when those centers were read.
+        if (actualSlot < beforeCenters.Length && !double.IsNaN(beforeCenters[actualSlot]))
+            RebindFollow(drag, beforeCenters[actualSlot]);
+        DragTrace($"BAND commit ->{actualSlot}");
+        return true;
+    }
+
+    /// <summary>
     /// Re-derive the ghost from this tick's truth. The promise is only
     /// alive while the dragged row is still unpinned, pins exist, and the
     /// row's center is over the shelf; any other state hides it. An
     /// unreadable measurement also hides it -- a ghost at a stale position
     /// is a wrong promise, and no ghost is the honest one.
     /// </summary>
-    private void UpdatePinPreview(DragSession drag, double draggedCenter)
+    private void UpdatePinPreview(DragSession drag)
     {
+        // The POINTER's Y, not the dragged row's centre. BandTargetSlot
+        // arbitrates on the pointer, and it acts on that answer by pinning
+        // an arriving row the moment it gets one -- so a ghost gated on the
+        // centre disagrees by the grab offset, up to half a row height.
+        // Grab a body row near its top edge and there is a band of
+        // positions where the band commits a pin while this refused to
+        // promise one, which is the drop landing somewhere the user was
+        // never shown. One reader of one number, or the promise is not a
+        // promise.
         var shelfBottom = ShelfBottomY();
         if (drag.Tab.IsPinned || _manager.PinCount == 0
-            || double.IsNaN(shelfBottom) || draggedCenter >= shelfBottom)
+            || double.IsNaN(shelfBottom) || double.IsNaN(drag.LastPointerY)
+            || drag.LastPointerY >= shelfBottom)
         {
             HidePinPreview();
             return;
         }
 
-        // The slot one past the end of the band, asked of the band itself
-        // rather than derived from the last square's center. A band wraps,
-        // so "the next slot" is sometimes beside the last square and
-        // sometimes at the start of a new row, and only the panel that
-        // arranges the squares knows which -- re-deriving it here would be
-        // a second layout opinion that disagrees at every column boundary.
-        var slot = BandSlotRect(_manager.PinCount);
+        // The slot the pointer is actually over, asked of the band itself
+        // rather than derived here. A band wraps, so a slot is sometimes
+        // beside the last square and sometimes at the start of a new row,
+        // and only the panel that arranges the squares knows which --
+        // re-deriving it would be a second layout opinion that disagrees at
+        // every column boundary.
+        //
+        // The ghost and the landing are the SAME answer: both come from
+        // BandTargetSlot, so the promise cannot differ from what the release
+        // does. Falling back to the end slot when the pointer is not over
+        // the band keeps the old promise for the approach, which is the
+        // only time that gate is open and the band has not answered.
+        var slot = BandSlotRect(BandTargetSlot(drag) ?? _manager.PinCount);
         if (double.IsNaN(slot.X) || double.IsNaN(slot.Y))
         {
             HidePinPreview();
@@ -4538,6 +4728,64 @@ internal sealed partial class VerticalTabStrip : UserControl
         {
             return double.NaN;
         }
+    }
+
+    /// <summary>
+    /// The band slot the pointer is asking for, or null when the pointer is
+    /// not over the band and the linear machine owns the gesture.
+    ///
+    /// This is the arbitration between the two engines, and the axis it
+    /// arbitrates on is the machine's own. The band spans the pane's width,
+    /// so horizontally there is nothing to decide -- the only question is
+    /// whether the pointer's Y is inside the band's rows. Above the shelf's
+    /// bottom the band answers; below it the list does. Split that way the
+    /// two engines cannot both claim a tick, which is what keeps the
+    /// handover from needing a state machine of its own.
+    ///
+    /// Null on three refusals rather than a guess:
+    ///   - no X. A driver that supplies only Y (the seam's Y-only drag, and
+    ///     every pre-band caller) gets the linear behaviour it has always
+    ///     had, instead of a hit test against a column it never named.
+    ///   - no pins. There is no band to hit-test, and nothing else picks
+    ///     the gesture up either: TabPinBoundary.Classify only answers Pin
+    ///     for a slot inside the pinned prefix, and with no pins there is
+    ///     no such slot. So no drag creates the FIRST pin, before this
+    ///     change or after it -- the refusal is right, but do not read it
+    ///     as "the boundary classification handles that case".
+    ///   - a run drag. A group cannot be pinned, so the band is not a place
+    ///     it can land.
+    /// </summary>
+    private int? BandTargetSlot(DragSession drag)
+    {
+        if (drag.Group is not null) return null;
+        if (double.IsNaN(drag.LastPointerX)) return null;
+        if (_manager.PinCount == 0) return null;
+
+        var shelfBottom = ShelfBottomY();
+        if (double.IsNaN(shelfBottom) || drag.LastPointerY >= shelfBottom) return null;
+
+        Windows.Foundation.Point local;
+        try
+        {
+            local = TransformToVisual(_pinnedPanel).TransformPoint(
+                new Windows.Foundation.Point(drag.LastPointerX, drag.LastPointerY));
+        }
+        catch (Exception ex) when (IsLayoutReadFailure(ex))
+        {
+            // The band is not arranged into the tree this tick. No target
+            // is the honest answer; the linear machine's own measurements
+            // are refused the same way one tick at a time.
+            return null;
+        }
+        if (double.IsNaN(local.X) || double.IsNaN(local.Y)) return null;
+
+        // One more slot than there are pins when the dragged tab is not one
+        // of them: it is arriving, and the slot past the end is a real place
+        // for it to land -- the same slot the ghost draws. A pin already in
+        // the band is only ever reordered among the squares that exist.
+        var slots = drag.Tab.IsPinned ? _manager.PinCount : _manager.PinCount + 1;
+        return TabPinBand.NearestSlot(
+            local.X, local.Y, Math.Max(1, _pinnedPanel.Columns), slots);
     }
 
     /// <summary>
@@ -4880,6 +5128,26 @@ internal sealed partial class VerticalTabStrip : UserControl
         {
             return item.TransformToVisual(this)
                 .TransformPoint(new Windows.Foundation.Point(0, 0)).Y + item.ActualHeight / 2;
+        }
+        catch (Exception ex) when (IsLayoutReadFailure(ex))
+        {
+            return double.NaN;
+        }
+    }
+
+    /// <summary>
+    /// An element's centre X in strip space, for the one caller that needs
+    /// a second axis: the seam's drag, which has to be able to name a square
+    /// on a band row. NaN when the element has no arranged truth, the same
+    /// refusal <see cref="RowCenterY"/> makes.
+    /// </summary>
+    private double RowCenterX(FrameworkElement item)
+    {
+        if (item.ActualWidth <= 0) return double.NaN;
+        try
+        {
+            return item.TransformToVisual(this)
+                .TransformPoint(new Windows.Foundation.Point(0, 0)).X + item.ActualWidth / 2;
         }
         catch (Exception ex) when (IsLayoutReadFailure(ex))
         {
@@ -5278,7 +5546,14 @@ internal sealed partial class VerticalTabStrip : UserControl
             return outcome.Fail("drag row has no arranged center; layout has not run");
 
         const uint seamPointer = 0x5749_4E54; // 'WINT'; no real pointer carries it
-        DragPress(row, seamPointer, y);
+        // The pointer's X, carried so a walk that ends inside the pinned
+        // band can say WHICH square it means. A band row holds several
+        // squares at one Y, so a Y-only walk cannot name one of them --
+        // which is the whole reason the band answers a hit test rather than
+        // a crossing. Seeded from the row's own centre, so a drag that
+        // never touches the band moves along the axis it always did.
+        double x = RowCenterX(row);
+        DragPress(row, seamPointer, y, x);
 
         // Steps of 12px: past the 4px start threshold on the first move,
         // under the row pitch, so each tick is one honest crossing decision
@@ -5291,9 +5566,16 @@ internal sealed partial class VerticalTabStrip : UserControl
 
             var (rows, managerIndex) = DragSlots();
             int slot = managerIndex.IndexOf(to);
-            double target = slot >= 0 && slot < rows.Count
-                ? RowCenterY(rows[slot])
-                : double.NaN;
+            // A destination inside the band is a POINT, not a height: the
+            // band's own slot rect, which is the same geometry the drop
+            // preview and the panel's arrange read. Outside it, the row's
+            // centre height and the X the walk already holds.
+            var band = to < _manager.PinCount ? BandSlotRect(slot) : default;
+            var toBand = to < _manager.PinCount && !double.IsNaN(band.X);
+            double target = toBand
+                ? band.Y + band.Height / 2
+                : slot >= 0 && slot < rows.Count ? RowCenterY(rows[slot]) : double.NaN;
+            double targetX = toBand ? band.X + band.Width / 2 : x;
             // An unreadable target means the strip is mid-arrange (a commit
             // churned the containers); stand still this tick and re-read
             // the next, exactly as a hovering pointer would.
@@ -5308,18 +5590,23 @@ internal sealed partial class VerticalTabStrip : UserControl
                 // own token; once the commit lands it comes back to the
                 // center and settles there -- the overshoot-and-return a
                 // human finger performs.
+                //
+                // The band takes no such token: it commits on the NEAREST
+                // square, so aiming at the square's centre is already the
+                // answer and an overshoot would aim at its neighbour.
                 bool committed = _manager.IndexOf(tab) == to;
-                if (committed && Math.Abs(target - y) <= 1)
+                if (committed && Math.Abs(target - y) <= 1 && Math.Abs(targetX - x) <= 1)
                 {
                     reached = true;
                     break;
                 }
-                double aim = committed
+                double aim = committed || toBand
                     ? target
                     : target + Math.Sign(to - from)
                         * (TabStripMotion.CrossingHysteresisPx + 4);
                 y += Math.Clamp(aim - y, -stepPx, stepPx);
-                DragMove(seamPointer, y);
+                x += Math.Clamp(targetX - x, -stepPx, stepPx);
+                DragMove(seamPointer, y, x);
             }
 
             // One handoff below the drag tick's Normal priority: the
@@ -5340,6 +5627,12 @@ internal sealed partial class VerticalTabStrip : UserControl
 
         DragRelease(seamPointer, y);
         outcome.Landed = _manager.IndexOf(tab);
+        // A drag into the band CHANGES this, and the manager is the only
+        // honest witness to it: the release classifies pin-out, so the
+        // gesture's own aim does not tell a caller what it got. Reported
+        // by every other drag entry point, and its absence here read as a
+        // product bug for as long as this path skipped it.
+        outcome.Pinned = tab.IsPinned;
         outcome.Order = TabStripProjection.Rows(_manager)
             .Select(t => t.EffectiveTitle).ToList();
         if (outcome.Landed != to)

--- a/windows/scripts/vtab-strip-geometry.ps1
+++ b/windows/scripts/vtab-strip-geometry.ps1
@@ -7,9 +7,12 @@
     behind the window, and the questions asked here are about where things
     were laid out, which layout answers exactly.
 
-    One process, one seeded state (two pins, one group, two loose tabs),
-    measured at both pane widths: compact (the 48px rail the strip starts
-    in) and expanded (the pinned sidebar, reached with toggle-sidebar).
+    Two processes. The geometry legs run in one, over a single seeded
+    state (two pins, one group, two loose tabs) measured at both pane
+    widths: compact (the 48px rail the strip starts in) and expanded (the
+    pinned sidebar, reached with toggle-sidebar). The band drag runs in a
+    second, because it needs four pins and an expanded pane -- a column
+    boundary inside the staged state rather than beyond it.
 
     Checks, each at both widths unless stated:
 
@@ -37,6 +40,25 @@
       header-fits           a group header's painted span -- swatch through
                             chevron -- stays inside the pane at both
                             widths.
+
+    And in the second process, expanded only, with four pins staged:
+
+      band-reorder          dragging a pin left over its neighbour swaps
+                            them. Impossible on the crossing engine
+                            outright: squares sharing a band row share the
+                            Y it compares, so no crossing between them can
+                            ever be produced.
+      band-drop-slot        a body tab dragged into the band lands at the
+                            slot it was aimed at, and comes back PINNED.
+                            Aimed at the last slot rather than the first,
+                            because slot 0 is what the old engine produced
+                            for every arrival and could not tell a working
+                            drop from a broken one.
+      band-drop-rect        ...and the square is arranged where the manager
+                            says it is: on the last occupied band row,
+                            right of every pin sharing it. The column count
+                            is derived from the arranged rects, so the
+                            check does not assume a four-column band.
 
     Findings are collected rather than thrown one at a time: a geometry run
     that reports the first bad number and stops hides the rest of the
@@ -119,6 +141,115 @@ function Save-StripShot([int64]$Hwnd64, [string]$Name) {
 }
 
 # ---- the checks ------------------------------------------------------------
+
+# The band's own drag, which the linear crossing engine cannot do.
+#
+# Five pins in the expanded pane, so the band is two rows of four and one:
+# a column boundary is inside the staged state rather than beyond it, and a
+# reorder that only works while every pin shares one row would show here.
+#
+# Three claims, each read back off the MANAGER (the seam's state block)
+# rather than off the gesture's own report:
+#
+#   band-reorder     dragging a pin left over its neighbour swaps them. On
+#                    the crossing engine this was impossible outright:
+#                    squares sharing a band row share the Y it compares, so
+#                    no crossing between them can ever be produced.
+#   band-drop-slot   dragging a body tab into the band lands it at the slot
+#                    it was walked to, NOT at slot 0. The drain-the-crossings
+#                    loop committed 2->1, re-evaluated against the identical
+#                    centre, committed 1->0, and put every arriving tab at
+#                    the front of the band whatever the pointer said.
+#   band-drop-rect   ...and the square is ARRANGED there, asked of
+#                    element-rects rather than trusted from the model. A
+#                    model that moved while the panel drew the old order is
+#                    the failure this file exists to catch.
+function Test-BandDrag($Session) {
+    # Its OWN session, staged from launch rather than re-seeded into the
+    # one the geometry checks used. Re-seeding a live session -- tearing
+    # five tabs down and rebuilding them with pins already in an expanded
+    # vertical pane -- took the app down twice with exit 2173 and no
+    # crash.log entry, which is the layout-switch crash family
+    # seam-acceptance.ps1 exists to stage. Not this harness's question, and
+    # not a shape it should be provoking on the way to asking its own.
+    foreach ($i in 0, 1, 2, 3) {
+        [void](Invoke-SeamCommand $Session @{ op = 'pin'; index = $i; via = 'router' })
+    }
+    # Four pinned, one loose. Selection off the band so the selection
+    # chrome is not sitting on a square being dragged.
+    [void](Invoke-SeamCommand $Session @{ op = 'select'; index = 4 })
+    [void](Invoke-SeamCommand $Session @{ op = 'toggle-sidebar' })
+
+    $before = Invoke-SeamCommand $Session @{ op = 'get-state' }
+    $order = @($before.state.tabs | ForEach-Object { $_.title })
+    if ($order.Count -lt 5) { throw "HARVEST_MISS: the drag leg seeded $($order.Count) tabs" }
+    if ($before.state.paneWidth -le 96) {
+        throw "HARVEST_MISS: the drag leg's pane is $($before.state.paneWidth)px, wanted the expanded sidebar"
+    }
+
+    # Reorder INSIDE a band row: the third pin onto the second's slot.
+    # The drag op answers with `order` and `landed`, not a state block.
+    $moved = Invoke-SeamCommand $Session @{ op = 'drag'; from = 2; to = 1 }
+    $after = @($moved.order)
+    $want = @($order[0], $order[2], $order[1], $order[3], $order[4])
+    Add-Check 'band-reorder' (
+        'dragged pin 2 onto slot 1: [{0}], wanted [{1}]' -f
+            ($after -join ','), ($want -join ',')) (($after -join ',') -eq ($want -join ','))
+
+    # A body tab into the band, aimed at the LAST slot rather than the
+    # first. Slot 0 is what the old engine produced for every arrival, so
+    # a target of 0 here could not tell a working drop from a broken one.
+    $arrived = Invoke-SeamCommand $Session @{ op = 'drag'; from = 4; to = 3 }
+    $landed = @($arrived.order)
+    $ok = $landed.Count -ge 4 -and $landed[3] -eq $order[4] `
+        -and [int]$arrived.landed -eq 3 -and [bool]$arrived.pinned
+    Add-Check 'band-drop-slot' (
+        "'{0}' landed at {1} pinned={2}; order [{3}]" -f
+            $order[4], $arrived.landed, [bool]$arrived.pinned, ($landed -join ',')) $ok
+
+    # ...and the square is arranged where the manager says it is.
+    $rects = Invoke-SeamCommand $Session @{ op = 'element-rects' }
+    $pins = @($rects.rects.pinned)
+    $target = @($pins | Where-Object { $_.title -eq $order[4] })
+    if ($target.Count -ne 1) {
+        Add-Check 'band-drop-rect' (
+            "the band arranges {0} squares titled '{1}'" -f $target.Count, $order[4]) $false
+    } elseif (-not $target[0].row.visible) {
+        # A FINDING, not a harness miss. Assert-Rect throws HARVEST_MISS
+        # here, which the catch below turns into exit 1 -- "nothing is known
+        # about the product" -- but a newly pinned square with no arranged
+        # box is precisely the defect this check exists to name: a model
+        # that moved while the panel drew the old order. Exit 1 would let a
+        # gate keyed on findings read the headline bug as infrastructure
+        # noise.
+        Add-Check 'band-drop-rect' (
+            "the newly pinned square '{0}' is not arranged at all" -f $order[4]) $false
+    } else {
+        # READING ORDER is the claim, and it needs no column count at all.
+        # The band lays its slots out left to right, wrapping, so sorting
+        # the arranged squares by row then column must reproduce the
+        # manager's pinned prefix exactly -- and the dropped tab landed at
+        # manager index 3, so it must be the fourth square read that way.
+        #
+        # Deriving a column count and predicting a row/column was the
+        # obvious alternative and it is a trap twice over: assuming four
+        # columns is a false finding as soon as the pane fits five, and
+        # "the last occupied row" is simply wrong here, because slot 3 of
+        # five in a four-column band is row 0, not the row holding the
+        # fifth pin. Reading order sidesteps the arithmetic and asserts the
+        # thing the check is actually named for.
+        $r = $target[0].row
+        $reading = @($pins | Sort-Object `
+            @{ Expression = { [Math]::Round($_.row.y) } }, `
+            @{ Expression = { $_.row.x } })
+        $at = [Array]::IndexOf(@($reading | ForEach-Object { $_.title }), $order[4])
+        $ok = $at -eq 3
+        Add-Check 'band-drop-rect' (
+            "'{0}' is square {1} in reading order (want 3); at ({2:F1},{3:F1}); band reads [{4}]" -f
+                $order[4], $at, $r.x, $r.y,
+                (($reading | ForEach-Object { $_.title }) -join ',')) $ok
+    }
+}
 
 # A pinned tab is an icon square, and that change of shape is what marks
 # the zone now that nothing is drawn between the zones. So the square is
@@ -303,6 +434,19 @@ try {
 
     if ($session.Proc.HasExited) {
         throw "APP_EXIT: the app exited during the run (code $($session.Proc.ExitCode))"
+    }
+
+    # The band's own drag, in its own process. See Test-BandDrag.
+    Stop-SeamSession $session
+    $session = Start-SeamSession -ExePath $ExePath -ConfigText $Config
+    [void](Invoke-SeamCommand $session @{ op = 'seed-tabs'; count = 5; titles = $names })
+    Write-Host ''
+    Write-Host '=== band drag (four pins, expanded) ==='
+    Test-BandDrag $session
+    Save-StripShot $session.Hwnd64 'band-drag'
+
+    if ($session.Proc.HasExited) {
+        throw "APP_EXIT: the app exited during the drag leg (code $($session.Proc.ExitCode))"
     }
 }
 catch {


### PR DESCRIPTION
Closes #932. Stacked on #922 — targets that branch, not `windows`.

The vertical drag machine commits on a crossing along one axis. A wrapping band puts several squares at one Y, so between them no crossing can ever be produced, and the comparison that fires for one square fires for every square on its row. `TabPinBand.NearestSlot` answers which square a point is asking for instead, and carries half a pitch of hysteresis for free.

Arbitration is on the machine's own axis: above the shelf's bottom the band answers, below it the list does. The start threshold gains a two-axis door for the one surface that needs it — a reorder between two squares on a row is pure sideways travel at an unchanging Y, which the one-axis threshold kept a click forever.

Two bugs surfaced on the way:

- **The release read a different edge than the arbitration.** It classified pin-out against the band panel's rect, which is inset inside the shelf `BandTargetSlot` reads — so the panel's own margins (`RowInsetVertical` 2px, `BandInsetBottom` 4px) were a strip where the drag pinned a row and the release promptly unpinned it. One edge now, `ShelfBottomY`, read by both. No top bound either: above the shelf the band still answers, so above the shelf the release must still keep.
- **`TestSeamDragOutcome.Pinned` was never assigned by `drag`.** Four of the five seam drag paths set it; the one the band leg uses did not, so every drop read back `pinned=False` regardless of what the product did — a default masquerading as a measurement. This is what the band leg was actually reporting, and it would have made any release-side fix look like it had worked or not at random.

## Verified

- `vtab-strip-geometry.ps1` — all 13 geometry checks green at both pane widths, including the three new ones: `band-reorder`, `band-drop-slot` (`landed at 3 pinned=True`) and `band-drop-rect` (column 3 of row 0, sharing its row with three other pins).
- Full managed suite: 3446 passed, 0 failed. `just signoff` PASS.
- Four guards, each proven red by mutation and reverted: both engines calling `ShelfBottomY`; `DragRelease` never touching `_pinnedPanel`; the count-pinned sweep that all five seam drag paths report the pin state (receiver pinned, so a stray `.Pinned` cannot satisfy it); and `Pin_out_is_release_classified` re-pointed from the old two-bound expression to the new invariant.

## What this does not cover

- The band's reflow glide is still a composition animation no arranged rect records — only its wiring is guarded.
- Only the vertical strip. The horizontal strip's pinned squares have no `element-rects` op and no seam drag op.
- The harness stages four pins in the expanded pane. A band drag that breaks only at some other column count is not covered.

## Review round

Independently reviewed by a second agent. **Three blockers**, plus five important and several minor; all applied, each guard mutation-proved red and reverted.

### Blockers

**The release's zone guard had been made weaker, not stronger.** The expression it replaced — `releaseY >= shelfTop && releaseY <= shelfBottom` — carried its own connective *inside* the asserted substring, so a flip between the comparisons went red. Dropping to one bound and keeping a substring assertion silently gave up the `&&` joining the NaN guard. Under `||`, `inZone` is permanently true and **pin-out stops working entirely**, with every test green. It is asserted as a tree now: the conjunction, its left operand, and the comparison's kind.

**The ghost and the commit read different numbers.** `UpdatePinPreview` gated on `draggedCenter` while the arbitration reads `LastPointerY`; they differ by the grab offset, up to half a row height. So there was a band of pointer positions — keyed to where in the row the user grabbed — in which the drag pinned an arriving tab while the preview had refused to promise anything. The tab landed somewhere no ghost was ever shown. One reading now, and the guard names the variable and forbids the other.

**`EvaluateDrag` finished the tick on a torn-down session.** `CommitBandTarget`'s cancels return `false` rather than returning, so the tail re-derived the ghost and the dwell after `EndDrag` had cleared both — adding a fresh `VerticalTabPinnedRow` to `PreviewHost` that nothing owns, and which `CountLeakedMotion` does not count, so the drag oracle reported a clean gesture with a phantom pin left on the shelf.

### Important

- **A pinned row is never handed to the crossing engine at all.** The claim that the drain-the-crossings behaviour was retired held only while the pointer was over the band: carry a square below the shelf, `BandTargetSlot` declines, and the loop gets that same array of equal centres and drains three commits in one tick. Below the shelf a pinned row's position among body rows is meaningless anyway — the release decides where it lands.
- **The two-axis start threshold is per-axis, not straight-line.** A radius-4 disc is *smaller* than the one-axis rule's ±4 square, so 3px of horizontal and 3px of vertical travel (4.24) lifted a click on a 40px icon — and a lifted press ending in the zone keeps its pin and never activates, because only the click path calls `ActivateFromShelf`. Taking the larger of the two axes is the OR of two one-axis rules: Y is exactly what it was, X gets a door of the same width.
- **Two more guards were vacuous.** The edge guard proved `ShelfBottomY` was *called* but said nothing about how the value was used, and missed that B2 had made a third reader; it now pins all three and asserts the refusal polarity as a tree, since `>` and `>=` are both `BinaryExpressionSyntax`. The seam sweep checked that `outcome.Pinned` was assigned but not *what* — `outcome.Pinned = false` survived it, which is the identical defect it was written for — nor *when*; it now pins the value and requires the assignment to follow `DragRelease`.
- **`band-drop-rect` reported its own headline defect as a harness error.** An unarranged square threw `HARVEST_MISS`, which the runner turns into exit 1 — "nothing is known about the product" — so a gate keyed on findings would read the bug it exists to catch as infrastructure noise.

The harness then caught a defect in the *fix* to that check: deriving "last occupied row" is wrong, because slot 3 of five in a four-column band is row 0. It now asserts reading order instead — sort the arranged squares by row then column and the dropped tab must be fourth, because that is its manager index. No column count, no predicted row, and it verifies the whole arranged order against the model rather than one square's position.
