### PR TITLE
tabs: the seam cover cannot drift

### DIFF
--- a/windows/Ghostty.Tests/Wiring/ActiveTabFieldWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/ActiveTabFieldWiringTests.cs
@@ -31,6 +31,7 @@ public sealed class ActiveTabFieldWiringTests
 {
     private const string VerticalStrip = "Tabs.VerticalTabStrip.xaml.cs";
     private const string HorizontalStrip = "Tabs.TabHost.xaml.cs";
+    private const string MainWindowFile = "Ghostty.MainWindow.xaml.cs";
 
     /// <summary>
     /// Each strip and the method that takes the palette. They are the same
@@ -314,5 +315,60 @@ public sealed class ActiveTabFieldWiringTests
             .FirstOrDefault(v => v.Identifier.ValueText == name);
         Assert.True(declared?.Initializer is not null, $"no local '{name}' with an initializer");
         return declared!.Initializer!.Value.ToString();
+    }
+
+    /// <summary>
+    /// The seam cover is a copy of a fact the layout already knows (the
+    /// selected tab's span), and it drifts wherever that copy is not
+    /// re-derived: mid-switch (the cover's cell origin moves with the
+    /// collapsing lane while the span is measured in host space), during
+    /// strip scroll (no enumerated event fires), and across caption-inset
+    /// reflows (MinWidth moves slots without a SizeChanged). These pins are
+    /// the three doors the fix closed, plus the coordinate-basis fix that
+    /// makes the mid-flight door structural rather than timing-dependent.
+    /// </summary>
+    [Fact]
+    public void TheSeamCoverCannotDrift()
+    {
+        var window = ShellSource.Load(MainWindowFile);
+
+        // The cover lives in grid space, not in cell (1,1): a margin in
+        // cell space is only correct while the strip column reads zero.
+        var creation = window.Root.DescendantNodes()
+            .OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.Left.ToString().Contains("_tabSeamCover"))
+            .ToList();
+        Assert.Contains(creation,
+            a => a.Right.ToString().Contains("Microsoft.UI.Xaml.Shapes.Rectangle"));
+        var source = window.Root.ToString();
+        Assert.Contains("Grid.SetColumn(_tabSeamCover, 0)", source);
+        Assert.Contains("Grid.SetColumnSpan(_tabSeamCover, 2)", source);
+
+        // The seam gate refuses mid-switch placements: the landing's
+        // RefreshSeam re-places into a settled frame.
+        var gate = window.Method("OnSelectedTabSeamChanged");
+        Assert.Contains(gate.DescendantNodes().OfType<IdentifierNameSyntax>(),
+            i => i.Identifier.ValueText == "IsSwitching");
+
+        // A successful placement re-checks while the span is still moving
+        // and stops when it stops moving: the fixpoint arming.
+        var bridge = ShellSource.Load(HorizontalStrip).Method("UpdateSelectedTabBridge");
+        var successArm = bridge.DescendantNodes()
+            .OfType<IfStatementSyntax>()
+            .SingleOrDefault(i => i.Condition.ToString().Contains("_lastSeamLeft"));
+        Assert.NotNull(successArm);
+        Assert.Contains(successArm.Calls("ArmBridgeRetry"), _ => true);
+
+        // A user scroll moves the drawn tab without firing any enumerated
+        // event; the scroller's ViewChanged re-derives the span. The
+        // subscription must name the real handler - a neutralized no-op
+        // lambda still reads as a subscription.
+        var host = ShellSource.Load(HorizontalStrip).Root;
+        Assert.Contains(host.DescendantNodes().OfType<AssignmentExpressionSyntax>(),
+            a => a.IsKind(SyntaxKind.AddAssignmentExpression)
+                 && a.Right is IdentifierNameSyntax id
+                 && id.Identifier.ValueText == "OnTabStripScrollerViewChanged");
+        var handler = ShellSource.Load(HorizontalStrip).Method("OnTabStripScrollerViewChanged");
+        Assert.Contains(handler.Calls("QueueBridgeUpdate"), _ => true);
     }
 }

--- a/windows/Ghostty.Tests/Wiring/WindowTeardownWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/WindowTeardownWiringTests.cs
@@ -116,6 +116,7 @@ public class WindowTeardownWiringTests
         ("_host", "this window's own GhosttyHost; its events are raised from surface input, "
                   + "which a closing window no longer receives"),
         ("_tabManager", "this window's own TabManager"),
