### PR TITLE
gates: merge on a moved signoff window and file the risk instead of re-gating

### DIFF
--- a/.agents/scripts/README.md
+++ b/.agents/scripts/README.md
@@ -25,17 +25,27 @@ human) working in this repo uses the same contract:
   raw `gh pr merge` whose signoff window has moved (commits landed on
   `origin/windows` after the record's base) and names the guard recipe,
   because per #969 such a merge is allowed but its resignoff issue is not
-  optional; a same-window merge stays allowed raw.
-- `just merge-checked <n>` - the only way to merge a moved-window PR: the
-  merge guard (`merge_guard.py`) re-validates the record (missing, red and
-  ledger-blocked records still refuse; the policy forgives head movement,
-  never a bad run), measures the delta from the record's base to
-  `origin/windows` first-parent, squash-merges, reads back the squash sha,
-  and files a `resignoff-required` issue in the shape of the hand-filed
-  #970: the delta with per-commit attribution, the risks in words (same
-  files, same top-level directories, same signoff legs as the record's
-  scope), and the resignoff-in-flight status. `--dry-run` prints all of it
-  and mutates nothing.
+  optional; a same-window merge stays allowed raw, and any window answer
+  is only as fresh as the checkout's last fetch. Its honest limits: a hook
+  only sees commands typed through tools it is wired into, so the GitHub
+  web UI or mobile, a plain `git push` to `windows` (which has no branch
+  protection), and hosts without the hook wiring are all uncovered, and
+  `gh pr merge --auto` is judged at submit time.
+- `just merge-checked <n>` - the merge guard (`merge_guard.py`) and the
+  normal way to merge: it re-validates the record (missing, red,
+  scope-mismatched and ledger-blocked records still refuse; the policy
+  forgives head movement, never a bad run), fetches and measures the delta
+  from the record's base to `origin/windows` first-parent, squash-merges,
+  reads back the squash sha, verifies it against a second fetch, and files
+  a `resignoff-required` issue on the #970 template, with a structured
+  delta: per-commit attribution, the risks in words (same files, same
+  top-level directories, same signoff legs as the record's scope, plus the
+  never-signed-off squash itself), and the resignoff status. `--dry-run`
+  prints all of it and mutates nothing (it also accepts a MERGED pr);
+  `--file-only <n>` files the owed issue without merging, for a merge that
+  landed outside the guard. A bypass does not just skip the rule: the
+  resignoff issue only exists if the guard ran, since the record and the
+  delta it files both come from it.
 - `just doctor` - verify everything the gates depend on: required tools on
   PATH, scripts where the hook wiring points, settings parseable, nightly
   task registration. A Claude Code SessionStart hook runs the fast subset

--- a/.agents/scripts/README.md
+++ b/.agents/scripts/README.md
@@ -21,15 +21,30 @@ human) working in this repo uses the same contract:
   merged on credit; the session-start doctor reports it too.
 - `just pr-gate <n>` - validate a PR against the merge gate without
   merging: countable size limit, body present, no unchecked task items,
-  no spaced issue references, signoff present.
+  no spaced issue references, signoff present. The hook form also denies a
+  raw `gh pr merge` whose signoff window has moved (commits landed on
+  `origin/windows` after the record's base) and names the guard recipe,
+  because per #969 such a merge is allowed but its resignoff issue is not
+  optional; a same-window merge stays allowed raw.
+- `just merge-checked <n>` - the only way to merge a moved-window PR: the
+  merge guard (`merge_guard.py`) re-validates the record (missing, red and
+  ledger-blocked records still refuse; the policy forgives head movement,
+  never a bad run), measures the delta from the record's base to
+  `origin/windows` first-parent, squash-merges, reads back the squash sha,
+  and files a `resignoff-required` issue in the shape of the hand-filed
+  #970: the delta with per-commit attribution, the risks in words (same
+  files, same top-level directories, same signoff legs as the record's
+  scope), and the resignoff-in-flight status. `--dry-run` prints all of it
+  and mutates nothing.
 - `just doctor` - verify everything the gates depend on: required tools on
   PATH, scripts where the hook wiring points, settings parseable, nightly
   task registration. A Claude Code SessionStart hook runs the fast subset
   at the start of every session, so a broken gate environment is loud
   instead of silently absent.
 - `just gates-selftest` - prove the gates still catch what they exist for
