### PR TITLE
sync: identify the snapshot by its shape, not by being the newest merge

### DIFF
--- a/.agents/scripts/syncflow-selftest.sh
+++ b/.agents/scripts/syncflow-selftest.sh
@@ -289,6 +289,43 @@ expect_fail "a reused deep-history subject is still refused" "f1: fork file" J s
 ( cd work && git checkout -q windows && git branch -q -D series-wip )
 # The guards below need a standing wip; rebuild one without the sneaky work.
 J sync
+J sync-publish
+
+say "test 11: a PR that lands unsquashed is folded in whole"
+# The flow assumes PRs squash-merge into windows. When one lands as a merge
+# commit instead, it sits on the same first-parent chain as the snapshots while
+# its own commits sit off that chain. Both halves of sync have to cope: the
+# snapshot walk must not mistake it for a snapshot, and the fold must reach the
+# content, which a first-parent walk cannot see.
+( cd up && echo lib11 >> lib.txt && $G add -A && $G commit -qm "u12: unsquashed era" )
+( cd work
+  git checkout -q windows
+  git reset -q --hard refs/remotes/origin/windows
+  git checkout -q -b feature/unsquashed
+  echo one > mc1.txt && $G add -A && $G commit -qm "m1: first commit of an unsquashed PR"
+  echo two > mc2.txt && $G add -A && $G commit -qm "m2: second commit of an unsquashed PR"
+  git checkout -q windows
+  $G merge -q --no-ff -m "Merge pull request #999 from fixture/unsquashed" feature/unsquashed
+  git push -q origin windows
+)
+MC=$(git -C work rev-parse refs/heads/windows)
+check_eq "the fixture PR really is an unsquashed merge" \
+  "$(git -C work rev-list --count --min-parents=2 "$MC~1..$MC")" "1"
+quiet "sync survives a PR merge on the first-parent chain" J sync
+check "the merged PR's first commit is folded in" git -C work cat-file -e 'series-wip:mc1.txt'
+check "the merged PR's second commit is folded in" git -C work cat-file -e 'series-wip:mc2.txt'
+check_eq "the PR merge itself is not replayed as a commit" \
+  "$(git -C work log --oneline refs/remotes/upstream/main..series-wip | grep -c 'Merge pull request' || true)" "0"
+quiet "sync-verify fast (unsquashed fold)" J sync-verify fast
+J sync-publish
+MU=$(git -C origin.git rev-parse refs/heads/windows)
+check_eq "the new snapshot carries the series tree" \
+  "$(git -C work rev-parse "$MU^{tree}")" "$(git -C work rev-parse 'series-wip^{tree}')"
+check "the unsquashed PR reached the published tree" \
+  git -C work cat-file -e "$MU:mc2.txt"
+# A second sync is where the old walk broke: it reads the snapshot past the PR
+# merge still sitting on the chain below it.
+quiet "the next sync still finds the snapshot" J sync
 
 say "guards"
 ( cd work && git checkout -q -b random "$M4" )

--- a/justfile
+++ b/justfile
@@ -557,14 +557,22 @@ sync force="":
         exit 1
     fi
     prev="refs/tags/series/v${prev_n}"
-    # The last snapshot is the only merge commit in FORK-ONLY history, because
-    # PRs squash-merge - hence the range bound. Unbounded, this walk would
-    # sail past the fork's linear commits into upstream's first-parent chain,
-    # which is full of upstream's own PR merges, and return one of those; the
-    # bound excludes them while keeping the snapshot, which is never reachable
-    # from upstream/main. Before the first snapshot exists the range holds no
-    # merge at all, and the v0 tag plays the role.
-    mprev=$(git rev-list --min-parents=2 --first-parent -1 refs/remotes/upstream/main..refs/remotes/origin/windows)
+    # A snapshot merge is the one shape on windows whose SECOND parent is an
+    # upstream commit; every other merge there joins two fork commits. Reading
+    # it as 'the newest merge' instead assumed every PR squash-merges, and a
+    # PR that landed unsquashed sat on the same first-parent chain, was taken
+    # for the snapshot, and refused the sync while hiding its own commits from
+    # the fold below. The range bound stays: unbounded, the walk sails into
+    # upstream's first-parent chain, which is all merges. Before the first
+    # snapshot exists the range holds no merge at all, and the v0 tag plays
+    # the role.
+    mprev=""
+    for c in $(git rev-list --min-parents=2 --first-parent refs/remotes/upstream/main..refs/remotes/origin/windows); do
+        if git merge-base --is-ancestor "${c}^2" refs/remotes/upstream/main; then
+            mprev="$c"
+            break
+        fi
+    done
     if [ -z "$mprev" ]; then
         mprev=$(git rev-parse "${prev}^{commit}")
     fi
