### PR TITLE
window: the quick terminal survives a switcher call the platform refuses

### DIFF
--- a/windows/Ghostty.Tests/Wiring/QuickTerminalStartupWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/QuickTerminalStartupWiringTests.cs
@@ -1,0 +1,95 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// The quick terminal is optional; the app is not.
+///
+/// OnLaunched builds a second, hidden MainWindow on every launch, and every
+/// step of that build reaches Microsoft.UI.Windowing -- a surface that is
+/// allowed to refuse. It was observed refusing: AppWindow.IsShownInSwitchers
+/// threw NotImplementedException (E_NOTIMPL) on an ordinary machine, the
+/// throw escaped OnLaunched, and the process died mid-launch with a real
+/// window already on screen. Every Wintty build on that box stopped starting.
+///
+/// Two containments, and this pins both. The outer one keeps a refusal from
+/// costing the process; the inner one keeps a refusal of the one redundant
+/// call from costing the whole quick terminal.
+///
+/// Asserted as a tree, not as text: the point is that the calls sit INSIDE a
+/// try whose catch logs, and a substring check cannot tell that from a call
+/// sitting next to one.
+/// </summary>
+public class QuickTerminalStartupWiringTests
+{
+    [Fact]
+    public void TheQuakeWindowBuild_CannotTakeTheProcessDown()
+    {
+        var app = ShellSource.Load("App.xaml.cs");
+        var launched = app.Method("OnLaunched");
+
+        var built = Assert.Single(
+            launched.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+                .Where(a => a.Left.ToString() == "_quakeWindow"
+                            && a.Right is ObjectCreationExpressionSyntax)
+                .ToList(),
+            _ => true);
+
+        var guard = built.Ancestors().OfType<TryStatementSyntax>().FirstOrDefault();
+        Assert.True(
+            guard is not null,
+            "The quake window construction must sit inside a try. Unguarded, a "
+                + "windowing refusal escapes OnLaunched and kills startup.");
+
+        // Activation and the hide are part of the same exposure: both reach
+        // the same windowing surface, so both must be inside the SAME try.
+        // Pinned separately because moving either below the closing brace
+        // would leave the assignment guarded and the app still killable.
+        Assert.Single(guard!.Block.Calls("_quakeWindow.Activate"));
+        Assert.Single(guard.Block.Calls("_quakeWindow.AppWindow.Hide"));
+
+        var handler = Assert.Single(guard.Catches);
+        Assert.Single(
+            handler.Calls("Ghostty.Logging.StaticLoggers.App.LogQuakeWindowFailed"));
+
+        // Null, not left half-built: every consumer of _quakeWindow is
+        // null-safe, and a partially constructed one is not.
+        Assert.Contains(
+            handler.AssignsTo("_quakeWindow"),
+            a => a.Right.IsKind(SyntaxKind.NullLiteralExpression));
+    }
+
+    [Fact]
+    public void TheSwitcherCall_CannotCostTheQuickTerminal()
+    {
+        var win = ShellSource.Load("MainWindow.xaml.cs");
+        var apply = win.Method("ApplyQuickTerminalBehaviour");
+
+        var assigned = Assert.Single(
+            apply.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+                .Where(a => a.Left.ToString() == "AppWindow.IsShownInSwitchers")
+                .ToList(),
+            _ => true);
+
+        var guard = assigned.Ancestors().OfType<TryStatementSyntax>().FirstOrDefault();
+        Assert.True(
+            guard is not null,
+            "AppWindow.IsShownInSwitchers must sit inside a try. Its effect is "
+                + "redundant with WS_EX_TOOLWINDOW, so a refusal must cost nothing.");
+
+        var handler = Assert.Single(guard!.Catches);
+        Assert.Single(handler.Calls("_logger.LogSwitcherRefused"));
+
+        // The redundancy the swallow depends on: WS_EX_TOOLWINDOW is what
+        // actually hides the window, and it is applied outside the try, so a
+        // refusal above cannot skip it.
+        Assert.Contains("WS_EX_TOOLWINDOW", apply.ToString());
+        Assert.DoesNotContain(
+            guard.Block.DescendantNodes().OfType<IdentifierNameSyntax>(),
+            id => id.Identifier.ValueText == "WS_EX_TOOLWINDOW");
+    }
+}

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -941,12 +941,29 @@ public partial class App : Application
         // by the global hotkey via WindowsGlobalHotKey. Same MainWindow
         // class as a regular window, just with IsQuickTerminal = true
         // for the no-taskbar / no-AltTab / close-hides behaviour.
