### PR TITLE
ci: opt-in only, and the local signoff advertises on GitHub

### DIFF
--- a/.agents/scripts/signoff.py
+++ b/.agents/scripts/signoff.py
@@ -278,6 +278,52 @@ def defer(reason):
     return 0
 
 
+def post_github_status(record):
+    """Advertise a finished signoff on GitHub as a commit status.
+
+    The record on disk is the authority and the local merge gate reads it
+    from there; this only puts the green/red tick and the one-line summary
+    where the PR shows them, because GitHub runs nothing by default
+    anymore (CI is dispatch/tag opt-in). The token is whatever `gh`
+    already holds, the context is named so it can never be mistaken for
+    the GitHub-side workflow, and no detail URL is invented - the full
+    record lives in this machine's git dir, which has no URL.
+
+    Best-effort by construction: an unpushed head (422 - status before
+    push is the normal early-run case), a missing `gh`, or an offline box
+    prints one warning and changes nothing about the signoff's verdict.
+    Never called for deferrals - a deferred record is a borrow, not
+    evidence, and a tick for it would lie.
+    """
+    try:
+        remote = subprocess.run(["git", "remote", "get-url", "origin"],
+                                cwd=REPO_ROOT, text=True,
+                                capture_output=True, timeout=10).stdout
+        if "deblasis/wintty" not in remote:
+            return
+        legs = sorted(record["steps"])
+        total = round(sum(s["seconds"] for s in record["steps"].values()))
+        if record["pass"]:
+            state, desc = "success", (
+                f"PASS {len(legs)} leg(s) in {total}s: {', '.join(legs)}")
+        else:
+            bad = [f"{n} rc={s['rc']}" for n, s in sorted(record["steps"].items())
+                   if s["rc"] != 0]
+            state, desc = "failure", f"FAIL: {'; '.join(bad)}"
+        p = subprocess.run(
+            ["gh", "api", "--method", "POST",
+             f"repos/deblasis/wintty/statuses/{record['sha']}",
+             "-f", f"state={state}",
+             "-f", "context=signoff/ladder",
+             "-f", f"description={desc[:140]}"],
+            cwd=REPO_ROOT, text=True, capture_output=True, timeout=20)
+        if p.returncode != 0:
+            print(f"signoff: GitHub status not posted (signoff unaffected): "
+                  f"{p.stderr.strip()[:160]}")
+    except Exception as e:  # noqa: BLE001 - advertising must never fail the gate
+        print(f"signoff: GitHub status not posted (signoff unaffected): {e}")
+
+
 def settle(note):
     d = signoff_dir()
     if not d:
@@ -349,6 +395,7 @@ def main(argv):
     with open(path, "w", encoding="utf-8") as f:
         json.dump(record, f, indent=2)
     print(f"signoff: {'PASS' if ok else 'FAIL'} recorded for {head[:10]} at {path}")
+    post_github_status(record)
 
     # A green run of every leg is what deferred merges were borrowing
     # against, so it settles the ledger. A scoped run proves nothing about

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -1,13 +1,21 @@
 # Runs the C# test suites on the fork. Upstream test.yml gates every job on
 # ghostty-org/ghostty, so it is inert here; this workflow mirrors `just
-# test-win` so CI runs the same legs as the signoff ladder.
+# test-win` so a GitHub-side run executes the same legs as the signoff
+# ladder.
+#
+# OPT-IN ON THE COMMIT: pushes to windows run only when the head commit's
+# message contains "yesci"; a message that also contains "noci" skips
+# (noci wins when both are present). The job-level `if` skips before any
+# runner spins up, so an ordinary push costs nothing. The default gate
+# remains the local signoff ladder - its verdict is advertised on PRs as
+# the `signoff/ladder` commit status - and workflow_dispatch always runs,
+# as the explicit escape hatch.
 
 name: windows-tests
 
 on:
   push:
     branches: [windows]
-  pull_request: {}
   workflow_dispatch: {}
 
 concurrency:
@@ -19,7 +27,13 @@ permissions:
 
 jobs:
   test-win:
-    if: github.repository == 'deblasis/wintty'
+    # yesci/noci read the PUSH head commit's message (subject and body
+    # together). workflow_dispatch has no head_commit and always runs.
+    if: >-
+      github.repository == 'deblasis/wintty' &&
+      (github.event_name == 'workflow_dispatch' ||
+       (contains(github.event.head_commit.message, 'yesci') &&
+        !contains(github.event.head_commit.message, 'noci')))
     runs-on: windows-latest
     timeout-minutes: 90
     steps:
@@ -30,11 +44,11 @@ jobs:
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
 
       # No version input: installs the SDK pinned by the root global.json.
-      # cache: the WAS self-contained restore is large and a cold run is
-      # the tight one against the 90-minute budget.
+      # No cache: setup-dotnet's NuGet cache demands packages.lock.json
+      # files to hash and this repo has none - with `cache: true` the step
+      # hard-fails before anything builds ("Dependencies lock file is not
+      # found"). CI is rare now; a cold restore is fine.
       - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
-        with:
-          cache: true
 
       # Ghostty.csproj hard-errors without zig-out/lib/ghostty.dll
       # (ErrorIfNoLibghostty), so the dll must exist before any dotnet build.


### PR DESCRIPTION
Three changes from the CI investigation:

- The failing run's root cause: setup-dotnet's `cache: true` demands packages.lock.json files this repo has never had, so every run died in the setup step before building. Cache dropped.
- Runs are opt-in on the commit: a push to windows runs only when the head commit's message carries `yesci` (`noci` wins when both are present). The check is the job-level `if`, so an ordinary push skips before any runner spins up. `workflow_dispatch` stays as the explicit escape hatch; PRs never trigger. The default gate remains the local signoff ladder.
- The signoff script now posts its finished record to GitHub as a commit status (context `signoff/ladder`) through the existing gh auth: green/red tick plus a one-line summary in the PR - no app, no new credentials, no invented detail URL. Best-effort by construction: an unpushed head (422) or an offline box prints a warning and the verdict on disk is unchanged. Deferrals never post. Verified live: this PR's own signoff posted its tick.

Advisory, not enforcement: there is no branch protection, and none is wanted - the local pr-gate stays the merge authority. (Found along the way: deblasis/wintty is public, so hosted minutes are free - the real costs were the red-X noise and queue contention.)