### PR TITLE
seam: a failing op names what threw, and the acceptance run reaches its scenario

### DIFF
--- a/windows/Ghostty.Tests/Wiring/TestSeamWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TestSeamWiringTests.cs
@@ -600,4 +600,60 @@ public class TestSeamWiringTests
         var active = state.Calls("manager.IndexOf").Single();
         Assert.Equal("manager.ActiveTab", active.ArgumentList.Arguments[0].ToString());
     }
+
+    /// <summary>
+    /// Every failure the seam reports names the exception's TYPE, and the
+    /// op that actually failed.
+    ///
+    /// Reporting <c>ex.Message</c> alone was the whole of #942's diagnostic
+    /// half: several types that reach these handlers carry an empty Message,
+    /// so an acceptance run's first op answered
+    /// <c>{"ok":false,"op":"ui","error":""}</c> -- something threw, and the
+    /// seam would not say what. The op field lied as well: both failures in
+    /// the UI-thread marshal reported the literal "ui" rather than the
+    /// command that failed, so a driver reading the response alone could not
+    /// even name the op.
+    ///
+    /// Counts are pinned on both sweeps. A guard that only checks the sites
+    /// it knows about reports green the day a third reporting site is added
+    /// with the old shape.
+    /// </summary>
+    [Fact]
+    public void EveryReportedFailure_NamesTheExceptionType_AndTheFailingOp()
+    {
+        var seam = ShellSource.Load("Testing.TestSeam.cs");
+
+        // Nothing hands Error a bare message. The parse arm's interpolated
+        // "request is not JSON: {ex.Message}" is deliberately still allowed:
+        // JsonException always carries one, and it arrives with its context.
+        Assert.DoesNotContain(
+            seam.Root.Calls("Error"),
+            c => c.ArgumentList.Arguments.Count > 1 && c.Arg(1) == "ex.Message");
+
+        // The two unfiltered general handlers -- the dispatch's and the
+        // marshal's -- are the reporting sites, and both describe.
+        var general = seam.Root.DescendantNodes().OfType<CatchClauseSyntax>()
+            .Where(c => c.Filter is null && c.Declaration?.Type.ToString() == "Exception")
+            .ToList();
+        Assert.Equal(2, general.Count);
+        foreach (var handler in general) Assert.Single(handler.Calls("Describe"));
+
+        // Describe leads with the type, whatever the message turns out to
+        // be, and reaches for the frame that threw.
+        var describe = seam.Method("Describe");
+        Assert.Single(
+            describe.DescendantNodes().OfType<MemberAccessExpressionSyntax>().ToList(),
+            m => m.ToString() == "ex.GetType().Name");
+        Assert.Single(describe.Calls("TopFrame"));
+
+        // The marshal reports under the caller's op, never a fixed literal.
+        var marshal = seam.Method("RunOnUiThreadAsync");
+        Assert.Contains(marshal.ParameterList.Parameters, p => p.Identifier.ValueText == "op");
+        var reports = marshal.Calls("Error");
+        Assert.Equal(2, reports.Count);
+        foreach (var report in reports) Assert.Equal("op", report.Arg(0));
+
+        // And the op it reports under is the one the request named.
+        Assert.Equal("opName", seam.Method("ExecuteAsync").Call("RunOnUiThreadAsync").Arg(1));
+    }
 }

--- a/windows/Ghostty.Tests/Wiring/TestSeamWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TestSeamWiringTests.cs
@@ -626,9 +626,14 @@ public class TestSeamWiringTests
         // Nothing hands Error a bare message. The parse arm's interpolated
         // "request is not JSON: {ex.Message}" is deliberately still allowed:
         // JsonException always carries one, and it arrives with its context.
+        // Matched as a tree, not as the text "ex.Message": a new site spelled
+        // `catch (COMException e) { Error(op, e.Message); }` is a different
+        // identifier and would walk straight through a substring rule.
         Assert.DoesNotContain(
             seam.Root.Calls("Error"),
-            c => c.ArgumentList.Arguments.Count > 1 && c.Arg(1) == "ex.Message");
+            c => c.ArgumentList.Arguments.Count > 1
+                 && c.ArgumentList.Arguments[1].Expression is MemberAccessExpressionSyntax m
+                 && m.Name.Identifier.ValueText == "Message");
 
         // The two unfiltered general handlers -- the dispatch's and the
         // marshal's -- are the reporting sites, and both describe.
@@ -636,15 +641,34 @@ public class TestSeamWiringTests
             .Where(c => c.Filter is null && c.Declaration?.Type.ToString() == "Exception")
             .ToList();
         Assert.Equal(2, general.Count);
