### PR TITLE
badge: the app icon drags the window

### DIFF
--- a/windows/Ghostty/Branding/AppIconBadge.xaml.cs
+++ b/windows/Ghostty/Branding/AppIconBadge.xaml.cs
@@ -1,6 +1,11 @@
+using Windows.Foundation;
+using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media.Imaging;
+using Windows.Win32;
+using Windows.Win32.Foundation;
 
 namespace Ghostty.Branding;
 
@@ -18,16 +23,139 @@ public sealed partial class AppIconBadge : UserControl
     // XAML compiler emits a direct call at InitializeComponent; AOT-safe.
     public BitmapImage IconSource { get; } = new BitmapImage(AppIconSource.Current);
 
+    // The title-icon contract: click opens the menu, press-and-move drags
+    // the window. The badge sits at the title bar's left edge where a user
+    // expects chrome to move the window, and the SetTitleBar passthrough
+    // cannot reach it - an interactive element is exactly what that
+    // passthrough excludes. So the Button carries its own drag: captured,
+    // and once the pointer travels past a threshold the OS move loop takes
+    // over and the would-be click is swallowed.
+    private bool _pressed;
+    private bool _suppressClick;
+    private Point _pressPoint;
+    // The pointer the press started with; a move from any other pointer
+    // (a second finger, a mouse crossing while a dead touch press lingers)
+    // must not arm the drag.
+    private uint _pressPointerId;
+
+    private const nuint HTCAPTION = 2;
+
     public AppIconBadge()
     {
         InitializeComponent();
         HorizontalAlignment = HorizontalAlignment.Left;
         VerticalAlignment = VerticalAlignment.Top;
         Margin = Shell.TabChromeMetrics.AppIconMargin;
+
+        // handledEventsToo: the Button takes PointerPressed itself, and the
+        // drag has to see the press anyway. The handlers are wrapped in the
+        // WinRT delegate shape: the projection rejects a raw method group
+        // here with InvalidCastException across the ABI.
+        ClickTarget.AddHandler(PointerPressedEvent,
+            new PointerEventHandler(OnBadgePointerPressed), true);
+        ClickTarget.AddHandler(PointerMovedEvent,
+            new PointerEventHandler(OnBadgePointerMoved), true);
+        ClickTarget.AddHandler(PointerReleasedEvent,
+            new PointerEventHandler(OnBadgePointerReleased), true);
+        ClickTarget.AddHandler(PointerCanceledEvent,
+            new PointerEventHandler(OnBadgePointerCanceled), true);
+        // Capture can transfer away without a Cancel (another element
+        // capturing the same pointer, some deactivation paths) - a stale
+        // _pressed would then arm on the next unrelated in-contact move,
+        // the same hazard class the drag engines clear on.
+        ClickTarget.AddHandler(PointerCaptureLostEvent,
+            new PointerEventHandler(OnBadgeCaptureLost), true);
+        // The suppression only exists to eat the release after a drag;
+        // a keyboard or UIA activation is never that release.
+        ClickTarget.GotFocus += (_, _) => _suppressClick = false;
+    }
+
+    private void OnBadgePointerPressed(object sender, PointerRoutedEventArgs e)
+    {
+        // The caption contract is primary-button-only. Touch and pen have
+        // no other buttons to get wrong; a mouse must use the left one
+        // (middle-press-and-move is autoscroll muscle memory, not a drag).
+        if (e.Pointer.PointerDeviceType == PointerDeviceType.Mouse &&
+            !e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+            return;
+        _pressed = true;
+        _suppressClick = false;
+        _pressPointerId = e.Pointer.PointerId;
+        _pressPoint = e.GetCurrentPoint(this).Position;
+        ClickTarget.CapturePointer(e.Pointer);
+    }
+
+    private void OnBadgePointerMoved(object sender, PointerRoutedEventArgs e)
+    {
+        if (!_pressed || e.Pointer.PointerId != _pressPointerId) return;
+        if (!e.Pointer.IsInContact) return;
+        var p = e.GetCurrentPoint(this).Position;
+        var dx = p.X - _pressPoint.X;
+        var dy = p.Y - _pressPoint.Y;
+        // ~5 DIP before the move counts as a drag rather than a sloppy
+        // click - the same order as the system's own drag threshold.
+        if (dx * dx + dy * dy < 25) return;
+        _pressed = false;
+        _suppressClick = true;
+        ReleaseCapture(e.Pointer);
+        BeginWindowDrag();
+    }
+
+    /// <summary>
+    /// Enter the OS move loop from the icon's press: WM_NCLBUTTONDOWN on
+    /// HTCAPTION with the live cursor position is the same drag the
+    /// caption runs, and it is the canonical way a WinUI 3 app moves its
+    /// window from inside custom title-bar chrome (this SDK has no
+    /// AppWindow.DragMove). Dispatched synchronously like the system-menu
+    /// path: the move loop wants to start under live input.
+    /// </summary>
+    private void BeginWindowDrag()
+    {
+        var window = WindowHelper.GetWindow(this);
+        if (window is null) return;
+        if (!PInvoke.GetCursorPos(out var pos)) return;
+        var hwnd = new HWND(WinRT.Interop.WindowNative.GetWindowHandle(window));
+        PInvoke.ReleaseCapture();
+        PInvoke.SendMessage(
+            hwnd,
+            PInvoke.WM_NCLBUTTONDOWN,
+            (WPARAM)HTCAPTION,
+            new LPARAM((nint)((uint)pos.X | ((uint)pos.Y << 16))));
+    }
+
+    private void OnBadgePointerReleased(object sender, PointerRoutedEventArgs e)
+    {
+        if (!_pressed) return;
+        _pressed = false;
+        ReleaseCapture(e.Pointer);
+        // Below the threshold this release IS the click: let OnClick run.
+    }
+
+    private void OnBadgePointerCanceled(object sender, PointerRoutedEventArgs e)
+    {
+        _pressed = false;
+        ReleaseCapture(e.Pointer);
+    }
+
+    private void OnBadgeCaptureLost(object sender, PointerRoutedEventArgs e)
+    {
+        // The capture we armed is gone without a release: back to idle.
+        _pressed = false;
+    }
+
+    private void ReleaseCapture(Pointer pointer)
+    {
+        try { ClickTarget.ReleasePointerCapture(pointer); }
+        catch { /* already released */ }
     }
 
     private void OnClick(object sender, RoutedEventArgs e)
     {
+        if (_suppressClick)
+        {
+            _suppressClick = false;
+            return;
+        }
         var window = WindowHelper.GetWindow(this);
         if (window is null) return;
         SystemMenuPopup.ShowAt(window, ClickTarget);

--- a/windows/Ghostty/NativeMethods.txt
+++ b/windows/Ghostty/NativeMethods.txt
@@ -113,3 +113,5 @@ VARENUM
 // Ghostty.Core so the equivalence test in Ghostty.Tests can call it
 // without pulling in the WinUI 3 Ghostty assembly. AppearancePage
 // delegates to Ghostty.Core.
+ReleaseCapture
+WM_NCLBUTTONDOWN


### PR DESCRIPTION
The app icon is an interactive Button (click opens the application menu), and interactive elements are exactly what the SetTitleBar drag passthrough excludes - both hosts bind their drag region to a sibling of the badge, so pressing the icon initiated nothing.

The badge now carries the title-icon contract itself: press-and-move past ~5 DIP releases capture and enters the OS move loop (WM_NCLBUTTONDOWN on HTCAPTION with the live cursor position - this SDK has no AppWindow.DragMove), and the pending click is swallowed; below the threshold the click still opens the menu. Primary-button-only for mouse; moves are matched to the press's pointer id; capture loss disarms; keyboard/UIA activation is never suppressed.

Interop is CsWin32 (ReleaseCapture/WM_NCLBUTTONDOWN join NativeMethods.txt) - the projection also rejects raw method groups in AddHandler with InvalidCastException across the ABI, which took the window down at XAML instantiation until the handlers were wrapped in PointerEventHandler.

Verified: builds, boots in both layouts, layout toggle settles. The drag itself needs a pointer press, which this machine's rules forbid synthesizing - hand-test: click opens the menu; wiggle-then-release opens nothing; drag moves the window (snap layouts at screen top); menu opens immediately after a drag; Tab+Space opens it too.