+        ("_titleBar", "this window's own TitleBarCoordinator; its CaptionInsetChanged re-places strip chrome that dies with the window"),
         ("_verticalTabHost", "this window's own vertical tab host, constructed and held only by "
                              + "this window; its events are raised from strip drag and selection "
                              + "input, which a closing window no longer receives"),

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -848,7 +848,16 @@ public sealed partial class MainWindow : Window
             Height = Core.Panes.PaneChrome.SurfaceInset,
         };
         Grid.SetRow(_tabSeamCover, 1);
-        Grid.SetColumn(_tabSeamCover, 1);
+        // Grid space, not cell (1,1): the span is measured in the host's
+        // coordinates, and the host spans both columns with its origin at
+        // the grid's - so a margin in cell space is only right while
+        // StripColumn reads zero, which is every resting horizontal frame
+        // and NO frame of a switch back from vertical (the lane is still
+        // open). A placement that slips through mid-flight lands offset by
+        // the whole lane width. Same precedent the vertical cover cites
+        // for living across the whole RootGrid.
+        Grid.SetColumn(_tabSeamCover, 0);
+        Grid.SetColumnSpan(_tabSeamCover, 2);
         RootGrid.Children.Add(_tabSeamCover);
         _horizontalTabHost.SelectedTabSeamChanged += OnSelectedTabSeamChanged;
 
@@ -1081,6 +1090,9 @@ public sealed partial class MainWindow : Window
             isVerticalMode: () => _tabHost is VerticalTabHost);
         _titleBar.ApplyForCurrentMode();
         _titleBar.SyncCaptionInset();
+        // An inset change reflows the tab slots without any SizeChanged,
+        // so the seam cover - placed from slot offsets - re-places here.
+        _titleBar.CaptionInsetChanged += () => _horizontalTabHost.RefreshSeam();
 
         _taskbar = new TaskbarHost(this, _tabManager, loggerFactory.CreateLogger<TaskbarHost>());
 
@@ -3313,7 +3325,14 @@ public sealed partial class MainWindow : Window
         // few frames. Reading it here meant the first placement of every
         // session decided it was in vertical layout and hid the cover, and
         // nothing re-fired until the window happened to be resized.
-        if (width <= 0 || fill is null || _verticalTabsVisible || _stripForciblyHidden)
+        // Mid-switch the placement's own basis is in motion (the lane is
+        // collapsing, the hosts are cross-fading), so hide and let the
+        // landing's RefreshSeam re-place into a settled frame - FinishSwitch
+        // clears IsSwitching before the landing runs, so that placement
+        // sees an open gate. Without this term any bridge event landing in
+        // the 340ms flight paints the cover over chrome that is moving.
+        if (width <= 0 || fill is null || _verticalTabsVisible || _stripForciblyHidden
+            || _layout.IsSwitching)
         {
             _tabSeamCover.Visibility = Visibility.Collapsed;
             return;

--- a/windows/Ghostty/Shell/TitleBarCoordinator.cs
+++ b/windows/Ghostty/Shell/TitleBarCoordinator.cs
@@ -51,6 +51,15 @@ internal sealed class TitleBarCoordinator
     private TabModel? _titleHookedTab;
     private LeafPane? _activeLeaf;
 
+    /// <summary>
+    /// Fired when a caption-inset change has reflowed the strip's content.
+    /// The inset writes the drag region's MinWidth, which moves the tab
+    /// slots without any SizeChanged (the TabView's own size did not
+    /// change) - so whoever places strip-relative chrome from slot offsets
+    /// (the seam cover) needs this nudge or places from stale offsets.
+    /// </summary>
+    public event Action? CaptionInsetChanged;
+
     // Quake window: borderless, no OS caption buttons, so the reserved
     // caption inset (vertical column + horizontal drag-region MinWidth) is
     // dead space and the vertical-mode window title is noise. When set,
@@ -124,10 +133,16 @@ internal sealed class TitleBarCoordinator
                 // it, so setting the column is setting both. It used to
                 // carry its own copy of this width, which is one more
                 // thing that could disagree with the caption lane it is
-                // supposed to be part of.
+                // supposed to be part of. Fired only when the inset MOVED:
+                // AppWindow.Changed arrives per position change, so an
+                // unconditional fire ran the seam refresh on every
+                // mouse-move of a window drag.
+                if (_captionInset.Width.GridUnitType == GridUnitType.Pixel
+                    && Math.Abs(_captionInset.Width.Value - dip) < 0.01) return;
                 _captionInset.Width = new GridLength(dip);
                 if (_horizontalTabHost.DragRegion is FrameworkElement drag)
                     drag.MinWidth = dip;
+                CaptionInsetChanged?.Invoke();
             }
         }
         catch

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -228,6 +228,11 @@ internal sealed partial class TabHost : UserControl, ITabHost
         {
             FinishLift("teardown");
             UnhookAllGroups();
+            if (_tabStripScroller is { } scroller)
+            {
+                scroller.ViewChanged -= OnTabStripScrollerViewChanged;
+                _tabStripScroller = null;
+            }
         };
 
         // The drag lifecycle gates the seam cover below: mid-drag the
