### PR TITLE
layout: re-prime the hidden strip when tabs arrive

### DIFF
--- a/windows/Ghostty.Tests/Wiring/TabLayoutSwitchWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabLayoutSwitchWiringTests.cs
@@ -691,5 +691,44 @@ public class TabLayoutSwitchWiringTests
             $"the leader margin narrowed to {inAbove - outBelow:F3} of the switch "
             + $"(outgoing below half at {outBelow:F3}, incoming above at {inAbove:F3})");
     }
+
+    /// <summary>
+    /// Tabs added while the other layout's strip is collapsed never realize
+    /// their containers there - ItemsRepeater realizes only on a rendered
+    /// viewport - so the next switch toward it fades in nothing and the row
+    /// pops in late. PrimeHiddenStrip at construction covers the launch-time
+    /// containers; every arrival after that is covered by the prime inside
+    /// the TabAdded handler, which is the entire fix, so it is pinned here.
+    /// </summary>
+    [Fact]
+    public void TabArrivalsReprimeTheHiddenStrip_BehindTheCloseGate()
+    {
+        var window = Window();
+        // Exactly one TabAdded subscription primes; the quake-visibility
+        // subscription is a zero-work lambda and must not be the one caught.
+        var subscription = Assert.Single(
+            window.Root.DescendantNodes().OfType<AssignmentExpressionSyntax>(),
+            a => a.Left.ToString().EndsWith("_tabManager.TabAdded", StringComparison.Ordinal)
+                 && a.Right is ParenthesizedLambdaExpressionSyntax lambda
+                 && lambda.Body.Calls("_layout.PrimeHiddenStrip").Any());
+        var body = Assert.IsType<BlockSyntax>(
+            ((ParenthesizedLambdaExpressionSyntax)subscription.Right).Body).Statements;
+
+        // The close gate precedes the prime: a post-close add (a cross-window
+        // adoption racing the close) must not arm a three-frame Rendering
+        // lease that CancelStripPriming already ran to detach.
+        var gateIndex = body
+            .TakeWhile(s => s is not IfStatementSyntax i
+                            || !i.Condition.ToString().Contains("_isClosed"))
+            .Count();
+        var primeIndex = body
+            .TakeWhile(s => !s.Calls("_layout.PrimeHiddenStrip").Any())
+            .Count();
+        // Both have to exist, or TakeWhile silently returns the full count and
+        // the ordering assertion below passes while pinning nothing.
+        Assert.True(gateIndex < body.Count, "expected an _isClosed guard in the TabAdded handler");
+        Assert.True(primeIndex < body.Count, "expected the TabAdded handler to prime the hidden strip");
+        Assert.True(gateIndex < primeIndex, "the close gate must precede the prime");
+    }
 }
 

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -936,11 +936,25 @@ public sealed partial class MainWindow : Window
 
         _tabManager.TabAdded += (_, t) =>
         {
+            // Same convention as every tree-touching handler below: a
+            // post-close add (a cross-window adoption racing the close)
+            // must not arm a priming lease nobody cancels.
+            if (_isClosed) return;
             WireTabColor(t);
             AddPaneHost(t);
             AttachProcessTracking(t);
             SwapActivePane();
             ApplyPerTabChrome();
+            // Realized containers survive a strip being collapsed again,
+            // but containers for tabs added WHILE it is collapsed never
+            // come to exist - ItemsRepeater realizes only on a rendered
+            // viewport. Unprimed, the next switch toward that strip fades
+            // in nothing and the whole row pops in late once the viewport
+            // finally arrives mid-flight (measured: an empty caption band
+            // for ~420-490ms at 15 tabs, growing with tab count). Re-prime
+            // on every add so the row is realized before the switch needs
+            // it; the priming pass itself is three transparent frames.
+            _layout.PrimeHiddenStrip();
         };
         _tabManager.TabRemoved += (_, t) =>
         {
@@ -4181,6 +4195,13 @@ public sealed partial class MainWindow : Window
         _layout.SetStripHidden(hidden, _verticalTabsVisible);
         _stripForciblyHidden = hidden;
         RefreshBackdropChrome();
+
+        // The add that un-hid this strip ran the TabAdded prime while the
+        // strip was still hidden, so the prime refused; the just-added
+        // tab's container in the OTHER layout's strip would stay unbuilt
+        // until some later add. Un-hide is itself a strip-state change,
+        // so it gets its own prime.
+        if (!hidden) _layout.PrimeHiddenStrip();
 
         // The seam covers join the selected tab to the pane, so with no
         // strip there is nothing to join and the cover is a bar of tab


### PR DESCRIPTION
Containers for tabs added while the other layout's strip is collapsed never realize - ItemsRepeater realizes only on a rendered viewport, and realized containers survive collapse but new ones never arrive. The next switch toward that strip faded in nothing and the row popped in late: an empty caption band for ~420-490ms at 15 tabs, growing with tab count, on every switch - the owner's 'the horizontal tabs do not appear for a while after the active tab migrated', matching the intermittency hint (tabs added between switches).

PrimeHiddenStrip already spends three transparent frames realizing the row; it just only ran at construction. Now every TabAdded re-primes, behind the file's standard _isClosed gate (a post-close add must not arm a rendering lease nobody cancels - review catch), and the quake un-hide re-primes too (its own add ran while still hidden and was refused - review catch).

Filmed A/B, judged blind by a vision pass: the completely-empty band is GONE (zero fully-empty frames across all flights vs 6-7 before); the migrated active tab anchors the band from the first post-fade frame. Remaining - the row lands all at once rather than progressively - is the switch-time row rebuild, deliberately out of scope and tracked for the motion audit.

A mutation-verified wiring guard pins the prime call and its gate (both mutations go red, restore green). Review verdict: CLEAN - the interleavings walked include overlapping prime cycles (impossible: the collapsed-host check is a single-flight lock), tab-added-mid-switch (covered by the flight itself rendering both hosts), and teardown mid-prime.