-  (recorded-PR replays, matcher escapes, exemption anchoring) and that the
-  nightly scripts' helpers roundtrip. Runs `gitversion-selftest` first.
+  (recorded-PR replays, matcher escapes, exemption anchoring, the merge
+  guard's refusal matrix and golden issue body) and that the nightly
+  scripts' helpers roundtrip. Runs `gitversion-selftest` first.
 - `just release-gate-check` - prove the shipping-build gate REFUSES a leak,
   by evaluating Release rather than by reading the targets file. Three probe
   sets: the build-time refusal in both polarities and by both routes (a `-p:`

--- a/.agents/scripts/doctor.py
+++ b/.agents/scripts/doctor.py
@@ -40,7 +40,7 @@ REQUIRED_TOOLS = ["git", "gh", "just"]
 # Optional: the signoff ladder and the nightly appliance need these; their
 # absence is a note, not a failure, so non-Windows clones stay quiet.
 OPTIONAL_TOOLS = ["zig", "dotnet", "pwsh"]
-GATE_SCRIPTS = ["pr_gate.py", "workspace_guard.py", "signoff.py"]
+GATE_SCRIPTS = ["pr_gate.py", "workspace_guard.py", "signoff.py", "merge_guard.py"]
 
 
 def check(which=shutil.which, settings_path=None, script_dir=SCRIPT_DIR):

--- a/.agents/scripts/fixtures/pr958.json
+++ b/.agents/scripts/fixtures/pr958.json
@@ -1,0 +1,12 @@
+{
+ "number": 958,
+ "title": "osc: carry the shell's prompt state as one versioned hex payload",
+ "body": "The shell's prompt state (directory, command status, continuation depth) now travels as one versioned hex payload in a single OSC, so the terminal can consume it with one parser and one version check instead of chasing per-shell spellings. The powershell integration emits it after each prompt, the Zig terminal side parses it into a typed struct, and a new test file pins the wire format. Verified by the windows-tests leg on the exact head and by the fuzz suite's parser checks.",
+ "additions": 826,
+ "deletions": 5,
+ "headRefOid": "24c3ab8fa0a76631ea1ee31d8a00803526e41e71",
+ "files": [
+  {"path": "windows/scripts/ShellIntegrationPs1.Tests.ps1", "additions": 135, "deletions": 0},
+  {"path": "src/terminal/osc/parsers.zig", "additions": 1, "deletions": 0}
+ ]
+}

--- a/.agents/scripts/merge_guard.py
+++ b/.agents/scripts/merge_guard.py
@@ -1,0 +1,878 @@
+#!/usr/bin/env python3
+"""The merge guard: squash-merge a PR and file the resignoff ceremony.
+
+Policy (issue #969, decided 2026-09-03): a green signoff does not block on
+head movement. When `windows` moved after the record was taken, merge
+anyway and carry the risk explicitly in a `resignoff-required` issue
+instead of re-gating inline. The guard is that ceremony: it refuses on a
+missing or bad record, measures what the branch gained since the record's
+base, merges, and files the issue with the delta and the risks in words.
+
+Why a script and not a rule: enforcement has to work the way the
+signoff-per-head rule works. Agents read AGENTS.md and follow it because a
+script makes anything else the hard path; the pr_gate hook denies a raw
+`gh pr merge` whose signoff window has moved and names this script's
+recipe (`just merge-checked <pr>`). The guard is also the only place that
+knows how to build the issue body, which is what keeps the ceremony from
+drifting per-agent or per-memory.
+
+The delta is measured from the record's `base` (the merge base with
+origin/windows stamped when the record was written) to the current
+origin/windows head, first-parent only: sync-publish lands real merge
+commits, and a plain walk would disappear into upstream's history. A
+record written before base recording exists is base-unknown; the base is
+then estimated at merge time, which equals the original base whenever the
+branch only gained commits.
+
+Refusals (nothing is mutated when one fires): no local record for the PR
+head, a red record, a deferred record the ledger no longer permits, a
+checkout that is not this fork, a PR that is not open and mergeable or
+that does not target `windows`, a window that cannot be measured. The new
+policy forgives head movement only; it never forgives a bad or absent run.
+
+Modes:
+  <pr>            validate, squash-merge, read back the squash sha, file
+                  the resignoff-required issue when the window moved.
+  --dry-run <pr>  print the resolved inputs, the delta, the risks and the
+                  would-be issue body; mutate nothing.
+  --self-test     replay injected gh/git sessions: the guard must refuse on
+                  every refusal path, merge without filing on an unmoved
+                  window, file the #970-shaped body on a moved one, and
+                  mutate nothing under --dry-run.
+
+Exit codes: 0 merged (and filed, when owed); 1 the environment or a gh/git
+call failed part-way (said loudly, because the merge may already have
+landed); 2 a refusal, nothing mutated.
+
+Run with: just merge-checked <pr>
+"""
+
+import contextlib
+import io
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import gate_scope  # noqa: E402
+import pr_gate  # noqa: E402  (the repo predicate must agree with the hook's)
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+REPO = "deblasis/wintty"
+BASE_BRANCH = "windows"
+BASE_REF = "origin/" + BASE_BRANCH
+LABEL = "resignoff-required"
+PR_FIELDS = "number,title,headRefOid,state,mergeable,baseRefName,files"
+
+
+class GuardError(Exception):
+    """A gh/git call failed in a way the caller should print verbatim."""
+
+
+class Out:
+    """The slice of subprocess.CompletedProcess the runners' callers read.
+    The fakes return these so the guard code cannot tell a fake from a real
+    child process."""
+
+    def __init__(self, returncode, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def git_run(args, cwd=None):
+    return subprocess.run(["git"] + args, cwd=cwd or REPO_ROOT,
+                          capture_output=True, text=True, timeout=60)
+
+
+def gh_run(args, cwd=None):
+    return subprocess.run(["gh"] + args, cwd=cwd or REPO_ROOT,
+                          capture_output=True, text=True, timeout=120)
+
+
+def resolve_common_dir(git):
+    """The absolute git common dir, or None when it cannot be trusted. The
+    records live there, shared across worktrees; a dying session can kill
+    the git child and leave empty output, and acting on a guess would read
+    (or store) the record in the wrong place."""
+    out = git(["rev-parse", "--git-common-dir"])
+    common = out.stdout.strip()
+    if out.returncode != 0 or not common:
+        return None
+    if not os.path.isabs(common):
+        common = os.path.join(REPO_ROOT, common)
+    return common if os.path.isdir(common) else None
+
+
+def remote_slug(url):
+    """owner/name out of any remote spelling (ssh, https, a .git suffix), or
+    None. The fork answers to two names - the current one and the ghostty
+    name GitHub still redirects - and the checkout check must accept both,
+    so this is the parsing half and pr_gate.is_our_repo is the decision."""
+    m = re.search(r"[:/]([\w.-]+/[\w.-]+?)(?:\.git)?/?$", url or "")
+    return m.group(1).lower() if m else None
+
+
+def checkout_slug(git):
+    """The slug of this checkout's origin remote, or None when git cannot
+    answer; both cases refuse, they do not guess."""
+    out = git(["remote", "get-url", "origin"])
+    if out.returncode != 0:
+        return None
+    return remote_slug(out.stdout.strip())
+
+
+def gh_json(args, gh):
+    """Run gh and parse its JSON, raising GuardError on failure or on
+    unparseable output rather than returning a half-shaped PR."""
+    out = gh(args)
+    if out.returncode != 0:
+        raise GuardError((out.stderr or out.stdout).strip())
+    try:
+        return json.loads(out.stdout)
+    except ValueError as e:
+        raise GuardError(f"gh printed unparseable JSON: {e}") from e
+
+
+def load_pr(number, gh):
+    """The PR as the guard sees it: identity, mergeability, the target
+    branch, and the head sha the record must be keyed to."""
+    return gh_json(["pr", "view", str(number), "--repo", REPO, "--json", PR_FIELDS], gh)
+
+
+def load_record(common, head):
+    """(record, expected path). The record is keyed by the PR's exact head
+    sha, like the hook's own lookup; None means no run was recorded here,
+    which the policy treats as missing evidence, not as a pass."""
+    d = os.path.join(common, "pr-signoff")
+    path = os.path.join(d, f"{head}.json")
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f), path
+    except (OSError, ValueError):
+        return None, path
+
+
+def windows_head(git):
+    """The local position of origin/windows. Deliberately the local ref and
+    not a gh call: the delta is measured in THIS checkout's history, where
+    the record's base lives, and a stale ref simply means fetch first."""
+    out = git(["rev-parse", "--verify", BASE_REF])
+    sha = out.stdout.strip()
+    return sha if out.returncode == 0 and sha else None
+
+
+def record_base(rec, head, git):
+    """(base, estimated). The recorded base is authoritative; a legacy
+    record without one is base-unknown and the base is re-derived from the
+    merge base, which is stable under ordinary branch movement (commits
+    landing on windows do not move the merge base of an unchanged PR head)
+    and errs toward a larger, never smaller, delta when history was
+    rewritten."""
+    base = (rec or {}).get("base")
+    if base:
+        return base, False
+    out = git(["merge-base", head, BASE_REF])
+    if out.returncode != 0:
+        return None, True
+    return out.stdout.strip() or None, True
+
+
+def _paths(text):
+    return sorted(p.strip().replace("\\", "/") for p in text.splitlines() if p.strip())
+
+
+def commit_files(sha, git):
+    """Files one delta commit touched. First-parent is the honest answer for
+    a merge commit: the diff against what the branch actually gained. Plain
+    diff-tree answers a merge with nothing, which would read as an empty,
+    risk-free commit; older gits without --diff-merges fall back to the
+    plain form and under-report a merge rather than mis-report it."""
+    out = git(["diff-tree", "-r", "--name-only", "--no-commit-id",
+               "--diff-merges=first-parent", sha])
+    if out.returncode != 0:
+        out = git(["diff-tree", "-r", "--name-only", "--no-commit-id", sha])
+        if out.returncode != 0:
+            return []
+    return _paths(out.stdout)
+
+
+def delta_between(base, win, git):
+    """{commits, files}: what the branch gained between the record's base
+    and the merge-time head. First-parent is required, not cosmetic: the
+    commits that matter are the ones windows itself advanced by (PR
+    squashes, sync-publish merges), and a plain rev-list would walk every
+    upstream commit a sync merged in and drown the risk in noise."""
+    out = git(["rev-list", "--first-parent", f"{base}..{win}"])
+    if out.returncode != 0:
+        raise GuardError(f"rev-list failed: {out.stderr.strip()}")
+    shas = [s.strip() for s in out.stdout.splitlines() if s.strip()]
+    shas.reverse()  # oldest first, so the filed issue reads in landing order
+    commits = []
+    for sha in shas:
+        s = git(["show", "-s", "--format=%s", sha])
+        subject = s.stdout.strip().splitlines()[0] if s.stdout.strip() else "(no subject)"
+        commits.append({"sha": sha, "subject": subject, "files": commit_files(sha, git)})
+    d = git(["diff-tree", "-r", "--name-only", base, win])
+    if d.returncode != 0:
+        raise GuardError(f"diff-tree failed: {d.stderr.strip()}")
+    return {"commits": commits, "files": _paths(d.stdout)}
+
+
+def scope_overlap(rec, delta_files):
+    """Where the delta and the record's scope meet, in the three terms the
+    ceremony cares about: the same files, the same top-level directories,
+    the same signoff legs. The legs are recomputed from the delta's files
+    with gate_scope, so the question asked is exactly the one the record
+    answered, only against the branch as it now stands."""
+    scope = (rec or {}).get("scope") or {}
+    rec_paths = scope.get("paths") or []
+    rec_legs = set(scope.get("legs_run") or [])
+
+    def top_dirs(paths):
+        return {p.split("/")[0] for p in paths}
+
+    required = set(gate_scope.required_legs(delta_files))
+    return {
+        "files": sorted(set(delta_files) & set(rec_paths)),
+        "dirs": sorted(top_dirs(delta_files) & top_dirs(rec_paths)),
+        "legs": sorted(required & rec_legs),
+        "unknown": gate_scope.unknown_paths(delta_files),
+    }
+
+
+def risk_lines(overlap, delta_commits, delta_files):
+    """The risks in words, numbered for the issue. The first risk is the
+    delta itself and always fires; the rest fire only when an intersection
+    is non-empty, and when nothing intersects that is said outright, because
+    a silent risks section and a computed "none" are different claims."""
+    commits_note = "; ".join(f"`{c['sha'][:10]}` {c['subject']}" for c in delta_commits)
+    out = [
+        f"The delta itself: {len(delta_commits)} commit(s) ({commits_note}) landed on `windows` "
+        f"after the record's base, touching {len(delta_files)} file(s), and none of it was "
+        "exercised by the signed-off run."
+    ]
+    if overlap["files"]:
+        out.append("Same files as the record's scope: " +
+                   ", ".join(f"`{p}`" for p in overlap["files"]) +
+                   ". The green run covered these paths in their older state.")
+    if overlap["dirs"]:
+        out.append("Same top-level directories as the record's scope: " +
+                   ", ".join(f"`{d}/`" for d in overlap["dirs"]) +
+                   ". Both sides of the merge land in one place and were never run together.")
+    if overlap["legs"]:
+        out.append("Same signoff legs as the record: " +
+                   ", ".join(f"`{l}`" for l in overlap["legs"]) +
+                   ". The record ran them green against the old branch state; the result may "
+                   "no longer hold.")
+    if overlap["unknown"]:
+        out.append("The delta touches path(s) no scoping rule classifies: " +
+                   ", ".join(f"`{p}`" for p in overlap["unknown"][:5]) +
+                   ", so it could affect any leg.")
+    if len(out) == 1:
+        out.append("No file, directory or signoff-leg overlap between the delta and the "
+                   "record's scope was found; the residual risk is only that the signed-off "
+                   "code was not re-run against the branch as it now stands.")
+    return out
+
+
+def issue_title(pr, squash):
+    """One scannable line for the label's issue list: what merged, as what
+    squash, and why this issue exists."""
+    return (f"resignoff-required: PR #{pr.get('number', '?')} ({pr.get('title', 'untitled')}) "
+            f"squashed as {squash[:10]} on a moved windows window")
+
+
+def legs_note(rec):
+    """How the record's legs are described in the issue, mirroring the
+    hand-filed #970 wording. A red record never reaches this point, so the
+    only cases are a counted green run and the two flavours of record that
+    carry no per-step detail."""
+    steps = rec.get("steps") or {}
+    if steps:
+        return f"all {len(steps)} legs rc=0"
+    if rec.get("deferred"):
+        return "deferred record, no per-leg detail"
+    return "no per-leg detail recorded (legacy record)"
+
+
+def issue_body(pr, rec, rec_path, base, base_estimated, win, squash, delta, risks):
+    """The issue body, in exactly the shape of the hand-filed #970: an
+    intro line, the four identity bullets, the delta with per-commit
+    attribution, numbered risks, and the resignoff-in-flight status."""
+    base_line = f"- `windows` base at signoff time: `{base[:10]}`"
+    if base_estimated:
+        base_line += " (estimated at merge time: the record predates base recording)"
+    lines = [
+        "Filed by the merge guard (issue #969): this PR merged on a green signoff whose "
+        "`windows` window had already moved. Nothing was re-gated; the risk is carried here "
+        "instead.",
+        "",
+        f"- PR: #{pr.get('number', '?')}, squashed as `{squash[:10]}` on `windows`",
+        f"- Signed off: `{pr.get('headRefOid', '?')}` (record at `{rec_path}`, {legs_note(rec)})",
+        base_line,
+        f"- `windows` head at merge time: `{win[:10]}`",
+        "",
+        "## Delta (what merged between the record and the squash)",
+        "",
+        f"{len(delta['commits'])} commit(s) touching {len(delta['files'])} file(s):",
+        "",
+    ]
+    for c in delta["commits"]:
+        files = ", ".join(f"`{p}`" for p in c["files"])
+        lines.append(f"- `{c['sha'][:10]}` {c['subject']} [{len(c['files'])} file(s): {files}]")
+    lines += ["", "## Risks", ""]
+    lines += [f"{i}. {r}" for i, r in enumerate(risks, 1)]
+    lines += [
+        "",
+        "## Status",
+        "",
+        f"Resignoff for `{squash[:10]}`: not started. Phase 1 has no bot; when the #969 bot "
+        "lands it owns the lane run and closes this issue with the evidence.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def refusals(pr, rec, rec_path, ledger):
+    """Every reason the guard refuses before touching anything, as
+    (code, message) pairs. All of them are reported together, so one run
+    tells the agent everything to fix rather than only the first thing."""
+    out = []
+    head = pr.get("headRefOid", "?")
+    n = pr.get("number", "?")
+    if rec is None:
+        out.append(("signoff-missing",
+                    f"no local signoff record for head {head[:10]} (expected at {rec_path}). "
+                    "Run 'just signoff' on the PR branch; the guard merges on recorded "
+                    "evidence, never on a claim."))
+    else:
+        if not rec.get("deferred") and not rec.get("pass"):
+            failed = [k for k, v in (rec.get("steps") or {}).items() if v.get("rc") != 0]
+            out.append(("signoff-red",
+                        f"the signoff for {head[:10]} is red (failed: "
+                        f"{', '.join(failed) or 'unknown'}). The window policy forgives head "
+                        "movement, never a bad run; fix and rerun 'just signoff'."))
+        if rec.get("deferred"):
+            blockers = gate_scope.ledger_blockers(ledger)
+            if blockers:
+                out.append(("signoff-defer-blocked",
+                            "the deferred signoff for " + head[:10] + " is refused - " +
+                            "; ".join(blockers) +
+                            ". Settle the debt with 'just signoff-full' first; the guard does "
+                            "not extend credit the ledger refuses."))
+    if pr.get("state") != "OPEN":
+        out.append(("pr-not-open",
+                    f"PR #{n} is {pr.get('state') or 'in an unknown state'}, not OPEN."))
+    if pr.get("mergeable") != "MERGEABLE":
+        retry = " (GitHub may still be computing it; retry)" \
+            if pr.get("mergeable") == "UNKNOWN" else ""
+        out.append(("pr-not-mergeable",
+                    f"PR #{n} reports mergeable={pr.get('mergeable') or 'unknown'}{retry}."))
+    if pr.get("baseRefName") != BASE_BRANCH:
+        out.append(("base-branch",
+                    f"PR #{n} targets `{pr.get('baseRefName') or 'nothing resolvable'}`, not "
+                    f"`{BASE_BRANCH}`; the guard only knows the {BASE_BRANCH} ceremony."))
+    return out
+
+
+def display_path(path):
+    """Forward-slashed and repo-relative when the record lives under the
+    checkout, which is how AGENTS.md and the hand-filed #970 name records."""
+    p = os.path.abspath(path).replace("\\", "/")
+    root = REPO_ROOT.replace("\\", "/").rstrip("/") + "/"
+    if p.lower().startswith(root.lower()):
+        return p[len(root):]
+    return p
+
+
+def merge_flow(number, dry_run=False, gh=None, git=None, sleep=time.sleep):
+    """The whole sequence: validate, measure, merge, read back, file.
+    Returns the process exit code (see the module docstring). gh, git and
+    sleep are injectable so the self-test can replay whole sessions without
+    touching GitHub or the clock."""
+    gh = gh or gh_run
+    git = git or git_run
+    number = int(number)
+
+    common = resolve_common_dir(git)
+    if not common:
+        print("merge-guard: could not resolve the git common dir; refusing to act in a "
+              "half-dead session.")
+        return 2
+    slug = checkout_slug(git)
+    if not slug or not pr_gate.is_our_repo(slug):
+        print(f"merge-guard: wrong-repo: this checkout's origin is {slug or 'unresolvable'}; "
+              f"the guard only merges {REPO}.")
+        return 2
+    win = windows_head(git)
+    if not win:
+        print(f"merge-guard: could not resolve {BASE_REF} in this checkout; fetch first. "
+              "The delta cannot be measured without it.")
+        return 2
+
+    try:
+        pr = load_pr(number, gh)
+    except GuardError as e:
+        print(f"merge-guard: could not load PR #{number} from {REPO}: {e}")
+        return 1
+
+    head = pr.get("headRefOid") or ""
+    rec, rec_path = load_record(common, head)
+    ledger = gate_scope.load_ledger(os.path.join(common, "pr-signoff"))
+    problems = refusals(pr, rec, rec_path, ledger)
+    if problems:
+        print("merge-guard: refusing (nothing was mutated):")
+        for code, msg in problems:
+            print(f"merge-guard:   [{code}] {msg}")
+        return 2
+
+    base, estimated = record_base(rec, head, git)
+    if not base:
+        print("merge-guard: window-unknown: the record carries no base and no merge base is "
+              "resolvable; refusing rather than filing a blind issue.")
+        return 2
+    try:
+        delta = delta_between(base, win, git)
+    except GuardError as e:
+        print(f"merge-guard: could not measure the delta: {e}")
+        return 1
+    moved = bool(delta["commits"])
+    est = " (estimated)" if estimated else ""
+
+    if dry_run:
+        print(f"merge-guard: PR #{pr.get('number')} {pr.get('title', '')}")
+        print(f"merge-guard: head            {head}")
+        print(f"merge-guard: record          {display_path(rec_path)} "
+              f"(pass={rec.get('pass')}, deferred={bool(rec.get('deferred'))})")
+        print(f"merge-guard: record base     {base[:10]}{est}")
+        print(f"merge-guard: {BASE_REF} at merge time {win[:10]}")
+        print(f"merge-guard: delta           {len(delta['commits'])} commit(s), "
+              f"{len(delta['files'])} file(s)")
+        for c in delta["commits"]:
+            print(f"merge-guard:   {c['sha'][:10]} {c['subject']} [{len(c['files'])} file(s)]")
+        if not moved:
+            print("merge-guard: the window has not moved; a merge through the guard would "
+                  "file nothing.")
+            print("merge-guard: dry run: nothing merged, nothing filed.")
+            return 0
+        risks = risk_lines(scope_overlap(rec, delta["files"]), delta["commits"], delta["files"])
+        print("merge-guard: risks:")
+        for i, r in enumerate(risks, 1):
+            print(f"merge-guard:   {i}. {r}")
+        print("merge-guard: would merge with: gh pr merge "
+              f"{number} --repo {REPO} --squash --delete-branch")
+        print(f"merge-guard: would file issue titled: {issue_title(pr, '<squash-sha>')}")
+        print("merge-guard: with this body:")
+        print(issue_body(pr, rec, display_path(rec_path), base, estimated, win,
+                         "<squash-sha>", delta, risks))
+        print("merge-guard: dry run: nothing merged, nothing filed.")
+        return 0
+
+    out = gh(["pr", "merge", str(number), "--repo", REPO, "--squash", "--delete-branch"])
+    if out.returncode != 0:
+        print(f"merge-guard: the merge command failed (rc={out.returncode}): "
+              f"{(out.stderr or out.stdout).strip()}")
+        return 1
+
+    # The squash sha only exists once GitHub finishes the merge, so it is
+    # polled rather than assumed; without it the issue cannot be filed in
+    # the #970 shape, which names the squash.
+    squash = None
+    for _ in range(6):
+        try:
+            data = gh_json(["pr", "view", str(number), "--repo", REPO, "--json", "mergeCommit"],
+                           gh)
+            squash = (data.get("mergeCommit") or {}).get("oid")
+        except GuardError:
+            squash = None
+        if squash:
+            break
+        sleep(2)
+    if squash:
+        print(f"merge-guard: squashed as {squash[:10]}")
+    else:
+        print(f"merge-guard: the squash sha never appeared; the {LABEL} issue was NOT filed. "
+              "File it by hand with this body:")
+        print(issue_body(pr, rec, display_path(rec_path), base, estimated, win,
+                         "<squash-sha-unreadable>", delta,
+                         risk_lines(scope_overlap(rec, delta["files"]),
+                                    delta["commits"], delta["files"])))
+        return 1
+
+    if not moved:
+        print("merge-guard: the window had not moved since the record was taken; "
+              "nothing to file.")
+        return 0
+
+    body = issue_body(pr, rec, display_path(rec_path), base, estimated, win, squash, delta,
+                      risk_lines(scope_overlap(rec, delta["files"]),
+                                 delta["commits"], delta["files"]))
+    out = gh(["issue", "create", "--repo", REPO, "--label", LABEL,
+              "--title", issue_title(pr, squash), "--body", body])
+    if out.returncode != 0:
+        print(f"merge-guard: the merge landed but filing the {LABEL} issue failed "
+              f"(rc={out.returncode}): {(out.stderr or out.stdout).strip()}")
+        print("merge-guard: file it by hand with this body:")
+        print(body)
+        return 1
+    url = out.stdout.strip().splitlines()[-1] if out.stdout.strip() else "(no url printed)"
+    print(f"merge-guard: filed {LABEL}: {url}")
+    return 0
+
+
+class FakeGit:
+    """A router that answers only the spellings the guard issues, so a
+    scenario names what git would say and nothing more. An unhandled call
+    fails loudly instead of guessing, which is what keeps a self-test from
+    passing against a command the real flow never runs."""
+
+    def __init__(self, common, win, remote=None, merge_base=None, commits=None,
+                 all_files=None):
+        self.calls = []
+        self.common = common
+        self.win = win
+        self.remote = remote
+        self.merge_base = merge_base
+        self.commits = commits or []      # landing order, oldest first
+        self.all_files = all_files or []
+
+    def __call__(self, args, cwd=None):
+        self.calls.append(list(args))
+        a = args
+        if a[0] == "rev-parse" and "--git-common-dir" in a:
+            return Out(0, self.common + "\n")
+        if a[:3] == ["rev-parse", "--verify", BASE_REF]:
+            return Out(0, self.win + "\n")
+        if a[0] == "remote":
+            return Out(0, (self.remote or "") + "\n")
+        if a[0] == "merge-base":
+            if self.merge_base:
+                return Out(0, self.merge_base + "\n")
+            return Out(1, "")
+        if a[0] == "rev-list":
+            lo = a[-1].split("..")[0]
+            shas = [] if lo == self.win else [c["sha"] for c in reversed(self.commits)]
+            return Out(0, "".join(s + "\n" for s in shas))
+        if a[:3] == ["show", "-s", "--format=%s"]:
+            sha = a[3]
+            for c in self.commits:
+                if c["sha"] == sha:
+                    return Out(0, c["subject"] + "\n")
+            return Out(1, "")
+        # Per-commit form first: it is a prefix-shape of the two-commit one,
+        # and the order of these branches is the difference between a per
+        # commit file list and the whole delta.
+        if a[0] == "diff-tree" and "--no-commit-id" in a:
+            sha = a[-1]
+            for c in self.commits:
+                if c["sha"] == sha:
+                    return Out(0, "".join(p + "\n" for p in c["files"]))
+            return Out(0, "")
+        if a[0] == "diff-tree" and len(a) == 5:
+            return Out(0, "".join(p + "\n" for p in self.all_files))
+        return Out(1, "", f"unexpected git call: {a}")
+
+
+class FakeGh:
+    """Records every call and answers the three spellings the flow uses:
+    pr view (fields, and mergeCommit after the merge), pr merge, and issue
+    create."""
+
+    def __init__(self, pr, squash="e" * 40, merge_rc=0, issue_rc=0):
+        self.calls = []
+        self.pr = pr
+        self.squash = squash
+        self.merge_rc = merge_rc
+        self.issue_rc = issue_rc
+
+    def __call__(self, args, cwd=None):
+        self.calls.append(list(args))
+        j = " ".join(args)
+        if j.startswith("pr view") and "mergeCommit" in j:
+            return Out(0, json.dumps({"mergeCommit": {"oid": self.squash}}))
+        if j.startswith("pr view"):
+            return Out(0, json.dumps(self.pr))
+        if j.startswith("pr merge"):
+            return Out(0, "squashed\n") if self.merge_rc == 0 \
+                else Out(1, "", "merge refused by gh\n")
+        if j.startswith("issue create"):
+            return Out(0, "https://github.com/deblasis/wintty/issues/999\n") \
+                if self.issue_rc == 0 else Out(1, "", "issue create failed\n")
+        return Out(1, "", f"unexpected gh call: {j}")
+
+
+def make_pr(number, head, state="OPEN", mergeable="MERGEABLE", base_ref="windows"):
+    """A PR shaped the way gh returns it, with only the fields the guard
+    reads; the fixtures carry the real-world equivalents."""
+    return {"number": number, "title": f"synthetic pr {number}", "headRefOid": head,
+            "state": state, "mergeable": mergeable, "baseRefName": base_ref, "files": []}
+
+
+def write_record(common, head, record):
+    """Store a record where load_record will find it, so the self-test
+    exercises the real file path rather than a bypassed loader."""
+    d = os.path.join(common, "pr-signoff")
+    os.makedirs(d, exist_ok=True)
+    path = os.path.join(d, f"{head}.json")
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(record, f)
+    return path
+
+
+def run_capture(fn, *a, **kw):
+    """merge_flow's exit code and captured stdout, so assertions read the
+    agent-facing output and not the return code alone."""
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        rc = fn(*a, **kw)
+    return rc, buf.getvalue()
+
+
+def merged_calls(fgh):
+    """Whether any gh call was a merge, in any spelling the flow uses. A
+    bare pr view is not a mutation, so it does not count."""
+    return any(c[0] == "pr" and c[1] == "merge" for c in fgh.calls)
+
+
+def filed_calls(fgh):
+    """The issue-create calls, for asserting what was (or was not) filed."""
+    return [c for c in fgh.calls if c[0] == "issue" and c[1] == "create"]
+
+
+def bodies_of(fgh):
+    """The --body payload of every issue-create call."""
+    return [c[c.index("--body") + 1] for c in filed_calls(fgh) if "--body" in c]
+
+
+def self_test():
+    """Replay injected sessions against the refusal matrix, the same-window
+    merge, the moved-window filing against a hand-written golden body in
+    the #970 shape, the estimated-base legacy record, the dry-run's
+    nothing-mutated promise, and the remote-slug parsing."""
+    import shutil
+    import tempfile
+
+    failed = False
+
+    def report(ok, label, detail=""):
+        nonlocal failed
+        if not ok:
+            failed = True
+        print(f"{'ok ' if ok else 'FAIL'} {label}{': ' + detail if detail else ''}")
+
+    head = "d" * 40
+    base = "b" * 40
+    win = "a" * 40
+    c1, c2 = "1" * 40, "2" * 40
+    commits = [
+        {"sha": c1, "subject": "one: first landed change (#100)",
+         "files": ["windows/scripts/a.ps1"]},
+        {"sha": c2, "subject": "two: second landed change (#101)", "files": ["src/lib.zig"]},
+    ]
+    all_files = ["src/lib.zig", "windows/scripts/a.ps1"]
+    green = {"sha": head, "base": base, "steps": {"windows-tests": {"rc": 0},
+                                                  "zig-fmt": {"rc": 0}},
+             "pass": True, "scope": {"paths": ["windows/scripts/a.ps1"],
+                                     "legs_run": ["windows-tests", "zig-fmt"],
+                                     "justfile_legs": [], "reason": "scoped", "full": False}}
+    red = dict(green, **{"pass": False})
+    deferred = dict(green, deferred=True, reason="batching small prs")
+    legacy = {k: v for k, v in green.items() if k != "base"}
+
+    tmp = tempfile.mkdtemp(prefix="merge-guard-selftest-")
+    try:
+        # --- refusal matrix: each path refuses and issues no merge call.
+        cases = [
+            ("signoff-missing", make_pr(700, head), None, False),
+            ("signoff-red", make_pr(700, head), red, False),
+            ("signoff-defer-blocked", make_pr(700, head), deferred, True),
+            ("pr-not-open", make_pr(700, head, state="CLOSED"), green, False),
+            ("pr-not-mergeable", make_pr(700, head, mergeable="CONFLICTING"), green, False),
+            ("base-branch", make_pr(700, head, base_ref="main"), green, False),
+        ]
+        for label, pr, rec, with_ledger in cases:
+            td = tempfile.mkdtemp(dir=tmp)
+            if rec is not None:
+                write_record(td, head, rec)
+            if with_ledger:
+                import datetime
+                now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+                with open(os.path.join(td, "pr-signoff", gate_scope.LEDGER_NAME), "w",
+                          encoding="utf-8") as f:
+                    json.dump([{"sha": f"{i}" * 40, "created": now, "reason": "r"}
+                               for i in range(gate_scope.DEFER_MAX_OUTSTANDING)], f)
+            fgh = FakeGh(pr)
+            fgit = FakeGit(td, win, remote="https://github.com/deblasis/wintty.git",
+                           merge_base=base, commits=commits, all_files=all_files)
+            rc, out = run_capture(merge_flow, 700, gh=fgh, git=fgit)
+            report(rc == 2 and not merged_calls(fgh) and f"[{label}]" in out,
+                   "refuse-" + label, f"rc={rc}, merged={merged_calls(fgh)}")
+
+        # wrong-repo: a checkout of some other project never reaches gh.
+        td = tempfile.mkdtemp(dir=tmp)
+        write_record(td, head, green)
+        fgh = FakeGh(make_pr(700, head))
+        fgit = FakeGit(td, win, remote="https://github.com/other/fork.git",
+                       merge_base=base, commits=commits, all_files=all_files)
+        rc, out = run_capture(merge_flow, 700, gh=fgh, git=fgit)
+        report(rc == 2 and not fgh.calls and "wrong-repo" in out,
+               "refuse-wrong-repo", f"rc={rc}, gh calls={len(fgh.calls)}")
+
+        # window-unknown: a legacy record with no base and none derivable.
+        td = tempfile.mkdtemp(dir=tmp)
+        write_record(td, head, legacy)
+        fgh = FakeGh(make_pr(700, head))
+        fgit = FakeGit(td, win, remote="https://github.com/deblasis/wintty.git",
+                       merge_base=None, commits=commits, all_files=all_files)
+        rc, out = run_capture(merge_flow, 700, gh=fgh, git=fgit)
+        report(rc == 2 and not merged_calls(fgh) and not filed_calls(fgh)
+               and "window-unknown" in out,
+               "refuse-window-unknown", f"rc={rc}")
+
+        # --- same window: merges, files nothing.
+        td = tempfile.mkdtemp(dir=tmp)
+        write_record(td, head, dict(green, base=win))
+        fgh = FakeGh(make_pr(700, head))
+        fgit = FakeGit(td, win, remote="https://github.com/deblasis/wintty.git",
+                       merge_base=win, commits=[], all_files=[])
+        rc, out = run_capture(merge_flow, 700, gh=fgh, git=fgit)
+        report(rc == 0 and merged_calls(fgh) and not filed_calls(fgh)
+               and "nothing to file" in out,
+               "same-window", f"rc={rc}, merged={merged_calls(fgh)}, "
+                              f"filed={len(filed_calls(fgh))}")
+
+        # --- moved window: files the issue with the golden body.
+        td = tempfile.mkdtemp(dir=tmp)
+        rec_path = write_record(td, head, green)
+        fgh = FakeGh(make_pr(700, head))
+        fgit = FakeGit(td, win, remote="https://github.com/deblasis/wintty.git",
+                       merge_base=base, commits=commits, all_files=all_files)
+        rc, out = run_capture(merge_flow, 700, gh=fgh, git=fgit)
+        bodies = bodies_of(fgh)
+        golden = (
+            "Filed by the merge guard (issue #969): this PR merged on a green signoff whose "
+            "`windows` window had already moved. Nothing was re-gated; the risk is carried "
+            "here instead.\n"
+            "\n"
+            "- PR: #700, squashed as `eeeeeeeeee` on `windows`\n"
+            f"- Signed off: `{head}` (record at `{rec_path.replace(chr(92), '/')}`, "
+            "all 2 legs rc=0)\n"
+            f"- `windows` base at signoff time: `{base[:10]}`\n"
+            f"- `windows` head at merge time: `{win[:10]}`\n"
+            "\n"
+            "## Delta (what merged between the record and the squash)\n"
+            "\n"
+            "2 commit(s) touching 2 file(s):\n"
+            "\n"
+            f"- `{c1[:10]}` one: first landed change (#100) "
+            "[1 file(s): `windows/scripts/a.ps1`]\n"
+            f"- `{c2[:10]}` two: second landed change (#101) [1 file(s): `src/lib.zig`]\n"
+            "\n"
+            "## Risks\n"
+            "\n"
+            "1. The delta itself: 2 commit(s) (`1111111111` one: first landed change (#100); "
+            "`2222222222` two: second landed change (#101)) landed on `windows` after the "
+            "record's base, touching 2 file(s), and none of it was exercised by the "
+            "signed-off run.\n"
+            "2. Same files as the record's scope: `windows/scripts/a.ps1`. The green run "
+            "covered these paths in their older state.\n"
+            "3. Same top-level directories as the record's scope: `windows/`. Both sides of "
+            "the merge land in one place and were never run together.\n"
+            "4. Same signoff legs as the record: `windows-tests`, `zig-fmt`. The record ran "
+            "them green against the old branch state; the result may no longer hold.\n"
+            "\n"
+            "## Status\n"
+            "\n"
+            "Resignoff for `eeeeeeeeee`: not started. Phase 1 has no bot; when the #969 bot "
+            "lands it owns the lane run and closes this issue with the evidence.\n"
+        )
+        report(rc == 0 and len(bodies) == 1 and bodies[0] == golden,
+               "moved-window-golden-body",
+               "body matches the #970 shape" if rc == 0 else f"rc={rc}, out={out}")
+        if bodies and bodies[0] != golden:
+            report(False, "golden-diff",
+                   "\n--- got ---\n" + bodies[0] + "\n--- want ---\n" + golden)
+        filed = filed_calls(fgh)
+        report(bool(filed) and "--label" in filed[0] and LABEL in filed[0],
+               "issue-labelled", f"filed={len(filed)}")
+
+        # --- legacy record without a base: estimated, still files, and says so.
+        td = tempfile.mkdtemp(dir=tmp)
+        write_record(td, head, legacy)
+        fgh = FakeGh(make_pr(700, head))
+        fgit = FakeGit(td, win, remote="https://github.com/deblasis/wintty.git",
+                       merge_base=base, commits=commits, all_files=all_files)
+        rc, _ = run_capture(merge_flow, 700, gh=fgh, git=fgit)
+        bodies = bodies_of(fgh)
+        report(rc == 0 and bodies and "estimated at merge time" in bodies[0],
+               "legacy-base-estimated", f"rc={rc}, filed={bool(bodies)}")
+
+        # --- dry run: the full picture, zero mutations.
+        td = tempfile.mkdtemp(dir=tmp)
+        write_record(td, head, green)
+        fgh = FakeGh(make_pr(700, head))
+        fgit = FakeGit(td, win, remote="https://github.com/deblasis/wintty.git",
+                       merge_base=base, commits=commits, all_files=all_files)
+        rc, out = run_capture(merge_flow, 700, dry_run=True, gh=fgh, git=fgit)
+        mutated = merged_calls(fgh) or bool(filed_calls(fgh))
+        report(rc == 0 and not mutated and "## Risks" in out and "not started" in out
+               and "nothing merged, nothing filed" in out,
+               "dry-run-mutates-nothing", f"rc={rc}, mutated={mutated}")
+
+        # dry run over an unmoved window says nothing would be filed either.
+        td = tempfile.mkdtemp(dir=tmp)
+        write_record(td, head, dict(green, base=win))
+        fgh = FakeGh(make_pr(700, head))
+        fgit = FakeGit(td, win, remote="https://github.com/deblasis/wintty.git",
+                       merge_base=win, commits=[], all_files=[])
+        rc, out = run_capture(merge_flow, 700, dry_run=True, gh=fgh, git=fgit)
+        report(rc == 0 and not merged_calls(fgh) and not filed_calls(fgh)
+               and "file nothing" in out,
+               "dry-run-same-window", f"rc={rc}")
+
+        # --- merge refused by gh: loud failure, nothing filed.
+        td = tempfile.mkdtemp(dir=tmp)
+        write_record(td, head, green)
+        fgh = FakeGh(make_pr(700, head), merge_rc=1)
+        fgit = FakeGit(td, win, remote="https://github.com/deblasis/wintty.git",
+                       merge_base=base, commits=commits, all_files=all_files)
+        rc, out = run_capture(merge_flow, 700, gh=fgh, git=fgit)
+        report(rc == 1 and not filed_calls(fgh) and "failed" in out,
+               "merge-fails-loud", f"rc={rc}")
+
+        # --- remote slug parsing, shared with the hook's repo predicate.
+        slug_cases = [
+            ("git@github.com:deblasis/wintty.git", "deblasis/wintty"),
+            ("https://github.com/deblasis/wintty", "deblasis/wintty"),
+            ("ssh://git@github.com/deblasis/ghostty.git", "deblasis/ghostty"),
+            ("https://github.com/other/fork.git", "other/fork"),
+            ("", None),
+        ]
+        for url, expect in slug_cases:
+            got = remote_slug(url)
+            report(got == expect, "remote-slug", f"{url!r} -> {got}")
+        report(pr_gate.is_our_repo(remote_slug("git@github.com:deblasis/ghostty.git")),
+               "slug-matches-hook-predicate", "the guard and the hook agree on the fork")
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+    print("SELF-TEST " + ("FAILED" if failed else "PASSED"))
+    return 1 if failed else 0
+
+
+def main(argv):
+    if "--self-test" in argv:
+        return self_test()
+    dry = "--dry-run" in argv
+    positional = [a for a in argv if not a.startswith("-")]
+    if len(positional) != 1 or not positional[0].isdigit():
+        print(__doc__)
+        return 2
+    return merge_flow(int(positional[0]), dry_run=dry)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.agents/scripts/merge_guard.py
+++ b/.agents/scripts/merge_guard.py
@@ -14,7 +14,9 @@ script makes anything else the hard path; the pr_gate hook denies a raw
 `gh pr merge` whose signoff window has moved and names this script's
 recipe (`just merge-checked <pr>`). The guard is also the only place that
 knows how to build the issue body, which is what keeps the ceremony from
-drifting per-agent or per-memory.
+drifting per-agent or per-memory. The hook's own docstring lists the paths
+this does not cover (the web UI, a bare `git push`, hosts without the
+hook); the guard closes none of those either.
 
 The delta is measured from the record's `base` (the merge base with
 origin/windows stamped when the record was written) to the current
@@ -22,27 +24,42 @@ origin/windows head, first-parent only: sync-publish lands real merge
 commits, and a plain walk would disappear into upstream's history. A
 record written before base recording exists is base-unknown; the base is
 then estimated at merge time, which equals the original base whenever the
-branch only gained commits.
+branch only gained commits. The guard fetches `origin windows` itself
+before measuring, because a window measured against a stale ref computes
+a zero delta out of thin air; a failed fetch demotes the measurement to
+possibly-stale, which is printed loudly and carried into the filed issue.
 
 Refusals (nothing is mutated when one fires): no local record for the PR
 head, a red record, a deferred record the ledger no longer permits, a
-checkout that is not this fork, a PR that is not open and mergeable or
-that does not target `windows`, a window that cannot be measured. The new
-policy forgives head movement only; it never forgives a bad or absent run.
+record whose file set or legs no longer match the PR (the same
+revalidation the hook does: window movement is forgiven, a record that no
+longer describes this PR is not), a checkout that is not this fork, a PR
+that is not open and mergeable or that does not target `windows`, and a
+window that cannot be measured. The policy forgives head movement only;
+it never forgives a bad or absent run.
 
 Modes:
-  <pr>            validate, squash-merge, read back the squash sha, file
-                  the resignoff-required issue when the window moved.
-  --dry-run <pr>  print the resolved inputs, the delta, the risks and the
-                  would-be issue body; mutate nothing.
-  --self-test     replay injected gh/git sessions: the guard must refuse on
-                  every refusal path, merge without filing on an unmoved
-                  window, file the #970-shaped body on a moved one, and
-                  mutate nothing under --dry-run.
+  <pr>             validate, squash-merge, read back the squash sha, verify
+                   it against a second fetch, file the resignoff-required
+                   issue when the window moved.
+  --dry-run <pr>   print the resolved inputs, the delta, the risks and the
+                   would-be issue body; mutate nothing. Also the recovery
+                   preview for a PR that already merged (it accepts MERGED
+                   and uses the recorded mergeCommit as the squash).
+  --file-only <pr> compute the delta and file the issue, never merge. The
+                   recovery tool for a merge that landed outside the guard
+                   (or whose squash sha could not be read back): the owed
+                   resignoff issue still needs filing.
+  --self-test      replay injected gh/git sessions: the guard must refuse
+                   on every refusal path, merge without filing on an
+                   unmoved window, file the #970 template (with a
+                   structured delta) on a moved one, and mutate nothing
+                   under --dry-run.
 
-Exit codes: 0 merged (and filed, when owed); 1 the environment or a gh/git
-call failed part-way (said loudly, because the merge may already have
-landed); 2 a refusal, nothing mutated.
+Exit codes: 0 merged or filed as asked; 1 the environment or a gh/git call
+failed part-way (said loudly, because the merge may already have landed);
+2 a refusal, nothing mutated - including a PR that could not be loaded,
+since nothing has been touched at that point either.
 
 Run with: just merge-checked <pr>
 """
@@ -51,7 +68,6 @@ import contextlib
 import io
 import json
 import os
-import re
 import subprocess
 import sys
 import time
@@ -61,11 +77,28 @@ import gate_scope  # noqa: E402
 import pr_gate  # noqa: E402  (the repo predicate must agree with the hook's)
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-REPO = "deblasis/wintty"
-BASE_BRANCH = "windows"
-BASE_REF = "origin/" + BASE_BRANCH
+# One repo name and one branch name, aliased from pr_gate: a hook and a
+# guard that must agree on "which repo, which branch, how far did it move"
+# cannot be allowed to carry divergent copies of either answer.
+REPO = pr_gate.REPO
+BASE_BRANCH = pr_gate.BASE_BRANCH
+BASE_REF = pr_gate.BASE_REF
 LABEL = "resignoff-required"
-PR_FIELDS = "number,title,headRefOid,state,mergeable,baseRefName,files"
+PR_FIELDS = "number,title,headRefOid,state,mergeable,baseRefName,mergeCommit,files"
+
+# Rendering caps. A rewritten base can turn `base..head` into hundreds of
+# commits, and an issue nobody reads protects nothing; the full list stays
+# one git command away and the body says it was capped.
+MAX_COMMIT_BULLETS = 15
+MAX_COMMIT_FILES = 12
+MAX_RISK_COMMITS = 10
+
+# The hand-filed #970 names commits with 9-character prefixes; the template
+# keeps that spelling so a filed issue and its hand-written ancestor read
+# alike side by side.
+SHORT_SHA = 9
+_NUM_WORDS = {2: "two", 3: "three", 4: "four", 5: "five", 6: "six", 7: "seven",
+              8: "eight", 9: "nine", 10: "ten"}
 
 
 class GuardError(Exception):
@@ -107,22 +140,27 @@ def resolve_common_dir(git):
     return common if os.path.isdir(common) else None
 
 
-def remote_slug(url):
-    """owner/name out of any remote spelling (ssh, https, a .git suffix), or
-    None. The fork answers to two names - the current one and the ghostty
-    name GitHub still redirects - and the checkout check must accept both,
-    so this is the parsing half and pr_gate.is_our_repo is the decision."""
-    m = re.search(r"[:/]([\w.-]+/[\w.-]+?)(?:\.git)?/?$", url or "")
-    return m.group(1).lower() if m else None
-
-
 def checkout_slug(git):
     """The slug of this checkout's origin remote, or None when git cannot
-    answer; both cases refuse, they do not guess."""
+    answer; both cases refuse, they do not guess. Parsing is pr_gate's
+    normalize_slug, the same normalizer the hook's repo predicate runs, so
+    a host-qualified remote cannot pass the hook and slip the guard."""
     out = git(["remote", "get-url", "origin"])
     if out.returncode != 0:
         return None
-    return remote_slug(out.stdout.strip())
+    return pr_gate.normalize_slug(out.stdout.strip())
+
+
+def fetch_windows(git):
+    """`git fetch origin windows`, True on success. The guard fetches on
+    its own because the entire point is measuring the window at merge
+    time, and a local ref is only as fresh as the last fetch; the hook
+    stays fast and local instead, which is exactly why its same-window
+    allowance is worded as "as fresh as your last fetch". A failed fetch
+    does not stop the flow (an offline host may still have a correct
+    local ref), it demotes the measurement to possibly-stale, which is
+    printed loudly and carried into the filed issue."""
+    return git(["fetch", "origin", BASE_BRANCH]).returncode == 0
 
 
 def gh_json(args, gh):
@@ -139,14 +177,17 @@ def gh_json(args, gh):
 
 def load_pr(number, gh):
     """The PR as the guard sees it: identity, mergeability, the target
-    branch, and the head sha the record must be keyed to."""
+    branch, the head sha the record must be keyed to, and (for an already
+    merged PR) the squash sha the recovery modes file against."""
     return gh_json(["pr", "view", str(number), "--repo", REPO, "--json", PR_FIELDS], gh)
 
 
 def load_record(common, head):
     """(record, expected path). The record is keyed by the PR's exact head
     sha, like the hook's own lookup; None means no run was recorded here,
-    which the policy treats as missing evidence, not as a pass."""
+    which the policy treats as missing evidence, not as a pass. A corrupt
+    file reads as absent for the same reason: raising out of a guard is a
+    denial of the guard, not a failure of the run."""
     d = os.path.join(common, "pr-signoff")
     path = os.path.join(d, f"{head}.json")
     try:
@@ -157,9 +198,9 @@ def load_record(common, head):
 
 
 def windows_head(git):
-    """The local position of origin/windows. Deliberately the local ref and
-    not a gh call: the delta is measured in THIS checkout's history, where
-    the record's base lives, and a stale ref simply means fetch first."""
+    """The local position of origin/windows, read after fetch_windows.
+    Deliberately a local ref and not a gh call: the delta is measured in
+    THIS checkout's history, where the record's base lives."""
     out = git(["rev-parse", "--verify", BASE_REF])
     sha = out.stdout.strip()
     return sha if out.returncode == 0 and sha else None
@@ -222,14 +263,19 @@ def delta_between(base, win, git):
     return {"commits": commits, "files": _paths(d.stdout)}
 
 
-def scope_overlap(rec, delta_files):
-    """Where the delta and the record's scope meet, in the three terms the
+def scope_overlap(rec, delta_files, pr_files=None):
+    """Where the delta and the compared scope meet, in the three terms the
     ceremony cares about: the same files, the same top-level directories,
     the same signoff legs. The legs are recomputed from the delta's files
     with gate_scope, so the question asked is exactly the one the record
-    answered, only against the branch as it now stands."""
+    answered, only against the branch as it now stands. When the record
+    predates scoping (no scope.paths), the PR's own file list stands in as
+    the comparison set: an unscoped record ran the whole ladder, but the
+    intersections still say something worth reading."""
     scope = (rec or {}).get("scope") or {}
-    rec_paths = scope.get("paths") or []
+    rec_paths = scope.get("paths")
+    if rec_paths is None:
+        rec_paths = pr_files or []
     rec_legs = set(scope.get("legs_run") or [])
 
     def top_dirs(paths):
@@ -248,8 +294,14 @@ def risk_lines(overlap, delta_commits, delta_files):
     """The risks in words, numbered for the issue. The first risk is the
     delta itself and always fires; the rest fire only when an intersection
     is non-empty, and when nothing intersects that is said outright, because
-    a silent risks section and a computed "none" are different claims."""
-    commits_note = "; ".join(f"`{c['sha'][:10]}` {c['subject']}" for c in delta_commits)
+    a silent risks section and a computed "none" are different claims. The
+    commit list inside the first risk is capped like the body: a rewritten
+    base must not turn the headline risk into a wall of shas."""
+    shown = delta_commits[:MAX_RISK_COMMITS]
+    commits_note = "; ".join(f"`{short(c['sha'])}` {c['subject']}" for c in shown)
+    hidden = len(delta_commits) - len(shown)
+    if hidden:
+        commits_note += f"; and {hidden} more"
     out = [
         f"The delta itself: {len(delta_commits)} commit(s) ({commits_note}) landed on `windows` "
         f"after the record's base, touching {len(delta_files)} file(s), and none of it was "
@@ -279,75 +331,147 @@ def risk_lines(overlap, delta_commits, delta_files):
     return out
 
 
+def short(sha):
+    """A sha prefix at the template's length, or the value verbatim: the
+    placeholders the dry-run and the unreadable-squash path use are not
+    shas and must not be cut mid-word."""
+    return sha[:SHORT_SHA] if len(sha) > SHORT_SHA else sha
+
+
 def issue_title(pr, squash):
     """One scannable line for the label's issue list: what merged, as what
     squash, and why this issue exists."""
     return (f"resignoff-required: PR #{pr.get('number', '?')} ({pr.get('title', 'untitled')}) "
-            f"squashed as {squash[:10]} on a moved windows window")
+            f"squashed as {short(squash)} on a moved windows window")
 
 
 def legs_note(rec):
-    """How the record's legs are described in the issue, mirroring the
-    hand-filed #970 wording. A red record never reaches this point, so the
+    """How the record's legs are described in the issue, matching the
+    hand-filed #970's wording ("all four legs rc=0"), which is why small
+    counts are spelled out. A red record never reaches this point, so the
     only cases are a counted green run and the two flavours of record that
     carry no per-step detail."""
     steps = rec.get("steps") or {}
     if steps:
-        return f"all {len(steps)} legs rc=0"
+        n = len(steps)
+        return f"all {_NUM_WORDS.get(n, n)} legs rc=0"
     if rec.get("deferred"):
         return "deferred record, no per-leg detail"
     return "no per-leg detail recorded (legacy record)"
 
 
-def issue_body(pr, rec, rec_path, base, base_estimated, win, squash, delta, risks):
-    """The issue body, in exactly the shape of the hand-filed #970: an
-    intro line, the four identity bullets, the delta with per-commit
-    attribution, numbered risks, and the resignoff-in-flight status."""
-    base_line = f"- `windows` base at signoff time: `{base[:10]}`"
-    if base_estimated:
-        base_line += " (estimated at merge time: the record predates base recording)"
+def display_path(sha):
+    """The record's path as public output names it: the canonical
+    `.git/pr-signoff/<sha>.json`, never the machine's absolute path, which
+    leaks a home directory into a filed issue and varies per clone. The
+    hand-filed #970 used exactly this canonical form."""
+    return f".git/pr-signoff/{sha}.json"
+
+
+def issue_body(pr, rec, rec_path, base, base_estimated, win, squash, delta, risks,
+               notes=(), backlog=None):
+    """The issue body: the #970 template, with a structured delta. The
+    hand-filed original proved the shape; computing it here is what keeps
+    the next filing from drifting per-agent or per-memory. Caps keep a
+    rewritten-history merge from producing a body nobody reads, the fixed
+    last risk names the one thing no re-run can ever cover (the squash
+    commit itself was never signed off), and `notes` carries the
+    measurement caveats (a stale fetch, a rewritten base, movement in
+    flight) that would otherwise live only in the agent's console."""
     lines = [
         "Filed by the merge guard (issue #969): this PR merged on a green signoff whose "
         "`windows` window had already moved. Nothing was re-gated; the risk is carried here "
         "instead.",
         "",
-        f"- PR: #{pr.get('number', '?')}, squashed as `{squash[:10]}` on `windows`",
+        f"- PR: #{pr.get('number', '?')}, squashed as `{short(squash)}` on `windows`",
         f"- Signed off: `{pr.get('headRefOid', '?')}` (record at `{rec_path}`, {legs_note(rec)})",
-        base_line,
-        f"- `windows` head at merge time: `{win[:10]}`",
+    ]
+    base_line = f"- `windows` base at signoff time: `{short(base)}`"
+    if base_estimated:
+        base_line += " (estimated at merge time: the record predates base recording)"
+    lines.append(base_line)
+    lines.append(f"- `windows` head at merge time: `{short(win)}`")
+    if notes:
+        lines += ["", "## Notes", ""] + [f"- {n}" for n in notes]
+    lines += [
         "",
         "## Delta (what merged between the record and the squash)",
         "",
         f"{len(delta['commits'])} commit(s) touching {len(delta['files'])} file(s):",
         "",
     ]
-    for c in delta["commits"]:
-        files = ", ".join(f"`{p}`" for p in c["files"])
-        lines.append(f"- `{c['sha'][:10]}` {c['subject']} [{len(c['files'])} file(s): {files}]")
+    shown = delta["commits"][:MAX_COMMIT_BULLETS]
+    for c in shown:
+        files = c["files"][:MAX_COMMIT_FILES]
+        rendered = ", ".join(f"`{p}`" for p in files)
+        more = len(c["files"]) - len(files)
+        if more:
+            rendered += f", +{more} more file(s)"
+        lines.append(f"- `{short(c['sha'])}` {c['subject']} "
+                     f"[{len(c['files'])} file(s): {rendered}]")
+    hidden = len(delta["commits"]) - len(shown)
+    if hidden:
+        lines.append(f"- and {hidden} more commit(s) (capped; `git log --first-parent "
+                     f"{short(base)}..{short(win)}` has the full list)")
     lines += ["", "## Risks", ""]
     lines += [f"{i}. {r}" for i, r in enumerate(risks, 1)]
+    lines.append(
+        f"{len(risks) + 1}. The squash commit itself was never signed off: the green record "
+        f"covers `{short(pr.get('headRefOid', '?'))}` and the squash rewrote that history "
+        f"into `{short(squash)}`.")
     lines += [
         "",
         "## Status",
         "",
-        f"Resignoff for `{squash[:10]}`: not started. Phase 1 has no bot; when the #969 bot "
-        "lands it owns the lane run and closes this issue with the evidence.",
+        f"Resignoff for `{short(squash)}`: not started at filing time. Check "
+        "`incoda status --queue wintty` before queuing a run; the #969 bot owns this lane "
+        "once it lands.",
+        f"Squash commit: `{squash}`" + (" (full sha)" if len(squash) == 40 else ""),
     ]
+    if backlog:
+        lines.append(backlog)
     return "\n".join(lines) + "\n"
 
 
-def refusals(pr, rec, rec_path, ledger):
+def backlog_line(gh):
+    """One `gh issue list` call at filing time, as 'Outstanding ... (oldest
+    #M)'. The count is taken before this issue is created, so the number is
+    the backlog the filer saw, not one that already includes itself. None
+    when gh cannot answer: the backlog line is context, not evidence, and
+    must not be allowed to fail a merge that already landed."""
+    out = gh(["issue", "list", "--repo", REPO, "--label", LABEL,
+              "--state", "open", "--json", "number,createdAt"])
+    if out.returncode != 0:
+        return None
+    try:
+        issues = json.loads(out.stdout)
+    except ValueError:
+        return None
+    if not issues:
+        return None
+    oldest = min(issues, key=lambda i: i.get("createdAt", ""))
+    return (f"Outstanding `{LABEL}` issues at filing time: {len(issues)} "
+            f"(oldest #{oldest.get('number', '?')}).")
+
+
+def refusals(pr, rec, ledger, mode="merge"):
     """Every reason the guard refuses before touching anything, as
     (code, message) pairs. All of them are reported together, so one run
-    tells the agent everything to fix rather than only the first thing."""
+    tells the agent everything to fix rather than only the first thing.
+    The scope revalidation is the hook's own two checks: a record whose
+    file set or legs no longer match the PR must be re-taken even though
+    the window policy forgives movement. The recovery modes forgive the
+    closed-state checks instead, because their whole point is a PR that
+    already merged."""
     out = []
     head = pr.get("headRefOid", "?")
     n = pr.get("number", "?")
     if rec is None:
         out.append(("signoff-missing",
-                    f"no local signoff record for head {head[:10]} (expected at {rec_path}). "
-                    "Run 'just signoff' on the PR branch; the guard merges on recorded "
-                    "evidence, never on a claim."))
+                    f"no local signoff record for head {head[:10]} (expected at "
+                    f"{display_path(head)}). Run 'just signoff' on the PR branch; the guard "
+                    "merges on recorded evidence, never on a claim (records live in this "
+                    "clone's git dir; a signoff run on another machine does not count here)."))
     else:
         if not rec.get("deferred") and not rec.get("pass"):
             failed = [k for k, v in (rec.get("steps") or {}).items() if v.get("rc") != 0]
@@ -363,14 +487,48 @@ def refusals(pr, rec, rec_path, ledger):
                             "; ".join(blockers) +
                             ". Settle the debt with 'just signoff-full' first; the guard does "
                             "not extend credit the ledger refuses."))
-    if pr.get("state") != "OPEN":
-        out.append(("pr-not-open",
-                    f"PR #{n} is {pr.get('state') or 'in an unknown state'}, not OPEN."))
-    if pr.get("mergeable") != "MERGEABLE":
-        retry = " (GitHub may still be computing it; retry)" \
-            if pr.get("mergeable") == "UNKNOWN" else ""
-        out.append(("pr-not-mergeable",
-                    f"PR #{n} reports mergeable={pr.get('mergeable') or 'unknown'}{retry}."))
+        scope = rec.get("scope")
+        if scope is not None and rec.get("pass") and not rec.get("deferred"):
+            pr_paths = sorted(f["path"].replace("\\", "/") for f in pr.get("files", []))
+            rec_paths = scope.get("paths")
+            if rec_paths is not None and sorted(rec_paths) != pr_paths:
+                out.append(("signoff-stale",
+                            f"the signoff for {head[:10]} was computed over a different file "
+                            f"set than this PR reports ({len(rec_paths)} vs {len(pr_paths)} "
+                            "paths). Re-run 'just signoff'; the guard files the delta for "
+                            "branch movement, never for a PR that changed under its record."))
+            else:
+                required = set(gate_scope.required_legs(
+                    pr_paths, justfile_legs=scope.get("justfile_legs")))
+                missing = sorted(required - set(scope.get("legs_run") or []))
+                if missing:
+                    out.append(("signoff-scope",
+                                f"the signoff for {head[:10]} did not run {', '.join(missing)},"
+                                " which this PR's files require. Re-run 'just signoff' (or "
+                                "'just signoff-full')."))
+    if mode == "merge":
+        if pr.get("state") != "OPEN":
+            out.append(("pr-not-open",
+                        f"PR #{n} is {pr.get('state') or 'in an unknown state'}, not OPEN; if "
+                        "it is MERGED, the owed resignoff issue still needs filing - "
+                        f"`--dry-run {n}` regenerates the body, `--file-only {n}` files it."))
+        if pr.get("mergeable") != "MERGEABLE":
+            retry = " (GitHub may still be computing it; retry)" \
+                if pr.get("mergeable") == "UNKNOWN" else ""
+            out.append(("pr-not-mergeable",
+                        f"PR #{n} reports mergeable={pr.get('mergeable') or 'unknown'}{retry}."))
+    else:
+        # Recovery modes: MERGED is their whole point, OPEN is the normal
+        # path's business, anything else is unreasonable.
+        if pr.get("state") not in ("MERGED", "OPEN"):
+            out.append(("pr-not-open",
+                        f"PR #{n} is {pr.get('state') or 'in an unknown state'}; only an OPEN "
+                        "or MERGED PR can be reasoned about."))
+        if mode == "file-only" and pr.get("state") == "OPEN":
+            out.append(("pr-still-open",
+                        f"PR #{n} is still open; `--file-only` exists for merges that already "
+                        f"landed. Use `just merge-checked {n}` to merge, or `--dry-run {n}` to "
+                        "preview."))
     if pr.get("baseRefName") != BASE_BRANCH:
         out.append(("base-branch",
                     f"PR #{n} targets `{pr.get('baseRefName') or 'nothing resolvable'}`, not "
@@ -378,21 +536,54 @@ def refusals(pr, rec, rec_path, ledger):
     return out
 
 
-def display_path(path):
-    """Forward-slashed and repo-relative when the record lives under the
-    checkout, which is how AGENTS.md and the hand-filed #970 name records."""
-    p = os.path.abspath(path).replace("\\", "/")
-    root = REPO_ROOT.replace("\\", "/").rstrip("/") + "/"
-    if p.lower().startswith(root.lower()):
-        return p[len(root):]
-    return p
+def verify_squash_parent(squash, win, number, git, notes):
+    """Second fetch + parent check after the squash is read back. GitHub put
+    the squash on `windows` while this flow was running; if the branch moved
+    again in flight, the measured window is already behind the merge and the
+    filed delta understates it. The remedy is a re-measure against the
+    squash's actual parent and an amend of the issue, so both are said out
+    loud and the caveat rides in the body too."""
+    fetch_windows(git)
+    out = git(["rev-parse", f"{squash}^"])
+    parent = out.stdout.strip() if out.returncode == 0 else None
+    if not parent or parent == win:
+        return
+    print("merge-guard: WARNING: `windows` moved in flight: the squash's parent is "
+          f"{short(parent)}, not the {short(win)} the delta was measured from. Re-run "
+          f"`just merge-checked {number} --dry-run` against that parent and amend the "
+          "filed issue.")
+    notes.append("`windows` moved in flight: the squash's parent is `" + short(parent) +
+                 "`, not the measured `" + short(win) + "`. Re-run "
+                 f"`just merge-checked {number} --dry-run` against that parent and amend "
+                 "this issue.")
 
 
-def merge_flow(number, dry_run=False, gh=None, git=None, sleep=time.sleep):
-    """The whole sequence: validate, measure, merge, read back, file.
-    Returns the process exit code (see the module docstring). gh, git and
-    sleep are injectable so the self-test can replay whole sessions without
-    touching GitHub or the clock."""
+def file_issue(pr, rec, head, base, base_estimated, win, squash, delta, risks, notes, gh):
+    """Render the body and file the labelled issue, printing the body for a
+    hand filing when gh refuses. Returns this step's exit code: 0 filed,
+    1 not filed. The body is on stdout either way, so a human (or a follow
+    -up `gh issue create`) is never blocked by a transient gh failure."""
+    body = issue_body(pr, rec, display_path(head), base, base_estimated, win, squash,
+                      delta, risks, notes=notes, backlog=backlog_line(gh))
+    out = gh(["issue", "create", "--repo", REPO, "--label", LABEL,
+              "--title", issue_title(pr, squash), "--body", body])
+    if out.returncode != 0:
+        print(f"merge-guard: filing the {LABEL} issue failed (rc={out.returncode}): "
+              f"{(out.stderr or out.stdout).strip()}")
+        print("merge-guard: file it by hand with this body:")
+        print(body)
+        return 1
+    url = out.stdout.strip().splitlines()[-1] if out.stdout.strip() else "(no url printed)"
+    print(f"merge-guard: filed {LABEL}: {url}")
+    return 0
+
+
+def merge_flow(number, mode="merge", gh=None, git=None, sleep=time.sleep):
+    """The whole sequence: fetch, validate, measure, merge, read back,
+    verify, file. mode is "merge", "dry-run" or "file-only". Returns the
+    process exit code (see the module docstring). gh, git and sleep are
+    injectable so the self-test can replay whole sessions without touching
+    GitHub or the clock."""
     gh = gh or gh_run
     git = git or git_run
     number = int(number)
@@ -405,8 +596,16 @@ def merge_flow(number, dry_run=False, gh=None, git=None, sleep=time.sleep):
     slug = checkout_slug(git)
     if not slug or not pr_gate.is_our_repo(slug):
         print(f"merge-guard: wrong-repo: this checkout's origin is {slug or 'unresolvable'}; "
-              f"the guard only merges {REPO}.")
+              f"the guard only merges {REPO}. Clone {REPO} (or point this checkout's origin "
+              "at it) and re-run.")
         return 2
