### PR TITLE
gates: the ladder proves the shipping gate refuses a leak, not just that it is spelled right

### DIFF
--- a/.agents/scripts/README.md
+++ b/.agents/scripts/README.md
@@ -30,6 +30,15 @@ human) working in this repo uses the same contract:
 - `just gates-selftest` - prove the gates still catch what they exist for
   (recorded-PR replays, matcher escapes, exemption anchoring) and that the
   nightly scripts' helpers roundtrip. Runs `gitversion-selftest` first.
+- `just release-gate-check` - prove the shipping-build gate REFUSES a leak,
+  by evaluating Release rather than by reading the targets file. Three probe
+  sets: the build-time refusal in both polarities and by both routes (a `-p:`
+  on the derived property, and an environment variable); what a Release
+  evaluation actually defines, per project, since the target reads
+  `DemoEnabled` and never `DefineConstants`; and the two `#if !DEBUG` facts
+  in `ShippingBuildGateTests`, each asserted by name and by a count of
+  exactly one, because that class also holds facts that run in Debug.
+  Windows-only, and nothing compiles: the target is invoked directly.
 - `just gitversion-selftest` - prove a tag outside the release namespace
   cannot name a version. `sync-publish` tags each published snapshot
   `series/vN` and Config.init panics on a tag it does not recognise, so

--- a/.agents/scripts/gate_scope.py
+++ b/.agents/scripts/gate_scope.py
@@ -62,6 +62,15 @@ PREFIX_SUFFIX_RULES = (
     ("windows/", ".csproj", (LEG_WIN, LEG_RELEASE_GATE)),
     ("windows/", ".props", (LEG_WIN, LEG_RELEASE_GATE)),
     ("windows/", ".targets", (LEG_WIN, LEG_RELEASE_GATE)),
+    ("windows/", ".sln", (LEG_WIN, LEG_RELEASE_GATE)),
+    # A response file is the sharp one. MSBuild treats its contents as
+    # command-line arguments, so `-p:Demo=true` in one arrives as a GLOBAL
+    # property: it satisfies the opt-in test the gate uses to tell a
+    # deliberate opt-in from a leak, AND defines DEMO_OPTIN, which compiles
+    # the runtime guard out as well. Every check stays green and demo mode
+    # ships.
+    ("windows/", ".rsp", (LEG_WIN, LEG_RELEASE_GATE)),
+    ("windows/", ".config", (LEG_WIN, LEG_RELEASE_GATE)),
 )
 
 # Ordered, first match wins, so a more specific prefix must precede its