@@ -614,8 +622,12 @@ sync force="":
     plus=$(git cherry HEAD refs/remotes/origin/windows "$mprev" | awk '$1 == "+" { print $2 }')
     fold=""
     if [ -n "$plus" ]; then
-        # git cherry answers membership; the rev-list keeps first-parent order.
-        fold=$(git rev-list --reverse --first-parent --no-merges "${mprev}..refs/remotes/origin/windows" \
+        # git cherry answers membership; the rev-list keeps topological order.
+        # Not --first-parent: a PR that lands as a merge keeps its content off
+        # that chain, so the narrower walk folded in every squash around it
+        # and dropped the whole PR without a word. The full walk minus merges
+        # is exactly the set git cherry measures, which is why the two agree.
+        fold=$(git rev-list --reverse --topo-order --no-merges "${mprev}..refs/remotes/origin/windows" \
             | grep -Fx -f <(printf '%s\n' "$plus") || true)
     fi
     if [ -n "$fold" ]; then
@@ -752,7 +764,14 @@ sync-publish ack="":
     #                named, and the publish refuses unless each is explicitly
     #                acknowledged with a reason that lands in history.
     prev="refs/tags/series/v${prev_n}"
-    mprev=$(git rev-list --min-parents=2 --first-parent -1 refs/remotes/upstream/main..refs/remotes/origin/windows)
+    # The snapshot is identified by its shape, not by being newest; see sync.
+    mprev=""
+    for c in $(git rev-list --min-parents=2 --first-parent refs/remotes/upstream/main..refs/remotes/origin/windows); do
+        if git merge-base --is-ancestor "${c}^2" refs/remotes/upstream/main; then
+            mprev="$c"
+            break
+        fi
+    done
     if [ -z "$mprev" ]; then
         mprev=$(git rev-parse "${prev}^{commit}")
     fi


### PR DESCRIPTION
`just sync` refused every replay with:

```
REFUSING: the last snapshot on windows (6345152bd) does not carry the
tree of series/v2. The published branch and the series diverged;
find out which one moved before replaying anything.
```

Nothing had diverged. `tree(series/v2)` and `tree(ec7cc4ec9c)` are both `b5fbe0f9ee`. PR #768 landed as a merge commit rather than a squash, and the walk that looked for "the newest merge in fork-only history" returned it instead of the snapshot.

The refusal was the harmless half. The fold-in walk is `--first-parent --no-merges`, and a merged PR keeps its content off the first-parent chain, so it could not see #768's 29 commits at all. Had the refusal been overridden, the replay would have folded in every squash around it and dropped the whole PR silently — no conflict, no failing test.

## Changes

**Identify a snapshot by its shape.** A snapshot merge is the only merge on `windows` whose second parent is a commit from the base project; every other merge there joins two fork commits. `sync` and `sync-publish` now walk for that instead of taking the newest merge. The tree check stays exactly as it was, and goes back to meaning what it says.

**Fold the full history, minus merges.** Dropping `--first-parent` for `--topo-order` makes the walk reach a merged PR's own commits. This is also the set `git cherry` already measures for membership, so the two now agree instead of disagreeing silently — on the live branch both independently answered 163.

## Coverage

`sync-selftest` gains an unsquashed-PR scenario: 50 checks to 59. Verified red before the fix and green after — without it the run fails on the refusal *and* on both of the PR's commits missing from the series.

```
### test 11: a PR that lands unsquashed is folded in whole
FAIL - sync survives a PR merge on the first-parent chain
FAIL - the merged PR's first commit is folded in
FAIL - the merged PR's second commit is folded in
```

## Prevention

The repository now allows squash merges only (`allow_merge_commit` and `allow_rebase_merge` both off), so the merge button cannot produce another one. `sync-publish` is unaffected — it pushes its snapshot merge directly rather than through the button. This change is the defence in depth behind that.