+    if not fetch_windows(git):
+        print(f"merge-guard: WARNING: `git fetch origin {BASE_BRANCH}` failed; the delta is "
+              f"measured against a possibly stale {BASE_REF}. Re-check against a fresh fetch "
+              "and amend the filed issue if it changed.")
+        stale = True
+    else:
+        stale = False
     win = windows_head(git)
     if not win:
         print(f"merge-guard: could not resolve {BASE_REF} in this checkout; fetch first. "
@@ -416,13 +615,15 @@ def merge_flow(number, dry_run=False, gh=None, git=None, sleep=time.sleep):
     try:
         pr = load_pr(number, gh)
     except GuardError as e:
+        # rc 2, not 1: nothing has been touched, so this is a refusal in
+        # every sense the exit codes describe.
         print(f"merge-guard: could not load PR #{number} from {REPO}: {e}")
-        return 1
+        return 2
 
     head = pr.get("headRefOid") or ""
-    rec, rec_path = load_record(common, head)
+    rec, _rec_path = load_record(common, head)
     ledger = gate_scope.load_ledger(os.path.join(common, "pr-signoff"))
-    problems = refusals(pr, rec, rec_path, ledger)
+    problems = refusals(pr, rec, ledger, mode)
     if problems:
         print("merge-guard: refusing (nothing was mutated):")
         for code, msg in problems:
@@ -434,6 +635,11 @@ def merge_flow(number, dry_run=False, gh=None, git=None, sleep=time.sleep):
         print("merge-guard: window-unknown: the record carries no base and no merge base is "
               "resolvable; refusing rather than filing a blind issue.")
         return 2
+    ancestor = git(["merge-base", "--is-ancestor", base, win]).returncode == 0
+    if not ancestor:
+        print("merge-guard: WARNING: the record's base is not an ancestor of the merge-time "
+              f"{BASE_REF} head (history was rewritten); the delta below is capped and may "
+              "not be a faithful 'what landed' list. Re-run 'just signoff' if in doubt.")
     try:
         delta = delta_between(base, win, git)
     except GuardError as e:
@@ -442,35 +648,69 @@ def merge_flow(number, dry_run=False, gh=None, git=None, sleep=time.sleep):
     moved = bool(delta["commits"])
     est = " (estimated)" if estimated else ""
 
-    if dry_run:
+    notes = []
+    if stale:
+        notes.append(f"`git fetch origin {BASE_BRANCH}` failed before measuring, so this "
+                     f"delta is computed against a possibly stale {BASE_REF}; re-run "
+                     f"`just merge-checked {number} --dry-run` after a fresh fetch and amend "
+                     "this issue if it changed.")
+    if not ancestor:
+        notes.append("the record's base is not an ancestor of the merge-time `windows` head "
+                     "(history was rewritten); the delta below is capped and may not be a "
+                     "faithful 'what landed' list.")
+    pr_files = [f["path"].replace("\\", "/") for f in pr.get("files", [])]
+    risks = risk_lines(scope_overlap(rec, delta["files"], pr_files),
+                       delta["commits"], delta["files"])
+
+    if mode == "dry-run":
+        squash = (pr.get("mergeCommit") or {}).get("oid") or "<squash>"
         print(f"merge-guard: PR #{pr.get('number')} {pr.get('title', '')}")
         print(f"merge-guard: head            {head}")
-        print(f"merge-guard: record          {display_path(rec_path)} "
+        print(f"merge-guard: record          {display_path(head)} "
               f"(pass={rec.get('pass')}, deferred={bool(rec.get('deferred'))})")
-        print(f"merge-guard: record base     {base[:10]}{est}")
-        print(f"merge-guard: {BASE_REF} at merge time {win[:10]}")
+        print(f"merge-guard: record base     {short(base)}{est}")
+        print(f"merge-guard: {BASE_REF} at merge time {short(win)}")
         print(f"merge-guard: delta           {len(delta['commits'])} commit(s), "
               f"{len(delta['files'])} file(s)")
         for c in delta["commits"]:
-            print(f"merge-guard:   {c['sha'][:10]} {c['subject']} [{len(c['files'])} file(s)]")
+            print(f"merge-guard:   {short(c['sha'])} {c['subject']} "
+                  f"[{len(c['files'])} file(s)]")
         if not moved:
             print("merge-guard: the window has not moved; a merge through the guard would "
                   "file nothing.")
             print("merge-guard: dry run: nothing merged, nothing filed.")
             return 0
-        risks = risk_lines(scope_overlap(rec, delta["files"]), delta["commits"], delta["files"])
-        print("merge-guard: risks:")
-        for i, r in enumerate(risks, 1):
-            print(f"merge-guard:   {i}. {r}")
-        print("merge-guard: would merge with: gh pr merge "
-              f"{number} --repo {REPO} --squash --delete-branch")
-        print(f"merge-guard: would file issue titled: {issue_title(pr, '<squash-sha>')}")
+        if pr.get("state") == "MERGED":
+            print("merge-guard: this PR is already MERGED; the body below is the recovery "
+                  "body (file it with `--file-only`).")
+        else:
+            print("merge-guard: would merge with: gh pr merge "
+                  f"{number} --repo {REPO} --squash --delete-branch")
+        print(f"merge-guard: would file issue titled: {issue_title(pr, squash)}")
         print("merge-guard: with this body:")
-        print(issue_body(pr, rec, display_path(rec_path), base, estimated, win,
-                         "<squash-sha>", delta, risks))
+        # The backlog line is in the preview too, so the dry-run body is
+        # what filing would actually produce, backlog included.
+        print(issue_body(pr, rec, display_path(head), base, estimated, win, squash,
+                         delta, risks, notes=notes, backlog=backlog_line(gh)))
         print("merge-guard: dry run: nothing merged, nothing filed.")
         return 0
 
+    if mode == "file-only":
+        squash = (pr.get("mergeCommit") or {}).get("oid")
+        if not squash:
+            print(f"merge-guard: GitHub reports no mergeCommit for PR #{number} yet; nothing "
+                  "to file against. Retry shortly, or file by hand from a --dry-run body.")
+            return 1
+        verify_squash_parent(squash, win, number, git, notes)
+        if not moved:
+            print("merge-guard: the measured delta is empty; filing anyway because "
+                  "--file-only was asked for explicitly (delete the issue if that was "
+                  "wrong).")
+        return file_issue(pr, rec, head, base, estimated, win, squash, delta, risks,
+                          notes, gh)
+
+    # mode == "merge": the real thing. From here on a failure is a 1, not
+    # a 2, because the merge may already have landed.
     out = gh(["pr", "merge", str(number), "--repo", REPO, "--squash", "--delete-branch"])
     if out.returncode != 0:
         print(f"merge-guard: the merge command failed (rc={out.returncode}): "
@@ -479,7 +719,7 @@ def merge_flow(number, dry_run=False, gh=None, git=None, sleep=time.sleep):
 
     # The squash sha only exists once GitHub finishes the merge, so it is
     # polled rather than assumed; without it the issue cannot be filed in
-    # the #970 shape, which names the squash.
+    # the #970 template, which names the squash.
     squash = None
     for _ in range(6):
         try:
@@ -491,36 +731,22 @@ def merge_flow(number, dry_run=False, gh=None, git=None, sleep=time.sleep):
         if squash:
             break
         sleep(2)
-    if squash:
-        print(f"merge-guard: squashed as {squash[:10]}")
-    else:
+    if not squash:
         print(f"merge-guard: the squash sha never appeared; the {LABEL} issue was NOT filed. "
-              "File it by hand with this body:")
-        print(issue_body(pr, rec, display_path(rec_path), base, estimated, win,
-                         "<squash-sha-unreadable>", delta,
-                         risk_lines(scope_overlap(rec, delta["files"]),
-                                    delta["commits"], delta["files"])))
+              f"File it with `python .agents/scripts/merge_guard.py --file-only {number}` "
+              "once GitHub reports the mergeCommit, or by hand with this body:")
+        print(issue_body(pr, rec, display_path(head), base, estimated, win, "<squash>",
+                         delta, risks, notes=notes))
         return 1
+    print(f"merge-guard: squashed as {short(squash)}")
+    verify_squash_parent(squash, win, number, git, notes)
 
     if not moved:
         print("merge-guard: the window had not moved since the record was taken; "
               "nothing to file.")
         return 0
-
-    body = issue_body(pr, rec, display_path(rec_path), base, estimated, win, squash, delta,
-                      risk_lines(scope_overlap(rec, delta["files"]),
-                                 delta["commits"], delta["files"]))
-    out = gh(["issue", "create", "--repo", REPO, "--label", LABEL,
-              "--title", issue_title(pr, squash), "--body", body])
-    if out.returncode != 0:
-        print(f"merge-guard: the merge landed but filing the {LABEL} issue failed "
-              f"(rc={out.returncode}): {(out.stderr or out.stdout).strip()}")
-        print("merge-guard: file it by hand with this body:")
-        print(body)
-        return 1
-    url = out.stdout.strip().splitlines()[-1] if out.stdout.strip() else "(no url printed)"
-    print(f"merge-guard: filed {LABEL}: {url}")
-    return 0
+    return file_issue(pr, rec, head, base, estimated, win, squash, delta, risks,
+                      notes, gh)
 
 
 class FakeGit:
@@ -530,7 +756,7 @@ class FakeGit:
     passing against a command the real flow never runs."""
 
     def __init__(self, common, win, remote=None, merge_base=None, commits=None,
-                 all_files=None):
+                 all_files=None, fetch_ok=True, ancestor_ok=True, squash_parent=None):
         self.calls = []
         self.common = common
         self.win = win
@@ -538,6 +764,9 @@ class FakeGit:
         self.merge_base = merge_base
         self.commits = commits or []      # landing order, oldest first
         self.all_files = all_files or []
+        self.fetch_ok = fetch_ok
+        self.ancestor_ok = ancestor_ok
+        self.squash_parent = squash_parent
 
     def __call__(self, args, cwd=None):
         self.calls.append(list(args))
@@ -546,8 +775,16 @@ class FakeGit:
             return Out(0, self.common + "\n")
         if a[:3] == ["rev-parse", "--verify", BASE_REF]:
             return Out(0, self.win + "\n")
+        if a[0] == "rev-parse" and len(a) == 2 and a[1].endswith("^"):
+            # The squash's parent: the measured window unless the scenario
+            # says the branch moved again in flight.
+            return Out(0, (self.squash_parent or self.win) + "\n")
         if a[0] == "remote":
             return Out(0, (self.remote or "") + "\n")
+        if a[0] == "fetch":
+            return Out(0, "") if self.fetch_ok else Out(1, "", "could not resolve host\n")
+        if a[:2] == ["merge-base", "--is-ancestor"]:
+            return Out(0, "") if self.ancestor_ok else Out(1, "")
         if a[0] == "merge-base":
             if self.merge_base:
                 return Out(0, self.merge_base + "\n")
@@ -577,38 +814,50 @@ class FakeGit:
 
 
 class FakeGh:
-    """Records every call and answers the three spellings the flow uses:
-    pr view (fields, and mergeCommit after the merge), pr merge, and issue
-    create."""
+    """Records every call and answers the spellings the flow uses: pr view
+    (fields, and mergeCommit after the merge), pr merge, issue list, and
+    issue create."""
 
-    def __init__(self, pr, squash="e" * 40, merge_rc=0, issue_rc=0):
+    def __init__(self, pr, squash="e" * 40, merge_rc=0, issue_rc=0, backlog=(),
+                 fail_view=False):
         self.calls = []
         self.pr = pr
         self.squash = squash
         self.merge_rc = merge_rc
         self.issue_rc = issue_rc
+        self.backlog = list(backlog)
+        self.fail_view = fail_view
 
     def __call__(self, args, cwd=None):
         self.calls.append(list(args))
         j = " ".join(args)
-        if j.startswith("pr view") and "mergeCommit" in j:
+        if j.startswith("pr view") and self.fail_view:
+            return Out(1, "", "gh: could not resolve to a pull request\n")
+        # The read-back poll asks for mergeCommit alone; the fields fetch
+        # also contains the word, so match the poll by its exact tail.
+        if j.startswith("pr view") and j.endswith("--json mergeCommit"):
             return Out(0, json.dumps({"mergeCommit": {"oid": self.squash}}))
         if j.startswith("pr view"):
             return Out(0, json.dumps(self.pr))
         if j.startswith("pr merge"):
             return Out(0, "squashed\n") if self.merge_rc == 0 \
                 else Out(1, "", "merge refused by gh\n")
+        if j.startswith("issue list"):
+            return Out(0, json.dumps(self.backlog))
         if j.startswith("issue create"):
             return Out(0, "https://github.com/deblasis/wintty/issues/999\n") \
                 if self.issue_rc == 0 else Out(1, "", "issue create failed\n")
         return Out(1, "", f"unexpected gh call: {j}")
 
 
-def make_pr(number, head, state="OPEN", mergeable="MERGEABLE", base_ref="windows"):
+def make_pr(number, head, state="OPEN", mergeable="MERGEABLE", base_ref="windows",
+            merge_commit=None, files=()):
     """A PR shaped the way gh returns it, with only the fields the guard
     reads; the fixtures carry the real-world equivalents."""
     return {"number": number, "title": f"synthetic pr {number}", "headRefOid": head,
-            "state": state, "mergeable": mergeable, "baseRefName": base_ref, "files": []}
+            "state": state, "mergeable": mergeable, "baseRefName": base_ref,
+            "mergeCommit": {"oid": merge_commit} if merge_commit else None,
+            "files": [{"path": p} for p in files]}
 
 
 def write_record(common, head, record):
@@ -633,7 +882,7 @@ def run_capture(fn, *a, **kw):
 
 def merged_calls(fgh):
     """Whether any gh call was a merge, in any spelling the flow uses. A
-    bare pr view is not a mutation, so it does not count."""
+    bare pr view or issue list is not a mutation, so neither counts."""
     return any(c[0] == "pr" and c[1] == "merge" for c in fgh.calls)
 
 
@@ -648,10 +897,13 @@ def bodies_of(fgh):
 
 
 def self_test():
-    """Replay injected sessions against the refusal matrix, the same-window
-    merge, the moved-window filing against a hand-written golden body in
-    the #970 shape, the estimated-base legacy record, the dry-run's
-    nothing-mutated promise, and the remote-slug parsing."""
+    """Replay injected sessions against the refusal matrix (including the
+    hook's scope revalidation), the same-window merge, the moved-window
+    filing against a golden body in the #970 template, the real #958
+    numbers against #970's actual bullets, the estimated-base legacy
+    record, the recovery modes, the fetch/verify warnings, the rendering
+    caps, the dry-run's nothing-mutated promise, and the remote-slug
+    parsing shared with the hook."""
     import shutil
     import tempfile
 
@@ -681,17 +933,26 @@ def self_test():
     red = dict(green, **{"pass": False})
     deferred = dict(green, deferred=True, reason="batching small prs")
     legacy = {k: v for k, v in green.items() if k != "base"}
+    files_ok = ("windows/scripts/a.ps1",)
 
     tmp = tempfile.mkdtemp(prefix="merge-guard-selftest-")
     try:
         # --- refusal matrix: each path refuses and issues no merge call.
+        narrow_legs = dict(green, scope=dict(green["scope"], paths=["src/lib.zig"],
+                                             legs_run=[]))
         cases = [
-            ("signoff-missing", make_pr(700, head), None, False),
-            ("signoff-red", make_pr(700, head), red, False),
-            ("signoff-defer-blocked", make_pr(700, head), deferred, True),
-            ("pr-not-open", make_pr(700, head, state="CLOSED"), green, False),
-            ("pr-not-mergeable", make_pr(700, head, mergeable="CONFLICTING"), green, False),
-            ("base-branch", make_pr(700, head, base_ref="main"), green, False),
+            ("signoff-missing", make_pr(700, head, files=files_ok), None, False),
+            ("signoff-red", make_pr(700, head, files=files_ok), red, False),
+            ("signoff-defer-blocked", make_pr(700, head, files=files_ok), deferred, True),
+            ("pr-not-open", make_pr(700, head, state="CLOSED", files=files_ok), green, False),
+            ("pr-not-mergeable", make_pr(700, head, mergeable="CONFLICTING",
+                                         files=files_ok), green, False),
+            ("base-branch", make_pr(700, head, base_ref="main", files=files_ok), green, False),
+            # The guard revalidates scope exactly like the hook: a record
+            # over a different file set, and a record that skipped a leg
+            # the PR's own files require, both refuse.
+            ("signoff-stale", make_pr(700, head, files=("other/file.zig",)), green, False),
+            ("signoff-scope", make_pr(700, head, files=("src/lib.zig",)), narrow_legs, False),
         ]
         for label, pr, rec, with_ledger in cases:
             td = tempfile.mkdtemp(dir=tmp)
@@ -711,20 +972,22 @@ def self_test():
             report(rc == 2 and not merged_calls(fgh) and f"[{label}]" in out,
                    "refuse-" + label, f"rc={rc}, merged={merged_calls(fgh)}")
 
-        # wrong-repo: a checkout of some other project never reaches gh.
+        # wrong-repo: a checkout of some other project never reaches gh,
+        # and the message names the remedy.
         td = tempfile.mkdtemp(dir=tmp)
         write_record(td, head, green)
         fgh = FakeGh(make_pr(700, head))
         fgit = FakeGit(td, win, remote="https://github.com/other/fork.git",
                        merge_base=base, commits=commits, all_files=all_files)
         rc, out = run_capture(merge_flow, 700, gh=fgh, git=fgit)
-        report(rc == 2 and not fgh.calls and "wrong-repo" in out,
+        report(rc == 2 and not fgh.calls and "wrong-repo" in out
+               and "clone deblasis/wintty" in out.lower(),
                "refuse-wrong-repo", f"rc={rc}, gh calls={len(fgh.calls)}")
 
         # window-unknown: a legacy record with no base and none derivable.
         td = tempfile.mkdtemp(dir=tmp)
         write_record(td, head, legacy)
-        fgh = FakeGh(make_pr(700, head))
+        fgh = FakeGh(make_pr(700, head, files=files_ok))
         fgit = FakeGit(td, win, remote="https://github.com/deblasis/wintty.git",
                        merge_base=None, commits=commits, all_files=all_files)
         rc, out = run_capture(merge_flow, 700, gh=fgh, git=fgit)
@@ -732,10 +995,21 @@ def self_test():
                and "window-unknown" in out,
                "refuse-window-unknown", f"rc={rc}")
 
+        # pr load failure before anything is touched: a refusal (rc 2),
+        # not a part-way failure.
+        td = tempfile.mkdtemp(dir=tmp)
+        write_record(td, head, green)
+        fgh = FakeGh(make_pr(700, head), merge_rc=0, fail_view=True)
+        rc, out = run_capture(merge_flow, 700, gh=fgh, git=FakeGit(
+            td, win, remote="https://github.com/deblasis/wintty.git",
+            merge_base=base, commits=commits, all_files=all_files))
+        report(rc == 2 and not merged_calls(fgh) and not filed_calls(fgh),
+               "refuse-pr-unloadable", f"rc={rc}")
+
         # --- same window: merges, files nothing.
         td = tempfile.mkdtemp(dir=tmp)
         write_record(td, head, dict(green, base=win))
-        fgh = FakeGh(make_pr(700, head))
+        fgh = FakeGh(make_pr(700, head, files=files_ok))
         fgit = FakeGit(td, win, remote="https://github.com/deblasis/wintty.git",
                        merge_base=win, commits=[], all_files=[])
         rc, out = run_capture(merge_flow, 700, gh=fgh, git=fgit)
@@ -746,8 +1020,8 @@ def self_test():
 
         # --- moved window: files the issue with the golden body.
         td = tempfile.mkdtemp(dir=tmp)
-        rec_path = write_record(td, head, green)
-        fgh = FakeGh(make_pr(700, head))
+        write_record(td, head, green)
+        fgh = FakeGh(make_pr(700, head, files=files_ok))
         fgit = FakeGit(td, win, remote="https://github.com/deblasis/wintty.git",
                        merge_base=base, commits=commits, all_files=all_files)
         rc, out = run_capture(merge_flow, 700, gh=fgh, git=fgit)
@@ -757,24 +1031,25 @@ def self_test():
             "`windows` window had already moved. Nothing was re-gated; the risk is carried "
             "here instead.\n"
             "\n"
-            "- PR: #700, squashed as `eeeeeeeeee` on `windows`\n"
-            f"- Signed off: `{head}` (record at `{rec_path.replace(chr(92), '/')}`, "
-            "all 2 legs rc=0)\n"
-            f"- `windows` base at signoff time: `{base[:10]}`\n"
-            f"- `windows` head at merge time: `{win[:10]}`\n"
+            "- PR: #700, squashed as `eeeeeeeee` on `windows`\n"
+            f"- Signed off: `{head}` (record at `.git/pr-signoff/{head}.json`, "
+            "all two legs rc=0)\n"
+            f"- `windows` base at signoff time: `{base[:SHORT_SHA]}`\n"
+            f"- `windows` head at merge time: `{win[:SHORT_SHA]}`\n"
             "\n"
             "## Delta (what merged between the record and the squash)\n"
             "\n"
             "2 commit(s) touching 2 file(s):\n"
             "\n"
-            f"- `{c1[:10]}` one: first landed change (#100) "
+            f"- `{c1[:SHORT_SHA]}` one: first landed change (#100) "
             "[1 file(s): `windows/scripts/a.ps1`]\n"
-            f"- `{c2[:10]}` two: second landed change (#101) [1 file(s): `src/lib.zig`]\n"
+            f"- `{c2[:SHORT_SHA]}` two: second landed change (#101) "
+            "[1 file(s): `src/lib.zig`]\n"
             "\n"
             "## Risks\n"
             "\n"
-            "1. The delta itself: 2 commit(s) (`1111111111` one: first landed change (#100); "
-            "`2222222222` two: second landed change (#101)) landed on `windows` after the "
+            "1. The delta itself: 2 commit(s) (`111111111` one: first landed change (#100); "
+            "`222222222` two: second landed change (#101)) landed on `windows` after the "
             "record's base, touching 2 file(s), and none of it was exercised by the "
             "signed-off run.\n"
             "2. Same files as the record's scope: `windows/scripts/a.ps1`. The green run "
@@ -783,15 +1058,19 @@ def self_test():
             "the merge land in one place and were never run together.\n"
             "4. Same signoff legs as the record: `windows-tests`, `zig-fmt`. The record ran "
             "them green against the old branch state; the result may no longer hold.\n"
+            f"5. The squash commit itself was never signed off: the green record covers "
+            f"`{head[:SHORT_SHA]}` and the squash rewrote that history into `eeeeeeeee`.\n"
             "\n"
             "## Status\n"
             "\n"
-            "Resignoff for `eeeeeeeeee`: not started. Phase 1 has no bot; when the #969 bot "
-            "lands it owns the lane run and closes this issue with the evidence.\n"
+            "Resignoff for `eeeeeeeee`: not started at filing time. Check "
+            "`incoda status --queue wintty` before queuing a run; the #969 bot owns this "
+            "lane once it lands.\n"
+            f"Squash commit: `{'e' * 40}` (full sha)\n"
         )
         report(rc == 0 and len(bodies) == 1 and bodies[0] == golden,
                "moved-window-golden-body",
-               "body matches the #970 shape" if rc == 0 else f"rc={rc}, out={out}")
+               "body matches the #970 template" if rc == 0 else f"rc={rc}, out={out}")
         if bodies and bodies[0] != golden:
             report(False, "golden-diff",
                    "\n--- got ---\n" + bodies[0] + "\n--- want ---\n" + golden)