-        foreach (var handler in general) Assert.Single(handler.Calls("Describe"));
+        // The RESPONSE must carry Describe's result. "Describe is called
+        // somewhere in the handler" is satisfied by
+        //     Debug.WriteLine(Describe(ex));
+        //     done.SetResult(Error(op, "command failed"));
+        // which restores #942's symptom exactly, so the argument is pinned.
+        foreach (var handler in general)
+        {
+            Assert.Equal("Describe(ex)", handler.Call("Error").Arg(1));
+        }
 
         // Describe leads with the type, whatever the message turns out to
         // be, and reaches for the frame that threw.
         var describe = seam.Method("Describe");
-        Assert.Single(
-            describe.DescendantNodes().OfType<MemberAccessExpressionSyntax>().ToList(),
-            m => m.ToString() == "ex.GetType().Name");
+        // The type SEEDS the builder, so it is unconditional. Merely finding
+        // `ex.GetType().Name` somewhere in the method also passes for
+        //     if (!string.IsNullOrWhiteSpace(ex.Message)) text.Append(ex.GetType().Name)...
+        // which answers an empty-message exception with no type at all.
+        var seeded = Assert.Single(
+            describe.DescendantNodes().OfType<ObjectCreationExpressionSyntax>().ToList(),
+            o => o.Type.ToString() == "StringBuilder");
+        Assert.Equal("ex.GetType().Name", seeded.ArgumentList!.Arguments[0].ToString());
+
+        // And the frame is appended, not merely computed.
         Assert.Single(describe.Calls("TopFrame"));
+        Assert.Contains(
+            describe.DescendantNodes().OfType<InvocationExpressionSyntax>(),
+            i => i.ArgumentList.Arguments.Count == 1
+                 && i.ArgumentList.Arguments[0].ToString() == "frame");
 
         // The marshal reports under the caller's op, never a fixed literal.
         var marshal = seam.Method("RunOnUiThreadAsync");

--- a/windows/Ghostty/Testing/TestSeam.cs
+++ b/windows/Ghostty/Testing/TestSeam.cs
@@ -333,6 +333,7 @@ internal static class TestSeam
             {
                 return await RunOnUiThreadAsync(
                     window,
+                    opName,
                     () => ExecuteOnUiThreadAsync(window, opName, root),
                     settle: !IsObserver(opName));
             }
@@ -340,7 +341,7 @@ internal static class TestSeam
             {
                 // A command that throws IS a finding: the response carries
                 // it and the app keeps running.
-                return Error(opName, ex.Message);
+                return Error(opName, Describe(ex));
             }
         }
     }
@@ -367,7 +368,8 @@ internal static class TestSeam
     /// window's UI thread and the response awaits the work.
     /// </summary>
     private static Task<string> RunOnUiThreadAsync(
-        MainWindow window, Func<Task<string>> action, bool settle = true)
+        MainWindow window, string op, Func<Task<string>> action,
+        bool settle = true)
     {
         var done = new TaskCompletionSource<string>(
             TaskCreationOptions.RunContinuationsAsynchronously);
@@ -380,10 +382,10 @@ internal static class TestSeam
                     if (settle) window.TestSeamSettleLayout();
                     done.SetResult(result);
                 }
-                catch (Exception ex) { done.SetResult(Error("ui", ex.Message)); }
+                catch (Exception ex) { done.SetResult(Error(op, Describe(ex))); }
             }))
         {
-            done.SetResult(Error("ui", "dispatcher unavailable"));
+            done.SetResult(Error(op, "dispatcher unavailable"));
         }
         return done.Task;
     }
@@ -1101,6 +1103,49 @@ internal static class TestSeam
         // this flush. The dispose-time flush is too late for a read.
         json.Flush();
         return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    /// <summary>