-        _quakeWindow = new MainWindow(
-            _configService, _bootstrapHost, _lifetimeSupervisor, factory,
-            isQuickTerminal: true);
-        _quakeWindow.Closed += OnAnyWindowClosedInternal;
-        _quakeWindow.Activate();          // creates the HWND
-        _quakeWindow.AppWindow.Hide();    // immediately hide
+        // Every call in here reaches Microsoft.UI.Windowing, and that
+        // surface is allowed to refuse -- IsShownInSwitchers has been seen
+        // throwing NotImplementedException (E_NOTIMPL) on a machine where
+        // nothing else was wrong. Unguarded, any one of them takes the whole
+        // process down mid-launch, AFTER the real window above is already on
+        // screen, which reads to a user as a crash rather than as a missing
+        // feature. The quake window is optional; the app is not. Same shape
+        // as the tray icon below, and _quakeWindow is nullable precisely so
+        // the rest of the app copes with it never being built.
+        try
+        {
+            _quakeWindow = new MainWindow(
+                _configService, _bootstrapHost, _lifetimeSupervisor, factory,
+                isQuickTerminal: true);
+            _quakeWindow.Closed += OnAnyWindowClosedInternal;
+            _quakeWindow.Activate();          // creates the HWND
+            _quakeWindow.AppWindow.Hide();    // immediately hide
+        }
+        catch (System.Exception ex)
+        {
+            _quakeWindow = null;
+            Ghostty.Logging.StaticLoggers.App.LogQuakeWindowFailed(ex);
+        }
 
         // Chord comes from quick-terminal-key config (Default = Ctrl+`).
         // MOD_NOREPEAT prevents auto-fire while the user holds the chord.
@@ -2206,6 +2223,12 @@ internal static partial class AppLogExtensions
                    Level = LogLevel.Warning,
                    Message = "A forwarded launch could not be acted on; it was dropped.")]
     internal static partial void LogInboundLaunchFailed(
+        this ILogger<App> logger, System.Exception ex);
+
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Startup.QuakeWindowFailed,
+                   Level = LogLevel.Warning,
+                   Message = "The quick terminal could not be built; its hotkey does nothing this session.")]
+    internal static partial void LogQuakeWindowFailed(
         this ILogger<App> logger, System.Exception ex);
 
     [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Startup.TrayInitFailed,

--- a/windows/Ghostty/Logging/LogEvents.cs
+++ b/windows/Ghostty/Logging/LogEvents.cs
@@ -15,6 +15,7 @@ internal static class LogEvents
         public const int TrayInitFailed      = 2003;
         public const int StaleAumidRemoved   = 2004;
         public const int ConfigOpenFailed    = 2005;
+        public const int QuakeWindowFailed   = 2006;
     }
 
     // 2100-2199: Clipboard
@@ -67,6 +68,7 @@ internal static class LogEvents
         // 2500 retired (was ConfigOpenFailed; the action moved to App and
         // logs under Startup.ConfigOpenFailed). Not reused: old logs carry it.
         public const int DialogDrainFailed = 2501;
