### PR TITLE
renderer: a DX12 resource is retired against the fence, not released mid-draw

### DIFF
--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -40,6 +40,7 @@ pub const dcomp = @import("directx12/dcomp.zig");
 pub const descriptor_heap = @import("directx12/descriptor_heap.zig");
 pub const device = @import("directx12/device.zig");
 pub const dxgi = @import("directx12/dxgi.zig");
+pub const retire = @import("directx12/retire.zig");
 
 pub const custom_shader_target: shadertoy.Target = .hlsl;
 
@@ -144,12 +145,29 @@ init_command_list: ?*d3d12.ID3D12GraphicsCommandList = null,
 /// Must be saved here because GetCurrentBackBufferIndex advances after Present.
 pending_frame_index: u32 = 0,
 
-/// Deferred frame completion state. DX12 must signal the GPU fence before
-/// releasing the frame semaphore (which happens in frameCompleted), because
-/// frame.resize() reuses descriptor slots that the GPU may still be reading.
-/// Metal's completion handler naturally runs after GPU finish; DX12's
-/// complete() runs before command list execution, so we defer frameCompleted
-/// to drawFrameEnd() which runs after ExecuteCommandLists + Signal.
+/// Deferred frame completion state. DX12 must at least submit the frame
+/// and signal the GPU fence before releasing the frame semaphore (which
+/// happens in frameCompleted), because frame.resize() reuses descriptor
+/// slots. Metal's completion handler runs after the GPU finishes; DX12's
+/// complete() runs before command list execution, so we defer
+/// frameCompleted to drawFrameEnd() which runs after ExecuteCommandLists
+/// + Signal.
+///
+/// Note what this does NOT buy, because the sentence above overstates it:
+/// a signal is not a completion, so the frame semaphore says nothing about
+/// whether the GPU has finished the frame it releases. Resource lifetimes
+/// must not lean on it -- that is what the device's retirement queue is
+/// for (issue #944).
+///
+/// Which means the "because frame.resize() reuses descriptor slots" reason
+/// is NOT satisfied by this deferral, and that hole is still open:
+/// CustomShaderState.resize reuses front_srv_slot/back_srv_slot in the
+/// SHADER-VISIBLE heap, and it runs before beginFrame's per-slot fence
+/// wait. The retirement queue keeps the old resource alive, so this is no
+/// longer a use-after-free -- but the descriptor is overwritten while the
+/// previous submission may still sample through it, so that frame reads
+/// the wrong texture. Descriptor lifetime is a different mechanism from
+/// resource lifetime and wants its own fix; tracked separately.
 pending_complete: ?struct {
     renderer: *Renderer,
     health: rendererpkg.Health,
@@ -428,9 +446,14 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX12 {
 }
 
 pub fn deinit(self: *DirectX12) void {
-    // Wait for GPU to finish before releasing anything.
+    // Wait for GPU to finish before releasing anything. Everything below
+    // final-releases resources directly rather than retiring them, so a
+    // failed drain has to be visible: it means the back buffers and frame
+    // command allocators go away while the GPU may still be using them.
     if (self.dev) |*dev_ptr| {
-        dev_ptr.waitForGpu() catch {};
+        dev_ptr.waitForGpu() catch |err| {
+            log.err("waitForGpu before renderer teardown failed: {}", .{err});
+        };
     }
 
     // Release init command list if never flushed (error during init).
@@ -528,12 +551,17 @@ pub fn flushInitCommands(self: *DirectX12) void {
     self.pending_command_list = null;
 }
 
-/// Block until the GPU finishes all submitted work.
-/// Must be called before freeing any GPU resources (textures,
-/// buffers, pipelines) to prevent use-after-free on the GPU.
+/// Block until the GPU finishes all submitted work, then release
+/// everything the retirement queue is holding.
+///
+/// Used by the generic renderer before it destroys state the retirement
+/// queue does not cover -- PSOs and root signatures on a shader reinit,
+/// and every frame's resources at teardown.
 pub fn waitGpu(self: *DirectX12) void {
     if (self.dev) |*dev_ptr| {
-        dev_ptr.waitForGpu() catch {};
+        dev_ptr.waitForGpu() catch |err| {
+            log.err("waitForGpu failed: {}; GPU state may still be in use", .{err});
+        };
     }
 }
 
@@ -549,9 +577,11 @@ pub fn drawFrameEnd(self: *DirectX12) void {
     // frameCompleted (called by the defer below) posts the swap-chain
     // semaphore, which allows the next frame to proceed.  In Metal the
     // completion handler fires after the GPU finishes; DX12's complete()
-    // fires before ExecuteCommandLists, so we must defer the semaphore
-    // release until after the fence signal to prevent frame.resize()
-    // from overwriting descriptor slots the GPU hasn't finished reading.
+    // fires before ExecuteCommandLists, so we defer the semaphore release
+    // until after the fence signal -- the frame is at least submitted and
+    // has a fence value by then.  It is not finished: anything whose
+    // lifetime depends on the GPU actually being done goes through
+    // dev.retirement, not the semaphore.
     defer {
         if (self.pending_complete) |pc| {
             self.pending_complete = null;
@@ -597,7 +627,15 @@ pub fn drawFrameEnd(self: *DirectX12) void {
         f.fence_value = new_fence_value;
     }
     const signal_hr = dev_ptr.command_queue.Signal(dev_ptr.fence, new_fence_value);
-    if (com.FAILED(signal_hr)) {
+    if (!com.FAILED(signal_hr)) {
+        // Bind every resource retired since the last submission to this
+        // frame's fence value. Anything retired before this signal can
+        // only have been referenced by work submitted at or before it, so
+        // reaching this value is proof the GPU is done reading it. If the
+        // Signal failed there is nothing to bind them to; they stay staged
+        // for the next successful submission, or for teardown.
+        dev_ptr.retirement.seal(new_fence_value);
+    } else {
         log.err("fence Signal failed: 0x{x}", .{@as(u32, @bitCast(signal_hr))});
         // A TDR between Present and Signal leaves the fence unsignaled.
         // Without this check the next beginFrame would deadlock waiting
@@ -874,6 +912,12 @@ pub inline fn beginFrame(
         _ = d3d12.WaitForSingleObject(dev_ptr.fence_event, d3d12.INFINITE);
     }
 
+    // Free resources whose last referencing submission the GPU has now
+    // finished. This reads the fence rather than assuming the wait above
+    // covers a given resource: the wait is per-slot, while a retirement
+    // may have been sealed against any submission.
+    dev_ptr.retirement.collect(dev_ptr.fence.GetCompletedValue());
+
     // Point the target at the chosen render target resource and RTV.
     target.resource = render_target;
     target.rtv_handle = rtv_handle;
@@ -925,6 +969,7 @@ fn handleDeviceRemoved(self: *DirectX12) void {
 pub inline fn bufferOptions(self: DirectX12) bufferpkg.Options {
     return .{
         .device = if (self.dev) |*d| d.device else null,
+        .retire = if (self.dev) |*d| d.retirement else null,
     };
 }
 
@@ -946,6 +991,7 @@ pub inline fn textureOptions(self: DirectX12) Texture.Options {
         .device = if (self.dev) |*d| d.device else null,
         .command_list = self.pending_command_list,
         .srv_heap = self.srv_heap,
+        .retire = if (self.dev) |*d| d.retirement else null,
     };
 }
 
@@ -963,6 +1009,7 @@ pub inline fn renderTargetTextureOptions(
         .command_list = self.pending_command_list,
         .srv_heap = self.srv_heap,
         .rtv_heap = self.rtv_heap,
+        .retire = if (self.dev) |*d| d.retirement else null,
         .pixel_format = .B8G8R8A8_UNORM,
         .render_target = true,
         .rtv_slot = rtv_slot,
@@ -993,6 +1040,7 @@ pub inline fn imageTextureOptions(
         .device = if (self.dev) |*d| d.device else null,
         .command_list = self.pending_command_list,
         .srv_heap = self.srv_heap,
+        .retire = if (self.dev) |*d| d.retirement else null,
         .pixel_format = switch (format) {
             .gray => .R8_UNORM,
             .rgba => .R8G8B8A8_UNORM,
@@ -1017,6 +1065,7 @@ pub fn initAtlasTexture(
         .device = if (self.dev) |*d| d.device else null,
         .command_list = self.pending_command_list,
         .srv_heap = self.srv_heap,
+        .retire = if (self.dev) |*d| d.retirement else null,
         .pixel_format = pixel_format,
     }, size, size, null);
 }
@@ -1035,6 +1084,7 @@ test {
     _ = descriptor_heap;
     _ = device;
     _ = dxgi;
+    _ = retire;
 }
 
 test "DirectX12 does not have frame_fence_values" {

--- a/src/renderer/directx12/Texture.zig
+++ b/src/renderer/directx12/Texture.zig
@@ -14,6 +14,7 @@ const d3d12 = @import("d3d12.zig");
 const dxgi = @import("dxgi.zig");
 const com = @import("com.zig");
 const DescriptorHeap = @import("descriptor_heap.zig").DescriptorHeap;
+const Retirement = @import("retire.zig").Retirement;
 
 const log = std.log.scoped(.directx12);
 
@@ -21,6 +22,16 @@ pub const Options = struct {
     device: ?*d3d12.ID3D12Device = null,
     command_list: ?*d3d12.ID3D12GraphicsCommandList = null,
     srv_heap: ?*DescriptorHeap = null,
+    /// Where this texture's resource and its upload staging buffers go
+    /// when they are no longer needed. Null releases them immediately,
+    /// which is only safe for a texture no submitted command list has ever
+    /// touched. DirectX12.zig's option builders always supply the device's
+    /// queue.
+    ///
+    /// Deliberately without a default, for the same reason as
+    /// buffer.Options.retire: an omitted field must not be able to mean
+    /// "release immediately" by accident.
+    retire: ?*Retirement,
     /// Required when render_target is true. RTV descriptors are allocated from
     /// a separate RTV descriptor heap (D3D12_DESCRIPTOR_HEAP_TYPE_RTV).
     rtv_heap: ?*DescriptorHeap = null,
@@ -76,6 +87,16 @@ format: dxgi.DXGI_FORMAT = .R8_UNORM,
 device: ?*d3d12.ID3D12Device = null,
 /// Cached command list for replaceRegion uploads.
 command_list: ?*d3d12.ID3D12GraphicsCommandList = null,
+/// Deferred-release queue for this texture's resource and staging
+/// buffers. See Options.retire.
+///
+/// This one keeps its default, unlike Options.retire, because `Texture{}`
+/// is the zero-value idiom several tests use for a texture that owns
+/// nothing. That is safe only while `Texture.init` is the sole production
+/// constructor -- it is today. A hand-rolled `Texture{ .resource = ... }`
+/// in production would opt out of the queue with no compile error, so
+/// build textures through init.
+retire: ?*Retirement = null,
 /// Current resource state for barrier tracking.
 state: d3d12.D3D12_RESOURCE_STATES = d3d12.D3D12_RESOURCE_STATES.PIXEL_SHADER_RESOURCE,
 /// Staging buffers from the most recent upload, one per row-band, kept
@@ -167,6 +188,7 @@ pub fn init(opts: Options, width: usize, height: usize, data: ?[]const u8) Error
         .format = opts.pixel_format,
         .device = device,
         .command_list = opts.command_list,
+        .retire = opts.retire,
         .state = if (opts.render_target)
             d3d12.D3D12_RESOURCE_STATES.PIXEL_SHADER_RESOURCE
         else
@@ -189,9 +211,17 @@ pub fn init(opts: Options, width: usize, height: usize, data: ?[]const u8) Error
     return tex;
 }
 
+/// Give up this texture's GPU resource and any staging buffers.
+///
+/// Both go to the retirement queue rather than being released here.
+/// Textures are dropped from live code paths -- an image unloading, a
+/// custom-shader state being torn down when the shader is removed, a frame
+/// slot resizing -- while command lists that sample from them or copy into
+/// them are still executing. D3D12 does not retain what a submitted
+/// command list references.
 pub fn deinit(self: Texture) void {
     for (self.pending_staging.items) |staging| {
-        _ = staging.Release();
+        self.releaseResource(staging);
     }
     // deinit takes self by value to match Metal/OpenGL Texture and the
     // switch-capture call sites in image.zig. Copying self locally lets
@@ -200,10 +230,17 @@ pub fn deinit(self: Texture) void {
     var self_mut = self;
     self_mut.pending_staging.deinit(std.heap.c_allocator);
     if (self.resource) |res| {
-        _ = res.Release();
+        self.releaseResource(res);
     }
     // SRV descriptor is owned by the heap's linear allocator --
     // it gets freed when the heap itself is destroyed.
+}
+
+/// Hand a resource to the retirement queue, or release it outright when
+/// there is no queue (standalone textures in the GPU unit tests, which no
+/// submitted command list has ever referenced).
+fn releaseResource(self: *const Texture, resource: *d3d12.ID3D12Resource) void {
+    if (self.retire) |q| q.retire(resource) else _ = resource.Release();
 }
 
 /// Update the cached command list to the current frame's.
@@ -218,9 +255,12 @@ pub fn setCommandList(self: *Texture, cl: ?*d3d12.ID3D12GraphicsCommandList) voi
 ///
 /// The staging buffers are kept alive until the next replaceRegion call
 /// or deinit, because D3D12 does not extend resource lifetimes for
-/// recorded commands. The previous staging buffers are safe to release
-/// here because the frame's fence wait in beginFrame guarantees the GPU
-/// finished executing the prior CopyTextureRegion calls.
+/// recorded commands. The previous ones are retired rather than released:
+/// the fence wait in beginFrame covers only the frame slot being started,
+/// and a texture shared across slots (a kitty image, an atlas after a
+/// present-only frame has rotated the back buffer index out of step with
+/// the renderer's frame index) can still be read by a submission that wait
+/// says nothing about.
 ///
 /// Returns error{}!void for API compatibility with Metal's replaceRegion
 /// which cannot fail. DX12 upload failures are caught here and logged at
@@ -241,11 +281,11 @@ pub fn setCommandList(self: *Texture, cl: ?*d3d12.ID3D12GraphicsCommandList) voi
 /// it) but worth knowing if anyone calls replaceRegion on a multi-band
 /// region of a user-visible texture.
 pub fn replaceRegion(self: *Texture, x: usize, y: usize, width: usize, height: usize, data: []const u8) error{}!void {
-    // Release the staging buffers from the previous upload. Safe because
-    // beginFrame waited on the fence for this frame slot, so the GPU
-    // has finished reading from them.
+    // Retire the staging buffers from the previous upload. They are the
+    // source of CopyTextureRegion calls that may still be executing, so
+    // the retirement queue decides when they are actually freed.
     for (self.pending_staging.items) |prev| {
-        _ = prev.Release();
+        self.releaseResource(prev);
     }
     self.pending_staging.clearRetainingCapacity();
     self.pending_staging_bytes = 0;
@@ -366,11 +406,13 @@ fn uploadRegion(self: *Texture, x: u32, y: u32, width: u32, height: u32, data: [
         cmd_list.CopyTextureRegion(&dst_loc, x, y + band.start_row, 0, &src_loc, &src_box);
 
         // Keep the band's staging buffer alive until the GPU finishes the
-        // copy. Released together with the other bands at the start of
-        // the next replaceRegion or in deinit. On append failure we must
-        // release the just-created buffer to avoid leaking it.
+        // copy. Retired together with the other bands at the start of the
+        // next replaceRegion or in deinit. On append failure we hand it
+        // straight to the retirement queue instead of leaking it -- and
+        // not to a plain Release, because the CopyTextureRegion above
+        // already references it.
         self.pending_staging.append(std.heap.c_allocator, staging) catch {
-            _ = staging.Release();
+            self.releaseResource(staging);
             log.warn("failed to track staging buffer for chunked upload", .{});
             return error.UploadFailed;
         };
@@ -688,11 +730,30 @@ test "Texture pending_staging_bytes defaults to 0" {
 }
 
 test "Texture.Options defaults" {
-    const opts = Options{};
+    const opts = Options{ .retire = null };
     try std.testing.expect(opts.device == null);
     try std.testing.expect(opts.command_list == null);
     try std.testing.expect(opts.srv_heap == null);
     try std.testing.expectEqual(dxgi.DXGI_FORMAT.R8_UNORM, opts.pixel_format);
+}
+
+test "Texture.Options.retire has no default" {
+    // The one field that must not have one. An omitted `retire` would mean
+    // "release immediately", which is the GPU use-after-free this type
+    // exists to prevent -- and it would compile and test green while doing
+    // it. Having no default is what makes the compiler name every
+    // construction site, so it is worth a test of its own.
+    //
+    // The found flag is the anti-vacuity half: rename the field and the
+    // loop would otherwise match nothing and pass.
+    var found = false;
+    inline for (@typeInfo(Options).@"struct".fields) |field| {
+        if (comptime std.mem.eql(u8, field.name, "retire")) {
+            found = true;
+            try std.testing.expect(field.default_value_ptr == null);
+        }
+    }
+    try std.testing.expect(found);
 }
 
 test "Error set carries UploadFailed" {
@@ -765,7 +826,7 @@ test "setCommandList updates cached command list" {
 }
 
 test "Texture.Options has render_target field" {
-    const opts = Options{ .render_target = true };
+    const opts = Options{ .render_target = true, .retire = null };
     try std.testing.expect(opts.render_target);
 }
 

--- a/src/renderer/directx12/buffer.zig
+++ b/src/renderer/directx12/buffer.zig
@@ -12,6 +12,7 @@ const std = @import("std");
 
 const d3d12 = @import("d3d12.zig");
 const com = @import("com.zig");
+const Retirement = @import("retire.zig").Retirement;
 
 const log = std.log.scoped(.directx12);
 
@@ -19,6 +20,19 @@ const log = std.log.scoped(.directx12);
 /// bufferOptions() / uniformBufferOptions() / bgBufferOptions().
 pub const Options = struct {
     device: ?*d3d12.ID3D12Device = null,
+
+    /// Where the underlying resource goes when this buffer grows or is
+    /// destroyed. Null means release immediately, which is only safe when
+    /// no command list has ever referenced the buffer -- true for the
+    /// standalone buffers in the GPU unit tests, never true for a buffer
+    /// the renderer draws from. DirectX12.bufferOptions() always supplies
+    /// the device's queue.
+    ///
+    /// Deliberately without a default. Null is a real answer, but it must
+    /// be a said one: a builder that simply omitted the field would get a
+    /// bare Release back, which is the use-after-free this type exists to
+    /// prevent, and it would compile and test green while doing it.
+    retire: ?*Retirement,
 };
 
 /// Type-erased buffer handle for passing to RenderPass.Step.
@@ -179,7 +193,7 @@ pub fn Buffer(comptime T: type) type {
             const map_hr = res.Map(0, &read_range, &mapped);
             if (com.FAILED(map_hr) or mapped == null) {
                 log.err("Map for upload buffer failed: 0x{x}", .{@as(u32, @bitCast(map_hr))});
-                _ = res.Release();
+                if (self.opts.retire) |q| q.retire(res) else _ = res.Release();
                 return error.BufferMapFailed;
             }
 
@@ -193,9 +207,26 @@ pub fn Buffer(comptime T: type) type {
             };
         }
 
+        /// Give up this buffer's resource.
+        ///
+        /// The resource goes to the device's retirement queue rather than
+        /// being released here, because both callers -- a grow in `sync` /
+        /// `syncFromArrayLists`, and `deinit` -- can run while a command
+        /// list that binds this buffer as a vertex buffer is still
+        /// executing. D3D12 does not retain what a submitted command list
+        /// references, so releasing the last reference here is a GPU
+        /// use-after-free (issue #944: `ID3D12Resource::<final-release>:
+        /// CORRUPTION`, raised from inside `syncFromArrayLists` growing
+        /// the cell buffer mid-`drawFrame`).
+        ///
+        /// The mapped pointer is dropped immediately even though the
+        /// resource lives on: the upload heap stays mapped until the
+        /// resource is actually destroyed, so the pages the GPU is reading
+        /// remain valid, and nothing may write through the old pointer
+        /// once the buffer has moved on.
         fn release(self: *Self) void {
             if (self.resource) |res| {
-                _ = res.Release();
+                if (self.opts.retire) |q| q.retire(res) else _ = res.Release();
             }
             self.resource = null;
             self.mapped = null;

--- a/src/renderer/directx12/d3d12.zig
+++ b/src/renderer/directx12/d3d12.zig
@@ -855,7 +855,7 @@ pub const ID3D12CommandQueue = extern struct {
         BeginEvent: Reserved,
         EndEvent: Reserved,
         Signal: *const fn (*ID3D12CommandQueue, pFence: *ID3D12Fence, Value: u64) callconv(.winapi) HRESULT,
-        Wait: Reserved,
+        Wait: *const fn (*ID3D12CommandQueue, pFence: *ID3D12Fence, Value: u64) callconv(.winapi) HRESULT,
         GetTimestampFrequency: Reserved,
         GetClockCalibration: Reserved,
         GetDesc: Reserved,
@@ -867,6 +867,14 @@ pub const ID3D12CommandQueue = extern struct {
 
     pub inline fn Signal(self: *ID3D12CommandQueue, fence: *ID3D12Fence, value: u64) HRESULT {
         return self.vtable.Signal(self, fence, value);
+    }
+
+    /// Make the queue stall until `fence` reaches `value`. Nothing
+    /// submitted afterwards executes before then, which is how the
+    /// deferred-release test holds a frame provably in flight without
+    /// depending on how fast the GPU happens to be.
+    pub inline fn Wait(self: *ID3D12CommandQueue, fence: *ID3D12Fence, value: u64) HRESULT {
+        return self.vtable.Wait(self, fence, value);
     }
 
     pub inline fn Release(self: *ID3D12CommandQueue) u32 {
@@ -938,8 +946,15 @@ pub const ID3D12Fence = extern struct {
         // ID3D12Fence
         GetCompletedValue: *const fn (*ID3D12Fence) callconv(.winapi) u64,
         SetEventOnCompletion: *const fn (*ID3D12Fence, Value: u64, hEvent: HANDLE) callconv(.winapi) HRESULT,
-        Signal: Reserved,
+        Signal: *const fn (*ID3D12Fence, Value: u64) callconv(.winapi) HRESULT,
     };
+
+    /// CPU-side signal, as opposed to ID3D12CommandQueue::Signal which the
+    /// GPU reaches in queue order. Used to release a queue stalled on
+    /// `ID3D12CommandQueue::Wait`.
+    pub inline fn Signal(self: *ID3D12Fence, value: u64) HRESULT {
+        return self.vtable.Signal(self, value);
+    }
 
     pub inline fn GetCompletedValue(self: *ID3D12Fence) u64 {
         return self.vtable.GetCompletedValue(self);
@@ -1052,6 +1067,14 @@ pub const ID3D12Resource = extern struct {
 
     pub inline fn Release(self: *ID3D12Resource) u32 {
         return self.vtable.Release(self);
+    }
+
+    /// Take a reference. The returned count is documented by COM as being
+    /// for diagnostics only; the deferred-release test uses it that way --
+    /// comparing two readings of the same object rather than trusting an
+    /// absolute value.
+    pub inline fn AddRef(self: *ID3D12Resource) u32 {
+        return self.vtable.AddRef(self);
     }
 };
 

--- a/src/renderer/directx12/device.zig
+++ b/src/renderer/directx12/device.zig
@@ -18,6 +18,7 @@ const global = @import("../../global.zig");
 const d3d12 = @import("d3d12.zig");
 const dcomp = @import("dcomp.zig");
 const dxgi = @import("dxgi.zig");
+const Retirement = @import("retire.zig").Retirement;
 
 const GUID = com.GUID;
 const HRESULT = com.HRESULT;
@@ -36,6 +37,21 @@ command_queue: *d3d12.ID3D12CommandQueue,
 fence: *d3d12.ID3D12Fence,
 fence_value: std.atomic.Value(u64),
 fence_event: std.os.windows.HANDLE,
+
+/// Resources whose owners are done with them but which the GPU may still
+/// be reading. D3D12 does not retain what a submitted command list
+/// references, so a buffer or texture cannot be released the moment its
+/// owner drops it -- only once `fence` has reached the value its last
+/// referencing submission was signaled with. Everything that would
+/// otherwise call `Release` on a resource the renderer draws from goes
+/// through here instead.
+///
+/// Heap-allocated because `Device` is copied by value into `DirectX12`,
+/// which the generic renderer in turn passes around by value: buffers and
+/// textures capture this pointer in their options at creation time and
+/// must all reach the same queue. Same reason the descriptor heaps in
+/// DirectX12.zig are pointers.
+retirement: *Retirement,
 
 swap_chain: ?*dxgi.IDXGISwapChain1,
 
@@ -391,10 +407,18 @@ pub fn init(surface: @import("surface.zig").Surface, opts: InitOptions) !Device 
         _ = st.resource.Release();
     };
 
+    // Deferred-release queue. Backed by the C allocator because Device.init
+    // takes no allocator and the buffers/textures that retire into it also
+    // reach it from value-receiver deinits.
+    const retirement = try std.heap.c_allocator.create(Retirement);
+    errdefer std.heap.c_allocator.destroy(retirement);
+    retirement.* = .init(std.heap.c_allocator);
+
     return .{
         .device = dev,
         .command_queue = command_queue.?,
         .fence = fence.?,
+        .retirement = retirement,
         .fence_value = std.atomic.Value(u64).init(0),
         .fence_event = fence_event,
         .swap_chain = swap_chain,
@@ -408,7 +432,38 @@ pub fn init(surface: @import("surface.zig").Surface, opts: InitOptions) !Device 
 
 pub fn deinit(self: *Device) void {
     // Wait for GPU to finish before releasing anything.
-    self.waitForGpu() catch {};
+    //
+    // A failure here is not ignorable the way a swallowed `catch {}`
+    // implied: everything below this line final-releases resources the GPU
+    // may still be reading, which is the same corruption the retirement
+    // queue exists to prevent. The releases below have no alternative --
+    // they are owned here and nothing else will free them -- but the
+    // reason has to reach the log, and the device-removed reason
+    // distinguishes the benign case (the GPU is gone, so nothing is
+    // reading anything) from a live device whose fence we failed to
+    // signal. What the retirement queue holds DOES have an alternative;
+    // see below.
+    var drained = true;
+    self.waitForGpu() catch |err| {
+        drained = false;
+        const reason = self.device.GetDeviceRemovedReason();
+        log.err(
+            "waitForGpu before device teardown failed: {}, device removed reason 0x{x}; releasing GPU resources without a drain, and leaking {d} retired resource(s) rather than freeing them under a live GPU",
+            .{ err, @as(u32, @bitCast(reason)), self.retirement.count() },
+        );
+    };
+
+    // Free anything the retirement queue is still holding -- but only when
+    // the drain above actually succeeded. Device.deinit runs per surface,
+    // on every tab and split close, in a process that keeps running, so
+    // "the process is going away" is not available as a justification. On
+    // a failed wait the GPU may still be reading these, and leaking them
+    // is strictly safer than releasing them; the back-buffer and frame
+    // releases below have no such option, which is why the asymmetry is
+    // worth taking here.
+    if (drained) self.retirement.drainAll();
+    self.retirement.deinit();
+    std.heap.c_allocator.destroy(self.retirement);
 
     _ = d3d12.CloseHandle(self.fence_event);
     _ = self.fence.Release();
@@ -435,17 +490,24 @@ pub fn deinit(self: *Device) void {
 }
 
 /// Signal the fence from the command queue and block until the GPU catches up.
+///
+/// On success this is also a full drain of the retirement queue: the signal
+/// seals every resource retired since the last submission, and reaching it
+/// proves the GPU is done with all of them.
 pub fn waitForGpu(self: *Device) !void {
     const signal_value = self.fence_value.fetchAdd(1, .release) + 1;
 
     var hr = self.command_queue.Signal(self.fence, signal_value);
     if (FAILED(hr)) return error.FenceSignalFailed;
+    self.retirement.seal(signal_value);
 
     if (self.fence.GetCompletedValue() < signal_value) {
         hr = self.fence.SetEventOnCompletion(signal_value, self.fence_event);
         if (FAILED(hr)) return error.FenceSetEventFailed;
         _ = d3d12.WaitForSingleObject(self.fence_event, d3d12.INFINITE);
     }
+
+    self.retirement.collect(self.fence.GetCompletedValue());
 }
 
 /// Recreate the shared texture resource and its NT handle at a new

--- a/src/renderer/directx12/gpu_test.zig
+++ b/src/renderer/directx12/gpu_test.zig
@@ -472,7 +472,7 @@ test "Buffer: create, sync, deinit" {
     defer dev.deinit();
 
     const TestFloat = Buffer(f32);
-    var buf = try TestFloat.init(.{ .device = dev.device }, 64);
+    var buf = try TestFloat.init(.{ .device = dev.device, .retire = null }, 64);
     defer buf.deinit();
 
     try std.testing.expect(buf.resource != null);
@@ -491,7 +491,7 @@ test "Buffer: sync triggers realloc when data exceeds capacity" {
     defer dev.deinit();
 
     const TestU32 = Buffer(u32);
-    var buf = try TestU32.init(.{ .device = dev.device }, 4);
+    var buf = try TestU32.init(.{ .device = dev.device, .retire = null }, 4);
     defer buf.deinit();
 
     // Sync data that exceeds capacity -- should realloc at 2x.
@@ -508,7 +508,7 @@ test "Buffer: syncFromArrayLists concatenates correctly" {
     defer dev.deinit();
 
     const TestU32 = Buffer(u32);
-    var buf = try TestU32.init(.{ .device = dev.device }, 64);
+    var buf = try TestU32.init(.{ .device = dev.device, .retire = null }, 64);
     defer buf.deinit();
 
     var list1 = std.ArrayListUnmanaged(u32).empty;
@@ -528,7 +528,7 @@ test "Buffer: persistent mapping allows direct writes" {
     defer dev.deinit();
 
     const TestF32 = Buffer(f32);
-    var buf = try TestF32.init(.{ .device = dev.device }, 16);
+    var buf = try TestF32.init(.{ .device = dev.device, .retire = null }, 16);
     defer buf.deinit();
 
     // DX12 buffers are persistently mapped -- write directly.
@@ -550,11 +550,205 @@ test "Buffer: constant buffer (Uniforms)" {
 
     const Uniforms = extern struct { x: f32, y: f32, z: f32, w: f32 };
     const TestCB = Buffer(Uniforms);
-    var buf = try TestCB.init(.{ .device = dev.device }, 1);
+    var buf = try TestCB.init(.{ .device = dev.device, .retire = null }, 1);
     defer buf.deinit();
 
     try buf.sync(&.{Uniforms{ .x = 1.0, .y = 2.0, .z = 3.0, .w = 4.0 }});
     try std.testing.expectEqual(@as(u32, @sizeOf(Uniforms)), buf.buffer.stride);
+}
+
+// ---- Deferred release regression (issue #944) ----
+
+// Growing a cell buffer must not final-release the old resource while a
+// submission that reads it is still in flight.
+//
+// This is the crash in issue #944: `drawFrame` syncs the cell buffers at
+// a point where the only DX12 GPU drain -- the per-slot fence wait in
+// `beginFrame` -- has not happened yet, so `syncFromArrayLists` grew the
+// buffer and released a resource the previous frame's command list was
+// still reading. The debug layer answers that with
+// `ID3D12Resource::<final-release>: CORRUPTION`, raised as a native SEH
+// that kills the process with exit code 2173 and writes no crash.log.
+//
+// Determinism comes from `ID3D12CommandQueue::Wait`: the queue is parked
+// on a gate fence this test alone signals, so the submission that reads
+// the buffer provably cannot retire while the grow happens -- no
+// dependence on how fast the GPU is.
+//
+// The buffer is built from `DirectX12.bufferOptions()` rather than a
+// hand-written Options literal on purpose. That is the seam the fix
+// changes; a literal here would keep passing whether or not production
+// buffers are wired to the retirement queue.
+test "Buffer: a grow does not final-release a resource the GPU still reads" {
+    if (comptime builtin.os.tag != .windows) return;
+
+    const DirectX12 = @import("../DirectX12.zig");
+
+    // Shared-texture mode: a real device and command queue with no window
+    // or swap chain, so this runs headless.
+    var api: DirectX12 = .{ .allocator = std.testing.allocator };
+    // Skip loudly, never silently. This is the one test standing between
+    // the tree and a silent memory-corruption regression, so a box with no
+    // D3D12 adapter must show up in the run's skip count rather than
+    // reporting a pass it never earned.
+    api.dev = Device.init(.{ .shared_texture = .{
+        .width = 64,
+        .height = 64,
+    } }, .{}) catch return error.SkipZigTest;
+    defer api.dev.?.deinit();
+    const dev = &api.dev.?;
+
+    // A cell buffer through the production options path.
+    const CellBuffer = buffer_mod.Buffer(u32);
+    var buf = try CellBuffer.init(api.bufferOptions(), 4);
+    defer buf.deinit();
+    const old_resource = buf.resource orelse return error.BufferResourceMissing;
+
+    // Somewhere for the in-flight submission to copy the buffer into, so
+    // the command list genuinely references it.
+    var sink: ?*d3d12.ID3D12Resource = null;
+    {
+        const heap_props = d3d12.D3D12_HEAP_PROPERTIES{
+            .Type = .READBACK,
+            .CPUPageProperty = 0,
+            .MemoryPoolPreference = 0,
+            .CreationNodeMask = 0,
+            .VisibleNodeMask = 0,
+        };
+        const desc = d3d12.D3D12_RESOURCE_DESC{
+            .Dimension = .BUFFER,
+            .Alignment = 0,
+            .Width = 4 * @sizeOf(u32),
+            .Height = 1,
+            .DepthOrArraySize = 1,
+            .MipLevels = 1,
+            .Format = .UNKNOWN,
+            .SampleDesc = .{ .Count = 1, .Quality = 0 },
+            .Layout = .ROW_MAJOR,
+            .Flags = .NONE,
+        };
+        const hr = dev.device.CreateCommittedResource(
+            &heap_props,
+            0,
+            &desc,
+            d3d12.D3D12_RESOURCE_STATES.COPY_DEST,
+            null,
+            &d3d12.ID3D12Resource.IID,
+            @ptrCast(&sink),
+        );
+        if (com.FAILED(hr) or sink == null) return error.SinkCreationFailed;
+    }
+    defer _ = sink.?.Release();
+
+    var cmd_allocator: ?*d3d12.ID3D12CommandAllocator = null;
+    {
+        const hr = dev.device.CreateCommandAllocator(
+            .DIRECT,
+            &d3d12.ID3D12CommandAllocator.IID,
+            @ptrCast(&cmd_allocator),
+        );
+        if (com.FAILED(hr) or cmd_allocator == null) return error.CommandAllocatorCreationFailed;
+    }
+    defer _ = cmd_allocator.?.Release();
+
+    var command_list: ?*d3d12.ID3D12GraphicsCommandList = null;
+    {
+        const hr = dev.device.CreateCommandList(
+            0,
+            .DIRECT,
+            cmd_allocator.?,
+            null,
+            &d3d12.ID3D12GraphicsCommandList.IID,
+            @ptrCast(&command_list),
+        );
+        if (com.FAILED(hr) or command_list == null) return error.CommandListCreationFailed;
+    }
+    defer _ = command_list.?.Release();
+
+    // The gate. The queue blocks on it until this test signals it from the
+    // CPU, which is what makes "still in flight" a fact rather than a race.
+    var gate: ?*d3d12.ID3D12Fence = null;
+    {
+        const hr = dev.device.CreateFence(0, .NONE, &d3d12.ID3D12Fence.IID, @ptrCast(&gate));
+        if (com.FAILED(hr) or gate == null) return error.FenceCreationFailed;
+    }
+    defer _ = gate.?.Release();
+
+    // Record a read of the buffer. UPLOAD-heap buffers live in
+    // GENERIC_READ, which already includes COPY_SOURCE, so no barrier.
+    command_list.?.CopyBufferRegion(sink.?, 0, old_resource, 0, 4 * @sizeOf(u32));
+    if (com.FAILED(command_list.?.Close())) return error.CommandListCloseFailed;
+
+    // Park the queue, then submit. Nothing executes until the gate opens.
+    if (com.FAILED(dev.command_queue.Wait(gate.?, 1))) return error.QueueWaitFailed;
+    // Every exit from here on must open the gate AND drain before the
+    // defers unwind. Opening alone fixes the hang and buys a worse
+    // failure: the defers below release the command allocator, the command
+    // list and the sink LIFO, and the copy they belong to has just been
+    // let go, so a failing assertion would final-release resources the GPU
+    // is executing -- the exact CORRUPTION break this test is about, which
+    // kills the process with 2173 and reports nothing. Draining first
+    // means a red assertion stays a red assertion.
+    errdefer {
+        _ = gate.?.Signal(1);
+        dev.waitForGpu() catch {};
+    }
+    const lists = [_]*d3d12.ID3D12GraphicsCommandList{command_list.?};
+    dev.command_queue.ExecuteCommandLists(1, &lists);
+
+    // Signal the device fence the way drawFrameEnd does. Nothing is staged
+    // yet, so this seal is a no-op on the queue -- what it establishes is
+    // the fence value the grow below will be sealed against, and that the
+    // ordering matches production rather than being contrived here.
+    const work_value = dev.fence_value.fetchAdd(1, .release) + 1;
+    if (com.FAILED(dev.command_queue.Signal(dev.fence, work_value))) return error.FenceSignalFailed;
+    dev.retirement.seal(work_value);
+
+    // The submission is provably unretired.
+    try std.testing.expect(dev.fence.GetCompletedValue() < work_value);
+
+    // Hold our own reference so the resource survives for measurement even
+    // if the grow drops the buffer's. Reference counts are diagnostics
+    // only per COM, so the assertion compares two readings of the same
+    // object rather than trusting an absolute number.
+    _ = old_resource.AddRef();
+    const before = old_resource.AddRef();
+    _ = old_resource.Release();
+
+    // The bug: grow the buffer while that submission is in flight. This is
+    // exactly generic.zig's `frame.cells.syncFromArrayLists(...)` at the
+    // point where DX12 has not drained anything yet.
+    var big: [64]u32 = undefined;
+    for (&big, 0..) |*v, i| v.* = @intCast(i);
+    try buf.sync(&big);
+    try std.testing.expect(buf.resource != old_resource);
+
+    const after = old_resource.AddRef();
+    _ = old_resource.Release();
+
+    // Unfixed, `after` is one lower, and the reason matters: it is the
+    // BUFFER'S OWN reference that release() dropped. D3D12 holds no
+    // reference on a resource a command list merely references -- that is
+    // the whole premise of this bug, so "the reference D3D12 held" would
+    // be exactly backwards. Fixed, release() hands the resource to the
+    // retirement queue instead, which keeps that reference until the
+    // fence proves the copy done, so the two readings match.
+    //
+    // What the gate above buys is the PRECONDITION, not this count: it is
+    // what makes the assertion at the fence check true every run, so the
+    // grow provably happens while the copy is in flight rather than
+    // whenever the GPU is slow enough.
+    try std.testing.expectEqual(before, after);
+
+    // Open the gate and let everything retire, then verify the queue
+    // actually hands the resource back once the fence proves it safe.
+    if (com.FAILED(gate.?.Signal(1))) return error.GateSignalFailed;
+    dev.waitForGpu() catch return error.WaitForGpuFailed;
+    try std.testing.expectEqual(@as(usize, 0), dev.retirement.count());
+
+    // Drop the reference we took; the retirement queue already dropped
+    // the buffer's, so this is the last one.
+    _ = old_resource.Release();
 }
 
 test "Buffer: initFill creates buffer with data" {
@@ -563,7 +757,7 @@ test "Buffer: initFill creates buffer with data" {
 
     const TestU8 = Buffer(u8);
     const data = [_]u8{ 0xAA, 0xBB, 0xCC, 0xDD };
-    var buf = try TestU8.initFill(.{ .device = dev.device }, &data);
+    var buf = try TestU8.initFill(.{ .device = dev.device, .retire = null }, &data);
     defer buf.deinit();
 
     try std.testing.expectEqual(@as(usize, 4), buf.len);
@@ -592,6 +786,9 @@ test "Texture: create R8_UNORM with initial data" {
         .device = dev.device,
         .command_list = dev.command_list,
         .srv_heap = &srv_heap,
+        // Every submitted copy is drained by executeAndWait before this
+        // texture is destroyed, so an immediate release is safe here.
+        .retire = null,
         .pixel_format = .R8_UNORM,
     }, 4, 4, &data) catch return;
     defer tex.deinit();
@@ -623,6 +820,9 @@ test "Texture: create B8G8R8A8_UNORM without initial data" {
         .device = dev.device,
         .command_list = dev.command_list,
         .srv_heap = &srv_heap,
+        // Every submitted copy is drained by executeAndWait before this
+        // texture is destroyed, so an immediate release is safe here.
+        .retire = null,
         .pixel_format = .B8G8R8A8_UNORM,
     }, 8, 8, null) catch return;
     defer tex.deinit();
@@ -648,6 +848,9 @@ test "Texture: replaceRegion updates sub-region" {
         .device = dev.device,
         .command_list = dev.command_list,
         .srv_heap = &srv_heap,
+        // Every submitted copy is drained by executeAndWait before this
+        // texture is destroyed, so an immediate release is safe here.
+        .retire = null,
         .pixel_format = .B8G8R8A8_UNORM,
     }, 8, 8, null) catch return;
     defer tex.deinit();
@@ -1194,6 +1397,9 @@ test "post pipeline: scanline shader leaves row periodicity" {
         .device = dev,
         .command_list = command_list,
         .srv_heap = &srv_heap,
+        // Drained by the explicit fence waits this test already makes
+        // before teardown.
+        .retire = null,
         .rtv_heap = &rtv_heap,
         .pixel_format = .B8G8R8A8_UNORM,
         .render_target = true,
@@ -1214,7 +1420,10 @@ test "post pipeline: scanline shader leaves row periodicity" {
     var uniforms = std.mem.zeroes(shadertoy.Uniforms);
     uniforms.resolution = .{ @floatFromInt(W), @floatFromInt(H), 1.0 };
     uniforms.time = 0.25;
-    var ubuf = try buffer_mod.Buffer(shadertoy.Uniforms).init(.{ .device = dev }, 1);
+    // No retirement queue: this buffer is synced and read on the CPU side
+    // only, so nothing the GPU has in flight can reference it.
+    var ubuf = try buffer_mod.Buffer(shadertoy.Uniforms)
+        .init(.{ .device = dev, .retire = null }, 1);
     defer ubuf.deinit();
     try ubuf.sync(&.{uniforms});
 
@@ -1431,4 +1640,22 @@ test "post pipeline: scanline shader leaves row periodicity" {
     // row-to-row differences and roughly a third of rows dark.
     try std.testing.expect(max_diff > 10.0);
     try std.testing.expect(dark_rows > H / 8);
+}
+
+test "buffer.Options.retire has no default" {
+    // The buffer half of the same rule Texture.zig pins. A builder that
+    // omitted `retire` would get a bare Release on grow, which is the
+    // crash this fix is for, and nothing would fail. Having no default is
+    // what turns that into a compile error at every construction site.
+    //
+    // The found flag keeps the loop from passing vacuously if the field is
+    // ever renamed.
+    var found = false;
+    inline for (@typeInfo(buffer_mod.Options).@"struct".fields) |field| {
+        if (comptime std.mem.eql(u8, field.name, "retire")) {
+            found = true;
+            try std.testing.expect(field.default_value_ptr == null);
+        }
+    }
+    try std.testing.expect(found);
 }

--- a/src/renderer/directx12/retire.zig
+++ b/src/renderer/directx12/retire.zig
@@ -1,0 +1,320 @@
+//! Deferred release of D3D12 resources that the GPU may still be reading.
+//!
+//! D3D12, unlike Metal, does not retain the resources a command list
+//! references. Once `ExecuteCommandLists` has been called, every resource
+//! bound or copied by that list must stay alive until the fence value the
+//! submission was signaled with has been reached. Calling the final
+//! `Release` before then is a GPU use-after-free: the debug layer reports
+//! it as
+//!
+//!     ID3D12Resource::<final-release>: CORRUPTION: ... is referenced by
+//!     GPU operations in-flight on Command Queue ...
+//!
+//! and raises a native SEH from `D3D12SDKLayers!NDebug::ReportCorruption`,
+//! which no managed handler catches. In Release builds the same release is
+//! silent and the GPU reads freed memory.
+//!
+//! `Retirement` is the queue that makes those releases safe. Instead of
+//! releasing, an owner *retires* its resource here. Retirements accumulate
+//! in `staged` until the next queue submission seals them against that
+//! submission's fence value; `collect` then releases everything whose fence
+//! value the GPU has reached.
+//!
+//! Sealing at submission time rather than tagging at retire time is what
+//! makes this conservative by construction: whatever is staged when a
+//! submission is signaled can only have been referenced by work at or
+//! before that submission, so that one fence value covers it. A retirement
+//! that happens while a command list is open is sealed by that same list's
+//! own signal, which is exactly when its recorded reads finish.
+//!
+//! NOT single-threaded, and the reason it is safe is one layer up. Zig's
+//! `drawFrame` runs on the renderer thread AND on the WinUI UI thread --
+//! `Surface.draw` is explicitly required to support the latter, which is
+//! how `RequestRepaint` gets a frame out. What serialises every call into
+//! this queue is `Renderer.draw_mutex`, held for the whole body of
+//! `drawFrame` and by the other GPU-touching entry points (changeConfig,
+//! setScreenSize, displayRealized/Unrealized). Teardown is covered
+//! separately: the renderer thread is joined before `renderer.deinit()`.
+//!
+//! So do not add a `retire()` call from a path that does not hold that
+//! mutex -- `setTargetSize` runs on the apprt thread, for instance.
+//! `staged` is a plain ArrayListUnmanaged: two threads appending races
+//! `items.len`, which loses a resource or double-releases one, and the
+//! second is a GPU use-after-free that is silent in Release.
+//!
+//! One more coupling worth stating: `collect` trusts
+//! `ID3D12Fence::GetCompletedValue`, so this device's fence must stay
+//! producer-signalled -- only this queue advances it. In shared-texture
+//! mode the fence is created SHARED and handed out through
+//! `ghostty_surface_shared_texture`; no consumer signals it today, and if
+//! one ever did, the value would jump past work still in flight and
+//! `collect` would free resources the GPU is reading.
+const std = @import("std");
+
+const com = @import("com.zig");
+const d3d12 = @import("d3d12.zig");
+
+const log = std.log.scoped(.directx12);
+
+pub const Retirement = struct {
+    const Self = @This();
+
+    /// Backed by the C allocator so retiring stays callable from the
+    /// value-receiver `deinit` signatures that Buffer and Texture share
+    /// with the Metal/OpenGL backends (same reason Texture.pending_staging
+    /// uses it).
+    alloc: std.mem.Allocator = std.heap.c_allocator,
+
+    /// Retired since the last `seal`. These have no fence value yet
+    /// because the submission that will cover them has not happened.
+    staged: std.ArrayListUnmanaged(*d3d12.ID3D12Resource) = .empty,
+
+    /// Sealed retirements, each paired with the fence value that must be
+    /// reached before it is safe to release. Kept in insertion order,
+    /// which is also fence order, so `collect` can stop at the first
+    /// entry the GPU has not reached.
+    pending: std.ArrayListUnmanaged(Entry) = .empty,
+
+    pub const Entry = struct {
+        resource: *d3d12.ID3D12Resource,
+        fence_value: u64,
+    };
+
+    /// How many entries to reserve up front. A frame retires at most a
+    /// handful of resources (buffer grows are 2x, so logarithmic; image
+    /// vertex buffers are per-placement), and growing is cheap, so this
+    /// only exists to keep the steady state allocation-free.
+    const initial_capacity: usize = 32;
+
+    pub fn init(alloc: std.mem.Allocator) Self {
+        var self = Self{ .alloc = alloc };
+        self.staged.ensureTotalCapacity(alloc, initial_capacity) catch {};
+        self.pending.ensureTotalCapacity(alloc, initial_capacity) catch {};
+        return self;
+    }
+
+    /// Hand a resource over to the queue. The caller must consider its
+    /// reference given away -- it must not release or use the resource
+    /// afterwards.
+    ///
+    /// On allocation failure the reference is intentionally leaked rather
+    /// than released: leaking costs memory, releasing early corrupts the
+    /// GPU. The next `collect` cannot see it, so it is leaked for the
+    /// process lifetime.
+    pub fn retire(self: *Self, resource: *d3d12.ID3D12Resource) void {
+        self.staged.append(self.alloc, resource) catch {
+            log.err("deferred-release queue is out of memory; leaking a GPU resource rather than freeing one the GPU may still read", .{});
+        };
+    }
+
+    /// Bind everything staged so far to `fence_value`. Call immediately
+    /// after the command queue has been signaled with that value: work
+    /// referencing any staged resource was submitted at or before the
+    /// signal, so reaching it proves those reads are done.
+    pub fn seal(self: *Self, fence_value: u64) void {
+        if (self.staged.items.len == 0) return;
+        for (self.staged.items) |resource| {
+            self.pending.append(self.alloc, .{
+                .resource = resource,
+                .fence_value = fence_value,
+            }) catch {
+                log.err("deferred-release queue is out of memory; leaking a GPU resource rather than freeing one the GPU may still read", .{});
+            };
+        }
+        self.staged.clearRetainingCapacity();
+    }
+
+    /// Release every sealed retirement the GPU has reached. `completed` is
+    /// `ID3D12Fence::GetCompletedValue()`.
+    pub fn collect(self: *Self, completed: u64) void {
+        var released: usize = 0;
+        for (self.pending.items) |entry| {
+            if (entry.fence_value > completed) break;
+            _ = entry.resource.Release();
+            released += 1;
+        }
+        if (released == 0) return;
+        const remaining = self.pending.items.len - released;
+        std.mem.copyForwards(
+            Entry,
+            self.pending.items[0..remaining],
+            self.pending.items[released..],
+        );
+        self.pending.shrinkRetainingCapacity(remaining);
+    }
+
+    /// Release everything, sealed or not. Only valid once the GPU is known
+    /// to be idle -- i.e. straight after a successful full drain.
+    pub fn drainAll(self: *Self) void {
+        for (self.pending.items) |entry| _ = entry.resource.Release();
+        self.pending.clearRetainingCapacity();
+        for (self.staged.items) |resource| _ = resource.Release();
+        self.staged.clearRetainingCapacity();
+    }
+
+    /// Number of resources the queue is still holding, staged or sealed.
+    pub fn count(self: *const Self) usize {
+        return self.staged.items.len + self.pending.items.len;
+    }
+
+    /// Frees the queue's own memory. Any resource still held is leaked, so
+    /// callers must `drainAll` after a GPU drain first.
+    pub fn deinit(self: *Self) void {
+        if (self.count() != 0) {
+            log.warn(
+                "deferred-release queue deinited with {d} resource(s) still held",
+                .{self.count()},
+            );
+        }
+        self.staged.deinit(self.alloc);
+        self.pending.deinit(self.alloc);
+        self.* = undefined;
+    }
+};
+
+// --- Tests ---
+//
+// The bookkeeping is exercised here without a GPU by pointing the entries
+// at stand-in COM objects whose Release only decrements a counter. Nothing
+// here reaches D3D12; the GPU-side half of the fix is covered by the
+// deferred-release test in gpu_test.zig.
+
+var test_live: usize = 0;
+
+fn testRelease(_: *d3d12.ID3D12Resource) callconv(.winapi) u32 {
+    test_live -= 1;
+    return @intCast(test_live);
+}
+
+fn testUnused() callconv(.winapi) void {
+    unreachable;
+}
+
+fn testQueryInterface(
+    _: *d3d12.ID3D12Resource,
+    _: *const com.GUID,
+    _: *?*anyopaque,
+) callconv(.winapi) com.HRESULT {
+    unreachable;
+}
+
+fn testAddRef(_: *d3d12.ID3D12Resource) callconv(.winapi) u32 {
+    unreachable;
+}
+
+fn testMap(
+    _: *d3d12.ID3D12Resource,
+    _: u32,
+    _: ?*const d3d12.D3D12_RANGE,
+    _: *?*anyopaque,
+) callconv(.winapi) com.HRESULT {
+    unreachable;
+}
+
+fn testUnmap(_: *d3d12.ID3D12Resource, _: u32, _: ?*const d3d12.D3D12_RANGE) callconv(.winapi) void {
+    unreachable;
+}
+
+fn testGpuAddress(_: *d3d12.ID3D12Resource) callconv(.winapi) u64 {
+    unreachable;
+}
+
+const test_vtable: d3d12.ID3D12Resource.VTable = .{
+    .QueryInterface = &testQueryInterface,
+    .AddRef = &testAddRef,
+    .Release = &testRelease,
+    .GetPrivateData = &testUnused,
+    .SetPrivateData = &testUnused,
+    .SetPrivateDataInterface = &testUnused,
+    .SetName = &testUnused,
+    .GetDevice = &testUnused,
+    .Map = &testMap,
+    .Unmap = &testUnmap,
+    .GetDesc = &testUnused,
+    .GetGPUVirtualAddress = &testGpuAddress,
+    .WriteToSubresource = &testUnused,
+    .ReadFromSubresource = &testUnused,
+    .GetHeapProperties = &testUnused,
+};
+
+/// `n` stand-in resources, each a bare vtable pointer whose Release only
+/// decrements `test_live`.
+fn fakeResources(comptime n: usize) [n]d3d12.ID3D12Resource {
+    return [_]d3d12.ID3D12Resource{.{ .vtable = &test_vtable }} ** n;
+}
+
+test "Retirement: a retire alone releases nothing" {
+    var q = Retirement.init(std.testing.allocator);
+    defer q.deinit();
+    defer q.drainAll();
+
+    var res = fakeResources(1);
+    test_live = 1;
+    q.retire(&res[0]);
+
+    // Not sealed, so not even a fully-completed fence can free it: the
+    // submission that will reference it has not happened yet.
+    q.collect(std.math.maxInt(u64));
+    try std.testing.expectEqual(@as(usize, 1), test_live);
+    try std.testing.expectEqual(@as(usize, 1), q.count());
+}
+
+test "Retirement: collect frees only what the fence has reached" {
+    var q = Retirement.init(std.testing.allocator);
+    defer q.deinit();
+    defer q.drainAll();
+
+    var res = fakeResources(2);
+    test_live = 2;
+
+    q.retire(&res[0]);
+    q.seal(5);
+    q.retire(&res[1]);
+    q.seal(9);
+    try std.testing.expectEqual(@as(usize, 2), q.count());
+
+    // The GPU has not reached either value.
+    q.collect(4);
+    try std.testing.expectEqual(@as(usize, 2), test_live);
+
+    // Reaching 5 frees the first and only the first.
+    q.collect(5);
+    try std.testing.expectEqual(@as(usize, 1), test_live);
+    try std.testing.expectEqual(@as(usize, 1), q.count());
+
+    q.collect(9);
+    try std.testing.expectEqual(@as(usize, 0), test_live);
+    try std.testing.expectEqual(@as(usize, 0), q.count());
+}
+
+test "Retirement: seal covers everything staged since the last seal" {
+    var q = Retirement.init(std.testing.allocator);
+    defer q.deinit();
+    defer q.drainAll();
+
+    var res = fakeResources(3);
+    test_live = 3;
+
+    for (&res) |*r| q.retire(r);
+    q.seal(7);
+    q.collect(6);
+    try std.testing.expectEqual(@as(usize, 3), test_live);
+    q.collect(7);
+    try std.testing.expectEqual(@as(usize, 0), test_live);
+}
+
+test "Retirement: drainAll frees staged and sealed alike" {
+    var q = Retirement.init(std.testing.allocator);
+    defer q.deinit();
+
+    var res = fakeResources(2);
+    test_live = 2;
+
+    q.retire(&res[0]);
+    q.seal(11);
+    q.retire(&res[1]);
+
+    q.drainAll();
+    try std.testing.expectEqual(@as(usize, 0), test_live);
+    try std.testing.expectEqual(@as(usize, 0), q.count());
+}

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -391,7 +391,9 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             /// its slot in this list. Buffers outlive the GPU command
             /// list because DX12 IASetVertexBuffers does not retain the
             /// underlying resource. Recycled when this frame slot is
-            /// reused, after frame_sema confirms the GPU is done.
+            /// reused; the backend, not frame_sema, decides when the
+            /// underlying GPU resource is actually freed (see
+            /// recycleImageBuffers).
             image_instance_buffers: std.ArrayListUnmanaged(ImageBuffer) = .empty,
 
             const UniformBuffer = Buffer(shaderpkg.Uniforms);
@@ -483,10 +485,19 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 if (self.custom_shader_state) |*state| state.deinit();
             }
 
-            /// Drain all per-placement image vertex buffers from the
-            /// previous use of this frame slot. Safe to call only after
-            /// frame_sema has released this slot -- that signals the GPU
-            /// has finished reading them.
+            /// Drop all per-placement image vertex buffers from the
+            /// previous use of this frame slot.
+            ///
+            /// This does NOT mean the GPU is finished with them.
+            /// frame_sema only says the CPU may reuse this frame slot's
+            /// state; on Metal that coincides with GPU completion because
+            /// the completion handler posts it, but on DX12 the semaphore
+            /// is posted from `drawFrameEnd` after the fence *signal*,
+            /// i.e. after submission, not after execution. Deciding when
+            /// the GPU resource can really be freed is the backend's job:
+            /// Metal retains what a command buffer references, and DX12
+            /// routes `Buffer.deinit` through the device's deferred-release
+            /// queue (issue #944).
             pub fn recycleImageBuffers(self: *FrameState) void {
                 for (self.image_instance_buffers.items) |*b| b.deinit();
                 self.image_instance_buffers.clearRetainingCapacity();
@@ -1828,10 +1839,14 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             errdefer self.swap_chain.releaseFrame();
             // log.debug("drawing frame index={}", .{self.swap_chain.frame_index});
 
-            // `nextFrame` has waited on frame_sema, so the GPU is no
-            // longer reading last frame's image vertex buffers. Recycle
-            // them now, before any new draw calls in this frame can
-            // append fresh ones.
+            // `nextFrame` has waited on frame_sema, so this frame slot's
+            // state is ours again and last frame's image vertex buffers
+            // can be dropped before any new draw calls append fresh ones.
+            //
+            // frame_sema does not say the GPU has finished reading them --
+            // on DX12 it is posted after the fence signal rather than
+            // after completion. The backend's Buffer.deinit is what keeps
+            // the resources alive until the fence proves otherwise.
             frame.recycleImageBuffers();
 
             // If we need to reinitialize our shaders, do so.


### PR DESCRIPTION
Closes #944.

A Debug build died with exit **2173** while surfaces were torn down. That is `0x87D`, the D3D12 debug layer's own break code, raised through `RaiseException` — so no managed handler runs and **`crash.log` is never written**, and to a seam driver it reads as `PRODUCT_EXIT (code 2173)`, which blames the wrong thing entirely.

The dumps name the site, and it is not teardown. It is mid-draw:

```
drawFrame -> frame.cells.syncFromArrayLists -> Buffer(CellText).release() -> ID3D12Resource::Release
```

## The mechanism

The buffer syncs run at `generic.zig:1898`; `api.beginFrame` runs at `:1913`. `beginFrame`'s per-slot fence wait is the only thing on DX12 that proves the GPU finished that slot's previous submission — so a grow (`release()` then `allocate()`) frees the old resource **up to three frames early** (`swap_chain_count = 3`). Metal retains resources a command buffer references; D3D12 does not. Fatal under the debug layer, silent in Release, which is worse.

`frame_sema` does not cover it: `drawFrameEnd` posts `frameCompleted` after the fence **Signal** — after submission, not completion — so on DX12 the semaphore means "the work is queued". Three comments said it means the GPU is done. That is true on Metal, whose completion handler fires after the GPU finishes, and those comments are what made this look safe on inspection. They are corrected here.

## Not a regression

`git log -L` dates the three sites: release-on-grow to #119 (2026-04-03), the Signal-time `frameCompleted` to #315 (2026-04-23), the sync/`beginFrame` ordering to #371 (2026-05-15). Nothing since. What is new is the **load** — the test seam landed 2026-08-31 and began driving multi-surface churn on Debug builds; the first `0x87d` in the event log is 2026-09-01, across five different builds in two repos.

## The fix

A `Retirement` queue on the device. An owner hands a resource over instead of releasing it; `seal()` binds everything staged to the value the queue was just signalled with, and `collect()` frees the prefix the GPU has reached. `beginFrame` collects after its per-slot wait; `drawFrameEnd` seals after a successful `Signal`.

The tags are **global fence values, not per-slot**. The generic frame index and the DX12 back-buffer index do not agree — `presentLastTarget` advances the back buffer without taking a generic frame — so a per-slot tag would have quietly rested on them agreeing.

Two more places lean on the same false invariant and go with it: `recycleImageBuffers` deinits image buffers on it, and `Texture.replaceRegion`'s staging release. `Device.deinit`'s `waitForGpu() catch {}` released anyway when its own barrier failed; it now logs the error and the device-removed reason, the one benign case.

`Options.retire` carries **no default**. Null is a real answer — a standalone test buffer no command list ever references — but it has to be a said one: a builder that omitted the field would get a bare `Release` back, compiling and testing green while reinstating this exact bug. Removing the default is what makes the compiler name every construction site, and a test in each of `Texture.Options` and `buffer.Options` pins that the field has no `default_value_ptr`.

## Verified

- **The test holds the failure open rather than racing it.** `ID3D12CommandQueue::Wait` on a gate fence only the test signals means the submission reading the buffer provably cannot retire while the grow happens — so a release-on-grow is caught every time, not whenever the GPU is slow. It compares two `AddRef` readings of the same object rather than an absolute count, and never final-releases while the queue is gated, so it fails as an assertion rather than as a debug-layer SEH.
- **Red under mutation:** reverting `release()` to a bare `_ = res.Release()` takes it red — the reading drops by one, and that one is the buffer's *own* reference. D3D12 holds none on a resource a command list merely references; that is the premise of the bug. The fix is what hands that reference to the retirement queue instead of dropping it. Applied and reverted inside one queue slot.
- `just signoff` PASS: `zig-fmt` and the unfiltered `zig-tests`.

The three vtable additions in `d3d12.zig` (`ID3D12CommandQueue::Wait`, `ID3D12Fence::Signal`, `ID3D12Resource::AddRef`) each replace a `Reserved` placeholder **in place**, so no slot offset moves.

## What is NOT verified

- **Nobody has watched 2173 fail to happen.** The fix is proven by a deterministic unit test of the mechanism, not by a live GUI session under the debug layer reproducing the original crash and not crashing. That confirmation is still owed.
- A filtered `zig build test` run is not evidence here: Zig only semantically analyses test blocks matching `-Dtest-filter`, so two compile errors in unmatched tests survived a `79 pass` filtered run during development. Only the unfiltered leg counts.

## Deliberately not fixed

- **The generic frame index and the DX12 back-buffer index drift** (`presentLastTarget` presents without taking a generic frame). Real, and it is *why* the tags are global rather than per-slot — but making the indices agree is a separate change and wants its own issue.
- **`pending_staging_bytes` under-counts** by up to a few frames of staging, since it resets when staging buffers are retired rather than released. A trade-off of deferring, not a regression in kind.
- `Pipeline`/root-signature releases, back buffers and `recreateSharedTexture` all already sit behind a real `waitForGpu`. Checked, correct as-is.

## Review round

Independently reviewed by a second agent (not the one that wrote it). **No blockers**; four important findings and several minor, all applied:

- **`retire.zig` claimed to be single-threaded, and is not.** `drawFrame` runs on the renderer thread *and* the WinUI UI thread (`Surface.draw` is required to support the latter). What actually serialises the queue is `Renderer.draw_mutex`, one layer up. The header now says so and names the off-mutex paths to avoid, because the old comment invited a future `retire()` from a racing thread — and a racing `staged.append` double-releases, which is silent in Release.
- **The regression test reported PASS when it never ran.** `Device.init(...) catch return` meant any box without a D3D12 adapter silently skipped the one guard standing between this tree and a memory-corruption regression. Now `error.SkipZigTest`, so it lands in the run's skip count.
- **The test's `errdefer` opened the queue gate without draining**, so a failing assertion released a command allocator and sink mid-copy — the same CORRUPTION break this PR is about, killing the process with 2173 instead of reporting. It now signals *and* waits.
- **`Device.deinit` drained the retirement queue even after a failed `waitForGpu`**, justified by "the process is going away". It is not: `Device.deinit` runs per surface on every tab and split close. It now leaks those resources deliberately when the drain failed — strictly safer than freeing under a live GPU — and logs how many.

The review also confirmed, independently: the queue is per-`Device` and not shared across surfaces (`Device.init` creates a fresh queue and fence per call; only the `ID3D12Device` COM object is the adapter singleton), the seal/collect ordering is sound across frames, teardown, resize, device-loss and first-frame paths, all 100+ remaining `.Release()` sites in the DX12 tree are already behind a real drain, and the `Options.retire` sweep is complete.

### Found, not fixed here

`CustomShaderState.resize` reuses `front_srv_slot`/`back_srv_slot` in the **shader-visible** descriptor heap, and runs at `generic.zig:1899` — before `beginFrame`'s per-slot fence wait at `:1928`. So a descriptor is overwritten while the previous submission may still sample through it. Verified by reading the code, not taken on report. The retirement queue means this is no longer a use-after-free, but that frame samples the wrong texture. Descriptor lifetime is a different mechanism from resource lifetime, so it wants its own change; the comment that used to imply this was covered has been corrected rather than left to mislead.