@@ -799,10 +1078,80 @@ def self_test():
         report(bool(filed) and "--label" in filed[0] and LABEL in filed[0],
                "issue-labelled", f"filed={len(filed)}")
 
+        # The backlog line is one list call before the create, and names
+        # the oldest issue the filer saw (this one is not yet among them).
+        fgh2 = FakeGh(make_pr(700, head, files=files_ok), backlog=[
+            {"number": 968, "createdAt": "2026-09-02T10:00:00Z"},
+            {"number": 965, "createdAt": "2026-09-01T10:00:00Z"}])
+        fgit2 = FakeGit(td, win, remote="https://github.com/deblasis/wintty.git",
+                        merge_base=base, commits=commits, all_files=all_files)
+        rc, _ = run_capture(merge_flow, 701, gh=fgh2, git=fgit2)
+        bodies2 = bodies_of(fgh2)
+        lists = [c for c in fgh2.calls if c[:2] == ["issue", "list"]]
+        report(rc == 0 and len(lists) == 1 and bodies2
+               and "Outstanding `resignoff-required` issues at filing time: 2 "
+                   "(oldest #965)." in bodies2[0]
+               and fgh2.calls.index(lists[0]) < fgh2.calls.index(filed_calls(fgh2)[0]),
+               "backlog-line", f"rc={rc}, lists={len(lists)}")
+
+        # --- the real #958 numbers against #970's actual identity bullets,
+        # field for field: same fixture gh returned for the PR, the real
+        # base/head/squash the hand-filed issue recorded, and the record as
+        # the four-leg run it was.
+        with open(os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                               "fixtures", "pr958.json"), encoding="utf-8") as f:
+            pr958 = json.load(f)
+        # #970 keys the record to the head the run covered, not to the
+        # merge-time headRefOid the fixture carries, so the bullet test
+        # pins the signed-off sha explicitly, the way the hand filing did.
+        pr970 = dict(pr958, headRefOid="dff953aac5c50c3f9286ac2035d0ec88ad7817d6")
+        report(issue_title(pr970, "900e44bb44788e1b6bb7524cd5ad4cdc70f75e33")
+               == "resignoff-required: PR #958 (osc: carry the shell's prompt state as one "
+                  "versioned hex payload) squashed as 900e44bb4 on a moved windows window",
+               "n970-title", issue_title(pr970, "900e44bb44788e1b6bb7524cd5ad4cdc70f75e33"))
+        rec958 = {"pass": True,
+                  "steps": {leg: {"rc": 0} for leg in
+                            ("zig-fmt", "zig-tests", "windows-tests", "gates-selftest")},
+                  "scope": {"paths": ["windows/scripts/ShellIntegrationPs1.Tests.ps1",
+                                      "src/terminal/osc/parsers.zig"],
+                            "legs_run": ["zig-fmt", "zig-tests", "windows-tests",
+                                         "gates-selftest"],
+                            "justfile_legs": [], "reason": "scoped", "full": False}}
+        body958 = issue_body(
+            pr970, rec958, display_path(pr970["headRefOid"]),
+            "19110d76d2ee25345e6e9cfb2dca3dd93a9e9751", False,
+            "791cf03445f21e02027bd882d0c7da23821215b3",
+            "900e44bb44788e1b6bb7524cd5ad4cdc70f75e33",
+            {"commits": [{"sha": "c" * 40,
+                          "subject": "harnesses: SendInput retirement wave 0 - remain-title, "
+                                     "settings, mica-dpi onto the seam (#966)",
+                          "files": ["windows/scripts/fuzz-suite.ps1",
+                                    "windows/scripts/mouse-fuzz-mica-dpi.ps1",
+                                    "windows/scripts/mouse-fuzz-remain-title.ps1",
+                                    "windows/scripts/mouse-fuzz-settings.ps1"]}],
+             "files": ["windows/scripts/fuzz-suite.ps1",
+                       "windows/scripts/mouse-fuzz-mica-dpi.ps1",
+                       "windows/scripts/mouse-fuzz-remain-title.ps1",
+                       "windows/scripts/mouse-fuzz-settings.ps1"]},
+            risk_lines({"files": [], "dirs": ["windows"], "legs": ["windows-tests"],
+                        "unknown": []},
+                       [{"sha": "c" * 40, "subject": "harnesses"}],
+                       ["windows/scripts/fuzz-suite.ps1"]),
+        )
+        for bullet in (
+            "- PR: #958, squashed as `900e44bb4` on `windows`",
+            "- Signed off: `dff953aac5c50c3f9286ac2035d0ec88ad7817d6` (record at "
+            "`.git/pr-signoff/dff953aac5c50c3f9286ac2035d0ec88ad7817d6.json`, "
+            "all four legs rc=0)",
+            "- `windows` base at signoff time: `19110d76d`",
+            "- `windows` head at merge time: `791cf0344`",
+        ):
+            report(bullet in body958, "n970-bullet", bullet[:72])
+
         # --- legacy record without a base: estimated, still files, and says so.
         td = tempfile.mkdtemp(dir=tmp)
         write_record(td, head, legacy)