+        public const int SwitcherRefused   = 2502;
     }
 
     // 2600-2699: Settings UI

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -4032,7 +4032,30 @@ public sealed partial class MainWindow : Window
     /// </summary>
     private void ApplyQuickTerminalBehaviour()
     {
-        AppWindow.IsShownInSwitchers = false;
+        // Belt to the WS_EX_TOOLWINDOW braces below, and the one call here
+        // that reaches a platform surface allowed to refuse. It has been
+        // observed throwing NotImplementedException ("SetShownInSwitchers
+        // failed", E_NOTIMPL) from the WinAppSDK windowing layer, and
+        // because OnLaunched builds the quake window on EVERY launch, an
+        // unguarded throw here does not cost a taskbar icon -- it takes the
+        // whole app down before any window exists, with no way back short of
+        // the platform recovering on its own.
+        //
+        // Nothing is lost by continuing. WS_EX_TOOLWINDOW, set immediately
+        // below, already hides the window from the taskbar AND from Alt+Tab;
+        // IsShownInSwitchers is the tidier API for half of that, not the
+        // load-bearing half.
+        try
+        {
+            AppWindow.IsShownInSwitchers = false;
+        }
+        catch (Exception refused)
+        {
+            _logger.LogWarning(
+                refused,
+                "AppWindow.IsShownInSwitchers refused on the quick terminal; "
+                + "WS_EX_TOOLWINDOW still hides it from the taskbar and Alt+Tab.");
+        }
 
         var hwnd = new HWND(WindowNative.GetWindowHandle(this));
         var ex = (WINDOW_EX_STYLE)PInvoke.GetWindowLong(hwnd, WINDOW_LONG_PTR_INDEX.GWL_EXSTYLE);

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -4022,7 +4022,8 @@ public sealed partial class MainWindow : Window
     /// One-shot setup applied when this window is the singleton quick
     /// (quake / drop-down) terminal:
     ///   - <c>AppWindow.IsShownInSwitchers = false</c> hides the icon
-    ///     from the taskbar.
+    ///     from the taskbar. Best-effort: the platform may refuse it, and
+    ///     WS_EX_TOOLWINDOW below already covers the taskbar by itself.
     ///   - <c>WS_EX_TOOLWINDOW</c> hides the window from the Alt+Tab
     ///     switcher (IsShownInSwitchers alone leaves it visible there).
     ///   - <c>AppWindow.Closing</c> is intercepted so the close button
@@ -4032,29 +4033,33 @@ public sealed partial class MainWindow : Window
     /// </summary>
     private void ApplyQuickTerminalBehaviour()
     {
-        // Belt to the WS_EX_TOOLWINDOW braces below, and the one call here
-        // that reaches a platform surface allowed to refuse. It has been
-        // observed throwing NotImplementedException ("SetShownInSwitchers
-        // failed", E_NOTIMPL) from the WinAppSDK windowing layer, and
-        // because OnLaunched builds the quake window on EVERY launch, an
-        // unguarded throw here does not cost a taskbar icon -- it takes the
-        // whole app down before any window exists, with no way back short of
-        // the platform recovering on its own.
+        // The one call in this method that reaches a platform surface
+        // allowed to refuse: observed throwing NotImplementedException
+        // ("SetShownInSwitchers failed", E_NOTIMPL) out of the WinAppSDK
+        // windowing layer.
         //
-        // Nothing is lost by continuing. WS_EX_TOOLWINDOW, set immediately
-        // below, already hides the window from the taskbar AND from Alt+Tab;
-        // IsShownInSwitchers is the tidier API for half of that, not the
-        // load-bearing half.
+        // OnLaunched now catches anything this constructor throws, so an
+        // unguarded refusal here would no longer take the process down -- it
+        // would cost the entire quick terminal instead. Bad trade, for a call
+        // whose effect is redundant: WS_EX_TOOLWINDOW, set immediately below,
+        // hides the window from the taskbar AND from Alt+Tab on its own. The
+        // assignment stays because it records the intent in the AppWindow
+        // model rather than only in a Win32 style bit; it is kept honest by
+        // being swallowed.
+        //
+        // Broad on purpose. The CLR's HRESULT mapping is not stable enough to
+        // enumerate -- the same refusal surfaces as NotImplementedException,
+        // COMException or a bare Exception carrying an HResult depending on
+        // the projection -- and the try body is one statement whose failure
+        // costs nothing, so over-catching costs a log line and under-catching
+        // costs the feature.
         try
         {
             AppWindow.IsShownInSwitchers = false;
         }
         catch (Exception refused)
         {
-            _logger.LogWarning(
-                refused,
-                "AppWindow.IsShownInSwitchers refused on the quick terminal; "
-                + "WS_EX_TOOLWINDOW still hides it from the taskbar and Alt+Tab.");
+            _logger.LogSwitcherRefused(refused);
         }
 
         var hwnd = new HWND(WindowNative.GetWindowHandle(this));
@@ -5533,6 +5538,12 @@ public sealed partial class MainWindow : Window
 
 internal static partial class MainWindowLogExtensions
 {
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.MainWindow.SwitcherRefused,
+                   Level = LogLevel.Warning,
+                   Message = "AppWindow.IsShownInSwitchers refused on the quick terminal; WS_EX_TOOLWINDOW still hides it from the taskbar and Alt+Tab")]
+    internal static partial void LogSwitcherRefused(
+        this ILogger<MainWindow> logger, System.Exception ex);
+
     [LoggerMessage(EventId = Ghostty.Logging.LogEvents.MainWindow.DialogDrainFailed,
                    Level = LogLevel.Warning,
                    Message = "DialogTracker drain failed")]


### PR DESCRIPTION
`App.OnLaunched` builds the quake window on **every** launch:

```csharp
_quakeWindow = new MainWindow(..., isQuickTerminal: true);
```

so `ApplyQuickTerminalBehaviour()` runs for every startup, and its first statement was an unguarded `AppWindow.IsShownInSwitchers = false`.

When the platform refuses that call — observed as `NotImplementedException` / "SetShownInSwitchers failed" / `E_NOTIMPL` from the WinAppSDK windowing layer — the throw escapes the `MainWindow` constructor and `OnLaunched`, and **the app dies before any window exists**. Not a missing taskbar icon: no window, nothing the user can act on, and no way back short of the platform recovering on its own.

Guarded and logged. Nothing is lost by continuing: `WS_EX_TOOLWINDOW`, set on the very next line, already hides the window from the taskbar **and** from Alt+Tab — `IsShownInSwitchers` is the tidier API for half of that, not the load-bearing half. The rest of the method already reasons this way, gating the borderless transition on the frame subclass having installed rather than running it unguarded.

## How it was found

It took this machine's entire GUI harness down mid-session. Every wintty build on the box stopped starting with the same stack, including worktrees this branch never touched — which is what ruled out any one tree, the build, the WinAppSDK version (three weeks old) and the shell.

Verified against that live failure rather than a synthetic one: with the guard, the app launches, the seam answers `get-state` and `seed-tabs`, and `crash.log` grows by 0 bytes.

---

## Review round

Reviewed with a subagent, which found the guard drawn in the wrong place.

`IsShownInSwitchers` was wrapped, but `SetBorderAndTitleBar`, `IsResizable`, `IsMinimizable` and `IsMaximizable` sit two statements below it on the same startup path, reaching the same `Microsoft.UI.Windowing` surface that had just refused — unguarded. So do `Activate()` and `AppWindow.Hide()` in `OnLaunched`. Guarding one and leaving five bare is not a defensible line.

The construction of the quake window is the try now, matching the tray icon a few lines below it. `_quakeWindow` was already nullable and every consumer already null-safe, so a failure costs the hotkey and nothing else.

The inner guard stays, for a different reason than it went in with: with the outer one, a refusal there would no longer kill the process — it would cost the entire quick terminal, a bad trade for a call whose effect is redundant.

**A sentence in my comment was false.** It claimed an unguarded throw takes the app down "before any window exists". `OnLaunched` builds and activates the real window first and the quake window after, so the process dies mid-launch with a window already on screen — which is *why* it reads as a crash rather than a missing feature. The conclusion held; the sentence did not.

Both failures now log through the source-generated `LoggerMessage` extensions this codebase uses for startup platform refusals, with their own event ids. A wiring guard pins both containments as a tree and is mutation-proved: moving the hide below the closing brace, or removing the inner try, each takes it red.