+    /// What an exception IS, not merely what it said. Several types that
+    /// reach these handlers carry an empty <see cref="Exception.Message"/>
+    /// -- XamlParseException among them -- so reporting the message alone
+    /// answers a driver with "something threw and I will not say what",
+    /// which is the one answer a seam exists to never give. The type name
+    /// is a diagnosis on its own; the inner exception is usually the real
+    /// one; the top frame says where to look.
+    /// </summary>
+    private static string Describe(Exception ex)
+    {
+        var text = new StringBuilder(ex.GetType().Name);
+        if (!string.IsNullOrWhiteSpace(ex.Message)) text.Append(": ").Append(ex.Message);
+        if (ex.InnerException is { } inner)
+        {
+            text.Append(" <- ").Append(inner.GetType().Name);
+            if (!string.IsNullOrWhiteSpace(inner.Message))
+            {
+                text.Append(": ").Append(inner.Message);
+            }
+        }
+        if (TopFrame(ex) is { } frame) text.Append(" at ").Append(frame);
+        return text.ToString();
+    }
+
+    /// <summary>
+    /// The first frame of the stack, preferring the inner exception's --
+    /// a wrapper's top frame is the wrapping site, not the fault. The whole
+    /// trace does not survive the response's one-line framing, and the
+    /// frame that threw is the one worth the bytes.
+    /// </summary>
+    private static string? TopFrame(Exception ex)
+    {
+        var trace = (ex.InnerException ?? ex).StackTrace ?? ex.StackTrace;
+        if (string.IsNullOrEmpty(trace)) return null;
+        foreach (var line in trace.Split('\n'))
+        {
+            var trimmed = line.Trim();
+            if (trimmed.Length > 0) return trimmed;
+        }
+        return null;
     }
 
     private static string Error(string op, string message)

--- a/windows/Ghostty/Testing/TestSeam.cs
+++ b/windows/Ghostty/Testing/TestSeam.cs
@@ -1118,12 +1118,13 @@ internal static class TestSeam
     {
         var text = new StringBuilder(ex.GetType().Name);
         if (!string.IsNullOrWhiteSpace(ex.Message)) text.Append(": ").Append(ex.Message);
-        if (ex.InnerException is { } inner)
+        var fault = Innermost(ex);
+        if (!ReferenceEquals(fault, ex))
         {
-            text.Append(" <- ").Append(inner.GetType().Name);
-            if (!string.IsNullOrWhiteSpace(inner.Message))
+            text.Append(" <- ").Append(fault.GetType().Name);
+            if (!string.IsNullOrWhiteSpace(fault.Message))
             {
-                text.Append(": ").Append(inner.Message);
+                text.Append(": ").Append(fault.Message);
             }
         }
         if (TopFrame(ex) is { } frame) text.Append(" at ").Append(frame);
@@ -1131,14 +1132,34 @@ internal static class TestSeam
     }
 
     /// <summary>