-        fgh = FakeGh(make_pr(700, head))
+        fgh = FakeGh(make_pr(700, head, files=files_ok))
         fgit = FakeGit(td, win, remote="https://github.com/deblasis/wintty.git",
                        merge_base=base, commits=commits, all_files=all_files)
         rc, _ = run_capture(merge_flow, 700, gh=fgh, git=fgit)
@@ -810,13 +1159,82 @@ def self_test():
         report(rc == 0 and bodies and "estimated at merge time" in bodies[0],
                "legacy-base-estimated", f"rc={rc}, filed={bool(bodies)}")
 
+        # An unscoped record (predates scope.path recording) falls back to
+        # the PR's own file list for the intersections.
+        ov = scope_overlap({"scope": None}, ["src/lib.zig"],
+                           pr_files=["src/lib.zig", "extra.txt"])
+        report(ov["files"] == ["src/lib.zig"] and ov["dirs"] == ["src"],
+               "scope-fallback", f"files={ov['files']}, dirs={ov['dirs']}")
+
+        # --- fetch failed: loud warning, and the stale caveat rides in the
+        # filed body.
+        td = tempfile.mkdtemp(dir=tmp)
+        write_record(td, head, green)
+        fgh = FakeGh(make_pr(700, head, files=files_ok))
+        fgit = FakeGit(td, win, remote="https://github.com/deblasis/wintty.git",
+                       merge_base=base, commits=commits, all_files=all_files,
+                       fetch_ok=False)
+        rc, out = run_capture(merge_flow, 700, gh=fgh, git=fgit)
+        bodies = bodies_of(fgh)
+        report(rc == 0 and "possibly stale" in out and bodies
+               and "## Notes" in bodies[0] and "possibly stale" in bodies[0],
+               "stale-fetch-warns", f"rc={rc}, noted={bool(bodies and '## Notes' in bodies[0])}")
+
+        # --- windows moved again in flight: the squash's parent is not the
+        # measured head; say the remediation out loud and in the body.
+        td = tempfile.mkdtemp(dir=tmp)
+        write_record(td, head, green)
+        fgh = FakeGh(make_pr(700, head, files=files_ok))
+        fgit = FakeGit(td, win, remote="https://github.com/deblasis/wintty.git",
+                       merge_base=base, commits=commits, all_files=all_files,
+                       squash_parent="f" * 40)
+        rc, out = run_capture(merge_flow, 700, gh=fgh, git=fgit)
+        bodies = bodies_of(fgh)
+        report(rc == 0 and "moved in flight" in out and bodies
+               and "moved in flight" in bodies[0],
+               "in-flight-warns", f"rc={rc}, noted={bool(bodies and 'moved in flight' in bodies[0])}")
+
+        # --- rewritten base: not an ancestor, capped body, loud line.
+        td = tempfile.mkdtemp(dir=tmp)
+        write_record(td, head, green)
+        fgh = FakeGh(make_pr(700, head, files=files_ok))
+        fgit = FakeGit(td, win, remote="https://github.com/deblasis/wintty.git",
+                       merge_base=base, commits=commits, all_files=all_files,
+                       ancestor_ok=False)
+        rc, out = run_capture(merge_flow, 700, gh=fgh, git=fgit)
+        bodies = bodies_of(fgh)
+        report(rc == 0 and "not an ancestor" in out and bodies
+               and "not an ancestor" in bodies[0],
+               "rewritten-base-warns", f"rc={rc}")
+
+        # --- rendering caps: a rewritten history must not produce a wall.
+        many = [{"sha": f"{i:02d}" * 20, "subject": f"change {i}",
+                 "files": [f"src/gen{j}.zig" for j in range(30)] if i == 3
+                 else ["src/one.zig"]}
+                for i in range(20)]
+        td = tempfile.mkdtemp(dir=tmp)
+        write_record(td, head, green)
+        fgh = FakeGh(make_pr(700, head, files=files_ok))
+        fgit = FakeGit(td, win, remote="https://github.com/deblasis/wintty.git",
+                       merge_base=base, commits=many,
+                       all_files=[f for c in many for f in c["files"]])
+        rc, _ = run_capture(merge_flow, 700, gh=fgh, git=fgit)
+        bodies = bodies_of(fgh)
+        bullets = [ln for ln in (bodies[0].splitlines() if bodies else [])
+                   if ln.startswith("- `") and " change " in ln]
+        report(rc == 0 and len(bullets) == MAX_COMMIT_BULLETS
+               and "- and 5 more commit(s) (capped" in (bodies[0] if bodies else "")
+               and "+18 more file(s)" in (bodies[0] if bodies else "")
+               and "; and 10 more" in (bodies[0] if bodies else ""),
+               "rendering-caps", f"rc={rc}, bullets={len(bullets)}")
+
         # --- dry run: the full picture, zero mutations.
         td = tempfile.mkdtemp(dir=tmp)
         write_record(td, head, green)