@@ -119,7 +128,7 @@ EXACT_RULES = {
     "build.zig.zon.json": ZIG_LEGS,
     "build.zig.zon.nix": (),
     "build.zig.zon.txt": (),
-    "global.json": (LEG_WIN,),
+    "global.json": (LEG_WIN, LEG_RELEASE_GATE),
     "Directory.Build.props": (LEG_WIN,),
     ".gitignore": (),
     ".gitattributes": (),

--- a/.agents/scripts/gate_scope.py
+++ b/.agents/scripts/gate_scope.py
@@ -24,8 +24,12 @@ LEG_FMT = "zig-fmt"
 LEG_ZIG = "zig-tests"
 LEG_WIN = "windows-tests"
 LEG_GATES = "gates-selftest"
+# Windows-only, and deliberately not folded into gates-selftest: that leg has
+# no [windows] attribute and runs where a Release build of a WinUI project
+# cannot.
+LEG_RELEASE_GATE = "release-gate"
 
-ALL_LEGS = (LEG_FMT, LEG_ZIG, LEG_WIN, LEG_GATES)
+ALL_LEGS = (LEG_FMT, LEG_ZIG, LEG_WIN, LEG_GATES, LEG_RELEASE_GATE)
 ZIG_LEGS = (LEG_FMT, LEG_ZIG)
 
 # The justfile defines the legs themselves, so editing a recipe a leg runs
@@ -45,7 +49,20 @@ RECIPE_LEGS = {
     "build-win": (LEG_WIN,),
     "gates-selftest": (LEG_GATES,),
     "gitversion-selftest": (LEG_GATES,),
+    "release-gate-check": (LEG_RELEASE_GATE,),
 }
+
+# Checked BEFORE the prefix rules, because these need both ends of the path.
+# A bare ".csproj" suffix rule would never fire for anything under windows/:
+# the windows/ prefix matches first and suffixes are only consulted when no
+# prefix did. And a project file is a real route into a leaking build -- a
+# DefineConstants;DEMO written straight into one never sets DemoEnabled, so
+# the build-time <Error> cannot see it and only the compiled result can.
+PREFIX_SUFFIX_RULES = (
+    ("windows/", ".csproj", (LEG_WIN, LEG_RELEASE_GATE)),
+    ("windows/", ".props", (LEG_WIN, LEG_RELEASE_GATE)),
+    ("windows/", ".targets", (LEG_WIN, LEG_RELEASE_GATE)),
+)
 
 # Ordered, first match wins, so a more specific prefix must precede its
 # parent. An empty tuple means the path cannot affect any leg.
@@ -73,6 +90,12 @@ PREFIX_RULES = (
 )
 
 EXACT_RULES = {
+    # The check itself. Not a gates-selftest member: that leg runs anywhere,
+    # and this one needs a Windows toolchain.
+    ".agents/scripts/release_gate_check.ps1": (LEG_RELEASE_GATE,),
+    # The compiled-result half of the shipping gate. It is #if !DEBUG, so
+    # editing it proves nothing until a Release run executes it.
+    "windows/Ghostty.Tests/Demo/ShippingBuildGateTests.cs": (LEG_WIN, LEG_RELEASE_GATE),
     # The gates leg runs this script's selftest, which needs no build.
     # Editing it must also run the check itself, and that needs the Zig
     # toolchain, so it rides the Zig leg through `just test`.
@@ -136,6 +159,9 @@ def legs_for_path(path):
     p = normalize(path)
     if p in EXACT_RULES:
         return EXACT_RULES[p]
+    for prefix, suffix, legs in PREFIX_SUFFIX_RULES:
+        if p.startswith(prefix) and p.endswith(suffix):
+            return legs
     for prefix, legs in PREFIX_RULES:
         if p.startswith(prefix):
             return legs

--- a/.agents/scripts/pr_gate.py
+++ b/.agents/scripts/pr_gate.py
@@ -516,6 +516,14 @@ def self_test():
         (["windows/Ghostty.Tests/Demo/ShippingBuildGateTests.cs"], False,
          ["release-gate", "windows-tests"]),
         ([".agents/scripts/release_gate_check.ps1"], False, ["release-gate"]),
+        # A response file under windows/ turns its contents into command-line
+        # arguments, i.e. GLOBAL properties -- the one shape that satisfies
+        # the gate's own opt-in test while also compiling the runtime guard
+        # out. It must not resolve to windows-tests alone.
+        (["windows/Directory.Build.rsp"], False, ["release-gate", "windows-tests"]),
+        (["windows/Ghostty.sln"], False, ["release-gate", "windows-tests"]),
+        # The SDK pin is the MSBuild that evaluates the gate.
+        (["global.json"], False, ["release-gate", "windows-tests"]),
         (["src/a.zig", "windows/b.cs"], False, ["windows-tests", "zig-fmt", "zig-tests"]),
         (["brand/new/dir/thing.bin"], False, sorted(gate_scope.ALL_LEGS)),
         (["justfile"], list(gate_scope.ALL_LEGS), sorted(gate_scope.ALL_LEGS)),

--- a/.agents/scripts/pr_gate.py
+++ b/.agents/scripts/pr_gate.py
@@ -506,6 +506,16 @@ def self_test():
         (["src/build/GitVersion.zig"], False, ["gates-selftest", "zig-fmt", "zig-tests"]),
         (["src/build/Config.zig"], False, ["gates-selftest", "zig-fmt", "zig-tests"]),
         (["windows/App.xaml.cs"], False, ["windows-tests"]),
+        # The release gate is narrow on purpose: ordinary shell source does
+        # not pull it in, but anything that can define a constant or set the
+        # gate properties does. The .csproj case is the one a plain suffix
+        # rule could not express -- the windows/ prefix matches first, and
+        # suffixes are only consulted when no prefix did.
+        (["windows/Ghostty/Ghostty.csproj"], False, ["release-gate", "windows-tests"]),
+        (["windows/Directory.Build.targets"], False, ["release-gate", "windows-tests"]),
+        (["windows/Ghostty.Tests/Demo/ShippingBuildGateTests.cs"], False,
+         ["release-gate", "windows-tests"]),
+        ([".agents/scripts/release_gate_check.ps1"], False, ["release-gate"]),
         (["src/a.zig", "windows/b.cs"], False, ["windows-tests", "zig-fmt", "zig-tests"]),
         (["brand/new/dir/thing.bin"], False, sorted(gate_scope.ALL_LEGS)),
         (["justfile"], list(gate_scope.ALL_LEGS), sorted(gate_scope.ALL_LEGS)),

--- a/.agents/scripts/release_gate_check.ps1
+++ b/.agents/scripts/release_gate_check.ps1
@@ -1,0 +1,132 @@
+#requires -Version 7
+<#
+    Does the shipping-build gate actually REFUSE a leak, in a real Release
+    evaluation?
+
+    Every other check on this gate reads windows/Directory.Build.targets and
+    asserts the property is WRITTEN correctly. That proves the gate is
+    spelled right, not that it behaves -- two different claims, and the repo
+    has been bitten by the gap twice (#926, #928). The ladder never built
+    Release at all, so `#if !DEBUG` facts and the <Error> conditions were
+    unenforced here and only ran in the release repo, against a pin that lags
+    (#929).
+
+    Nothing is compiled. The gate target is invoked directly, so each probe
+    is an MSBuild evaluation of a few seconds rather than a Release build.
+
+    Two halves, because the two routes into a leaking build are different:
+
+      - RefuseAGateLeakIntoARelease catches DemoEnabled/TestSeamEnabled set
+        from anywhere that is not a command-line -p: opt-in. Probed below in
+        both polarities and by both routes (a -p: on the derived property,
+        and an environment variable), because the mechanism that tells a
+        command-line opt-in from any other source is a subtle one: the
+        targets file reassigns Demo/TestSeam to "not-a-global", which MSBuild
+        silently discards for a global property and applies for every other
+        kind. If that ever stops working, the sanctioned opt-in starts
+        failing and the leak starts passing -- so both directions are pinned.
+
+      - ShippingBuildGateTests covers what the target cannot see: a
+        DefineConstants;DEMO written straight into a project file never sets
+        DemoEnabled, so no <Error> fires and only the compiled result gives
+        it away. Those tests are #if !DEBUG, so they need a real Release
+        test run.
+
+    Exits 0 when the gate holds, 1 when it does not or the check could not run.
+#>
+param(
+    # Skip the Release test run; probe the build-time target only. For a
+    # caller that has already run it, not for making a red run green.
+    [switch]$TargetOnly
+)
+$ErrorActionPreference = 'Stop'
+
+$repo = (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
+$proj = "$repo/windows/Ghostty/Ghostty.csproj"
+$tests = "$repo/windows/Ghostty.Tests/Ghostty.Tests.csproj"
+$target = 'RefuseAGateLeakIntoARelease'
+
+if (-not (Test-Path $proj)) { Write-Host "HARNESS: missing $proj"; exit 1 }
+
+$failures = 0
+
+function Invoke-Probe {
+    param(
+        [Parameter(Mandatory)][string]$What,
+        [string[]]$BuildArgs = @(),
+        # 'OK' for a build that must succeed, or the MSBuild code the refusal
+        # must carry. A refusal with the wrong code is a failure: it means
+        # something else broke, not that the gate fired.
+        [Parameter(Mandatory)][string]$Want,
+        [hashtable]$WithEnv = @{}
+    )
+    $saved = @{}
+    foreach ($k in $WithEnv.Keys) {
+        $saved[$k] = [Environment]::GetEnvironmentVariable($k)
+        [Environment]::SetEnvironmentVariable($k, $WithEnv[$k])
+    }
+    try {
+        $out = & dotnet build $proj -c Release /p:Platform=x64 -t:$target @BuildArgs 2>&1
+        $rc = $LASTEXITCODE
+    }
+    finally {
+        foreach ($k in $WithEnv.Keys) { [Environment]::SetEnvironmentVariable($k, $saved[$k]) }
+    }
+    $code = ($out | Select-String -Pattern 'WINTTY000[12]' | Select-Object -First 1)
+    $seen = if ($code) { ($code.Line -replace '.*(WINTTY000[12]).*', '$1') } else { '-' }
+
+    $ok = if ($Want -eq 'OK') { $rc -eq 0 } else { $rc -ne 0 -and $seen -eq $Want }
+    if ($ok) {
+        Write-Host ("  ok    {0,-44} (rc={1} code={2})" -f $What, $rc, $seen)
+    }
+    else {
+        Write-Host ("  FAIL  {0,-44} (rc={1} code={2}, wanted {3})" -f $What, $rc, $seen, $Want)
+        $script:failures++
+    }
+}
+
+Write-Host 'release-gate: the build-time refusal'
+# Control first. If a plain Release evaluation cannot even run, every refusal
+# below would "pass" for the wrong reason.
+Invoke-Probe -What 'plain Release evaluates'          -Want 'OK'
+Invoke-Probe -What 'sanctioned -p:Demo=true'          -Want 'OK' -BuildArgs @('/p:Demo=true')
+Invoke-Probe -What 'sanctioned -p:TestSeam=true'      -Want 'OK' -BuildArgs @('/p:TestSeam=true')
+Invoke-Probe -What 'leak: -p:DemoEnabled=true'        -Want 'WINTTY0002' -BuildArgs @('/p:DemoEnabled=true')
+Invoke-Probe -What 'leak: -p:TestSeamEnabled=true'    -Want 'WINTTY0001' -BuildArgs @('/p:TestSeamEnabled=true')
+Invoke-Probe -What 'leak: Demo=true in the env'       -Want 'WINTTY0002' -WithEnv @{ Demo = 'true' }
+Invoke-Probe -What 'leak: TestSeam=true in the env'   -Want 'WINTTY0001' -WithEnv @{ TestSeam = 'true' }
+
+if (-not $TargetOnly) {
+    Write-Host ''
+    Write-Host 'release-gate: the compiled-result tests (#if !DEBUG, so Release only)'
+    $out = & dotnet test $tests -c Release /p:Platform=x64 --nologo `
+        --filter 'FullyQualifiedName~ShippingBuildGateTests' 2>&1
+    $rc = $LASTEXITCODE
+    $summary = ($out | Select-String -Pattern 'Passed!|Failed!|No test matches' | Select-Object -First 1)
+    if ($summary) { Write-Host ("  {0}" -f $summary.Line.Trim()) }
+
+    # A filter that matches nothing exits 0. Green on zero tests is exactly
+    # the shape this whole issue is about, so the count is asserted, not the
+    # exit code alone.
+    $ran = ($out | Select-String -Pattern 'Passed:\s+(\d+)' | Select-Object -First 1)
+    $count = if ($ran) { [int]($ran.Matches[0].Groups[1].Value) } else { 0 }
+    if ($rc -ne 0) {
+        Write-Host '  FAIL  the Release gate tests did not pass'
+        $script:failures++
+    }
+    elseif ($count -lt 1) {
+        Write-Host '  FAIL  the filter matched no tests, so this leg proved nothing'
+        $script:failures++
+    }
+    else {
+        Write-Host ("  ok    {0} Release gate test(s) ran and passed" -f $count)
+    }
+}
+
+Write-Host ''
+if ($failures -gt 0) {
+    Write-Host ("release-gate: {0} check(s) failed" -f $failures)
+    exit 1
+}
+Write-Host 'release-gate: the shipping gate refuses what it should and admits what it should'
+exit 0

--- a/.agents/scripts/release_gate_check.ps1
+++ b/.agents/scripts/release_gate_check.ps1
@@ -4,59 +4,80 @@
     evaluation?
 
     Every other check on this gate reads windows/Directory.Build.targets and
-    asserts the property is WRITTEN correctly. That proves the gate is
-    spelled right, not that it behaves -- two different claims, and the repo
-    has been bitten by the gap twice (#926, #928). The ladder never built
-    Release at all, so `#if !DEBUG` facts and the <Error> conditions were
-    unenforced here and only ran in the release repo, against a pin that lags
-    (#929).
+    asserts the property is WRITTEN correctly. That proves the gate is spelled
+    right, not that it behaves -- two different claims, and the repo has been
+    bitten by the gap twice (#926, #928). The ladder never built Release at
+    all, so the #if !DEBUG facts and the <Error> conditions were unenforced
+    here and ran only in the release repo, against a pin that lags (#929).
 
-    Nothing is compiled. The gate target is invoked directly, so each probe
-    is an MSBuild evaluation of a few seconds rather than a Release build.
+    Three probe sets, because there are three different ways a leak gets in.
 
-    Two halves, because the two routes into a leaking build are different:
+    1. THE REFUSAL. RefuseAGateLeakIntoARelease catches DemoEnabled or
+       TestSeamEnabled set from anywhere that is not a command-line -p:
+       opt-in. Probed in both polarities and by both routes, because the
+       mechanism separating a command-line opt-in from every other source is
+       subtle: the targets file reassigns Demo/TestSeam to "not-a-global",
+       which MSBuild discards for a global property and applies for
+       everything else. If that stops working the sanctioned opt-in starts
+       failing AND the leak starts passing, so both directions are pinned.
 
-      - RefuseAGateLeakIntoARelease catches DemoEnabled/TestSeamEnabled set
-        from anywhere that is not a command-line -p: opt-in. Probed below in
-        both polarities and by both routes (a -p: on the derived property,
-        and an environment variable), because the mechanism that tells a
-        command-line opt-in from any other source is a subtle one: the
-        targets file reassigns Demo/TestSeam to "not-a-global", which MSBuild
-        silently discards for a global property and applies for every other
-        kind. If that ever stops working, the sanctioned opt-in starts
-        failing and the leak starts passing -- so both directions are pinned.
+    2. THE EVALUATED CONSTANTS. The target reads DemoEnabled, never
+       DefineConstants -- so a `DefineConstants;DEMO` written straight into a
+       project file is invisible to it. Nothing else looks either: the test
+       projects deliberately do not reference Ghostty.csproj, so no leg builds
+       or loads Wintty.dll. This asks MSBuild what Release actually evaluates
+       DefineConstants to, for every project under windows/, and refuses DEMO
+       or TESTSEAM. It carries its own control -- under -p:Demo=true the token
+       MUST appear -- because "no DEMO found" is also what a query returning
+       nothing looks like.
 
-      - ShippingBuildGateTests covers what the target cannot see: a
-        DefineConstants;DEMO written straight into a project file never sets
-        DemoEnabled, so no <Error> fires and only the compiled result gives
-        it away. Those tests are #if !DEBUG, so they need a real Release
-        test run.
+    3. THE COMPILED RESULT. ShippingBuildGateTests covers what neither of the
+       above can: sources compiled in with no property saying so. Those facts
+       are #if !DEBUG, so they need a real Release test run, and each is
+       asserted BY NAME with a count of exactly one. A floor of one does not
+       work here -- the class has four facts and only two are Release-only, so
+       a floor is satisfied by the two that already run in Debug, and
+       inverting the #if !DEBUG guard would pass.
+
+    What this does NOT prove, stated so the leg is not read as wider than it
+    is: that the target is still WIRED into a build (it is invoked by name
+    here, so a broken BeforeTargets would not show -- the file-text checks in
+    ShippingBuildGateTests cover that, and this complements them rather than
+    superseding them); that a Release build compiles at all; and nothing about
+    solution-level configuration mapping in Ghostty.sln.
 
     Exits 0 when the gate holds, 1 when it does not or the check could not run.
 #>
 param(
-    # Skip the Release test run; probe the build-time target only. For a
-    # caller that has already run it, not for making a red run green.
-    [switch]$TargetOnly
+    # Skip the Release test run; probe MSBuild only. For a caller that has
+    # already run it, not for making a red run green.
+    [switch]$NoTestRun
 )
 $ErrorActionPreference = 'Stop'
 
+# VSTest and the SDK localise their output, and this parses it. Pin English so
+# a non-English host fails on the gate rather than on the language.
+$env:DOTNET_CLI_UI_LANGUAGE = 'en'
+
 $repo = (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
-$proj = "$repo/windows/Ghostty/Ghostty.csproj"
-$tests = "$repo/windows/Ghostty.Tests/Ghostty.Tests.csproj"
+$app = Join-Path $repo 'windows/Ghostty/Ghostty.csproj'
+$tests = Join-Path $repo 'windows/Ghostty.Tests/Ghostty.Tests.csproj'
 $target = 'RefuseAGateLeakIntoARelease'
+if (-not (Test-Path $app)) { Write-Host "HARNESS: missing $app"; exit 1 }
 
-if (-not (Test-Path $proj)) { Write-Host "HARNESS: missing $proj"; exit 1 }
+$script:failures = 0
+function Fail([string]$Text) { Write-Host "  FAIL  $Text"; $script:failures++ }
+function Pass([string]$Text) { Write-Host "  ok    $Text" }
 
-$failures = 0
+# ---- 1. the refusal ------------------------------------------------------
 
-function Invoke-Probe {
+function Invoke-Refusal {
     param(
         [Parameter(Mandatory)][string]$What,
         [string[]]$BuildArgs = @(),
-        # 'OK' for a build that must succeed, or the MSBuild code the refusal
-        # must carry. A refusal with the wrong code is a failure: it means
-        # something else broke, not that the gate fired.
+        # 'OK', or the MSBuild code the refusal must carry. A refusal with the
+        # wrong code is a failure: it means something else broke, not that the
+        # gate fired.
         [Parameter(Mandatory)][string]$Want,
         [hashtable]$WithEnv = @{}
     )
@@ -66,66 +87,97 @@ function Invoke-Probe {
         [Environment]::SetEnvironmentVariable($k, $WithEnv[$k])
     }
     try {
-        $out = & dotnet build $proj -c Release /p:Platform=x64 -t:$target @BuildArgs 2>&1
+        $out = & dotnet build $app -c Release /p:Platform=x64 -t:$target @BuildArgs 2>&1
         $rc = $LASTEXITCODE
     }
     finally {
         foreach ($k in $WithEnv.Keys) { [Environment]::SetEnvironmentVariable($k, $saved[$k]) }
     }
-    $code = ($out | Select-String -Pattern 'WINTTY000[12]' | Select-Object -First 1)
-    $seen = if ($code) { ($code.Line -replace '.*(WINTTY000[12]).*', '$1') } else { '-' }
 
-    $ok = if ($Want -eq 'OK') { $rc -eq 0 } else { $rc -ne 0 -and $seen -eq $Want }
-    if ($ok) {
-        Write-Host ("  ok    {0,-44} (rc={1} code={2})" -f $What, $rc, $seen)
+    $line = $out | Select-String -Pattern 'WINTTY000[12]' | Select-Object -First 1
+    # Match, not a greedy replace: a line naming both codes reports the first.
+    $seen = if ($line) { [regex]::Match($line.Line, 'WINTTY000[12]').Value } else { '-' }
+
+    if ($Want -eq 'OK') {
+        if ($rc -eq 0) { Pass "$What (rc=0)" }
+        else { Fail "$What (rc=$rc code=$seen, wanted success)" }
     }
-    else {
-        Write-Host ("  FAIL  {0,-44} (rc={1} code={2}, wanted {3})" -f $What, $rc, $seen, $Want)
-        $script:failures++
-    }
+    elseif ($rc -ne 0 -and $seen -eq $Want) { Pass "$What (refused $seen)" }
+    else { Fail "$What (rc=$rc code=$seen, wanted $Want)" }
 }
 
-Write-Host 'release-gate: the build-time refusal'
-# Control first. If a plain Release evaluation cannot even run, every refusal
-# below would "pass" for the wrong reason.
-Invoke-Probe -What 'plain Release evaluates'          -Want 'OK'
-Invoke-Probe -What 'sanctioned -p:Demo=true'          -Want 'OK' -BuildArgs @('/p:Demo=true')
-Invoke-Probe -What 'sanctioned -p:TestSeam=true'      -Want 'OK' -BuildArgs @('/p:TestSeam=true')
-Invoke-Probe -What 'leak: -p:DemoEnabled=true'        -Want 'WINTTY0002' -BuildArgs @('/p:DemoEnabled=true')
-Invoke-Probe -What 'leak: -p:TestSeamEnabled=true'    -Want 'WINTTY0001' -BuildArgs @('/p:TestSeamEnabled=true')
-Invoke-Probe -What 'leak: Demo=true in the env'       -Want 'WINTTY0002' -WithEnv @{ Demo = 'true' }
-Invoke-Probe -What 'leak: TestSeam=true in the env'   -Want 'WINTTY0001' -WithEnv @{ TestSeam = 'true' }
+Write-Host 'release-gate 1/3: the build-time refusal'
+Invoke-Refusal -What 'plain Release evaluates'        -Want 'OK'
+Invoke-Refusal -What 'sanctioned -p:Demo=true'        -Want 'OK' -BuildArgs @('/p:Demo=true')
+Invoke-Refusal -What 'sanctioned -p:TestSeam=true'    -Want 'OK' -BuildArgs @('/p:TestSeam=true')
+Invoke-Refusal -What 'leak: -p:DemoEnabled=true'      -Want 'WINTTY0002' -BuildArgs @('/p:DemoEnabled=true')
+Invoke-Refusal -What 'leak: -p:TestSeamEnabled=true'  -Want 'WINTTY0001' -BuildArgs @('/p:TestSeamEnabled=true')
+Invoke-Refusal -What 'leak: Demo=true in the env'     -Want 'WINTTY0002' -WithEnv @{ Demo = 'true' }
+Invoke-Refusal -What 'leak: TestSeam=true in the env' -Want 'WINTTY0001' -WithEnv @{ TestSeam = 'true' }
 
-if (-not $TargetOnly) {
+# ---- 2. the evaluated constants ------------------------------------------
+
+function Get-Constants {
+    param([Parameter(Mandatory)][string]$Proj, [string[]]$Extra = @())
+    $out = & dotnet msbuild $Proj -p:Configuration=Release -p:Platform=x64 `
+        -getProperty:DefineConstants @Extra 2>&1
+    if ($LASTEXITCODE -ne 0) { return $null }
+    # Split into tokens rather than substring-matching: TESTSEAM_OPTIN
+    # contains TESTSEAM, and DEMO_OPTIN contains DEMO.
+    return @(($out | Select-Object -Last 1).ToString().Split(';') |
+        ForEach-Object { $_.Trim() } | Where-Object { $_ })
+}
+
+Write-Host ''
+Write-Host 'release-gate 2/3: what a Release evaluation actually defines'
+
+$sep = [IO.Path]::DirectorySeparatorChar
+$projects = Get-ChildItem (Join-Path $repo 'windows') -Recurse -Filter '*.csproj' |
+    Where-Object {
+        $parts = $_.FullName.Split($sep)
+        ($parts -notcontains 'obj') -and ($parts -notcontains 'bin')
+    } | Sort-Object Name
+
+if ($projects.Count -lt 1) { Fail 'found no project files to evaluate' }
+
+# The control first. If the query cannot see a constant that IS there, every
+# clean result below means nothing.
+$withOptIn = Get-Constants -Proj $app -Extra @('-p:Demo=true')
+if ($null -eq $withOptIn) { Fail 'the DefineConstants query failed on the app project' }
+elseif ($withOptIn -notcontains 'DEMO') { Fail 'the query cannot see DEMO even under -p:Demo=true, so it proves nothing' }
+else { Pass 'control: the query does see DEMO under -p:Demo=true' }
+
+foreach ($p in $projects) {
+    $c = Get-Constants -Proj $p.FullName
+    if ($null -eq $c) { Fail ('could not evaluate DefineConstants for {0}' -f $p.Name); continue }
+    $leaked = @($c | Where-Object { $_ -eq 'DEMO' -or $_ -eq 'TESTSEAM' })
+    if ($leaked.Count -gt 0) { Fail ('{0} defines {1} in Release' -f $p.Name, ($leaked -join ',')) }
+    else { Pass ('{0}: neither DEMO nor TESTSEAM' -f $p.Name) }
+}
+
+# ---- 3. the compiled result ----------------------------------------------
+
+if (-not $NoTestRun) {
     Write-Host ''
-    Write-Host 'release-gate: the compiled-result tests (#if !DEBUG, so Release only)'
-    $out = & dotnet test $tests -c Release /p:Platform=x64 --nologo `
-        --filter 'FullyQualifiedName~ShippingBuildGateTests' 2>&1
-    $rc = $LASTEXITCODE
-    $summary = ($out | Select-String -Pattern 'Passed!|Failed!|No test matches' | Select-Object -First 1)
-    if ($summary) { Write-Host ("  {0}" -f $summary.Line.Trim()) }
-
-    # A filter that matches nothing exits 0. Green on zero tests is exactly
-    # the shape this whole issue is about, so the count is asserted, not the
-    # exit code alone.
-    $ran = ($out | Select-String -Pattern 'Passed:\s+(\d+)' | Select-Object -First 1)
-    $count = if ($ran) { [int]($ran.Matches[0].Groups[1].Value) } else { 0 }
-    if ($rc -ne 0) {
-        Write-Host '  FAIL  the Release gate tests did not pass'
-        $script:failures++
-    }
-    elseif ($count -lt 1) {
-        Write-Host '  FAIL  the filter matched no tests, so this leg proved nothing'
-        $script:failures++
-    }
-    else {
-        Write-Host ("  ok    {0} Release gate test(s) ran and passed" -f $count)
+    Write-Host 'release-gate 3/3: the compiled-result facts (#if !DEBUG, so Release only)'
+    foreach ($fact in 'A_shipping_build_carries_no_demo_code', 'A_shipping_build_carries_no_test_seam') {
+        $out = & dotnet test $tests -c Release /p:Platform=x64 --nologo `
+            --filter "FullyQualifiedName~$fact" 2>&1
+        $rc = $LASTEXITCODE
+        $m = $out | Select-String -Pattern 'Passed:\s+(\d+)' | Select-Object -First 1
+        $n = if ($m) { [int]$m.Matches[0].Groups[1].Value } else { 0 }
+        # By name, and exactly one. A filter matching nothing exits 0, and this
+        # class also holds facts that run in Debug -- so neither the exit code
+        # nor a count floor can carry this claim.
+        if ($rc -ne 0) { Fail "$fact did not pass" }
+        elseif ($n -ne 1) { Fail "$fact ran $n time(s), wanted exactly 1 -- is it still #if !DEBUG?" }
+        else { Pass "$fact ran and passed" }
     }
 }
 
 Write-Host ''
-if ($failures -gt 0) {
-    Write-Host ("release-gate: {0} check(s) failed" -f $failures)
+if ($script:failures -gt 0) {
+    Write-Host ('release-gate: {0} check(s) failed' -f $script:failures)
     exit 1
 }
 Write-Host 'release-gate: the shipping gate refuses what it should and admits what it should'

--- a/.agents/scripts/signoff.py
+++ b/.agents/scripts/signoff.py
@@ -42,6 +42,7 @@ LEG_COMMANDS = {
     gate_scope.LEG_ZIG: ["just", "test"],
     gate_scope.LEG_WIN: ["just", "test-win"],
     gate_scope.LEG_GATES: ["just", "gates-selftest"],
+    gate_scope.LEG_RELEASE_GATE: ["just", "release-gate-check"],
 }
 
 

--- a/justfile
+++ b/justfile
@@ -1553,11 +1553,6 @@ gitversion-selftest:
 # scripts' helpers roundtripping. `gitversion-selftest` runs first.
 #
 # Prove the gates still catch what they exist for.
-# Prove the shipping-build gate refuses a leak in a real Release evaluation (#929)
-[windows]
-release-gate-check:
-    pwsh -NoProfile -File .agents/scripts/release_gate_check.ps1
-
 gates-selftest: gitversion-selftest
     python .agents/scripts/pr_gate.py --self-test
     python .agents/scripts/workspace_guard.py --self-test
@@ -1565,3 +1560,8 @@ gates-selftest: gitversion-selftest
     python .agents/scripts/test_reachability.py --self-test
     pwsh -NoProfile -File .agents/scripts/nightly_fuzz.ps1 -SelfTest
     pwsh -NoProfile -File .agents/scripts/nightly_control.ps1 -SelfTest
+
+# Prove the shipping-build gate refuses a leak in a real Release evaluation (#929)
+[windows]
+release-gate-check:
+    pwsh -NoProfile -File .agents/scripts/release_gate_check.ps1

--- a/justfile
+++ b/justfile
@@ -1553,6 +1553,11 @@ gitversion-selftest:
 # scripts' helpers roundtripping. `gitversion-selftest` runs first.
 #
 # Prove the gates still catch what they exist for.
+# Prove the shipping-build gate refuses a leak in a real Release evaluation (#929)
+[windows]
+release-gate-check:
+    pwsh -NoProfile -File .agents/scripts/release_gate_check.ps1
+
 gates-selftest: gitversion-selftest
     python .agents/scripts/pr_gate.py --self-test
     python .agents/scripts/workspace_guard.py --self-test


### PR DESCRIPTION
Closes #929.

Every existing check on the DEMO and TESTSEAM gates reads `windows/Directory.Build.targets` and asserts the property is *written* correctly. None of them evaluated it. Those are different claims, and the gap has bitten this repo twice — #926 landed a guard that failed every Release run and would have merged green, and #928 worked around the same shape again.

A new **`release-gate`** leg does the evaluation.

## Not a Release leg

Option (1) in the issue — adding a real Release build to the ladder — would roughly double the merge gate's wall-clock while CI is unavailable. Instead the gate target is invoked directly with `-t:RefuseAGateLeakIntoARelease`, so nothing compiles: seven build-time probes cost about twenty seconds, and the whole leg about fifty with the test half included. It runs only when something that can actually turn the gate off has changed.

## Both routes, because they are different

**`RefuseAGateLeakIntoARelease`** catches `DemoEnabled`/`TestSeamEnabled` set from anywhere that is not a command-line opt-in. Probed in both polarities and by both routes — a `-p:` on the derived property, and an environment variable.

Both directions are pinned, not just the refusals. The mechanism that distinguishes a command-line opt-in from every other source is subtle: the targets file reassigns `Demo`/`TestSeam` to `not-a-global`, which MSBuild silently discards for a global property and applies for everything else. If that ever stops working, the sanctioned opt-in starts failing **and** the leak starts passing — so `-p:Demo=true` and `-p:TestSeam=true` are asserted to still succeed alongside the four refusals.

**`ShippingBuildGateTests`** covers what the target structurally cannot see: a `DefineConstants;DEMO` written straight into a project file never sets `DemoEnabled`, so no `<Error>` fires and only the compiled result gives it away. Those tests are `#if !DEBUG`, so this half needs a real Release test run. The check asserts the test **count**, not the exit code — a filter matching nothing exits 0, and green-on-zero-tests is the exact shape this issue is about.

## Scoping

`Directory.Build.*`, any `windows/**/*.csproj`, the gate tests and the check script pull the leg in; ordinary shell source still gets `windows-tests` alone.

That needed a rule form constraining both ends of a path. A project file is a real route into a leak, but a bare `.csproj` suffix rule never fires under `windows/`: the prefix matches first, and suffixes are only consulted when no prefix did.

The leg is its own rather than folded into `gates-selftest`, which has no `[windows]` attribute and runs where a Release build of a WinUI project cannot.

## Proof

Mutation-proved against the issue's acceptance criterion — deleting the `WINTTY0002` condition, making a plain Release build enable demo, and writing `DEMO` into a project file behind the target's back each take the check red, with a green baseline and restore either side. The new scope rules are pinned in `pr_gate --self-test`.

Signoff on this branch scheduled and ran the new leg on its own commit: `release-gate -> rc=0`.

---

## Review round

Reviewed with a subagent, which found the leg dishonest in two ways.

**The test half was false-green on the mutation #929 itself names.** `ShippingBuildGateTests` holds four facts and only two are `#if !DEBUG`; the other two are file-text reads the Debug leg already runs. A floor of one was therefore satisfied by tests that say nothing about Release — so inverting the `#if !DEBUG` guard, which deletes exactly the coverage this leg exists to add, passed. Each Release-only fact is now asserted **by name with a count of exactly one**, and that mutation goes red with `ran 0 time(s), wanted exactly 1`.

**The leg claimed a route it could not reach.** The comment on the `.csproj` scoping rule said it exists because a `DefineConstants;DEMO` is invisible to the build-time target — true, and nothing else looked either: the target reads `DemoEnabled` and never `DefineConstants`, and the test projects deliberately do not reference `Ghostty.csproj`, so no leg builds or loads `Wintty.dll`. Rather than narrow the claim, a third probe set closes it: MSBuild is asked what a Release evaluation actually defines, per project, for every project under `windows/`, and `DEMO`/`TESTSEAM` as whole tokens is a failure. It carries its own control — under `-p:Demo=true` the token must appear — because "no DEMO found" and "the query returned nothing" are otherwise identical.

**And the sharpest route was not one of ours.** MSBuild reads `Directory.Build.rsp` walking up from the working directory and treats its contents as *command-line arguments* — so `-p:Demo=true` in one arrives as a **global** property: it satisfies the very opt-in test the gate uses to tell a deliberate opt-in from a leak, **and** defines `DEMO_OPTIN`, which compiles the runtime guard out too. Every check green, demo mode shipping. `.rsp`, `.sln` and `.config` under `windows/` now pull the leg, as does `global.json` — the SDK pin is the MSBuild that evaluates the gate.

Also: the recipe had been inserted between `gates-selftest`'s doc comment and its body, so `just --list` showed that comment against the new recipe; the README's gate list did not mention it; the parsed VSTest output is localised, so the SDK UI language is pinned; and the script header now states what the leg does **not** prove — that the target is still wired into a build, that Release compiles, or anything about solution configuration mapping. It complements the file-text checks rather than superseding them.
