### PR TITLE
test-win: run the IconGen and SplashGen suites the solution already builds

### DIFF
--- a/justfile
+++ b/justfile
@@ -191,6 +191,11 @@ test-win:
     dotnet build windows/Ghostty.sln /p:Platform=x64
     dotnet test windows/Ghostty.Tests/Ghostty.Tests.csproj /p:Platform=x64 --blame-hang --blame-hang-timeout 5m
     dotnet test windows/Ghostty.Tests.Windows/Ghostty.Tests.Windows.csproj /p:Platform=x64 --blame-hang --blame-hang-timeout 5m
+    # IconGen/SplashGen were compiled by the solution line above but executed
+    # by nothing until a coverage audit caught it; AnyCPU in the sln, so they
+    # take no /p:Platform=x64 unlike the two above.
+    dotnet test dist/windows/IconGen.Tests/IconGen.Tests.csproj --blame-hang --blame-hang-timeout 5m
+    dotnet test dist/windows/SplashGen.Tests/SplashGen.Tests.csproj --blame-hang --blame-hang-timeout 5m
 
 # Launch two instances a few hundred ms apart and watch for a launch splash
 # owned by the one that should be forwarding itself to the other. Opens real


### PR DESCRIPTION
The coverage audit caught them compiled and executed by nothing — 115 test cases (73 IconGen + 42 SplashGen) that read as coverage from the recipe's build line while no recipe, CI job, or suite entry ever ran them. The exact failure class the repo's own `test-reachability` oracle warns about, sitting in the ladder itself.

The fix is two `dotnet test` lines in `test-win`. They take no `/p:Platform=x64` unlike the two projects above them: the solution maps the dist/windows projects to **Any CPU** (their csprojs declare no Platform, `windows/Directory.Build.props` is not in their ancestor chain, and their only dependencies are AnyCPU — the Ghostty.Core types are source-linked, not referenced), so the flag would force a redundant rebuild of projects the build line just finished.

The gate run IS the verification: signoff's `test-win` leg executed both suites under the ladder for the first time — 73 + 42 passed, exit 0, PASS recorded for `ec6f2bd458`. Coverage item 3 of the audit.