-        fgh = FakeGh(make_pr(700, head))
+        fgh = FakeGh(make_pr(700, head, files=files_ok))
         fgit = FakeGit(td, win, remote="https://github.com/deblasis/wintty.git",
                        merge_base=base, commits=commits, all_files=all_files)
-        rc, out = run_capture(merge_flow, 700, dry_run=True, gh=fgh, git=fgit)
+        rc, out = run_capture(merge_flow, 700, mode="dry-run", gh=fgh, git=fgit)
         mutated = merged_calls(fgh) or bool(filed_calls(fgh))
         report(rc == 0 and not mutated and "## Risks" in out and "not started" in out
                and "nothing merged, nothing filed" in out,
@@ -825,36 +1243,77 @@ def self_test():
         # dry run over an unmoved window says nothing would be filed either.
         td = tempfile.mkdtemp(dir=tmp)
         write_record(td, head, dict(green, base=win))
-        fgh = FakeGh(make_pr(700, head))
+        fgh = FakeGh(make_pr(700, head, files=files_ok))
         fgit = FakeGit(td, win, remote="https://github.com/deblasis/wintty.git",
                        merge_base=win, commits=[], all_files=[])
-        rc, out = run_capture(merge_flow, 700, dry_run=True, gh=fgh, git=fgit)
+        rc, out = run_capture(merge_flow, 700, mode="dry-run", gh=fgh, git=fgit)
         report(rc == 0 and not merged_calls(fgh) and not filed_calls(fgh)
                and "file nothing" in out,
                "dry-run-same-window", f"rc={rc}")
 
+        # --- recovery: a MERGED pr under --dry-run uses the recorded
+        # mergeCommit as the squash and still mutates nothing.
+        td = tempfile.mkdtemp(dir=tmp)
+        write_record(td, head, green)
+        fgh = FakeGh(make_pr(700, head, state="MERGED", mergeable="MERGEABLE",
+                             merge_commit="e" * 40, files=files_ok))
+        fgit = FakeGit(td, win, remote="https://github.com/deblasis/wintty.git",
+                       merge_base=base, commits=commits, all_files=all_files)
+        rc, out = run_capture(merge_flow, 700, mode="dry-run", gh=fgh, git=fgit)
+        report(rc == 0 and not merged_calls(fgh) and not filed_calls(fgh)
+               and "already MERGED" in out and "eeeeeeeee" in out,
+               "dry-run-merged-recovery", f"rc={rc}")
+
+        # --- recovery: --file-only files the owed issue and never merges.
+        td = tempfile.mkdtemp(dir=tmp)
+        write_record(td, head, green)
+        fgh = FakeGh(make_pr(700, head, state="MERGED", merge_commit="e" * 40,
+                             files=files_ok))
+        fgit = FakeGit(td, win, remote="https://github.com/deblasis/wintty.git",
+                       merge_base=base, commits=commits, all_files=all_files)
+        rc, out = run_capture(merge_flow, 700, mode="file-only", gh=fgh, git=fgit)
+        report(rc == 0 and not merged_calls(fgh) and len(filed_calls(fgh)) == 1,
+               "file-only-files", f"rc={rc}, merged={merged_calls(fgh)}, "
+                                  f"filed={len(filed_calls(fgh))}")
+
+        # --file-only on a still-open pr is refused with the pointer back
+        # to the normal path.
+        td = tempfile.mkdtemp(dir=tmp)
+        write_record(td, head, green)
+        fgh = FakeGh(make_pr(700, head, files=files_ok))
+        fgit = FakeGit(td, win, remote="https://github.com/deblasis/wintty.git",
+                       merge_base=base, commits=commits, all_files=all_files)
+        rc, out = run_capture(merge_flow, 700, mode="file-only", gh=fgh, git=fgit)
+        report(rc == 2 and not merged_calls(fgh) and not filed_calls(fgh)
+               and "pr-still-open" in out,
+               "file-only-open-refused", f"rc={rc}")
+
         # --- merge refused by gh: loud failure, nothing filed.
         td = tempfile.mkdtemp(dir=tmp)
         write_record(td, head, green)
-        fgh = FakeGh(make_pr(700, head), merge_rc=1)
+        fgh = FakeGh(make_pr(700, head, files=files_ok), merge_rc=1)
         fgit = FakeGit(td, win, remote="https://github.com/deblasis/wintty.git",
                        merge_base=base, commits=commits, all_files=all_files)
         rc, out = run_capture(merge_flow, 700, gh=fgh, git=fgit)
         report(rc == 1 and not filed_calls(fgh) and "failed" in out,
                "merge-fails-loud", f"rc={rc}")
 
-        # --- remote slug parsing, shared with the hook's repo predicate.
+        # --- remote slug parsing, shared with the hook's repo predicate:
+        # the checkout check goes through pr_gate.normalize_slug, so any
+        # spelling the hook accepts, the guard accepts.
         slug_cases = [
             ("git@github.com:deblasis/wintty.git", "deblasis/wintty"),
             ("https://github.com/deblasis/wintty", "deblasis/wintty"),
             ("ssh://git@github.com/deblasis/ghostty.git", "deblasis/ghostty"),
+            ("github.com/deblasis/wintty/", "deblasis/wintty"),
             ("https://github.com/other/fork.git", "other/fork"),
             ("", None),
         ]
         for url, expect in slug_cases:
-            got = remote_slug(url)
+            got = pr_gate.normalize_slug(url)
             report(got == expect, "remote-slug", f"{url!r} -> {got}")
-        report(pr_gate.is_our_repo(remote_slug("git@github.com:deblasis/ghostty.git")),
+        report(pr_gate.normalize_slug("git@github.com:deblasis/ghostty.git")
+               in pr_gate.FORK_SLUGS,
                "slug-matches-hook-predicate", "the guard and the hook agree on the fork")
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
@@ -866,12 +1325,17 @@ def self_test():
 def main(argv):
     if "--self-test" in argv:
         return self_test()
-    dry = "--dry-run" in argv
+    if "--dry-run" in argv:
+        mode = "dry-run"
+    elif "--file-only" in argv:
+        mode = "file-only"
+    else:
+        mode = "merge"
     positional = [a for a in argv if not a.startswith("-")]
     if len(positional) != 1 or not positional[0].isdigit():
         print(__doc__)
         return 2
-    return merge_flow(int(positional[0]), dry_run=dry)
+    return merge_flow(int(positional[0]), mode=mode)
 
 
 if __name__ == "__main__":

--- a/.agents/scripts/pr_gate.py
+++ b/.agents/scripts/pr_gate.py
@@ -27,6 +27,12 @@ endpoint) unless the PR passes:
                   Scoping keeps that affordable, and the gate recomputes the
                   requirement here so a cheap record cannot stand in for an
                   expensive one.
+  window          a raw merge of a PR whose signoff window has moved (commits
+                  landed on origin/windows after the record's base) is denied
+                  and pointed at `just merge-checked <pr>`: per #969 the
+                  merge itself is allowed, but the resignoff issue the guard
+                  files is not optional, and a raw merge skips it. A
+                  same-window merge (delta empty) stays allowed raw.
 
 The size thresholds fit this repository's merge history: focused
 single-concern PRs stay comfortably under the block line, and the warn line
@@ -37,7 +43,8 @@ a missing interpreter means no gate (the hook host does not fail closed on
 spawn errors), and command matching is textual, so `gh` aliases or variable
 indirection can sidestep it. The matcher normalizes line continuations and
 quoting and covers the `gh.exe` and `gh api` spellings; anything cleverer is
-out of scope for a string scan.
+out of scope for a string scan. `--match-head-commit` and friends stay out
+of scope with it.
 
 Modes:
   --hook          PreToolUse hook: read tool-call JSON on stdin, deny or allow.
@@ -60,6 +67,14 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import gate_scope  # noqa: E402
 
 REPO = "deblasis/ghostty"
+# The fork answers to two names: this one, which GitHub still resolves (and
+# redirects), and deblasis/wintty, which AGENTS.md tells every agent to
+# spell. A gate keyed to a single spelling is a gate with a hole: the
+# sanctioned `--repo deblasis/wintty` form is exactly the one a single-name
+# comparison silently exempts. Both names therefore mean this repo, and
+# every other repo stays out of scope.
+FORK_SLUGS = ("deblasis/ghostty", "deblasis/wintty")
+BASE_REF = "origin/windows"
 WARN_LINES = 500
 BLOCK_LINES = 900
 BODY_MIN_CHARS = 200
@@ -100,6 +115,17 @@ def normalize_command(command):
 def matchable(command):
     """A quote-stripped form, so quoting cannot split the words apart."""
     return normalize_command(command).replace('"', " ").replace("'", " ")
+
+
+def is_our_repo(slug):
+    """True for any spelling of this fork: either name, either case, with or
+    without a .git suffix. The one comparison every repo-scoped decision in
+    this gate goes through, so a new spelling is fixed here once or
+    nowhere."""
+    s = (slug or "").strip().lower()
+    if s.endswith(".git"):
+        s = s[:-4]
+    return s in FORK_SLUGS
 
 
 def is_exempt(path):
@@ -285,6 +311,85 @@ def is_merge_command(command):
     return bool(MERGE_RE.search(m) or API_MERGE_RE.search(m))
 
 
+def git_run(args, cwd=None):
+    """The real git runner, module-level so the self-test can substitute it
+    the way doctor.py injects resolvers. Takes git's own argument list (no
+    leading "git"), the same shape merge_guard's runner and fakes speak."""
+    return subprocess.run(["git"] + args, cwd=cwd or None, capture_output=True,
+                          text=True, timeout=15)
+
+
+def windows_head(cwd, run=None):
+    """The local position of origin/windows, or None. Local on purpose: the
+    record's base is a local-history sha, so the comparison has to happen in
+    the same history a fetch keeps current."""
+    run = run or git_run
+    out = run(["rev-parse", "--verify", BASE_REF], cwd)
+    sha = out.stdout.strip()
+    return sha if out.returncode == 0 and sha else None
+
+
+def record_base(rec, head, cwd, run=None):
+    """(base, estimated). The recorded base is authoritative; a legacy
+    record without one is base-unknown, never "the window did not move", so
+    the base is re-derived from the merge base. That estimate is stable
+    under ordinary movement (commits landing on windows do not move the
+    merge base of an unchanged head) and errs toward a larger delta when
+    history was rewritten, which is the direction a guard should err."""
+    base = (rec or {}).get("base")
+    if base:
+        return base, False
+    run = run or git_run
+    out = run(["merge-base", head, BASE_REF], cwd)
+    if out.returncode != 0:
+        return None, True
+    return (out.stdout.strip() or None), True
+
+
+def delta_count(base, win, cwd, run=None):
+    """How many commits windows advanced by since `base`, first-parent only:
+    PR squashes and sync-publish merges are what moved, and a plain count
+    would drown in whatever upstream history a sync merged in. None means
+    git could not answer, which the caller treats as cannot-verify."""
+    run = run or git_run
+    out = run(["rev-list", "--first-parent", "--count", f"{base}..{win}"], cwd)
+    if out.returncode != 0:
+        return None
+    try:
+        return int(out.stdout.strip())
+    except ValueError:
+        return None
+
+
+def policy_deny(pr, lookup, cwd, run=None):
+    """The window half of #969's policy. Returns a deny reason when the
+    signoff record's base differs from the current origin/windows head (a
+    non-empty delta), because a raw merge would skip the resignoff issue
+    the merge guard files; None when the merge may proceed raw. A missing
+    record stays out of the way: check_signoff already refuses it, and one
+    refusal naming the fix beats two naming different fixes."""
+    head = pr.get("headRefOid", "")
+    rec = lookup(head)
+    if rec is None:
+        return None
+    base, estimated = record_base(rec, head, cwd, run)
+    if not base:
+        return None
+    win = windows_head(cwd, run)
+    if not win:
+        return None
+    n = delta_count(base, win, cwd, run)
+    if n is None or n == 0:
+        return None
+    est = ", re-estimated at merge time from a legacy record" if estimated else ""
+    return (
+        f"pr-gate: this PR's signoff window has moved{est} - {n} commit(s) landed on "
+        f"{BASE_REF} since the record's base, and a raw merge would skip the resignoff "
+        f"ceremony. Merge through the guard instead, which files the resignoff-required "
+        f"issue with the delta: `just merge-checked {pr.get('number', '?')}`"
+    )
+
+
 def parse_merge_command(command):
     """Returns (repo, pr_number_or_None) for a merge command."""
     joined = normalize_command(command)
@@ -356,8 +461,8 @@ def hook_main():
     cwd = payload.get("cwd") or os.getcwd()
 
     repo, number = parse_merge_command(command)
-    if repo.lower() != REPO:
-        sys.exit(0)  # other repos are out of this gate's scope
+    if not is_our_repo(repo):
+        sys.exit(0)  # genuinely other repos are out of this gate's scope
     if number is None:
         try:
             out = subprocess.run(
@@ -373,9 +478,13 @@ def hook_main():
     except Exception as e:
         deny(f"pr-gate: could not fetch PR #{number} to validate it ({e}). Refusing to merge unvalidated.")
 
-    errors, warnings = check_pr(pr, signoff_lookup_factory(cwd), ledger_for(cwd))
+    lookup = signoff_lookup_factory(cwd)
+    errors, warnings = check_pr(pr, lookup, ledger_for(cwd))
     if errors:
         deny("pr-gate blocked this merge:\n- " + "\n- ".join(m for _, m in errors))
+    policy = policy_deny(pr, lookup, cwd)
+    if policy:
+        deny(policy)
     if warnings:
         print(json.dumps({
             "hookSpecificOutput": {
@@ -466,10 +575,32 @@ def self_test():
         ("gh pr merge 7 --repo=deblasis/other-repo", ("deblasis/other-repo", 7)),
         ("gh api -X PUT repos/deblasis/ghostty/pulls/55/merge", ("deblasis/ghostty", 55)),
         ("gh pr merge --squash", (REPO, None)),
+        # The spelling AGENTS.md sanctions: it must parse to a repo the gate
+        # claims, not to a hole in it.
+        ("gh pr merge 958 --repo deblasis/wintty --squash --delete-branch",
+         ("deblasis/wintty", 958)),
+        ("gh pr merge 958 --repo=deblasis/wintty", ("deblasis/wintty", 958)),
+        ("gh pr merge 958 --repo DEBLASIS/WINTTY", ("DEBLASIS/WINTTY", 958)),
     ]
     for cmd, expect in parse_cases:
         got = parse_merge_command(cmd)
         report(got == expect, "parse", f"{cmd!r} -> {got}")
+
+    # Repo identity: both fork names, both cases, .git suffix, whitespace.
+    # A foreign repo stays foreign.
+    repo_cases = [
+        ("deblasis/wintty", True),
+        ("deblasis/ghostty", True),
+        ("DEBLASIS/Wintty", True),
+        ("deblasis/wintty.git", True),
+        (" deblasis/wintty ", True),
+        ("ghostty-org/ghostty", False),
+        ("deblasis/other", False),
+        ("", False),
+        (None, False),
+    ]
+    for slug, expect in repo_cases:
+        report(is_our_repo(slug) == expect, "repo", f"{slug!r} -> {is_our_repo(slug)}")
 
     exempt_cases = [
         ("LICENSE", True),
@@ -593,6 +724,130 @@ def self_test():
         ok = len(blockers) == len(expect_fragments) and all(
             any(frag in b for b in blockers) for frag in expect_fragments)
         report(ok, "ledger", f"{len(entries)} entries -> {blockers or ['clear']}")
+
+    # Window policy (#969): a raw merge of a moved window is denied with the
+    # guard's exact invocation; a same-window merge stays allowed raw; a red
+    # or missing record stays check_signoff's business. The git resolver is
+    # injected, so each case spells out what git answers.
+    class R:
+        def __init__(self, returncode, stdout="", stderr=""):
+            self.returncode, self.stdout, self.stderr = returncode, stdout, stderr
+
+    BASE = "19110d76d2ee25345e6e9cfb2dca3dd93a9e9751"
+    WIN = "791cf03445f21e02027bd882d0c7da23821215b3"
+    HEAD = "24c3ab8fa0a76631ea1ee31d8a00803526e41e71"
+
+    def mk_run(win, merge_base, count):
+        def run(args, cwd=None):
+            j = " ".join(args)
+            if j.startswith("rev-parse --verify"):
+                return R(0, win + "\n") if win else R(1)
+            if j.startswith("merge-base"):
+                return R(0, merge_base + "\n") if merge_base else R(1)
+            if j.startswith("rev-list"):
+                return R(0, f"{count}\n") if count is not None else R(1)
+            return R(1, "", "unexpected: " + j)
+        return run
+
+    moved_rec = {"pass": True, "base": BASE, "steps": {}}
+    same_rec = {"pass": True, "base": WIN, "steps": {}}
+    legacy_rec = {"pass": True, "steps": {}}
+    pr970ish = {"number": 958, "headRefOid": HEAD}
+
+    policy_cases = [
+        ("moved-window", pr970ish, moved_rec, mk_run(WIN, BASE, 1), True,
+         "just merge-checked 958"),
+        ("same-window", pr970ish, same_rec, mk_run(WIN, WIN, 0), False, None),
+        ("legacy-base-behind", pr970ish, legacy_rec, mk_run(WIN, BASE, 2), True,
+         "re-estimated at merge time"),
+        ("legacy-base-current", pr970ish, legacy_rec, mk_run(WIN, WIN, 0), False, None),
+        ("no-record", pr970ish, None, mk_run(WIN, BASE, 1), False, None),
+        ("git-cannot-answer", pr970ish, moved_rec, mk_run(None, BASE, None), False, None),
+    ]
+    for label, pr, rec, run, expect_deny, needle in policy_cases:
+        lookup = (lambda sha: rec) if rec is not None else (lambda sha: None)
+        got = policy_deny(pr, lookup, None, run)
+        ok = (got is not None and needle in got) if expect_deny else got is None
+        report(ok, "window-policy", f"{label} -> {'deny' if got else 'allow'}")
+
+    # End-to-end hook replay over the hand-filed #970 numbers, through the
+    # sanctioned --repo deblasis/wintty spelling that the old single-name
+    # comparison silently exempted. The gh, record-store and git resolvers
+    # are substituted, so hook_main runs exactly as the host invokes it.
+    import contextlib
+    import io
+    import tempfile
+
+    pr958 = load(958)
+    record = {
+        "sha": pr958["headRefOid"],
+        "base": BASE,
+        "pass": True,
+        "steps": {"windows-tests": {"rc": 0}, "zig-fmt": {"rc": 0}, "zig-tests": {"rc": 0}},
+        "scope": {"paths": [f["path"] for f in pr958["files"]],
+                  "legs_run": ["windows-tests", "zig-fmt", "zig-tests"],
+                  "justfile_legs": [], "reason": "scoped", "full": False},
+    }
+
+    def feed_hook(payload):
+        buf = io.StringIO()
+        old_stdin = sys.stdin
+        sys.stdin = io.StringIO(json.dumps(payload))
+        try:
+            with contextlib.redirect_stdout(buf):
+                hook_main()
+        except SystemExit:
+            pass
+        finally:
+            sys.stdin = old_stdin
+        return buf.getvalue()
+
+    mod = sys.modules[__name__]
+    saved = {n: getattr(mod, n)
+             for n in ("fetch_pr", "signoff_lookup_factory", "ledger_for", "git_run")}
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            rec_dir = os.path.join(td, "pr-signoff")
+            os.makedirs(rec_dir)
+
+            def store(sha, rec):
+                with open(os.path.join(rec_dir, sha + ".json"), "w", encoding="utf-8") as f:
+                    json.dump(rec, f)
+
+            store(pr958["headRefOid"], record)
+            mod.fetch_pr = lambda number, repo, cwd=None: pr958
+            mod.ledger_for = lambda cwd: []
+            mod.signoff_lookup_factory = lambda cwd: (
+                lambda sha: json.load(
+                    open(os.path.join(rec_dir, sha + ".json"), encoding="utf-8")))
+
+            mod.git_run = mk_run(WIN, BASE, 1)
+            moved = feed_hook({"tool_input": {
+                "command": "gh pr merge 958 --repo deblasis/wintty --squash --delete-branch"},
+                "cwd": td})
+            report('"permissionDecision": "deny"' in moved
+                   and "just merge-checked 958" in moved,
+                   "hook-replay-moved", "the sanctioned spelling is denied into the guard")
+
+            # Same numbers, unmoved window: the raw merge stays allowed and
+            # the hook says nothing.
+            mod.git_run = mk_run(WIN, WIN, 0)
+            record["base"] = WIN
+            store(pr958["headRefOid"], record)
+            quiet = feed_hook({"tool_input": {
+                "command": "gh pr merge 958 --repo deblasis/wintty --squash --delete-branch"},
+                "cwd": td})
+            report(quiet.strip() == "", "hook-replay-same-window",
+                   "a raw merge of an unmoved window stays allowed")
+
+            # A genuinely foreign repo is still nobody's business.
+            foreign = feed_hook({"tool_input": {
+                "command": "gh pr merge 958 --repo other/project --squash"}, "cwd": td})
+            report(foreign.strip() == "", "hook-replay-foreign-repo",
+                   "other repos stay out of scope")
+    finally:
+        for n, fn in saved.items():
+            setattr(mod, n, fn)
 
     print("SELF-TEST " + ("FAILED" if failed else "PASSED"))
     sys.exit(1 if failed else 0)

--- a/.agents/scripts/pr_gate.py
+++ b/.agents/scripts/pr_gate.py
@@ -32,19 +32,31 @@ endpoint) unless the PR passes:
                   and pointed at `just merge-checked <pr>`: per #969 the
                   merge itself is allowed, but the resignoff issue the guard
                   files is not optional, and a raw merge skips it. A
-                  same-window merge (delta empty) stays allowed raw.
+                  same-window merge (delta empty) stays allowed raw, but
+                  note the hook is fast and local on purpose: it judges the
+                  window against the local origin/windows, which is only as
+                  fresh as the last fetch.
 
 The size thresholds fit this repository's merge history: focused
 single-concern PRs stay comfortably under the block line, and the warn line
 marks where splitting into a stack is usually worth it.
 
-Known limits, accepted deliberately: a hook can only gate what spawns it, so
-a missing interpreter means no gate (the hook host does not fail closed on
-spawn errors), and command matching is textual, so `gh` aliases or variable
-indirection can sidestep it. The matcher normalizes line continuations and
-quoting and covers the `gh.exe` and `gh api` spellings; anything cleverer is
-out of scope for a string scan. `--match-head-commit` and friends stay out
-of scope with it.
+Known limits, accepted deliberately, and named rather than pretended away:
+a hook can only gate what spawns it, so a missing interpreter means no gate
+(the hook host does not fail closed on spawn errors), and command matching
+is textual, so `gh` aliases, variable indirection, or the GraphQL
+`mergePullRequest` mutation can sidestep it. The matcher normalizes line
+continuations and quoting and covers the `gh.exe` and `gh api` REST
+spellings; anything cleverer is out of scope for a string scan.
+`--match-head-commit` and friends stay out of scope with it. Also
+uncovered: merging in the GitHub web UI or mobile app, a plain `git push`
+straight to `windows` (which carries no branch protection today), any agent
+host without this hook wired, and `gh pr merge --auto`, whose window is
+judged when the command is submitted, not when GitHub later fires the
+merge. None of these leave evidence: the resignoff issue exists only if
+the guard ran, so a bypass loses the record, not just the rule. Branch
+protection on `windows` and a phase-2 reconciliation job are the
+structural follow-ups.
 
 Modes:
   --hook          PreToolUse hook: read tool-call JSON on stdin, deny or allow.
@@ -66,15 +78,20 @@ from fnmatch import fnmatch
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import gate_scope  # noqa: E402
 
-REPO = "deblasis/ghostty"
-# The fork answers to two names: this one, which GitHub still resolves (and
-# redirects), and deblasis/wintty, which AGENTS.md tells every agent to
-# spell. A gate keyed to a single spelling is a gate with a hole: the
-# sanctioned `--repo deblasis/wintty` form is exactly the one a single-name
-# comparison silently exempts. Both names therefore mean this repo, and
-# every other repo stays out of scope.
-FORK_SLUGS = ("deblasis/ghostty", "deblasis/wintty")
-BASE_REF = "origin/windows"
+# One spelling, one alias list, shared with merge_guard: this is the value
+# every repo-scoped decision in the gates reads.
+REPO = "deblasis/wintty"
+# The old name GitHub still resolves (and redirects). A gate keyed to a
+# single spelling is a gate with a hole: the redirect name on fetches and
+# full-URL or HOST/OWNER/REPO --repo values are all the same repo, and
+# every one of them must land in the same comparison.
+REPO_REDIRECT = "deblasis/ghostty"
+FORK_SLUGS = (REPO, REPO_REDIRECT)
+# One branch name and one ref spelling: the merge guard aliases these, so a
+# hook and a guard that must agree on "what did windows move by" cannot
+# quietly start meaning two different branches.
+BASE_BRANCH = "windows"
+BASE_REF = "origin/" + BASE_BRANCH
 WARN_LINES = 500
 BLOCK_LINES = 900
 BODY_MIN_CHARS = 200
@@ -117,15 +134,34 @@ def matchable(command):
     return normalize_command(command).replace('"', " ").replace("'", " ")
 
 
-def is_our_repo(slug):
-    """True for any spelling of this fork: either name, either case, with or
-    without a .git suffix. The one comparison every repo-scoped decision in
-    this gate goes through, so a new spelling is fixed here once or
-    nowhere."""
-    s = (slug or "").strip().lower()
+def normalize_slug(value):
+    """OWNER/REPO out of any spelling of a repo name: a bare slug, a
+    HOST/OWNER/REPO value, a full https or ssh URL, a scp-style git@host:
+    form, with any case, a .git suffix, or a trailing slash. Returns None
+    when nothing slug-shaped remains. This is the one normalizer for every
+    repo string the gates compare; a comparison run on a raw spelling is
+    how the `--repo deblasis/wintty` bypass happened (see is_our_repo)."""
+    s = (value or "").strip().lower()
+    if not s:
+        return None
+    s = re.sub(r"^[a-z][a-z0-9+.-]*://", "", s)  # https://, ssh://
+    s = re.sub(r"^[\w.-]+@", "", s)              # git@, ssh user@
+    s = s.replace(":", "/")                      # scp-style host:owner/repo
+    s = s.rstrip("/")
     if s.endswith(".git"):
         s = s[:-4]
-    return s in FORK_SLUGS
+    parts = [p for p in s.split("/") if p]
+    if len(parts) < 2:
+        return None
+    return "/".join(parts[-2:])
+
+
+def is_our_repo(value):
+    """True for any spelling of this fork: either name (the current one and
+    the redirect), bare, host-qualified, or a full URL. The one comparison
+    every repo-scoped decision in the gates goes through, so a new spelling
+    is fixed here once or nowhere."""
+    return normalize_slug(value) in FORK_SLUGS
 
 
 def is_exempt(path):
@@ -168,7 +204,9 @@ def check_signoff(pr, signoff_lookup, ledger=None):
     rec = signoff_lookup(head)
     if rec is None:
         return ([("signoff-missing",
-                  f"No local signoff for head {head[:10]}. Run 'just signoff' on the PR branch and retry.")], [])
+                  f"No local signoff for head {head[:10]}. Run 'just signoff' on the PR branch "
+                  "and retry (records live in this clone's git dir; a signoff run on another "
+                  "machine does not count here).")], [])
 
     errors, warnings = [], []
 
@@ -282,7 +320,11 @@ def signoff_lookup_factory(cwd):
         try:
             with open(path, encoding="utf-8") as f:
                 return json.load(f)
-        except OSError:
+        except (OSError, ValueError):
+            # ValueError covers corrupt JSON: a half-written record raising
+            # out of the hook would exit 1, which the harness treats as
+            # non-blocking, and an unreadable record must read as absent
+            # (signoff-missing), never as a pass.
             return None
 
     return lookup
@@ -365,28 +407,39 @@ def policy_deny(pr, lookup, cwd, run=None):
     """The window half of #969's policy. Returns a deny reason when the
     signoff record's base differs from the current origin/windows head (a
     non-empty delta), because a raw merge would skip the resignoff issue
-    the merge guard files; None when the merge may proceed raw. A missing
-    record stays out of the way: check_signoff already refuses it, and one
-    refusal naming the fix beats two naming different fixes."""
+    the merge guard files; None only when the raw merge may proceed. A
+    missing record stays out of the way: check_signoff already refuses it,
+    and one refusal naming the fix beats two naming different fixes.
+
+    Fails closed like every sibling check: when a record exists but the
+    window cannot be measured (no local origin/windows, a legacy record
+    with no derivable base, git failing), the deny is issued anyway. The
+    guard re-measures with a fetch of its own, so "cannot verify here" is
+    exactly the case for the guard and never a reason to wave a merge
+    through."""
     head = pr.get("headRefOid", "")
     rec = lookup(head)
     if rec is None:
         return None
-    base, estimated = record_base(rec, head, cwd, run)
-    if not base:
-        return None
+    number = pr.get("number", "?")
+    guard = f"Merge through the guard instead: `just merge-checked {number}`."
     win = windows_head(cwd, run)
     if not win:
+        return (f"pr-gate: the signoff window cannot be measured - {BASE_REF} does not "
+                f"resolve in this checkout (fetch first). {guard}")
+    base, estimated = record_base(rec, head, cwd, run)
+    n = delta_count(base, win, cwd, run) if base else None
+    if n is None:
+        why = ("the legacy record carries no base and none is derivable" if not base
+               else "git could not measure the delta")
+        return (f"pr-gate: the signoff window cannot be verified - {why}. {guard}")
+    if n == 0:
         return None
-    n = delta_count(base, win, cwd, run)
-    if n is None or n == 0:
-        return None
-    est = ", re-estimated at merge time from a legacy record" if estimated else ""
+    est = " (re-estimated at merge time from a legacy record)" if estimated else ""
     return (
         f"pr-gate: this PR's signoff window has moved{est} - {n} commit(s) landed on "
         f"{BASE_REF} since the record's base, and a raw merge would skip the resignoff "
-        f"ceremony. Merge through the guard instead, which files the resignoff-required "
-        f"issue with the delta: `just merge-checked {pr.get('number', '?')}`"
+        f"ceremony. {guard}"
     )
 
 
@@ -482,7 +535,16 @@ def hook_main():
     errors, warnings = check_pr(pr, lookup, ledger_for(cwd))
     if errors:
         deny("pr-gate blocked this merge:\n- " + "\n- ".join(m for _, m in errors))
-    policy = policy_deny(pr, lookup, cwd)
+    # The window check must fail closed like its siblings: an exception
+    # escaping (a git timeout, a dying session) would exit 1, which a hook
+    # host treats as non-blocking, i.e. an ungated merge. Any surprise here
+    # is therefore a deny, never a shrug.
+    try:
+        policy = policy_deny(pr, lookup, cwd)
+    except Exception as e:
+        deny(f"pr-gate: the window check itself failed ({e}); refusing to merge "
+             f"unmeasured. Fetch and retry, or run `just merge-checked {number}`, "
+             "which measures (with a fetch) and files the resignoff issue.")
     if policy:
         deny(policy)
     if warnings:
@@ -576,24 +638,44 @@ def self_test():
         ("gh api -X PUT repos/deblasis/ghostty/pulls/55/merge", ("deblasis/ghostty", 55)),
         ("gh pr merge --squash", (REPO, None)),
         # The spelling AGENTS.md sanctions: it must parse to a repo the gate
-        # claims, not to a hole in it.
+        # claims, not to a hole in it. Host-qualified values must parse
+        # too; is_our_repo does the host stripping, so the raw string here
+        # round-trips.
         ("gh pr merge 958 --repo deblasis/wintty --squash --delete-branch",
          ("deblasis/wintty", 958)),
         ("gh pr merge 958 --repo=deblasis/wintty", ("deblasis/wintty", 958)),
         ("gh pr merge 958 --repo DEBLASIS/WINTTY", ("DEBLASIS/WINTTY", 958)),
+        ("gh pr merge 978 --repo github.com/deblasis/wintty --squash",
+         ("github.com/deblasis/wintty", 978)),
+        ("gh pr merge 978 --repo https://github.com/deblasis/wintty --squash",
+         ("https://github.com/deblasis/wintty", 978)),
     ]
     for cmd, expect in parse_cases:
         got = parse_merge_command(cmd)
         report(got == expect, "parse", f"{cmd!r} -> {got}")
 
-    # Repo identity: both fork names, both cases, .git suffix, whitespace.
-    # A foreign repo stays foreign.
+    # Repo identity: both fork names, both cases, .git suffix, whitespace,
+    # and every host-qualified/URL shape a --repo value or a remote can
+    # arrive in. A wrong-owner variant stays foreign even when the repo
+    # name matches, which is the whole point of normalizing before
+    # comparing.
     repo_cases = [
         ("deblasis/wintty", True),
         ("deblasis/ghostty", True),
         ("DEBLASIS/Wintty", True),
         ("deblasis/wintty.git", True),
         (" deblasis/wintty ", True),
+        ("deblasis/wintty/", True),
+        ("github.com/deblasis/wintty", True),
+        ("https://github.com/deblasis/wintty", True),
+        ("https://github.com/deblasis/wintty.git", True),
+        ("git@github.com:deblasis/wintty", True),
+        ("git@github.com:deblasis/wintty.git", True),
+        ("ssh://git@github.com/deblasis/wintty", True),
+        ("github.com/deblasis/wintty/", True),
+        ("github.com/other/wintty", False),
+        ("https://github.com/other/wintty.git", False),
+        ("other/wintty", False),
         ("ghostty-org/ghostty", False),
         ("deblasis/other", False),
         ("", False),
@@ -762,13 +844,32 @@ def self_test():
          "re-estimated at merge time"),
         ("legacy-base-current", pr970ish, legacy_rec, mk_run(WIN, WIN, 0), False, None),
         ("no-record", pr970ish, None, mk_run(WIN, BASE, 1), False, None),
-        ("git-cannot-answer", pr970ish, moved_rec, mk_run(None, BASE, None), False, None),
+        # Fail closed: a record exists but the window cannot be measured,
+        # for any of the three reasons, is a deny naming the guard, not a
+        # silent allow.
+        ("no-local-windows", pr970ish, moved_rec, mk_run(None, BASE, None), True,
+         "cannot be measured"),
+        ("legacy-base-underivable", pr970ish, legacy_rec, mk_run(WIN, None, None), True,
+         "cannot be verified"),
+        ("git-cannot-answer", pr970ish, moved_rec, mk_run(WIN, BASE, None), True,
+         "cannot be verified"),
     ]
     for label, pr, rec, run, expect_deny, needle in policy_cases:
         lookup = (lambda sha: rec) if rec is not None else (lambda sha: None)
         got = policy_deny(pr, lookup, None, run)
         ok = (got is not None and needle in got) if expect_deny else got is None
         report(ok, "window-policy", f"{label} -> {'deny' if got else 'allow'}")
+
+    # A corrupt record file must read as absent, not raise: an exception
+    # out of the hook exits 1, which the harness treats as non-blocking.
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        rec_dir = os.path.join(td, "pr-signoff")
+        os.makedirs(rec_dir)
+        with open(os.path.join(rec_dir, "c" * 40 + ".json"), "w", encoding="utf-8") as f:
+            f.write("{not json")
+        lookup = signoff_lookup_factory(td)
+        report(lookup("c" * 40) is None, "corrupt-record", "corrupt JSON reads as absent")
 
     # End-to-end hook replay over the hand-filed #970 numbers, through the
     # sanctioned --repo deblasis/wintty spelling that the old single-name
@@ -845,6 +946,29 @@ def self_test():
                 "command": "gh pr merge 958 --repo other/project --squash"}, "cwd": td})
             report(foreign.strip() == "", "hook-replay-foreign-repo",
                    "other repos stay out of scope")
+
+            # Host-qualified spellings resolve to the same slug: a full URL
+            # must land in exactly the same place the bare name does, and a
+            # same-owner-elsewhere repo must not be mistaken for ours.
+            mod.git_run = mk_run(WIN, BASE, 1)
+            record["base"] = BASE
+            store(pr958["headRefOid"], record)
+            hostq = feed_hook({"tool_input": {
+                "command": "gh pr merge 958 --repo github.com/deblasis/wintty --squash"},
+                "cwd": td})
+            report('"permissionDecision": "deny"' in hostq
+                   and "just merge-checked 958" in hostq,
+                   "hook-replay-host-qualified",
+                   "a full-URL --repo is normalized, not bypassed")
+
+            mod.git_run = mk_run(WIN, WIN, 0)
+            record["base"] = WIN
+            store(pr958["headRefOid"], record)
+            wrong_owner = feed_hook({"tool_input": {
+                "command": "gh pr merge 958 --repo github.com/other/wintty --squash"},
+                "cwd": td})
+            report(wrong_owner.strip() == "", "hook-replay-wrong-owner",
+                   "same-named repo under another owner stays foreign")
     finally:
         for n, fn in saved.items():
             setattr(mod, n, fn)

--- a/.agents/scripts/signoff.py
+++ b/.agents/scripts/signoff.py
@@ -19,6 +19,14 @@ The record is keyed by commit sha, so it survives worktree switches and
 cannot vouch for code that was changed after the run. Rerun after any
 amend or rebase.
 
+Each record also carries `base`, the merge base with origin/windows at
+the time the run was taken. The merge guard (#969) reads it to measure
+what moved on the branch between the run and the merge, so a green record
+whose window has since moved can merge anyway with the risk filed instead
+of re-gating inline. Records written before this field existed have no
+base; downstream readers must treat that as base-unknown and re-estimate,
+never as "the window did not move".
+
 Usage: just signoff          (scoped to what changed)
        just signoff-full     (every leg, whatever changed)
 """
@@ -157,18 +165,21 @@ def justfile_legs(base):
 
 
 def plan(full=False):
-    """Returns (legs, paths, justfile_legs, reason)."""
+    """Returns (legs, paths, justfile_legs, reason, base). `base` is the
+    merge base with origin/windows, recorded in the payload so the merge
+    guard can later measure what moved; it is resolved even for a full run,
+    which scoping does not need but the record should still carry."""
     every = sorted(gate_scope.ALL_LEGS)
     base = merge_base()
     if full:
-        return every, None, every, "--full requested"
+        return every, None, every, "--full requested", base
     if not base:
-        return every, None, every, f"could not resolve a merge base with {BASE_REF}"
+        return every, None, every, f"could not resolve a merge base with {BASE_REF}", None
     paths = changed_paths(base)
     if paths is None:
-        return every, None, every, "could not list changed paths"
+        return every, None, every, "could not list changed paths", base
     if not paths:
-        return every, [], every, "no changes against the base; nothing to scope"
+        return every, [], every, "no changes against the base; nothing to scope", base
     jf = sorted(justfile_legs(base)) if "justfile" in paths else []
     legs = gate_scope.required_legs(paths, justfile_legs=jf)
     unknown = gate_scope.unknown_paths(paths)
@@ -178,7 +189,29 @@ def plan(full=False):
         reason = f"scoped to {len(paths)} changed path(s); justfile edit touches {', '.join(jf)}"
     else:
         reason = f"scoped to {len(paths)} changed path(s)"
-    return legs, paths, jf, reason
+    return legs, paths, jf, reason, base
+
+
+def record_payload(head, base, steps, ok, legs, paths, jf, reason, full):
+    """The record shape both write paths share. `base` rides at the top
+    level next to `sha` because the guard reads the pair together: the run
+    vouches for `sha` against a branch that was at `base`. A None base is
+    legal (git could not resolve one) and means base-unknown downstream,
+    never "the window did not move"."""
+    return {
+        "sha": head,
+        "base": base,
+        "created": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "steps": steps,
+        "pass": ok,
+        "scope": {
+            "legs_run": legs,
+            "paths": paths,
+            "justfile_legs": jf,
+            "reason": reason,
+            "full": bool(full),
+        },
+    }
 
 
 def signoff_dir():
@@ -222,24 +255,17 @@ def defer(reason):
         return 1
 
     head = run(["git", "rev-parse", "HEAD"]).stdout.strip()
-    legs, paths, jf, _ = plan(False)
+    legs, paths, jf, _, base = plan(False)
     created = datetime.datetime.now(datetime.timezone.utc).isoformat()
-    record = {
-        "sha": head,
-        "created": created,
-        "steps": {},
-        "pass": True,
-        "deferred": True,
-        "reason": reason.strip(),
-        "scope": {
-            "legs_run": list(gate_scope.ALL_LEGS),
-            "legs_deferred": legs,
-            "paths": paths,
-            "justfile_legs": jf,
-            "reason": "deferred",
-            "full": False,
-        },
-    }
+    # A deferral borrows against a future run, so its record needs the same
+    # base a real one carries: the guard has to know which window the credit
+    # was issued against when it later measures what moved.
+    record = record_payload(head, base, {}, True, list(gate_scope.ALL_LEGS),
+                            paths, jf, "deferred", False)
+    record["created"] = created
+    record["deferred"] = True
+    record["reason"] = reason.strip()
+    record["scope"]["legs_deferred"] = legs
     with open(os.path.join(d, f"{head}.json"), "w", encoding="utf-8") as f:
         json.dump(record, f, indent=2)
     entries.append({"sha": head, "created": created, "reason": reason.strip(),
@@ -287,7 +313,7 @@ def main(argv):
         print(dirty)
         return 1
 
-    legs, paths, jf, reason = plan(full)
+    legs, paths, jf, reason, base = plan(full)
     print(f"signoff: {reason}")
     print(f"signoff: legs: {', '.join(legs) if legs else '(none needed)'}")
 
@@ -318,19 +344,7 @@ def main(argv):
         return 2
     outdir = os.path.join(common, "pr-signoff")
     os.makedirs(outdir, exist_ok=True)
-    record = {
-        "sha": head,
-        "created": datetime.datetime.now(datetime.timezone.utc).isoformat(),
-        "steps": results,
-        "pass": ok,
-        "scope": {
-            "legs_run": legs,
-            "paths": paths,
-            "justfile_legs": jf,
-            "reason": reason,
-            "full": bool(full),
-        },
-    }
+    record = record_payload(head, base, results, ok, legs, paths, jf, reason, full)
     path = os.path.join(outdir, f"{head}.json")
     with open(path, "w", encoding="utf-8") as f:
         json.dump(record, f, indent=2)
@@ -405,6 +419,17 @@ def self_test():
     report(_hunk_lines(deletion, "-") == {20, 21, 22}, "hunk-deletion", str(sorted(_hunk_lines(deletion, "-"))))
     report(_hunk_lines(deletion, "+") == set(), "hunk-deletion-new", str(sorted(_hunk_lines(deletion, "+"))))
 
+    # The record must carry the window it was taken against: the merge guard
+    # reads `base` next to `sha` to measure what moved on the branch. A None
+    # base must still be PRESENT in the payload, so a reader distinguishing
+    # "unknown" from "did not move" can tell them apart by key, not by guess.
+    payload = record_payload("a" * 40, "b" * 40, {"windows-tests": {"rc": 0}}, True,
+                             ["windows-tests"], ["windows/x.cs"], [], "scoped", False)
+    report(payload["base"] == "b" * 40 and payload["sha"] == "a" * 40, "record-base",
+           f"sha/base recorded: {payload['sha'][:8]}/{payload['base'][:8]}")
+    report("base" in record_payload("a" * 40, None, {}, True, [], None, [], "r", False),
+           "record-base-null", "an unknown base is recorded as null, not omitted")
+
     print("SELF-TEST " + ("FAILED" if failed else "PASSED"))
     return 1 if failed else 0
 
@@ -414,10 +439,11 @@ if __name__ == "__main__":
     if "--self-test" in argv:
         sys.exit(self_test())
     if "--plan" in argv:
-        legs, paths, jf, reason = plan("--full" in argv)
+        legs, paths, jf, reason, base = plan("--full" in argv)
         print(f"reason: {reason}")
         print(f"legs:   {', '.join(legs) if legs else '(none needed)'}")
         print(f"paths:  {len(paths) if paths is not None else 'unknown'}")
+        print(f"base:   {base or 'unknown'}")
         sys.exit(0)
     if "--debt" in argv:
         report_debt()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,17 +46,19 @@ The rules above are upstream's. They do not describe how work lands here.
 
 Issues and PRs against `deblasis/wintty` are the normal, required workflow:
 branch from `windows`, open a PR with `--repo deblasis/wintty`, get it
-reviewed, run `just signoff` green against the exact head sha, and squash
-merge through `just merge-checked <pr>` - never a raw `gh pr merge`. The
-`pr_gate` hook refuses a merge without that signoff, and it also refuses a
-raw merge whose signoff window has moved (commits landed on `windows` after
-the record's base): per #969 the merge itself is then still allowed, but it
-goes through the guard, which files the `resignoff-required` issue carrying
-the delta and the risks instead of re-gating inline. A same-window merge
-may still go raw. The one deliberate exception is `just sync-publish`, which
-lands the upstream snapshot merge without a PR; in exchange it runs its own
-assertions at publish time: nothing windows merged may be missing from the
-replay, and work no PR reviewed may ride along unnamed or unacknowledged.
+reviewed, run `just signoff` green against the exact head sha, and merge
+through `just merge-checked <pr>` by default. A raw `gh pr merge` is
+tolerated only for a provably same-window merge, and your view of
+`windows` is only as fresh as your last fetch. The `pr_gate` hook refuses
+a merge without that signoff, and it also refuses a raw merge whose
+signoff window has moved (commits landed on `windows` after the record's
+base): per #969 the merge itself is then still allowed, but it goes
+through the guard, which files the `resignoff-required` issue carrying
+the delta and the risks instead of re-gating inline. The one deliberate
+exception is `just sync-publish`, which lands the upstream snapshot merge
+without a PR; in exchange it runs its own assertions at publish time:
+nothing windows merged may be missing from the replay, and work no PR
+reviewed may ride along unnamed or unacknowledged.
 
 Always pass `--repo deblasis/wintty`. Never open anything against
 `ghostty-org/ghostty`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,11 +47,16 @@ The rules above are upstream's. They do not describe how work lands here.
 Issues and PRs against `deblasis/wintty` are the normal, required workflow:
 branch from `windows`, open a PR with `--repo deblasis/wintty`, get it
 reviewed, run `just signoff` green against the exact head sha, and squash
-merge. The `pr_gate` hook refuses a merge without that signoff. The one
-deliberate exception is `just sync-publish`, which lands the upstream
-snapshot merge without a PR; in exchange it runs its own assertions at
-publish time: nothing windows merged may be missing from the replay, and
-work no PR reviewed may ride along unnamed or unacknowledged.
+merge through `just merge-checked <pr>` - never a raw `gh pr merge`. The
+`pr_gate` hook refuses a merge without that signoff, and it also refuses a
+raw merge whose signoff window has moved (commits landed on `windows` after
+the record's base): per #969 the merge itself is then still allowed, but it
+goes through the guard, which files the `resignoff-required` issue carrying
+the delta and the risks instead of re-gating inline. A same-window merge
+may still go raw. The one deliberate exception is `just sync-publish`, which
+lands the upstream snapshot merge without a PR; in exchange it runs its own
+assertions at publish time: nothing windows merged may be missing from the
+replay, and work no PR reviewed may ride along unnamed or unacknowledged.
 
 Always pass `--repo deblasis/wintty`. Never open anything against
 `ghostty-org/ghostty`.

--- a/justfile
+++ b/justfile
@@ -1542,6 +1542,15 @@ signoff-debt:
 pr-gate pr:
     python .agents/scripts/pr_gate.py --check-pr {{pr}}
 
+# Squash-merge a PR through the merge guard (#969): the record is validated,
+# the delta between its base and origin/windows is measured, and a
+# resignoff-required issue is filed when the window moved. Raw `gh pr merge`
+# of a moved-window PR is denied by the pr_gate hook, which names this
+# recipe. `--dry-run` shows the inputs, delta, risks and issue body without
+# touching anything: python .agents/scripts/merge_guard.py --dry-run <pr>.
+merge-checked pr:
+    python .agents/scripts/merge_guard.py {{pr}}
+
 # Check that everything the gates depend on is present and wired: tools on
 # PATH, scripts where the hooks point, settings parseable, nightly task
 # registration. A SessionStart hook runs the fast subset automatically.
@@ -1573,12 +1582,15 @@ doctor:
 gitversion-selftest:
     pwsh -NoProfile -File .agents/scripts/gitversion_selftest.ps1
 
-# Recorded-PR replays, matcher escapes, exemption anchoring, and the nightly
-# scripts' helpers roundtripping. `gitversion-selftest` runs first.
+# Recorded-PR replays, matcher escapes, exemption anchoring, the merge
+# guard's refusal matrix and golden issue body, and the nightly scripts'
+# helpers roundtripping. `gitversion-selftest` runs first.
 #
 # Prove the gates still catch what they exist for.
 gates-selftest: gitversion-selftest
     python .agents/scripts/pr_gate.py --self-test
+    python .agents/scripts/signoff.py --self-test
+    python .agents/scripts/merge_guard.py --self-test
     python .agents/scripts/workspace_guard.py --self-test
     python .agents/scripts/doctor.py --self-test
     python .agents/scripts/test_reachability.py --self-test


### PR DESCRIPTION
# 969 phase 1: record the signoff base, gate raw merges, and add the merge guard

Closes the phase-1 slice of #969. Phase 2 (the bot that runs the lane and closes the issues) is not in this PR; the bottom section says what it will own.

## What landed

**`signoff.py` - the record learns its base.**
Every signoff record now stamps `base`, the merge base of the PR head with `origin/windows` at run time (`--plan` prints it too). This is the anchor every later window question is measured from. A record without it is base-unknown downstream, never silently "unmoved": both consumers re-derive the base from the merge base at read time and say they estimated.

**`pr_gate.py` - the hook grows a window policy.**
- The hook denies a raw `gh pr merge` / `gh api .../merge` when the PR's signoff record exists but its window has moved (first-parent delta from the record's base to the local `origin/windows` head), naming the guard recipe: `just merge-checked <n>`. The deny message carries the estimated-base caveat for legacy records.
- The policy fails closed: a record whose window cannot be verified (no local `origin/windows`, a legacy base that is not derivable, git failing to answer) denies too, and any exception out of the check denies, because a hook's exit 1 is non-blocking for the harness. The guard re-measures with a fetch of its own, so "cannot verify here" is exactly the case for the guard.
- The repo bypass is fixed the honest way: one `normalize_slug` (scheme, `user@`, scp-style colon, `.git`, case, trailing slash, host part) now feeds both the hook's repo predicate and the guard's checkout check, so `--repo github.com/deblasis/wintty` or a full URL can no longer pass the hook and slip the guard. Parse tests cover bare, host-qualified, https, ssh, scp-style, `.git`, trailing slash, and wrong-owner staying foreign.
- The signoff lookup reads a corrupt record file as absent (`OSError` and `ValueError`), never raises through the hook.
- The docstring now names what is deliberately uncovered: the GitHub web UI or mobile, a plain `git push` to `windows` (no branch protection today), hosts without the hook wiring, and `gh pr merge --auto` being judged at submit time. The `mergePullRequest` GraphQL mutation is named in the same list. No "only way" claims.

**`merge_guard.py` (new) - the ceremony itself.**
`just merge-checked <pr>`: refuse if anything is actually wrong, fetch, measure, merge, verify, file.
- Refusals (rc 2, nothing mutated, all reported together): signoff-missing (with the note that records live in this clone's git dir, so a signoff run on another machine does not count), signoff-red, signoff-defer-blocked, signoff-stale and signoff-scope (the same scope revalidation the hook does: the window policy forgives movement, not a record that no longer describes the PR), wrong-repo (names the remedy: clone `deblasis/wintty` or point origin at it), pr-not-open (with the recovery pointer), pr-not-mergeable, base-branch, pr-unloadable, window-unknown.
- `git fetch origin windows` before measuring: a stale local ref cannot compute a zero delta out of thin air. A failed fetch prints loudly, still proceeds, and the staleness rides into the filed issue as a note. The hook stays fast and local on purpose; its same-window allowance is worded as "only as fresh as your last fetch".
- Delta: first-parent `rev-list` from the record's base to the merge-time head (sync-publish lands real merge commits; a plain walk would drown in upstream history), files via two-commit `diff-tree`, per-commit files via `--diff-merges=first-parent` with a plain fallback for older gits.
- Risk lines in words: the delta itself, same files / same top-level directories / same signoff legs as the record's scope (legs recomputed with `gate_scope.required_legs`), unknown paths, and the fixed line that the squash commit itself was never signed off. Rendering is capped (15 commit bullets, 12 files per commit with "+N more", capped risk commit list) so a rewritten base cannot produce a body nobody reads; `merge-base --is-ancestor` detects a rewritten base and says so loudly instead.
- Sequence: squash-merge via `gh pr merge <n> --repo deblasis/wintty --squash --delete-branch`, poll-read the squash sha, then a second fetch plus `git rev-parse <squash>^` verifies the squash's parent is the measured head. Movement in flight prints the remediation (re-run `--dry-run` against that parent, amend the issue) and carries it into the body.
- The issue is filed on the #970 template, with a structured delta: the four identity bullets (spelled-out leg counts, 9-char prefixes, the canonical `.git/pr-signoff/<sha>.json` record path), the delta with per-commit attribution, the numbered risks, and a status that says to check `incoda status --queue wintty` before queuing and that the #969 bot owns the lane once it lands. One `gh issue list` call at filing time adds the outstanding count and the oldest issue (computed before the create, so the new issue does not count itself).
- Recovery modes: `--dry-run` mutates nothing (and accepts a MERGED pr, using the recorded mergeCommit); `--file-only <n>` files the owed issue without merging, for a merge that landed outside the guard or whose squash sha could not be read back. Both are referenced from the pr-not-open and squash-unreadable messages, because a bypass loses the record and the issue, not just the rule.
- gh/git runners are injectable in the doctor.py style; the self-test replays whole sessions.

**Docs and plumbing.** AGENTS.md now says merge through `just merge-checked <pr>` by default, a raw merge is tolerated only for a provably same-window merge, and your view of `windows` is only as fresh as your last fetch (the sync-publish exception stays). README drops the "only way" wording, names the uncovered paths, and states that the resignoff issue only exists if the guard ran. `signoff.py` gained `--self-test` (record-base cases); `just gates-selftest` runs all six gate self-tests plus the two nightly ones; `doctor.py` checks the new script exists where the wiring points.

## What phase 2 (the bot) adds

This PR only files the debt; it cannot pay it. The #969 bot is expected to: watch the `resignoff-required` label, for each open issue run the ladder on the squashed sha via the incoda lane, verify the delta claims in the issue against git before trusting them, close the issue with the evidence (leg results, sha, run log) when green, and escalate loudly when a run comes back red, including re-opening the merge decision. The status line in every filed issue points at `incoda status --queue wintty` so a human does not double-queue a run the bot is about to take.

## Follow-ups (separate issues, not this PR)

- Branch protection on `windows`. That is the actual fix for the uncovered `git push` path; a hook can only guard tool-typed commands.
- A phase-2 reconciliation job that periodically diffs filed issues against the merge history, so a bypass that dodged both the hook and the guard still gets caught after the fact.

## Verification

```
$ python .agents/scripts/pr_gate.py --self-test
ok  hook-replay-host-qualified: a full-URL --repo is normalized, not bypassed
ok  hook-replay-wrong-owner: same-named repo under another owner stays foreign
SELF-TEST PASSED

$ python .agents/scripts/merge_guard.py --self-test
ok  moved-window-golden-body: body matches the #970 template
ok  n970-title: resignoff-required: PR #958 (osc: carry the shell's prompt state as one
    versioned hex payload) squashed as 900e44bb4 on a moved windows window
ok  rendering-caps: rc=0, bullets=15
ok  stale-fetch-warns / in-flight-warns / rewritten-base-warns: rc=0
ok  file-only-files: rc=0, merged=False, filed=1
SELF-TEST PASSED

$ python .agents/scripts/signoff.py --self-test
ok  record-base: sha/base recorded: aaaaaaaa/bbbbbbbb
ok  record-base-null: an unknown base is recorded as null, not omitted
SELF-TEST PASSED

$ just gates-selftest
SELF-TEST PASSED   (x6 gate scripts)
SELF-TEST PASSED (idle=46.8m)
SELF-TEST PASSED
```

The merge-guard self-test also replays the real #958 merge: rendered from the actual `gh` fixture and #970's real base (`19110d76d`), head (`791cf0344`) and squash (`900e44bb4`), all four identity bullets reproduce #970's body field for field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
