### PR TITLE
tracking: one snapshot per tick, no overlap, cadence pays for itself

### DIFF
--- a/windows/Ghostty.Core/Profiles/Tracking/ProcessTreeWalker.cs
+++ b/windows/Ghostty.Core/Profiles/Tracking/ProcessTreeWalker.cs
@@ -21,7 +21,8 @@ internal readonly record struct DescendantInfo(string ExeBasename, string? Comma
 /// given root PID. "Innermost" = deepest by tree depth; ties broken by
 /// the snapshot's natural iteration order (deterministic on stable input).
 ///
-/// One snapshot per call. Caller invokes once per tracker tick (2 Hz).
+/// One snapshot per call. The tracker calls it once per tick, for every
+/// registered root at once.
 ///
 /// The generated CsWin32 class is <c>DWritePInvoke</c> (see
 /// NativeMethods.json "className") to avoid colliding with the
@@ -47,14 +48,22 @@ internal static class ProcessTreeWalker
         };
 
     /// <summary>
-    /// Returns the exe basename + command line of the innermost descendant
-    /// of <paramref name="rootPid"/>. Returns null when the root has no
-    /// descendants, has exited, or the snapshot fails. The command line
-    /// component is null when it could not be read (access denied, race
-    /// with process exit, etc.) but the basename is still reported.
+    /// ONE process snapshot resolves every root. The snapshot cost scales
+    /// with the whole machine's process count, not with any root's
+    /// subtree, so a caller answering N roots one at a time pays N
+    /// full-machine walks per tick - on a process-heavy box that is a
+    /// burned core (measured). The by-parent map is built once and shared;
+    /// each root's BFS then touches only that root's subtree. A root
+    /// missing from the answer reads as null.
     /// </summary>
