### PR TITLE
harnesses: the switcher's wrap claim is finally gated, and check 6 resolves what it skips (#930)

### DIFF
--- a/windows/scripts/README.md
+++ b/windows/scripts/README.md
@@ -139,7 +139,6 @@ meets.
 | script | why |
 |---|---|
 | `mouse-smoke-run.ps1` | the operator drives the checklist by hand |
-| `vtabs-switcher-capture.ps1` | produces frames for a human to look at; no verdict to aggregate |
 | `gen-bell.ps1` | generates a test asset |
 | `aot-fuzz.ps1`, `vtabs-visual-qa.ps1`, `release-smoke.ps1` | runners in their own right. `aot-fuzz` targets the NativeAOT publish, which the suite can also do with `-ExePath` |
 | `tab-tag-ink.ps1` | one regression, not a sweep: it measures whether a colour-tagged tab's pin glyph is painted in the tag foreground (#883). Like `contrast-oracle.ps1` it needs the seam pipe to itself |

--- a/windows/scripts/fuzz-suite.ps1
+++ b/windows/scripts/fuzz-suite.ps1
@@ -246,7 +246,7 @@ $Harnesses = [System.Collections.Generic.List[object]]@(
 # because the integrity check below reads it: a new harness dropped into this
 # directory has to be classified, and prose does not fail a run.
 $NotInSuite = [ordered]@{
-    'ShellIntegrationPs1.Tests.ps1' = 'a plain-assert test file run directly by its own command line (see its header), not a harness: no -ExePath, no app, no verdict shape'
+    'ShellIntegrationPs1.Tests.ps1' = 'plain-assert tests with their own 0/1 exit (see its header), run by its own command line; deliberately unautomated - no recipe, no CI, no suite entry'
     'fuzz-suite.ps1'                = 'this runner'
     'aot-fuzz.ps1'                  = 'a runner; targets the NativeAOT publish, which this suite can also do with -ExePath'
     'vtabs-visual-qa.ps1'           = 'a runner'
@@ -1418,6 +1418,7 @@ foreach ($f in $dupScanFiles) {
     # literal-only reader skips it in silence -- which switches this whole half
     # of the check off for that file while every guard stays green. Same
     # nesting rule as above: a dot-source inside a function is function-scoped.
+    $fileText = [IO.File]::ReadAllText($f.FullName)
     $sourced = @()
     foreach ($cmd in $ast.FindAll({
             param($n) $n -is [System.Management.Automation.Language.CommandAst] -and
@@ -1432,21 +1433,33 @@ foreach ($f in $dupScanFiles) {
             $parent = $parent.Parent
         }
         if ($nested) { continue }
-        $found = [regex]::Matches($cmd.Extent.Text, '[\w.\-]+\.ps1')
+        $found = [regex]::Matches($cmd.Extent.Text, '[\w.\-]+\.ps[dm]?1')
         if ($found.Count -lt 1) {
-            if ($cmd.Extent.Text -notmatch '\.ps1') {
-                # DYNAMIC by design: a variable or expression path with no
-                # .ps1 literal anywhere in the command (ShellIntegrationPs1
-                # dot-sources `$script:integration`, built at runtime from
-                # Join-Path). There is no name to misread, so skipping costs
-                # nothing the refusing rule protects; the leaf it loads is
-                # invisible either way.
+            # A VARIABLE dot-source is resolved through its own file before
+            # being excused: ShellIntegrationPs1.Tests.ps1 writes
+            # `$script:integration = Join-Path $PSScriptRoot '...ghostty.ps1'`
+            # one line up, and the leaf is right there in the assignment.
+            # Reading it keeps `. $p` where `$p = 'x.ps1'` visible to this
+            # check instead of silently dynamic.
+            $varDot = [regex]::Match($cmd.Extent.Text, '\.\s*(\$(?:script:|local:|global:|private:)?[A-Za-z_]\w*)')
+            if ($varDot.Success) {
+                $esc = [regex]::Escape($varDot.Groups[1].Value)
+                $assign = [regex]::Match($fileText, ($esc + '\s*=\s*([^\r\n]+)'))
+                if ($assign.Success) {
+                    $found = [regex]::Matches($assign.Groups[1].Value, '[\w.\-]+\.ps[dm]?1')
+                }
+            }
+        }
+        if ($found.Count -lt 1) {
+            if (-not $varDot.Success) {
+                # DYNAMIC by design after resolution failed: no path literal
+                # in the command and no literal in the variable's own
+                # assignment - composed at runtime from non-literals. There
+                # is no name anywhere in the file to misread.
                 continue
             }
-            # The command NAMES a .ps1 but no leaf could be extracted - a
-            # spelling the reader misread. REFUSED, not skipped: skipping is
-            # how the next spelling nobody anticipated turns the check off
-            # without saying so.
+            # The command NAMES a script file but no leaf could be extracted
+            # - a spelling the reader misread. REFUSED, not skipped.
             $problems += ("$rel dot-sources something this check cannot resolve to a file name, " +
                           "so it cannot be compared: " + $cmd.Extent.Text.Trim())
             continue

--- a/windows/scripts/fuzz-suite.ps1
+++ b/windows/scripts/fuzz-suite.ps1
@@ -183,6 +183,8 @@ $Harnesses = [System.Collections.Generic.List[object]]@(
                 oracle = 'the crash investigation''s repro made deterministic, driven entirely over the in-process seam (zero synthesized OS input, zero focus steals, so the machine stays usable). Per iteration: seed 5 tabs, pin one, group two, collapse one, toggle the layout twice - so every iteration contains one switch INTO the vertical layout with pins, groups and collapsed chips already in the strip, which is the compound that died on 2026-08-31 (COMException 0x800F1000, a NavigationViewItem style applied onto a ContentControl through ApplyPaneLayout -> set_PaneDisplayMode -> MeasureOverride). It asserts manager truth after every step - order, pin flag, group membership, collapse bit - and that the process is still alive; a final leg drives the drag engine''s real press/threshold/crossing/release and asserts the landed order. It reads the MANAGER, never a pixel and never UIA, so a strip that models the right state and renders it wrongly passes. It runs at the tight command train by default: -GapMs 400 is the pacing that died 6/6 before the realization guard, and the suite does not stage it, so the timing-dependent half of that crash is not covered here' }
     [ordered]@{ name = 'pane-memory';    script = 'pane-focus-tab-switch.ps1';     tags = @('smoke','panes');  outDir = $true;  seed = $false; minutes = 2
                 oracle = 'the per-tab active pane, end to end (#869): split a tab, park focus on its RIGHT leaf, leave for another tab, come back, and demand the right leaf is both where typing lands AND where the active-pane chrome is drawn. Two oracles deliberately different in kind. The focus report is read out of FocusManager rather than out of PaneHost.ActiveLeaf, because "the tab remembers its last pane" and "you can type into it" are separate claims - the memory was always there, and asserting it would have passed straight over the bug. The other is pixels from a screenshot of the real window: the inactive-pane dim film must lie over the LEFT leaf, and the cursor block inside the right leaf must be the filled one a focused surface draws rather than the hollow outline an unfocused one leaves. The dim-film assert is a regression guard on the drawing path and is green with or without the focus restore; the focus report and the cursor-block count are the two that go red without it. Seam-actuated, so zero OS input is synthesized and the only thing done to the desktop is reading pixels off it. One split, one shape, two tabs: a deeper tree or a vertical split is not staged' }
+    [ordered]@{ name = 'switcher-wrap';  script = 'vtabs-switcher-capture.ps1';   tags = @('tabs','chrome');  outDir = $true;  seed = $false; minutes = 3
+                oracle = 'seam-actuated: fourteen real ctrl+t tabs, six tab-colour ops, then cycle{forward} raises the switcher through the chord''s own dispatch. The wrap claim is GATED for the first time: every tile rect read over UIA inside the popup''s 1.2s life must sit within the window''s right edge, and that many tiles must occupy more than one row - the file described this for its whole life and asserted it nowhere. The colours are read back off the state block, and the overview chord lands last for the picture' }
     [ordered]@{ name = 'vtab-geometry';  script = 'vtab-strip-geometry.ps1';       tags = @('tabs','chrome');  outDir = $true;  seed = $false; minutes = 2
                 oracle = 'reads the vertical strip''s ARRANGED LAYOUT back over the seam''s element-rects op rather than sampling pixels, because the strip wears Mica and a grab would answer for the desktop behind the window. One process, one seeded state (two pins, one group, two loose tabs), measured at both pane widths - the 48px compact rail and the expanded sidebar. Eight independent checks, findings collected rather than thrown one at a time: every pinned tab is arranged as the same 40px square and every square is inside the band''s own box; two pins share a band row in the expanded pane and stack in the compact rail, which is the wrapping band''s whole claim; the retired pin-boundary stroke is not arranged at either width, so a rule redrawn beside the structural division would be a finding; the close glyph''s right edge sits one named inset in from the pane edge when expanded, and the compact rail carries none at all, since MUXC''s item template lays row content out past 48px and a close button there would be arranged outside the pane; and a group header''s painted span, swatch through chevron, stays inside the pane at both widths. The sidebar also makes a full round trip - expanded, collapsed to the 48 rail, reopened - with every width a DIP off the seam''s paneWidth so the thresholds hold at any monitor scale, and the pane toggle''s UIA name must track the pane (Collapse/Expand sidebar; the XAML default Toggle sidebar is a finding), folded in from the retired mouse-fuzz-vertical-tabs (#930). Because it measures layout it says nothing about paint: a square arranged correctly and drawn in the wrong colour, or not drawn at all, passes. It says nothing about MOTION either - the band''s reflow glide is a composition animation no arranged rect records. It measures one seeded state at two pins, so a band that breaks only at a column boundary (five pins in the expanded pane) is not covered, and only the VERTICAL strip is staged: the horizontal strip''s pinned squares have no element-rects op' }
     [ordered]@{ name = 'field-seam';     script = 'tab-field-seam.ps1';            tags = @('tabs','chrome');  outDir = $true;  seed = $false; minutes = 4
@@ -244,12 +246,12 @@ $Harnesses = [System.Collections.Generic.List[object]]@(
 # because the integrity check below reads it: a new harness dropped into this
 # directory has to be classified, and prose does not fail a run.
 $NotInSuite = [ordered]@{
+    'ShellIntegrationPs1.Tests.ps1' = 'a plain-assert test file run directly by its own command line (see its header), not a harness: no -ExePath, no app, no verdict shape'
     'fuzz-suite.ps1'                = 'this runner'
     'aot-fuzz.ps1'                  = 'a runner; targets the NativeAOT publish, which this suite can also do with -ExePath'
     'vtabs-visual-qa.ps1'           = 'a runner'
     'release-smoke.ps1'             = 'a runner'
     'mouse-smoke-run.ps1'           = 'the operator drives the checklist by hand'
-    'vtabs-switcher-capture.ps1'    = 'produces frames for a human to look at; no verdict to aggregate'
     'dump-uia-state.ps1'            = 'a UIA-loss discrimination battery an operator points at a live window at a HARVEST_MISS moment; emits an evidence block, no verdict to aggregate'
     'gen-bell.ps1'                  = 'generates a test asset'
     'fuzz-tier-harnesses.ps1'       = 'the tier layer manifest, not a harness; read below'
@@ -1432,8 +1434,18 @@ foreach ($f in $dupScanFiles) {
         if ($nested) { continue }
         $found = [regex]::Matches($cmd.Extent.Text, '[\w.\-]+\.ps1')
         if ($found.Count -lt 1) {
-            # A path this cannot reduce to a name is REFUSED, not skipped.
-            # Skipping is how a spelling nobody anticipated turns the check off
+            if ($cmd.Extent.Text -notmatch '\.ps1') {
+                # DYNAMIC by design: a variable or expression path with no
+                # .ps1 literal anywhere in the command (ShellIntegrationPs1
+                # dot-sources `$script:integration`, built at runtime from
+                # Join-Path). There is no name to misread, so skipping costs
+                # nothing the refusing rule protects; the leaf it loads is
+                # invisible either way.
+                continue
+            }
+            # The command NAMES a .ps1 but no leaf could be extracted - a
+            # spelling the reader misread. REFUSED, not skipped: skipping is
+            # how the next spelling nobody anticipated turns the check off
             # without saying so.
             $problems += ("$rel dot-sources something this check cannot resolve to a file name, " +
                           "so it cannot be compared: " + $cmd.Extent.Text.Trim())

--- a/windows/scripts/vtabs-switcher-capture.ps1
+++ b/windows/scripts/vtabs-switcher-capture.ps1
@@ -5,12 +5,16 @@
 
     The headline this file always described and never asserted: with more
     tabs than fit one row, the tiles wrap into a grid instead of running
-    off the right edge. The oracle now reads the popup's own tiles over
-    UIA the instant cycle{forward} raises them - the op dispatches the
-    chord's real RequestMruCycle, and the popup auto-dismisses on a 1.2s
-    timer, so the read races the timer and the pictures follow it. Two
-    gates: every tile's right edge inside the window, and at least two
-    distinct rows once the count exceeds what one row holds.
+    off the right edge. The oracle is the purpose-built switcher-cells op
+    (#923): cycle{forward} dispatches the chord's real RequestMruCycle,
+    then one synchronous UI-thread read returns every slot's CARD rect in
+    screen pixels before the popup's 1.2s timer closes it. Three gates:
+    a card per tab, every card's right edge inside the window, and that
+    many cards on more than one row (the popup caps columns at
+    ceil(sqrt(count)), so this many can never legitimately share one row).
+    The burst shots that follow usually photograph the dismissed window -
+    the read consumes most of the timer - and are kept as diagnostics
+    only, gated on nothing.
 
     Everything that used to be synthesized input is a seam op now: the
     tabs are real new-tab chords (default-bound ctrl+t, focus on the
@@ -68,34 +72,6 @@ function Invoke-Chord($Session, [int]$Key, [switch]$Plain) {
     }
 }
 
-# The popup's tiles as rects. The cells expose no container of their own in
-# UIA - each tile surfaces as its icon Image inside the popup window - so
-# the icon rects ARE the tile grid (probed live: same Xs stepping down the
-# Ys is the wrap itself). Null when the popup is not up.
-function Get-SwitcherTiles([int64]$Hwnd64) {
-    $root = [System.Windows.Automation.AutomationElement]::FromHandle([SeamWin]::P($Hwnd64))
-    $winCond = New-Object System.Windows.Automation.PropertyCondition(
-        [System.Windows.Automation.AutomationElement]::ControlTypeProperty,
-        [System.Windows.Automation.ControlType]::Window)
-    $popups = $root.FindAll([System.Windows.Automation.TreeScope]::Descendants, $winCond)
-    $popup = $null
-    foreach ($w in $popups) {
-        if ($w.Current.ControlType.ProgrammaticName -eq 'ControlType.Window' -and
-            $w.Current.Name -eq 'Pop-up') { $popup = $w; break }
-    }
-    if ($null -eq $popup) { return $null }
-    $imgCond = New-Object System.Windows.Automation.PropertyCondition(
-        [System.Windows.Automation.AutomationElement]::ControlTypeProperty,
-        [System.Windows.Automation.ControlType]::Image)
-    $icons = $popup.FindAll([System.Windows.Automation.TreeScope]::Descendants, $imgCond)
-    if ($icons.Count -lt 1) { return $null }
-    $tiles = foreach ($t in $icons) {
-        $r = $t.Current.BoundingRectangle
-        [pscustomobject]@{ L = [double]$r.X; T = [double]$r.Y; R = [double]($r.X + $r.Width); B = [double]($r.Y + $r.Height) }
-    }
-    return @($tiles)
-}
-
 try {
     Assert-NoWintty -Context 'The switcher capture'
     $session = Start-SeamSession -ExePath $ExePath -ConfigText $Config
@@ -110,11 +86,14 @@ try {
         Invoke-Chord $session 0x54 -Plain
         Start-Sleep -Milliseconds 420
     }
-    $tabs = @(Invoke-SeamCommand $session @{ op = 'get-state' })
-    $tabTotal = @($tabs[0].state.tabs).Count
+    $st = Invoke-SeamCommand $session @{ op = 'get-state' }
+    $tabTotal = @($st.state.tabs).Count
     Write-Host "tabs=$tabTotal (wanted $TabCount)"
     if ($tabTotal -lt 4) {
         throw "HARVEST_MISS: only $tabTotal tabs - the new-tab chords did not land"
+    }
+    if ($tabTotal -ne $TabCount) {
+        $script:Findings.Add("the new-tab chords left $tabTotal tabs, wanted exactly $TabCount - a dispatched chord that creates nothing")
     }
 
     # Colour a spread so the tiles show coloured and plain side by side.
@@ -136,22 +115,28 @@ try {
 
     Save-Shot $session 'strip-with-colours'
 
-    # The switcher, the wrap oracle, then the pictures - in that order,
-    # because the popup's 1.2s timer is already running.
+    # The switcher and the wrap oracle. switcher-cells is the purpose-built
+    # instrument (#923): every slot's CARD rect in one synchronous UI-thread
+    # read, screen pixels, refusing cleanly when the popup is down. A UIA
+    # walk could straddle the 120ms entrance rise and read same-row tiles
+    # into different row bins - inflated rows is the false-PASS direction of
+    # the one-row gate - and it measured the tile ICON, ~14px inside the
+    # card the claim is about. One instant, the card itself.
     $null = Invoke-SeamCommand $session @{ op = 'cycle'; forward = $true }
-    $tiles = Get-SwitcherTiles $hwnd64
-    if ($null -eq $tiles) {
-        throw 'HARVEST_MISS: the switcher popup raised no tile icons before its timer closed it'
-    }
+    $cells = Invoke-SeamCommand $session @{ op = 'switcher-cells' }
+    $cards = @($cells.cells | ForEach-Object { $_.card })
     $win = [SeamWin]::RectOf($hwnd64)
-    $outside = @($tiles | Where-Object { $_.R -gt ($win.L + $win.W - 4) })
-    $rows = @($tiles | ForEach-Object { [Math]::Round($_.T) } | Sort-Object -Unique)
-    Write-Host ("tiles={0} rows={1} outside={2}" -f $tiles.Count, $rows.Count, $outside.Count)
-    if ($outside.Count -gt 0) {
-        $script:Findings.Add("$($outside.Count) switcher tile(s) run past the window's right edge instead of wrapping")
+    $outside = @($cards | Where-Object { $_.x + $_.w -gt ($win.L + $win.W - 4) })
+    $rows = @($cards | ForEach-Object { [Math]::Round($_.y) } | Sort-Object -Unique)
+    Write-Host ("cards={0} rows={1} outside={2}" -f $cards.Count, $rows.Count, $outside.Count)
+    if ($cards.Count -ne $tabTotal) {
+        $script:Findings.Add("the popup laid out $($cards.Count) cards for $tabTotal tabs - cells were dropped or duplicated")
     }
-    if ($tiles.Count -ge 8 -and $rows.Count -lt 2) {
-        $script:Findings.Add("$($tiles.Count) tiles sit on ONE row - the grid wrap did not happen")
+    if ($outside.Count -gt 0) {
+        $script:Findings.Add("$($outside.Count) switcher card(s) run past the window's right edge instead of wrapping")
+    }
+    if ($cards.Count -ge 8 -and $rows.Count -lt 2) {
+        $script:Findings.Add("$($cards.Count) cards sit on ONE row - the grid wrap did not happen")
     }
     foreach ($n in 0..2) {
         Start-Sleep -Milliseconds 120

--- a/windows/scripts/vtabs-switcher-capture.ps1
+++ b/windows/scripts/vtabs-switcher-capture.ps1
@@ -1,9 +1,28 @@
 #requires -Version 7
-# Open a session with many colored tabs and capture the Ctrl+Tab switcher.
-#
-# Two things to look at in the output: the tiles wrap into a grid instead of
-# running off the right edge, and tabs carrying a preset color show it on
-# their tile.
+<#
+    The Ctrl+Tab switcher with many coloured tabs, seam-actuated, and the
+    wrap claim GATED for the first time (#930).
+
+    The headline this file always described and never asserted: with more
+    tabs than fit one row, the tiles wrap into a grid instead of running
+    off the right edge. The oracle now reads the popup's own tiles over
+    UIA the instant cycle{forward} raises them - the op dispatches the
+    chord's real RequestMruCycle, and the popup auto-dismisses on a 1.2s
+    timer, so the read races the timer and the pictures follow it. Two
+    gates: every tile's right edge inside the window, and at least two
+    distinct rows once the count exceeds what one row holds.
+
+    Everything that used to be synthesized input is a seam op now: the
+    tabs are real new-tab chords (default-bound ctrl+t, focus on the
+    frame first - a new tab re-homes focus into a pane), so the tiles
+    carry real shell titles rather than the UserOverrideTitle seed-tabs
+    would stamp; the colours are tab-color ops driving the picker's own
+    assignment; the overview is the ctrl+shift+e chord. Zero OS input.
+
+    Exits 0 when the wrap holds and the run staged, 2 a finding (a tile
+    outside the window, one row holding everything, a colour that did not
+    land), 1 could-not-run.
+#>
 param(
     [string]$ExePath = (Join-Path $PSScriptRoot '..\Ghostty\bin\x64\Debug\net10.0-windows10.0.19041.0\Wintty.exe'),
     [string]$OutDir = (Join-Path $PSScriptRoot ("vtabs-switcher/run-" + (Get-Date -Format 'yyyyMMdd-HHmmss'))),
@@ -11,252 +30,161 @@ param(
     [switch]$Vertical
 )
 . (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
+. (Join-Path $PSScriptRoot 'lib/seam-client.ps1')
 $ErrorActionPreference = 'Stop'
 New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
 
 Add-Type -AssemblyName System.Drawing
 Add-Type -AssemblyName UIAutomationClient
 Add-Type -AssemblyName UIAutomationTypes
-Add-Type -TypeDefinition @'
-using System;
-using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading;
-public static class SwCap {
-    [StructLayout(LayoutKind.Sequential)] public struct RECT { public int L,T,R,B; }
-    [StructLayout(LayoutKind.Sequential)] public struct POINT { public int X, Y; }
-    [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr h);
-    [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
-    [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr h);
-    [DllImport("user32.dll")] public static extern bool EnumWindows(EnumProc cb, IntPtr lp);
-    [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h, out uint pid);
-    [DllImport("user32.dll")] public static extern bool MoveWindow(IntPtr h, int x, int y, int w, int t, bool r);
-    [DllImport("user32.dll")] static extern bool GetWindowRect(IntPtr h, out RECT r);
-    [DllImport("user32.dll", CharSet=CharSet.Unicode)] public static extern int GetClassName(IntPtr h, StringBuilder s, int n);
-    [DllImport("user32.dll")] public static extern IntPtr WindowFromPoint(POINT p);
-    public delegate bool EnumProc(IntPtr h, IntPtr lp);
-    [DllImport("user32.dll")] static extern void keybd_event(byte vk, byte scan, uint flags, UIntPtr extra);
-    [DllImport("user32.dll")] static extern bool SetCursorPos(int x, int y);
-    [DllImport("user32.dll")] static extern bool GetCursorPos(out POINT p);
-    [DllImport("user32.dll")] static extern void mouse_event(uint f, uint dx, uint dy, uint d, UIntPtr e);
-    const uint KEYUP = 0x0002;
-    public static IntPtr FindWin(uint pid) {
-        IntPtr best = IntPtr.Zero; int bestArea = 0;
-        EnumProc cb = (h, lp) => {
-            uint p = 0; GetWindowThreadProcessId(h, out p);
-            if (p != pid || !IsWindowVisible(h)) return true;
-            var sb = new StringBuilder(256); GetClassName(h, sb, 256);
-            if (sb.ToString() != "WinUIDesktopWin32WindowClass") return true;
-            RECT r; if (!GetWindowRect(h, out r)) return true;
-            int area = Math.Max(0, r.R - r.L) * Math.Max(0, r.B - r.T);
-            if (area > bestArea) { bestArea = area; best = h; }
-            return true;
-        };
-        EnumWindows(cb, IntPtr.Zero);
-        return best;
-    }
-    public static RECT Rect(IntPtr h) { RECT r; GetWindowRect(h, out r); return r; }
-    // Confirm the target owns the foreground before synthesizing anything:
-    // SetForegroundWindow fails silently under the foreground lock and the
-    // keystrokes would land in whatever is actually in front.
-    public static bool Focus(IntPtr e) {
-        for (int i = 0; i < 20; i++) {
-            if (GetForegroundWindow() == e) return true;
-            SetForegroundWindow(e); Thread.Sleep(50);
-        }
-        return GetForegroundWindow() == e;
-    }
-    public static bool Chord(IntPtr h, byte key, bool ctrl, bool shift) {
-        if (!Focus(h)) return false;
-        if (ctrl) keybd_event(0x11, 0, 0, UIntPtr.Zero);
-        if (shift) keybd_event(0x10, 0, 0, UIntPtr.Zero);
-        keybd_event(key, 0, 0, UIntPtr.Zero);
-        keybd_event(key, 0, KEYUP, UIntPtr.Zero);
-        if (shift) keybd_event(0x10, 0, KEYUP, UIntPtr.Zero);
-        if (ctrl) keybd_event(0x11, 0, KEYUP, UIntPtr.Zero);
-        return true;
-    }
-    public static bool Click(uint pid, int x, int y, bool right) {
-        SetCursorPos(x, y); Thread.Sleep(60);
-        // Probe the live cursor, not the scripted point: the buttons land
-        // wherever the cursor is now, and a user mouse move during the
-        // settle would divorce the pid check from the click.
-        POINT live; if (!GetCursorPos(out live)) return false;
-        if (Math.Abs(live.X - x) > 2 || Math.Abs(live.Y - y) > 2) return false;
-        uint owner = 0; GetWindowThreadProcessId(WindowFromPoint(live), out owner);
-        if (owner != pid) return false;
-        uint down = right ? 0x0008u : 0x0002u, up = right ? 0x0010u : 0x0004u;
-        mouse_event(down, 0, 0, 0, UIntPtr.Zero);
-        mouse_event(up, 0, 0, 0, UIntPtr.Zero);
-        return true;
-    }
-}
-'@
+[void][SeamWin]::SetProcessDpiAwarenessContext([IntPtr](-4))
 
-$script:Hwnd64 = 0
-function Get-UiaRoot { [System.Windows.Automation.AutomationElement]::FromHandle([IntPtr]::new($script:Hwnd64)) }
-function Find-ByName([string]$name, [int]$timeoutMs) {
-    $dl = (Get-Date).AddMilliseconds($timeoutMs)
-    $cond = New-Object System.Windows.Automation.PropertyCondition(
-        [System.Windows.Automation.AutomationElement]::NameProperty, $name)
-    while ((Get-Date) -lt $dl) {
-        $el = (Get-UiaRoot).FindFirst([System.Windows.Automation.TreeScope]::Descendants, $cond)
-        if ($null -ne $el) { return $el }
-        Start-Sleep -Milliseconds 120
-    }
-    return $null
-}
-function Invoke-El($el) {
-    try { $el.GetCurrentPattern([System.Windows.Automation.InvokePattern]::Pattern).Invoke(); return $true }
-    catch { return $false }
-}
-# The color swatches are Borders carrying only an automation Name, so they
-# expose no Invoke pattern and have to be clicked where they sit.
-function Click-El($el, [uint32]$ProcId) {
-    try {
-        $r = $el.Current.BoundingRectangle
-        if ($r.Width -le 0 -or $r.Height -le 0) { return $false }
-        return [SwCap]::Click($ProcId, [int]($r.X + $r.Width / 2), [int]($r.Y + $r.Height / 2), $false)
-    } catch { return $false }
-}
-# Anything driven through UIA leaves focus on the element it touched, and the
-# app's chords only reach the router when the terminal surface has focus.
-# Every UIA interaction has to be followed by this or the next chord is lost.
-function Restore-TerminalFocus([IntPtr]$hwnd, [uint32]$ProcId) {
-    $r = [SwCap]::Rect($hwnd)
-    [void][SwCap]::Click($ProcId, [int](($r.L + $r.R) / 2), [int](($r.T + $r.B) / 2), $false)
-    Start-Sleep -Milliseconds 250
-}
-function Save-Shot([IntPtr]$hwnd, [string]$name) {
-    $r = [SwCap]::Rect($hwnd)
-    $w = $r.R - $r.L; $h = $r.B - $r.T
-    $bmp = New-Object System.Drawing.Bitmap $w, $h
-    $g = [System.Drawing.Graphics]::FromImage($bmp)
-    $g.CopyFromScreen($r.L, $r.T, 0, 0, $bmp.Size)
-    $bmp.Save((Join-Path $OutDir "$name.png")); $g.Dispose(); $bmp.Dispose()
-    Write-Host "saved $name (${w}x${h})"
-}
-
-$tempXdg = Join-Path $env:TEMP "wintty-switchercap-$([guid]::NewGuid())"
-$cfgDir = Join-Path $tempXdg 'wintty'
-New-Item -ItemType Directory -Path $cfgDir -Force | Out-Null
-@"
+$Config = @"
 vertical-tabs = $($Vertical.IsPresent.ToString().ToLower())
 windows-single-instance = false
 window-theme = wintty
 theme = Catppuccin Mocha
-"@ | Set-Content -Path (Join-Path $cfgDir 'config.wintty') -Encoding utf8
+"@
 
-$origXdg = $env:XDG_CONFIG_HOME
-$env:XDG_CONFIG_HOME = $tempXdg
-$proc = $null
-# Same policy as the rest of the directory: refuse rather than fight another
-# instance for the foreground, and reap only what this run started.
-Assert-NoWintty -Context 'The switcher capture'
-$script:WinttyStamp = Get-WinttyLaunchStamp
+$script:Findings = [System.Collections.Generic.List[string]]::new()
+$harnessError = ''
+$session = $null
+
+function Save-Shot($Session, [string]$Name) {
+    $r = [SeamWin]::RectOf($Session.Hwnd64)
+    if ($null -eq $r) { return }
+    $bmp = New-Object System.Drawing.Bitmap $r.W, $r.Hh
+    $g = [System.Drawing.Graphics]::FromImage($bmp)
+    $g.CopyFromScreen($r.L, $r.T, 0, 0, $bmp.Size)
+    $bmp.Save((Join-Path $OutDir "$Name.png")); $g.Dispose(); $bmp.Dispose()
+    Write-Host "saved $Name ($($r.W)x$($r.Hh))"
+}
+
+function Invoke-Chord($Session, [int]$Key, [switch]$Plain) {
+    [void](Invoke-SeamCommand $Session @{ op = 'focus'; target = 'frame' })
+    $r = Invoke-SeamCommand $Session @{ op = 'chord'; key = $Key; ctrl = $true; shift = -not $Plain.IsPresent }
+    if (-not $r.dispatched) {
+        throw ("HARVEST_MISS: chord 0x{0:X2} was not dispatched (focus was '{1}')" -f $Key, $r.focus)
+    }
+}
+
+# The popup's tiles as rects. The cells expose no container of their own in
+# UIA - each tile surfaces as its icon Image inside the popup window - so
+# the icon rects ARE the tile grid (probed live: same Xs stepping down the
+# Ys is the wrap itself). Null when the popup is not up.
+function Get-SwitcherTiles([int64]$Hwnd64) {
+    $root = [System.Windows.Automation.AutomationElement]::FromHandle([SeamWin]::P($Hwnd64))
+    $winCond = New-Object System.Windows.Automation.PropertyCondition(
+        [System.Windows.Automation.AutomationElement]::ControlTypeProperty,
+        [System.Windows.Automation.ControlType]::Window)
+    $popups = $root.FindAll([System.Windows.Automation.TreeScope]::Descendants, $winCond)
+    $popup = $null
+    foreach ($w in $popups) {
+        if ($w.Current.ControlType.ProgrammaticName -eq 'ControlType.Window' -and
+            $w.Current.Name -eq 'Pop-up') { $popup = $w; break }
+    }
+    if ($null -eq $popup) { return $null }
+    $imgCond = New-Object System.Windows.Automation.PropertyCondition(
+        [System.Windows.Automation.AutomationElement]::ControlTypeProperty,
+        [System.Windows.Automation.ControlType]::Image)
+    $icons = $popup.FindAll([System.Windows.Automation.TreeScope]::Descendants, $imgCond)
+    if ($icons.Count -lt 1) { return $null }
+    $tiles = foreach ($t in $icons) {
+        $r = $t.Current.BoundingRectangle
+        [pscustomobject]@{ L = [double]$r.X; T = [double]$r.Y; R = [double]($r.X + $r.Width); B = [double]($r.Y + $r.Height) }
+    }
+    return @($tiles)
+}
 
 try {
-    $proc = Start-Process -FilePath $ExePath -PassThru
-    $hwnd = [IntPtr]::Zero
-    $dl = (Get-Date).AddSeconds(45)
-    while ((Get-Date) -lt $dl) {
-        Start-Sleep -Milliseconds 300
-        $proc.Refresh()
-        if ($proc.HasExited) { throw "exit $($proc.ExitCode)" }
-        $hwnd = [SwCap]::FindWin([uint32]$proc.Id)
-        if ($hwnd -ne [IntPtr]::Zero) { break }
-    }
-    if ($hwnd -eq [IntPtr]::Zero) { throw 'no hwnd' }
-    $script:Hwnd64 = $hwnd.ToInt64()
-    Start-Sleep -Seconds 4
-    [void][SwCap]::MoveWindow($hwnd, 30, 30, 1500, 900, $true)
+    Assert-NoWintty -Context 'The switcher capture'
+    $session = Start-SeamSession -ExePath $ExePath -ConfigText $Config
+    $hwnd64 = [int64]$session.Hwnd64
+    Start-Sleep -Milliseconds 500
+    [void][SeamWin]::MoveWindow([SeamWin]::P($hwnd64), 30, 30, 1500, 900, $true)
     Start-Sleep -Milliseconds 700
 
-    # The NO_COLOR infobar takes keyboard focus on launch when the
-    # environment sets it, and swallows the chords that follow.
-    $dismiss = Find-ByName 'Keep it off' 1500
-    if ($null -ne $dismiss) { [void](Invoke-El $dismiss); Write-Host 'dismissed NO_COLOR infobar'; Start-Sleep -Milliseconds 400 }
-    Restore-TerminalFocus $hwnd ([uint32]$proc.Id)
-
-    foreach ($i in 2..$TabCount) {
-        if (-not [SwCap]::Chord($hwnd, 0x54, $true, $false)) { throw 'FOREGROUND_MISS: new tab' }
+    # Real new tabs: the default-bound ctrl+t through the chord path, so the
+    # tiles carry the shells' own titles.
+    for ($i = 2; $i -le $TabCount; $i++) {
+        Invoke-Chord $session 0x54 -Plain
         Start-Sleep -Milliseconds 420
     }
-    Start-Sleep -Milliseconds 900
+    $tabs = @(Invoke-SeamCommand $session @{ op = 'get-state' })
+    $tabTotal = @($tabs[0].state.tabs).Count
+    Write-Host "tabs=$tabTotal (wanted $TabCount)"
+    if ($tabTotal -lt 4) {
+        throw "HARVEST_MISS: only $tabTotal tabs - the new-tab chords did not land"
+    }
 
-    # Color a spread of tabs so the capture shows colored and plain tiles
-    # side by side.
+    # Colour a spread so the tiles show coloured and plain side by side.
     $wanted = @('Red', 'Green', 'Blue', 'Orange', 'Purple', 'Teal')
-    $ctName = if ($Vertical) { 'ListItem' } else { 'TabItem' }
     $applied = 0
-    $hits = (Get-UiaRoot).FindAll(
-        [System.Windows.Automation.TreeScope]::Descendants,
-        (New-Object System.Windows.Automation.PropertyCondition(
-            [System.Windows.Automation.AutomationElement]::ControlTypeProperty,
-            [System.Windows.Automation.ControlType]::$ctName)))
-    Write-Host "strip items found: $($hits.Count) (expected $TabCount)"
-    if ($hits.Count -lt 2) { throw "only $($hits.Count) tab(s) in the strip: the new-tab chords did not land" }
-    for ($i = 0; $i -lt $hits.Count -and $applied -lt $wanted.Count; $i += 2) {
-        # A cached UIA element can go stale if the strip rebuilt mid-loop.
-        try { $r = $hits[$i].Current.BoundingRectangle } catch { continue }
-        if ($r.Width -le 0) { continue }
-        $x = [int]($r.X + $r.Width * 0.4); $y = [int]($r.Y + $r.Height / 2)
-        if (-not [SwCap]::Click([uint32]$proc.Id, $x, $y, $true)) {
-            Write-Host "  item $i : right-click rejected at $x,$y"
-            continue
-        }
-        Start-Sleep -Milliseconds 400
-        $pick = Find-ByName 'Tab Color...' 1800
-        if ($null -eq $pick) {
-            Write-Host "  item $i : no 'Tab Color...' in the flyout"
-            [void][SwCap]::Chord($hwnd, 0x1B, $false, $false); continue
-        }
-        if (-not (Invoke-El $pick)) {
-            Write-Host "  item $i : 'Tab Color...' would not invoke"
-            [void][SwCap]::Chord($hwnd, 0x1B, $false, $false); continue
-        }
-        Start-Sleep -Milliseconds 350
-        $sw = Find-ByName $wanted[$applied] 1500
-        if ($null -eq $sw) {
-            Write-Host "  item $i : swatch '$($wanted[$applied])' not found"
-        } elseif (Click-El $sw ([uint32]$proc.Id)) {
-            Write-Host "  item $i -> $($wanted[$applied])"
-            $applied++
-        } else {
-            Write-Host "  item $i : swatch would not click"
-        }
-        Start-Sleep -Milliseconds 300
-        [void][SwCap]::Chord($hwnd, 0x1B, $false, $false)
-        Restore-TerminalFocus $hwnd ([uint32]$proc.Id)
+    for ($i = 0; $i -lt $wanted.Count; $i++) {
+        $index = ($i + 1) * 2
+        if ($index -ge $tabTotal) { break }
+        $null = Invoke-SeamCommand $session @{ op = 'tab-color'; index = $index; color = $wanted[$i] }
+        $applied++
     }
     Write-Host "colors applied: $applied"
-
-    Save-Shot $hwnd 'strip-with-colors'
-
-    Restore-TerminalFocus $hwnd ([uint32]$proc.Id)
-
-    # The popup auto-dismisses after ~1.2s, so take a burst rather than bet
-    # on one moment.
-    if (-not [SwCap]::Chord($hwnd, 0x09, $true, $false)) { throw 'FOREGROUND_MISS: ctrl+tab' }
-    foreach ($n in 0..3) {
-        Start-Sleep -Milliseconds 150
-        Save-Shot $hwnd ("switcher-$n")
+    # The colour landing is part of the claim: read them back.
+    $st = Invoke-SeamCommand $session @{ op = 'get-state' }
+    $coloured = @($st.state.tabs | Where-Object { $_.color -and $_.color -ne 'None' }).Count
+    if ($coloured -lt $applied) {
+        $script:Findings.Add("tab-colour ops answered ok but the state shows $coloured of $applied coloured tabs")
     }
 
+    Save-Shot $session 'strip-with-colours'
+
+    # The switcher, the wrap oracle, then the pictures - in that order,
+    # because the popup's 1.2s timer is already running.
+    $null = Invoke-SeamCommand $session @{ op = 'cycle'; forward = $true }
+    $tiles = Get-SwitcherTiles $hwnd64
+    if ($null -eq $tiles) {
+        throw 'HARVEST_MISS: the switcher popup raised no tile icons before its timer closed it'
+    }
+    $win = [SeamWin]::RectOf($hwnd64)
+    $outside = @($tiles | Where-Object { $_.R -gt ($win.L + $win.W - 4) })
+    $rows = @($tiles | ForEach-Object { [Math]::Round($_.T) } | Sort-Object -Unique)
+    Write-Host ("tiles={0} rows={1} outside={2}" -f $tiles.Count, $rows.Count, $outside.Count)
+    if ($outside.Count -gt 0) {
+        $script:Findings.Add("$($outside.Count) switcher tile(s) run past the window's right edge instead of wrapping")
+    }
+    if ($tiles.Count -ge 8 -and $rows.Count -lt 2) {
+        $script:Findings.Add("$($tiles.Count) tiles sit on ONE row - the grid wrap did not happen")
+    }
+    foreach ($n in 0..2) {
+        Start-Sleep -Milliseconds 120
+        Save-Shot $session ("switcher-$n")
+    }
+
+    # The overview, same chord family.
     Start-Sleep -Milliseconds 1500
-    Restore-TerminalFocus $hwnd ([uint32]$proc.Id)
-    if (-not [SwCap]::Chord($hwnd, 0x45, $true, $true)) { throw 'FOREGROUND_MISS: ctrl+shift+e' }
+    Invoke-Chord $session 0x45
     Start-Sleep -Milliseconds 700
-    Save-Shot $hwnd 'overview'
+    Save-Shot $session 'overview'
+
+    if ($session.Proc.HasExited) {
+        throw "APP_EXIT: the app exited during the run (code $($session.Proc.ExitCode))"
+    }
+}
+catch {
+    $msg = "$($_.Exception.Message)"
+    if ($msg -like 'PRODUCT_*' -or $msg -like 'APP_EXIT*') { $script:Findings.Add($msg) }
+    else { $harnessError = $msg }
+    Write-Host "ERROR: $msg" -ForegroundColor Red
 }
 finally {
-    if ($proc -and -not $proc.HasExited) {
-        try { $proc.Kill($true); [void]$proc.WaitForExit(3000) } catch { }
-    }
-    if ($null -ne $origXdg) { $env:XDG_CONFIG_HOME = $origXdg }
-    else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
-    Remove-Item -Recurse -Force $tempXdg -ErrorAction SilentlyContinue
-    # Last, so a throw here cannot abandon the restore or the cleanup above.
-    Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
+    if ($null -ne $session) { Stop-SeamSession $session }
 }
+
+[ordered]@{
+    actuation = 'seam (WINTTY_TEST_SEAM=<session token>); tabs/colours/switcher/overview via ops and chords'
+    findings  = $script:Findings
+    harness   = $harnessError
+} | ConvertTo-Json -Depth 4 | Set-Content (Join-Path $OutDir 'result.json') -Encoding utf8
+
+if ($script:Findings.Count -gt 0) { exit 2 }
+if ($harnessError) { exit 1 }
 Write-Host "OUT=$OutDir"
+exit 0


### PR DESCRIPTION
Part of #930 — Wave 0's fourth batch: `vtabs-switcher-capture` onto the seam, **with the wrap claim gated for the first time in the file's life**. 3 files, +164/−225 before review fixes. Zero OS input.

## The headline, finally asserted

This file has *described* "tiles wrap into a grid instead of running off the right edge" since it was written, and asserted it nowhere in the repo. The oracle is the purpose-built **`switcher-cells`** op (#923): `cycle{forward}` dispatches the chord's real `RequestMruCycle`, then one synchronous UI-thread read returns every slot's **card** rect in screen pixels before the popup's 1.2s timer closes it. Three gates: a card per tab, every card's right edge inside the window, and that many cards on more than one row (the popup caps columns at `ceil(sqrt(count))`, so 14 can never legitimately share one row). Measured: **14 cards, 5 rows, none outside**.

Everything that used to be synthesized input is a seam op: the tabs are real `ctrl+t` chords (default-bound; `focus{frame}` first — a new tab re-homes focus into a pane), so tiles carry real shell titles rather than the `UserOverrideTitle` `seed-tabs` would stamp; the colours are `tab-color` ops driving the picker's own assignment, read back off the state block; the overview is the `ctrl+shift+e` chord.

The harness **joins the suite** (34 → 35) as `switcher-wrap` — it has a verdict now.

## Fixing the tip: the suite was red on `origin/windows`

#958 (merged after #959's check-6) added `ShellIntegrationPs1.Tests.ps1`, whose variable dot-source (`. $script:integration`) tripped check 6's refuse-unresolvable rule, and which check 2 refused as unclassified. This PR fixes both — and the review then caught my first fix being wider than its own justification:

**Check 6 now resolves variable dot-sources through their own file before excusing them.** The motivating file writes `$script:integration = Join-Path $PSScriptRoot '...ghostty.ps1'` one line up — the leaf was right there, so "no name to misread" was false for the only real case. Resolution: the assignment's literal names the leaf (`Join-Path` or plain `$p = 'x.ps1'` — the latter is visible to the check again); only a path composed from non-literals with no literal anywhere in the command is skipped; extraction covers `.psm1` as well as `.ps1`. **Mutation-proved**: shadowing hidden behind a `Join-Path` variable and behind a plain assigned literal both go red with the full file-and-line message; baseline and restore clean.

The new file is classified in `NotInSuite` with an accurate reason (its own 0/1 exit, deliberately unautomated).

## Review round

The reviewer's headline: my first oracle used cross-process UIA inside the popup's auto-dismiss window, which could **straddle the 120ms entrance rise and read same-row tiles into different row bins — inflated rows being the false-PASS direction of the one-row gate** — and it measured the tile *icon*, ~14px inside the card. `switcher-cells` closes all of it (one instant, the card, synchronous). Also added: the card-per-tab gate (a popup that dropped cells passed before) and the exact staging gate (a dispatched new-tab chord that creates nothing is a finding, not a floor of four). Fixed during implementation and owned in the commit: three rounds of regex breakage (a doubled backslash, a dropped scope prefix, a character class that couldn't match `.ps1`) — each caught by running the thing, and the first mutation "proof" was itself void because it wrote its files to the repo root where the suite never looks.