-    /// The first frame of the stack, preferring the inner exception's --
+    /// The bottom of the wrapper chain: the exception that actually failed.
+    ///
+    /// One level of unwrapping is not enough. TargetInvocationException
+    /// wrapping AggregateException wrapping the real fault is ordinary here,
+    /// and stopping at depth one names a second wrapping site while the
+    /// fault stays anonymous -- the thing this reporting exists to avoid.
+    /// Bounded, because a cycle is pathological but a hang inside error
+    /// reporting is the worst possible place for one.
+    /// </summary>
+    private static Exception Innermost(Exception ex)
+    {
+        var current = ex;
+        for (var depth = 0; depth < 16 && current.InnerException is { } inner; depth++)
+        {
+            current = inner;
+        }
+        return current;
+    }
+
+    /// <summary>
+    /// The first frame of the stack, preferring the innermost exception's --
     /// a wrapper's top frame is the wrapping site, not the fault. The whole
     /// trace does not survive the response's one-line framing, and the
     /// frame that threw is the one worth the bytes.
     /// </summary>
     private static string? TopFrame(Exception ex)
     {
-        var trace = (ex.InnerException ?? ex).StackTrace ?? ex.StackTrace;
+        var trace = Innermost(ex).StackTrace ?? ex.StackTrace;
         if (string.IsNullOrEmpty(trace)) return null;
         foreach (var line in trace.Split('\n'))
         {

--- a/windows/scripts/lib/seam-client.ps1
+++ b/windows/scripts/lib/seam-client.ps1
@@ -162,10 +162,17 @@ function Wait-SeamReady($proc) {
 }
 
 # One app, one pipe, one scenario. The relaunch-per-scenario structure is
-# deliberate: repeated seed-tabs churn in a single process trips a known,
-# separately-filed 0xC0000005 in coreclr around the seventh cumulative
-# seed, and a fresh process per scenario both stays clear of that threshold
-# and keeps scenarios from contaminating each other.
+# deliberate: repeated churn in a single process trips a 0xC0000005, and a
+# fresh process per scenario both stays clear of it and keeps scenarios from
+# contaminating each other.
+#
+# This note used to say "around the seventh cumulative seed" and cite a
+# separately-filed issue. Both halves were checked on 2026-09-02 and are
+# wrong. Measured: the THIRD seed-tabs of a process, deterministically, and
+# only when a group has survived two layout round trips -- five bare seeds in
+# a row are harmless. No such issue exists in this repo. The crash faults in
+# CThemeResource::SetLastResolvedValue, reached from a synchronous
+# NavigationView.SelectedItem assignment inside TabManager.CloseTab.
 function Start-SeamSession(
     [Parameter(Mandatory)][string]$ExePath,
     [Parameter(Mandatory)][string]$ConfigText,
@@ -222,17 +229,30 @@ function Start-SeamSession(
     if ($Arguments.Count -gt 0) { $startArgs.ArgumentList = $Arguments }
     $proc = Start-Process @startArgs
     $session.Proc = $proc
-    $main = Wait-SeamReady $proc
-    $session.Hwnd64 = [int64]$main.Hwnd64
+    # Everything from here can throw -- Wait-SeamReady on a window that never
+    # appears or a splash that never drops, Wait-SeamPipe on a Release build
+    # with the seam compiled out, Connect-SeamPipe on a timeout -- and the
+    # caller does not hold the session yet, so ITS finally cannot clean up.
+    # Left alone that strands a running Wintty, and Assert-NoWintty refuses to
+    # kill instances it did not start, so one orphan blocks every seam harness
+    # on the machine until a human intervenes. Tear down here and rethrow.
+    try {
+        $main = Wait-SeamReady $proc
+        $session.Hwnd64 = [int64]$main.Hwnd64
 
-    # The seam pipe appears once OnLaunched has built the window.
-    [void](Wait-SeamPipe -Token $session.Token -Proc $proc)
-    $session.Pipe = Connect-SeamPipe -Token $session.Token
-    $session.Reader = [System.IO.StreamReader]::new($session.Pipe)
-    $session.Writer = [System.IO.StreamWriter]::new(
-        $session.Pipe, [System.Text.UTF8Encoding]::new($false))
-    $session.Writer.AutoFlush = $true
-    $session.Writer.NewLine = "`n"
+        # The seam pipe appears once OnLaunched has built the window.
+        [void](Wait-SeamPipe -Token $session.Token -Proc $proc)
+        $session.Pipe = Connect-SeamPipe -Token $session.Token
+        $session.Reader = [System.IO.StreamReader]::new($session.Pipe)
+        $session.Writer = [System.IO.StreamWriter]::new(
+            $session.Pipe, [System.Text.UTF8Encoding]::new($false))
+        $session.Writer.AutoFlush = $true
+        $session.Writer.NewLine = "`n"
+    }
+    catch {
+        Stop-SeamSession $session
+        throw
+    }
     return $session
 }
 
@@ -251,8 +271,14 @@ function Receive-SeamResponse([Parameter(Mandatory)]$Session, [string]$OpName = 
     $line = $Session.Reader.ReadLine()
     if ($null -eq $line) {
         if ($Session.Proc.HasExited) {
-            throw ("PRODUCT_EXIT: the seam pipe closed and the app exited " +
-                "(code {0}) during '{1}'" -f $Session.Proc.ExitCode, $OpName)
+            # Parens close before -f, which is the whole point: -f binds
+            # tighter than +, so with the paren at the end it would format
+            # only the second fragment. Correct here today purely because
+            # both placeholders happen to live in that fragment; moving one
+            # up would print it literally. Same bug shipped twice in
+            # seam-acceptance.ps1 before anyone saw the message.
+            throw (("PRODUCT_EXIT: the seam pipe closed and the app exited " +
+                "(code {0}) during '{1}'") -f $Session.Proc.ExitCode, $OpName)
         }
         throw ("HARNESS: the seam closed the connection without a response to '{0}'" -f $OpName)
     }

--- a/windows/scripts/seam-acceptance.ps1
+++ b/windows/scripts/seam-acceptance.ps1
@@ -21,14 +21,32 @@
     drag(1 -> 3) through the strip's real press/threshold/crossing/release
     sequence, asserting the landed order.
 
+    The launch goes through Start-SeamSession rather than being staged
+    here. That is not tidiness: the shared launcher waits for the window to
+    be READY -- a WinUI hwnd, then the splash gone -- where this script used
+    to send its first command as soon as the pipe existed, which is earlier;
+    and it strips NO_COLOR out of the child's environment, which a shell
+    that sets it (Claude Code's PowerShell tool does) otherwise turns into a
+    focus-stealing infobar across a third of the window. Both were #942.
+
     Exits 0 on pass, 2 on a product finding (the app died, refused a
-    command, or landed in a state the assertions reject), 1 when the harness
-    could not run and nothing is known about the product (the exe is
-    missing, a Wintty is already running, the seam pipe never appeared).
+    command, never showed a window or never dropped its splash, or landed in
+    a state the assertions reject), 1 when the harness could not run and
+    nothing is known about the product (the exe is missing, a Wintty is
+    already running, the seam pipe never appeared).
 #>
 param(
     [Parameter(Mandatory)][string]$ExePath,
     [Parameter(Mandatory)][string]$OutDir,
+    # This count does not currently decide whether the run passes. The app
+    # dies with 0xC0000005 on the THIRD seed-tabs of a process, whatever
+    # this is set to: at 5 that is iteration 3, and at 2 it is the drag
+    # leg's own seed. Measured 3/3, 2026-09-02.
+    #
+    # Start-SeamSession's note says "around the seventh cumulative seed"
+    # and cites a separately-filed issue. The threshold is three, and no
+    # such issue exists in this repo -- both halves of that note are
+    # repeated here only to say they were checked and are wrong.
     [ValidateRange(1, 100)][int]$Iterations = 5,
     # Milliseconds between commands. 0 is the tight train; 400 is the
     # pacing that let ordinary layout frames pass through freshly churned
@@ -56,57 +74,50 @@ $crashStamp = if (Test-Path $crashPath) {
     [datetime]::MinValue
 }
 
-$tempXdg = Join-Path $env:TEMP "wintty-seam-accept-$([guid]::NewGuid().ToString('N'))"
-New-Item -ItemType Directory -Force -Path (Join-Path $tempXdg 'wintty') | Out-Null
-@'
+$config = @'
 windows-single-instance = true
 window-save-state = never
 vertical-tabs = true
-'@ | Set-Content (Join-Path $tempXdg 'wintty\config.wintty') -Encoding utf8
+'@
 
-$origXdgSet = Test-Path Env:XDG_CONFIG_HOME
-$origXdg = if ($origXdgSet) { $env:XDG_CONFIG_HOME } else { $null }
-$origSeamSet = Test-Path Env:WINTTY_TEST_SEAM
-$origSeam = if ($origSeamSet) { $env:WINTTY_TEST_SEAM } else { $null }
-
-$script:Proc = $null
-$script:Reader = $null
-$script:Writer = $null
-$script:Pipe = $null
-$stamp = Get-WinttyLaunchStamp
+$script:Session = $null
 
 function Invoke-Seam {
     param([Parameter(Mandatory)][hashtable]$Command)
     if ($GapMs -gt 0) { Start-Sleep -Milliseconds $GapMs }
-    if ($script:Proc.HasExited) {
-        throw ("PRODUCT_EXIT: the app exited (code {0}) before '{1}'" -f
-            $script:Proc.ExitCode, $Command['op'])
-    }
-    $script:Writer.WriteLine(($Command | ConvertTo-Json -Compress -Depth 6))
-    $line = $script:Reader.ReadLine()
-    if ($null -eq $line) {
-        if ($script:Proc.HasExited) {
-            throw ("PRODUCT_EXIT: the seam pipe closed and the app exited " +
-                "(code {0}) during '{1}'" -f $script:Proc.ExitCode, $Command['op'])
-        }
-        throw ("HARNESS: the seam closed the connection without a " +
-            "response to '{0}'" -f $Command['op'])
-    }
-    $response = $line | ConvertFrom-Json
-    if ($null -eq $response) {
-        throw ("HARNESS: the seam answered '{0}' with a non-JSON line" -f
-            $Command['op'])
-    }
-    if (-not $response.ok) {
-        throw ("PRODUCT_FAIL: {0} -> {1}" -f $Command['op'], $response.error)
-    }
-    Write-Host ("OK {0}" -f $Command['op'])
-    return $response
+    return Invoke-SeamCommand $script:Session $Command
 }
 
 function Assert-Order {
     param($State, [string[]]$Want, [string]$What)
+    # A missing state block is a harness fault, not a product one. Without
+    # this the property walk yields $null, @() turns it into an empty list,
+    # and the comparison below reports "order is []" -- a PRODUCT_FAIL that
+    # names the app for a response this script was reading wrong. Which is
+    # exactly what the drag leg did; see Assert-DragOrder.
+    if ($null -eq $State.state -or $null -eq $State.state.tabs) {
+        throw ("HARNESS: {0}: the response carries no state.tabs to assert on" -f
+            $What)
+    }
     $got = @($State.state.tabs | ForEach-Object { $_.title })
+    if (($got -join ',') -ne ($Want -join ',')) {
+        throw ("PRODUCT_FAIL: {0}: order is [{1}], wanted [{2}]" -f
+            $What, ($got -join ','), ($Want -join ','))
+    }
+}
+
+# The drag ops answer with DragJson, which carries a flat `order` array and
+# NO state block. Asserting them with Assert-Order read $State.state.tabs as
+# $null on every drag, so the drag leg could only ever report "order is []"
+# -- it has never been capable of passing. Nobody saw it, because the run
+# died at its first op long before reaching this leg (#942).
+function Assert-DragOrder {
+    param($Response, [string[]]$Want, [string]$What)
+    if ($null -eq $Response.order) {
+        throw ("HARNESS: {0}: the drag response carries no order to assert on" -f
+            $What)
+    }
+    $got = @($Response.order)
     if (($got -join ',') -ne ($Want -join ',')) {
         throw ("PRODUCT_FAIL: {0}: order is [{1}], wanted [{2}]" -f
             $What, ($got -join ','), ($Want -join ','))
@@ -123,8 +134,8 @@ function Assert-SeamGroup {
     $got = @($group.members)
     if ($group.title -ne $Title -or ($got -join ',') -ne ($Members -join ',') `
         -or [bool]$group.collapsed -ne $Collapsed) {
-        throw ("PRODUCT_FAIL: group is title={0} members=[{1}] collapsed={2}, " +
-            "wanted title={3} members=[{4}] collapsed={5}" -f
+        throw (("PRODUCT_FAIL: group is title={0} members=[{1}] collapsed={2}, " +
+            "wanted title={3} members=[{4}] collapsed={5}") -f
             $group.title, ($got -join ','), $group.collapsed,
             $Title, ($Members -join ','), $Collapsed)
     }
@@ -133,22 +144,10 @@ function Assert-SeamGroup {
 # ---- run -----------------------------------------------------------------
 
 try {
-    $env:XDG_CONFIG_HOME = $tempXdg
-    $token = New-SeamToken
-    $env:WINTTY_TEST_SEAM = $token
-    $proc = Start-Process -FilePath $ExePath -PassThru `
-        -WorkingDirectory (Split-Path -Parent (Resolve-Path $ExePath))
-    $script:Proc = $proc
-    Write-Host "pid=$($proc.Id) pipe=$(Get-SeamPipeName $token) iterations=$Iterations"
-
-    # The seam pipe appears once OnLaunched has built the window.
-    [void](Wait-SeamPipe -Token $token -Proc $proc)
-    $script:Pipe = Connect-SeamPipe -Token $token
-    $script:Reader = [System.IO.StreamReader]::new($script:Pipe)
-    $script:Writer = [System.IO.StreamWriter]::new(
-        $script:Pipe, [System.Text.UTF8Encoding]::new($false))
-    $script:Writer.AutoFlush = $true
-    $script:Writer.NewLine = "`n"
+    $script:Session = Start-SeamSession -ExePath $ExePath -ConfigText $config
+    $proc = $script:Session.Proc
+    Write-Host ("pid={0} pipe={1} iterations={2}" -f
+        $proc.Id, (Get-SeamPipeName $script:Session.Token), $Iterations)
     Write-Host 'seam connected'
 
     for ($i = 1; $i -le $Iterations; $i++) {
@@ -202,7 +201,7 @@ try {
     Assert-Order $fresh $titles 'drag leg seed'
     [void](Invoke-Seam @{ op = 'unpin'; index = 0 })
     $drag = Invoke-Seam @{ op = 'drag'; from = 1; to = 3 }
-    Assert-Order $drag @('tab-1', 'tab-3', 'tab-4', 'tab-2', 'tab-5') 'drag leg'
+    Assert-DragOrder $drag @('tab-1', 'tab-3', 'tab-4', 'tab-2', 'tab-5') 'drag leg'
     if ($drag.landed -ne 3) {
         throw ("PRODUCT_FAIL: drag landed at {0}, wanted 3" -f $drag.landed)
     }
@@ -219,8 +218,8 @@ try {
         }
     }
 
-    Write-Host ("SEAM-ACCEPTANCE PASS: {0} iterations + drag leg, " +
-        "no flakes, no input injected" -f $Iterations)
+    Write-Host (("SEAM-ACCEPTANCE PASS: {0} iterations + drag leg, " +
+        "no flakes, no input injected") -f $Iterations)
     exit 0
 }
 catch {
@@ -230,21 +229,5 @@ catch {
     exit 2
 }
 finally {
-    if ($script:Writer) { try { $script:Writer.Dispose() } catch { } }
-    if ($script:Reader) { try { $script:Reader.Dispose() } catch { } }
-    if ($script:Pipe) { try { $script:Pipe.Dispose() } catch { } }
-
-    # Only the instance this run started; identified by stamp and exe path.
-    try {
-        Stop-WinttyStartedAfter -Since $stamp -ExePath (Resolve-Path $ExePath).Path
-    } catch {
-        Write-Host ("HARNESS: cleanup could not confirm every process it " +
-            "started: {0}" -f $_.Exception.Message)
-    }
-
-    if ($origXdgSet) { $env:XDG_CONFIG_HOME = $origXdg }
-    else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
-    if ($origSeamSet) { $env:WINTTY_TEST_SEAM = $origSeam }
-    else { Remove-Item Env:WINTTY_TEST_SEAM -ErrorAction SilentlyContinue }
-    Remove-Item $tempXdg -Recurse -Force -ErrorAction SilentlyContinue
+    if ($script:Session) { Stop-SeamSession $script:Session }
 }

--- a/windows/scripts/seam-acceptance.ps1
+++ b/windows/scripts/seam-acceptance.ps1
@@ -38,10 +38,13 @@
 param(
     [Parameter(Mandatory)][string]$ExePath,
     [Parameter(Mandatory)][string]$OutDir,
-    # This count does not currently decide whether the run passes. The app
-    # dies with 0xC0000005 on the THIRD seed-tabs of a process, whatever
-    # this is set to: at 5 that is iteration 3, and at 2 it is the drag
-    # leg's own seed. Measured 3/3, 2026-09-02.
+    # 1 is the only value that currently completes. The app dies with
+    # 0xC0000005 on the THIRD seed-tabs of a process (measured 3/3,
+    # 2026-09-02), and this count spends N seeds in the loop plus one more
+    # in the drag leg -- so at 2 and above the run dies before the drag leg
+    # it exists to exercise. The default is left at 5 so a green run means
+    # the crash is fixed rather than merely stepped around; use -Iterations 1
+    # to exercise the drag leg today.
     #
     # Start-SeamSession's note says "around the seventh cumulative seed"
     # and cites a separately-filed issue. The threshold is three, and no
@@ -88,17 +91,24 @@ function Invoke-Seam {
     return Invoke-SeamCommand $script:Session $Command
 }
 
-function Assert-Order {
-    param($State, [string[]]$Want, [string]$What)
-    # A missing state block is a harness fault, not a product one. Without
-    # this the property walk yields $null, @() turns it into an empty list,
-    # and the comparison below reports "order is []" -- a PRODUCT_FAIL that
-    # names the app for a response this script was reading wrong. Which is
-    # exactly what the drag leg did; see Assert-DragOrder.
-    if ($null -eq $State.state -or $null -eq $State.state.tabs) {
+# A missing state block is a harness fault, not a product one. Without this
+# a property walk yields $null, @() turns it into an empty list, and the
+# comparison reports "order is []" -- a PRODUCT_FAIL naming the app for a
+# response this script read wrong. Which is exactly what the drag leg did;
+# see Assert-DragOrder. Every reader of .state goes through here, because
+# guarding one of them and leaving three bare is how the first one was missed.
+function Assert-SeamState {
+    param($Response, [string]$What)
+    if ($null -eq $Response.state -or $null -eq $Response.state.tabs) {
         throw ("HARNESS: {0}: the response carries no state.tabs to assert on" -f
             $What)
     }
+    return $Response
+}
+
+function Assert-Order {
+    param($State, [string[]]$Want, [string]$What)
+    [void](Assert-SeamState $State $What)
     $got = @($State.state.tabs | ForEach-Object { $_.title })
     if (($got -join ',') -ne ($Want -join ',')) {
         throw ("PRODUCT_FAIL: {0}: order is [{1}], wanted [{2}]" -f
@@ -126,6 +136,7 @@ function Assert-DragOrder {
 
 function Assert-SeamGroup {
     param($State, [string]$Title, [string[]]$Members, [bool]$Collapsed)
+    [void](Assert-SeamState $State 'group assertion')
     $groups = @($State.state.groups)
     if ($groups.Count -ne 1) {
         throw ("PRODUCT_FAIL: expected one group, saw {0}" -f $groups.Count)
@@ -169,6 +180,7 @@ try {
 
         $collapsed = Invoke-Seam @{
             op = 'collapse'; index = 2; collapsed = $true }
+        [void](Assert-SeamState $collapsed "iteration $i collapse")
         if (-not $collapsed.state.tabs[2].collapsedGroup) {
             throw "PRODUCT_FAIL: iteration ${i}: group did not collapse"
         }
@@ -179,6 +191,7 @@ try {
         [void](Invoke-Seam @{ op = 'toggle-layout' })
 
         $state = Invoke-Seam @{ op = 'get-state' }
+        [void](Assert-SeamState $state "iteration $i final")
         if (-not $state.state.vertical) {
             throw "PRODUCT_FAIL: iteration ${i}: window did not come back vertical"
         }
@@ -225,8 +238,13 @@ try {
 catch {
     $message = $_.Exception.Message
     Write-Host $message
-    if ($message -like 'HARNESS:*') { exit 1 }
-    exit 2
+    # Positive test on the product prefixes, the way frame-keybind-check and
+    # the other harnesses classify. Testing for HARNESS:* instead would file
+    # Wait-SeamReady's HARVEST_MISS throws -- no WinUI hwnd, splash never
+    # dropped, both of which mean the harness could not observe -- as product
+    # findings against Wintty.
+    if ($message -like 'PRODUCT_*') { exit 2 }
+    exit 1
 }
 finally {
     if ($script:Session) { Stop-SeamSession $script:Session }


### PR DESCRIPTION
Closes #942.

The acceptance harness died on its first op and answered `{"ok":false,"op":"ui","error":""}`. Four defects were stacked behind that, and only the first was visible.

**The seam would not say what threw.** Both handlers reported `ex.Message` alone, and several types that reach them carry an empty one. `Describe` leads with the exception's type, adds the inner exception and the frame that threw. The UI-thread marshal also reported the literal op `"ui"` for both its failures, so the response could not name the command; it takes the caller's op now.

**The op was failing on readiness.** The script staged its own process instead of calling `Start-SeamSession`, so it waited only for the pipe — which appears earlier than the window can answer — and never stripped `NO_COLOR`. On the shared launcher now, and `seed-tabs` returns ok.

**The drag leg has never been capable of passing.** It asserted `$State.state.tabs` against a drag response, which carries a flat `order` array and no state block, so it reported `order is []` — a `PRODUCT_FAIL` blaming the app for a response the script was reading wrong. Both assertions now refuse with `HARNESS` when the field they need is absent, which is the difference between exit 1 and exit 2.

**Two messages never rendered.** `-f` binds tighter than `+`, so in a concatenation only the second literal is formatted. The success line read `PASS: {0} iterations`.

`seam-acceptance` passes at `-Iterations 1`, drag leg included, for the first time. It does not pass above that: the app dies with `0xC0000005` on the **third** `seed-tabs` of a process, 3/3, leaving no `crash.log` because a native AV escapes the managed handler. That is a product bug this change makes visible rather than one it introduces, and it is the next thing being taken up.

`Start-SeamSession`'s note calls that crash "around the seventh cumulative seed" and cites a separately-filed issue. The threshold is three, and no such issue exists in this repo. Both halves are recorded as checked and wrong rather than repeated.

Guard mutation-proved: reverting either handler to `ex.Message`, re-hardcoding `"ui"`, and dropping either the type or the frame from `Describe` each take it red.

---

## Review round

Reviewed with a subagent, which found two blockers and four more.

**A launch that failed stranded the app it started.** `Start-SeamSession` returns the session on its last line, and four things before that can throw — `Wait-SeamReady` on a window that never appears, `Wait-SeamPipe` on a build with the seam compiled out, `Connect-SeamPipe` on a timeout. The caller does not hold the session yet, so its `finally` cannot run: a Wintty is left alive with the shell's `XDG_CONFIG_HOME` and `WINTTY_TEST_SEAM` still rewritten. `Assert-NoWintty` then refuses to kill an instance it did not start, so one orphan blocks *every* seam harness on the machine. Moving this script onto the shared launcher introduced that; the inline version it replaced captured its process handle immediately and restored the environment unconditionally. Fixed in the launcher, so every consumer gets it.

**The guard pinned the wrong thing.** It asserted `Describe` is *called* in each handler, never that the response carries its result — `_ = Describe(ex); Error(op, "command failed")` satisfied it and restores the empty answer this PR exists to remove. The argument is pinned now and that mutation goes red. Two more of the same shape: the type name was pinned by existence rather than position, so moving it inside the message check would answer an empty-message exception with no type at all; and `TopFrame` was pinned as called, not as appended.

Also: the bare-message rule matched the text `ex.Message`, so a handler spelled `catch (COMException e)` was invisible — matched as a member access now. `HARVEST_MISS` was landing on exit 2, though it is this tree's idiom for "the harness could not observe", so a locked desktop would have filed a product bug against Wintty; the classifier tests the `PRODUCT_` prefix positively now, as the sibling harnesses do. The null-state refusal guarded one reader of four. `TopFrame` unwrapped one level while claiming to find the fault, and now walks to the innermost, bounded.