-    public static DescendantInfo? FindInnermostDescendant(uint rootPid)
+    public static IReadOnlyDictionary<uint, DescendantInfo?> FindInnermostDescendants(
+        IEnumerable<uint> rootPids)
     {
+        var roots = new List<uint>(rootPids);
+        var result = new Dictionary<uint, DescendantInfo?>(roots.Count);
+        if (roots.Count == 0) return result;
+        foreach (var root in roots) result[root] = null;
+
         var snapshot = DWritePInvoke.CreateToolhelp32Snapshot(
             CREATE_TOOLHELP_SNAPSHOT_FLAGS.TH32CS_SNAPPROCESS, 0);
         // CreateToolhelp32Snapshot returns INVALID_HANDLE_VALUE (-1) on
@@ -62,14 +71,14 @@ internal static class ProcessTreeWalker
         // named constant for that, so compare against the raw -1 sentinel
         // via explicit IntPtr-to-HANDLE conversion.
         var invalid = (HANDLE)new IntPtr(-1);
-        if (snapshot == invalid) return null;
+        if (snapshot == invalid) return result;
 
         try
         {
             var byParent = new Dictionary<uint, List<(uint Pid, string ExeBasename)>>();
             var entry = new PROCESSENTRY32W { dwSize = (uint)Marshal.SizeOf<PROCESSENTRY32W>() };
 
-            if (!DWritePInvoke.Process32FirstW(snapshot, ref entry)) return null;
+            if (!DWritePInvoke.Process32FirstW(snapshot, ref entry)) return result;
             do
             {
                 if (!byParent.TryGetValue(entry.th32ParentProcessID, out var list))
@@ -85,7 +94,9 @@ internal static class ProcessTreeWalker
             }
             while (DWritePInvoke.Process32NextW(snapshot, ref entry));
 
-            return DeepestDescendant(byParent, rootPid);
+            foreach (var root in roots)
+                result[root] = DeepestDescendant(byParent, root);
+            return result;
         }
         finally
         {

--- a/windows/Ghostty.Core/Profiles/Tracking/WindowsActiveProcessTracker.cs
+++ b/windows/Ghostty.Core/Profiles/Tracking/WindowsActiveProcessTracker.cs
@@ -1,14 +1,17 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 
 namespace Ghostty.Core.Profiles.Tracking;
 
 /// <summary>
 /// Polling implementation of <see cref="IActiveProcessTracker"/>. One
-/// <see cref="Timer"/>, two ticks per second. Each tick:
+/// <see cref="Timer"/>, self-scheduled so ticks never overlap. Each tick:
 ///  1. Snapshots the registered root PIDs.
-///  2. Walks the tree once per root via <see cref="ProcessTreeWalker"/>.
+///  2. Resolves every root against ONE process snapshot via
+///     <see cref="ProcessTreeWalker.FindInnermostDescendants"/>.
 ///  3. Runs each result through <see cref="ActiveProcessDebouncer"/>.
 ///  4. Raises <see cref="Changed"/> for every emission.
 /// </summary>
@@ -17,6 +20,8 @@ public sealed class WindowsActiveProcessTracker : IActiveProcessTracker
 {
     private const int TickIntervalMs = 500;
     private const int DebounceWindowMs = 250;
+    // The longest the adaptive cadence may stretch between walks.
+    private const int MaxDueMs = 30_000;
 
     private readonly Timer _timer;
     private readonly ConcurrentDictionary<int, byte> _roots = new();
@@ -27,7 +32,14 @@ public sealed class WindowsActiveProcessTracker : IActiveProcessTracker
 
     public WindowsActiveProcessTracker()
     {
-        _timer = new Timer(OnTick, state: null, dueTime: TickIntervalMs, period: TickIntervalMs);
+        // period: never. A fixed period re-enters OnTick while a slow tick
+        // (one full-machine process snapshot) is still walking, and the
+        // concurrent ticks pile up without bound - measured at more than a
+        // full core, from launch, on a process-heavy machine. The tick
+        // re-arms itself when its work is done, so the real cadence is one
+        // walk every (interval + work) and no walk ever overlaps another.
+        _timer = new Timer(OnTick, state: null,
+            dueTime: TickIntervalMs, period: Timeout.Infinite);
     }
 
     public void Register(int rootPid) => _roots.TryAdd(rootPid, 0);
@@ -52,14 +64,19 @@ public sealed class WindowsActiveProcessTracker : IActiveProcessTracker
     private void OnTick(object? state)
     {
         if (_disposed != 0) return;
-        var now = Environment.TickCount64;
-
-        foreach (var (rootPid, _) in _roots)
+        var walkStart = Environment.TickCount64;
+        try
         {
-            DescendantInfo? info;
+            var now = Environment.TickCount64;
+
+            // One snapshot for every root: the walk's cost is the whole
+            // machine's process count, so per-root snapshots multiply a
+            // machine-wide cost by the tab count.
+            IReadOnlyDictionary<uint, DescendantInfo?> infos;
             try
             {
-                info = ProcessTreeWalker.FindInnermostDescendant((uint)rootPid);
+                infos = ProcessTreeWalker.FindInnermostDescendants(
+                    _roots.Keys.Select(p => (uint)p));
             }
             catch (Exception ex)
             {
@@ -67,28 +84,49 @@ public sealed class WindowsActiveProcessTracker : IActiveProcessTracker
                 // common; suppress and treat as "no foreground" but record so a
                 // regressed tracker is diagnosable from the debug log.
                 System.Diagnostics.Debug.WriteLine(
-                    $"WindowsActiveProcessTracker: snapshot failed for pid={rootPid}: {ex.GetType().Name}: {ex.Message}");
-                info = null;
+                    $"WindowsActiveProcessTracker: snapshot failed: {ex.GetType().Name}: {ex.Message}");
+                infos = new Dictionary<uint, DescendantInfo?>();
             }
 
-            var exe = info?.ExeBasename;
-            var cmdline = info?.CommandLine;
-            var emission = _debouncer.Observe(rootPid, exe, commandLine: cmdline, nowMs: now);
-            if (emission is not null)
+            foreach (var (rootPid, _) in _roots)
             {
-                try
+                DescendantInfo? info = infos.GetValueOrDefault((uint)rootPid);
+                var exe = info?.ExeBasename;
+                var cmdline = info?.CommandLine;
+                var emission = _debouncer.Observe(rootPid, exe, commandLine: cmdline, nowMs: now);
+                if (emission is not null)
                 {
-                    Changed?.Invoke(this, new ActiveProcessChangedEventArgs(
-                        emission.RootPid, emission.ExeBasename, emission.CommandLine));
-                }
-                catch (Exception ex)
-                {
-                    // Subscribers must not crash the tracker. Log the failing handler
-                    // so it doesn't decay silently.
-                    System.Diagnostics.Debug.WriteLine(
-                        $"WindowsActiveProcessTracker: Changed subscriber threw: {ex.GetType().Name}: {ex.Message}");
+                    try
+                    {
+                        Changed?.Invoke(this, new ActiveProcessChangedEventArgs(
+                            emission.RootPid, emission.ExeBasename, emission.CommandLine));
+                    }
+                    catch (Exception ex)
+                    {
+                        // Subscribers must not crash the tracker. Log the failing handler
+                        // so it doesn't decay silently.
+                        System.Diagnostics.Debug.WriteLine(
+                            $"WindowsActiveProcessTracker: Changed subscriber threw: {ex.GetType().Name}: {ex.Message}");
+                    }
                 }
             }
+        }
+        finally
+        {
+            // The self-schedule: the next walk is due AFTER this one
+            // finished, never while it runs, and never more often than the
+            // walk itself can be paid for - on a process-heavy box one
+            // snapshot costs a large fraction of the interval, and polling
+            // at a fixed 2Hz spends most of a core on icon tracking. The
+            // 3x floor caps the duty cycle at a quarter (due time counts
+            // from the tick's end); quiet machines never notice it. The
+            // 30s ceiling bounds how long a transiently thrashing box can
+            // stretch the tracker's dead time. ObjectDisposed races the
+            // Dispose wait below; a lost re-arm is the shutdown case anyway.
+            var walkMs = Environment.TickCount64 - walkStart;
+            var dueMs = Math.Min(MaxDueMs, Math.Max(TickIntervalMs, 3 * (int)walkMs));
+            try { _timer.Change(dueMs, Timeout.Infinite); }
+            catch (ObjectDisposedException) { }
         }
     }
 }


### PR DESCRIPTION
The active-process tracker polled every 500ms with a fixed-period timer and walked the ENTIRE machine's process tree once per registered tab - the snapshot cost scales with the whole box's process count, not any root's subtree, so N tabs meant N full-machine walks per tick, and the fixed period re-entered ticks while slow walks were still running, piling them up without bound. Measured live in tonight's seam sessions: more than a full core, continuously, from launch.

Three changes, measured on the same process-heavy machine with 5 tabs:
- the walker resolves every registered root against ONE snapshot (one by-parent map, per-root BFS against it);
- self-scheduling timer (period never fires; the tick re-arms in a finally) - no two walks ever overlap;
- next due = max(interval, 3x measured tick), capped at 30s - duty stays under a quarter where a snapshot costs a large fraction of the interval, and a transiently thrashing box cannot stretch the tracker's dead time past half a minute. Quiet machines never notice it.

Idle CPU over 25s: >100% of one core before, 12.7% after. The residual is the Toolhelp snapshot's intrinsic machine-wide cost; going lower means a different enumeration API - noted as future work, not attempted here.