@@ -1455,7 +1460,24 @@ internal sealed partial class TabHost : UserControl, ITabHost
         // every settle, and the frames it is wrong in are the frames where a
         // line appears between the tab and the pane.
         SelectedTabSeamChanged?.Invoke(left, width, _field.Brush);
+
+        // A placement made while the strip is still moving - a
+        // bring-into-view settle, an equal-width reflow, a caption-inset
+        // resize - reads valid bounds, looks final, and was never
+        // revisited. Re-check on the next layout pass whenever the span
+        // MOVED; when it stops moving this stops arming, so the chain
+        // converges at the fixpoint instead of running forever.
+        if (left != _lastSeamLeft || width != _lastSeamWidth)
+        {
+            _lastSeamLeft = left;
+            _lastSeamWidth = width;
+            ArmBridgeRetry();
+        }
     }
+
+    // The last span a successful placement reported, for the fixpoint above.
+    private double _lastSeamLeft = double.NaN;
+    private double _lastSeamWidth = double.NaN;
 
     // -----------------------------------------------------------------
     // The group field, horizontal edition.
@@ -1661,6 +1683,7 @@ internal sealed partial class TabHost : UserControl, ITabHost
     {
         _tabListView ??= FindDescendantByName(TabViewControl, "TabListView");
         if (_tabListView is not { ActualWidth: > 0 } list) return null;
+        HookTabStripScroller(list);
 
         try
         {
@@ -1675,6 +1698,33 @@ internal sealed partial class TabHost : UserControl, ITabHost
             return null;
         }
     }
+
+    // The scroller the tab list scrolls inside. A user wheel or drag-scroll
+    // moves the drawn tab while its layout offset keeps reporting where the
+    // tab would be, and no enumerated event fires - so the cover sits over a
+    // stretch of border nowhere near the tab until the next unrelated
+    // refresh. ViewChanged re-derives the span, coalesced through the same
+    // queue every other refresh uses.
+    private Microsoft.UI.Xaml.Controls.ScrollViewer? _tabStripScroller;
+
+    private void HookTabStripScroller(Microsoft.UI.Xaml.UIElement list)
+    {
+        if (_tabStripScroller is not null) return;
+        var node = (Microsoft.UI.Xaml.DependencyObject?)list;
+        while (node is not null)
+        {
+            if (node is Microsoft.UI.Xaml.Controls.ScrollViewer scroller)
+            {
+                _tabStripScroller = scroller;
+                scroller.ViewChanged += OnTabStripScrollerViewChanged;
+                return;
+            }
+            node = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(node);
+        }
+    }
+
+    private void OnTabStripScrollerViewChanged(object? sender, object e)
+        => QueueBridgeUpdate();
 
     private static FrameworkElement? FindDescendantByName(DependencyObject root, string name)
     {


### PR DESCRIPTION
The rectangle covering the terminal border under the active tab drifted at times - the owner's report. The cover is a copy of a fact the layout already knows (the selected tab's span), and it drifted wherever that copy wasn't re-derived. Three doors, all closed:

- **Coordinate basis** (the grossest): the cover lived in grid cell (1,1) whose origin X is the strip lane's width, while its span is measured in host space spanning both columns. They agree only while the lane reads zero - every resting horizontal frame, and NO frame of a switch back from vertical. A placement slipping through mid-flight landed offset by the whole lane width. The cover now lives in grid space - the measurement's own frame - mirroring the vertical cover's own precedent.
- **Mid-flight gate**: `OnSelectedTabSeamChanged` lacked an `IsSwitching` term; it hides now and the landing's RefreshSeam re-places into a settled frame (FinishSwitch clears the flag before the landing runs).
- **Silent motion**: successful placements were never revisited - a scroll-settle, equal-width reflow, or caption-inset change (moves slots without SizeChanged) left a stale span. Placements now re-check while the span is MOVING and stop when it stops (a converging fixpoint, not a loop); the scroller's ViewChanged feeds the coalesced queue; the caption-inset path got its own event.

Verified: the at-rest oracle (tab-field-seam) holds - 126 span comparisons across six widths, worst sub-pixel drift 0 - and a mutation-verified wiring guard pins all four terms (each mutation goes red: gate removed, fixpoint arm removed, scroll subscription neutralized, cover cell reverted).

The architectural end-state (the Windows Terminal shape - the tab owns its border, no mask at all) is recorded separately as a spike, per the fan-out rule.