### PR TITLE
layout: the ghosts oracle counts what the switch left, not what lives there

### DIFF
--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -993,7 +993,15 @@ public sealed partial class MainWindow : Window
             // packaged contexts and the answer can change under the user
             // mid-session.
             motionEnabled: () => TabStripMotion.Enabled(
-                SystemAnimationsEnabled(), HighContrastChromeActive));
+                SystemAnimationsEnabled(), HighContrastChromeActive),
+            // The run label lives on the morph canvas for the window's
+            // whole lifetime, so the ghosts oracle has to know it is there
+            // or every switch ends reporting one ghost that is only the
+            // label. Keyed on parentage rather than on the field: if the
+            // label is ever reparented away, the count follows the canvas
+            // and a real leftover ghost still reads.
+            residentMorphChildren: () =>
+                _runLabel is { } label && TabMorphLayer.Children.Contains(label) ? 1 : 0);
         _layout.Snap(_verticalTabsVisible);
 
         // The horizontal strip's group run label lives here, on the morph
@@ -3309,7 +3317,7 @@ public sealed partial class MainWindow : Window
     // Built here rather than in XAML so it stays code-built and
     // non-focusable by construction -- visual sugar, no automation
     // surface, no light-dismiss plumbing to fight.
-    private TabRunLabel? _runLabel;
+    private readonly TabRunLabel? _runLabel;
 
     /// <summary>
     /// The motion gate the run label reads per fade. Same sources as the

--- a/windows/Ghostty/Shell/LayoutCoordinator.cs
+++ b/windows/Ghostty/Shell/LayoutCoordinator.cs
@@ -140,6 +140,11 @@ internal sealed class LayoutCoordinator
     /// </summary>
     private readonly Func<bool>? _motionEnabled;
 
+    // Children of the morph canvas that live there permanently (the run
+    // label). Everything the switch parks must be gone by its end; these
+    // never are, by design, so the ghosts oracle subtracts them.
+    private readonly Func<int> _residentMorphChildren;
+
     private bool _switching;
     // The timeline staged by the most recent switch, non-null exactly while
     // that switch is in flight: Animate stages it, and the landing callback
@@ -175,9 +180,11 @@ internal sealed class LayoutCoordinator
         FrameworkElement morphRoot,
         FrameworkElement paneHost,
         Func<TabModel?> activeTab,
-        Func<bool>? motionEnabled = null)
+        Func<bool>? motionEnabled = null,
+        Func<int>? residentMorphChildren = null)
     {
         _motionEnabled = motionEnabled;
+        _residentMorphChildren = residentMorphChildren ?? (() => 0);
         _horizontalTabHost = horizontalTabHost;
         _morphLayer = morphLayer;
         _morphRoot = morphRoot;
@@ -201,12 +208,25 @@ internal sealed class LayoutCoordinator
     public bool IsSwitching => _switching;
 
     /// <summary>
-    /// What is parked on the morph layer right now: the active-tab ghost,
-    /// the icon stand-in, and the run label the strips share it with. The
-    /// same count MorphTrace prints as <c>ghosts=</c>, exposed so the
-    /// filmstrip can assert per frame rather than only at the end.
+    /// What the SWITCH has parked on the morph layer right now: the
+    /// active-tab ghost and the icon stand-in. The run label shares the
+    /// canvas permanently (the one overlay both strips are measured in),
+    /// so it is excluded here - counted in, it reads as one ghost on
+    /// every frame of every switch, which is exactly what blinded the
+    /// morph fuzz's end-line oracle and the filmstrip's per-frame gate.
+    /// The same number MorphTrace prints as <c>ghosts=</c>, exposed so
+    /// the filmstrip can assert per frame rather than only at the end.
     /// </summary>
-    public int TestSeamMorphLayerCount => _morphLayer.Children.Count;
+    public int TestSeamMorphLayerCount => SwitchOwnedMorphChildren;
+
+    /// <summary>
+    /// The one expression both the trace's <c>ghosts=</c> and
+    /// <see cref="TestSeamMorphLayerCount"/> report: what the switch has
+    /// parked, residents excluded. Shared so the seam and the trace cannot
+    /// quietly disagree after some future edit to one of them.
+    /// </summary>
+    private int SwitchOwnedMorphChildren =>
+        Math.Max(0, _morphLayer.Children.Count - _residentMorphChildren());
 
     /// <summary>
     /// Snap both hosts and the vertical title bar to the end state
@@ -1102,7 +1122,7 @@ internal sealed class LayoutCoordinator
         // ground that already agrees with it.
         Snap(verticalTabs);
         MorphTrace(
-            $"SWITCH end ghosts={_morphLayer.Children.Count} morph={(_morph is null ? "null" : "LEAKED")} uiFrames={StopFrameCount()}");
+            $"SWITCH end ghosts={SwitchOwnedMorphChildren} morph={(_morph is null ? "null" : "LEAKED")} uiFrames={StopFrameCount()}");
         _switching = false;
         onCompleted?.Invoke();
     }


### PR DESCRIPTION
The group run label has shared the morph canvas with the switch since it landed - permanently, by design (the one overlay both strips are measured in). The ghosts counter kept counting raw layer children, so every switch end reported ghosts=1 (a phantom one-ghost leak on every switch), and layout-frame's morphLayer>=1 made the filmstrip's per-frame gate skip every frame - its selection assertion has not run since.

The coordinator now takes the resident count from the window (like activeTab and motionEnabled before it) and both readings subtract it: a real leftover ghost still reads; the label does not.

Verified red->green: the migrated morph fuzz PASSes (17 toggles -> 23 begins, 23/23 ends balanced, no leaks) where the same run before the fix filed 42 leaked switches.