### PR TITLE
tabs: a hidden tab's surface learns it is hidden

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -706,6 +706,7 @@ pub fn init(
             // The renderer arms its wait on `self.renderer_thread.wakeup`,
             // so only that instance may be notified.
             .renderer_wakeup = &self.renderer_thread.wakeup,
+            .renderer_visible = &self.renderer_thread.visible_flag,
             .renderer_mailbox = self.renderer_thread.mailbox,
             .surface_mailbox = .{ .surface = self, .app = app_mailbox },
         });

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -104,6 +104,13 @@ flags: packed struct {
     focused: bool = true,
 } = .{},
 
+/// Visibility as other threads may read it. `flags.visible` is owned by
+/// this thread; the atomic is the same fact published lock-free so the
+/// termio side can skip waking us for output nobody can see. The
+/// `.visible=true` transition rebuilds from terminal state, so dropped
+/// wakes cost nothing but the invisible frames.
+visible_flag: std.atomic.Value(bool) = .init(true),
+
 pub const DerivedConfig = struct {
     scrollback_compression: bool,
 
@@ -315,6 +322,12 @@ fn drainMailbox(self: *Thread) !void {
 
                 // Set our visible state
                 self.flags.visible = v;
+
+                // Publish for other threads: termio drops its
+                // output-driven redraw wakes while hidden (a wake with
+                // nothing to draw costs more than the frames it would
+                // have carried), so they need a lock-free read of this.
+                self.visible_flag.store(v, .release);
 
                 // Visibility affects our QoS class
                 self.setQosClass();

--- a/src/termio/Options.zig
+++ b/src/termio/Options.zig
@@ -1,5 +1,6 @@
 //! The options that are used to configure a terminal IO implementation.
 
+const std = @import("std");
 const xev = @import("../global.zig").xev;
 const apprt = @import("../apprt.zig");
 const renderer = @import("../renderer.zig");
@@ -37,6 +38,13 @@ renderer_state: *renderer.State,
 /// Some xev backends (IOCP) store the wait registration in the struct
 /// itself, so notifying a copy does nothing.
 renderer_wakeup: *xev.Async,
+
+/// The renderer's published visibility, if known. When set and the
+/// renderer is NOT visible, output-driven redraw wakes are dropped: the
+/// wake is the whole cost of an invisible frame, and the visibility
+/// transition rebuilds from terminal state regardless. Optional because
+/// embedders and tests that never hide a surface have no flag to share.
+renderer_visible: ?*const std.atomic.Value(bool) = null,
 
 /// The mailbox for renderer messages.
 renderer_mailbox: *renderer.Thread.Mailbox,

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -49,6 +49,10 @@ renderer_state: *renderer.State,
 /// a repaint should happen. See termio.Options for why this is a pointer.
 renderer_wakeup: *xev.Async,
 
+/// The renderer's published visibility, if the embedder shared it. See
+/// termio.Options for the semantics; null means never drop a wake.
+renderer_visible: ?*const std.atomic.Value(bool),
+
 /// The mailbox for notifying the renderer of things.
 renderer_mailbox: *renderer.Thread.Mailbox,
 
@@ -322,6 +326,7 @@ pub fn init(self: *Termio, alloc: Allocator, opts: termio.Options) !void {
         .surface_mailbox = opts.surface_mailbox,
         .renderer_state = opts.renderer_state,
         .renderer_wakeup = opts.renderer_wakeup,
+        .renderer_visible = opts.renderer_visible,
         .renderer_mailbox = opts.renderer_mailbox,
         .size = &self.size,
         .terminal = &self.terminal,
@@ -342,6 +347,7 @@ pub fn init(self: *Termio, alloc: Allocator, opts: termio.Options) !void {
         .config = opts.config,
         .renderer_state = opts.renderer_state,
         .renderer_wakeup = opts.renderer_wakeup,
+        .renderer_visible = opts.renderer_visible,
         .renderer_mailbox = opts.renderer_mailbox,
         .surface_mailbox = opts.surface_mailbox,
         .size = opts.size,

--- a/src/termio/Thread.zig
+++ b/src/termio/Thread.zig
@@ -369,8 +369,13 @@ fn drainMailbox(
     }
 
     // Trigger a redraw after we've drained so we don't waste cyces
-    // messaging a redraw.
+    // messaging a redraw. Dropped while the renderer is hidden: output
+    // nobody can see is not worth a thread wake, and the visibility
+    // transition rebuilds from terminal state regardless.
     if (redraw) {
+        if (io.renderer_visible) |v| {
+            if (!v.load(.acquire)) return;
+        }
         try io.renderer_wakeup.notify();
     }
 }

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -50,6 +50,10 @@ pub const StreamHandler = struct {
     /// a repaint should happen. See termio.Options for why this is a pointer.
     renderer_wakeup: *xev.Async,
 
+    /// The renderer's published visibility. Output-driven wakes are
+    /// dropped while it reads false; see termio.Options.
+    renderer_visible: ?*const std.atomic.Value(bool),
+
     /// The response to use for ENQ requests. The memory is owned by
     /// whoever owns StreamHandler.
     enquiry_response: []const u8,
@@ -146,6 +150,12 @@ pub const StreamHandler = struct {
     /// isn't guaranteed to happen immediately but it will happen as soon as
     /// practical.
     pub inline fn queueRender(self: *StreamHandler) !void {
+        // Output nobody can see is not worth a thread wake: while the
+        // renderer is hidden this is the entire cost of the frame, and
+        // the visibility transition rebuilds from terminal state.
+        if (self.renderer_visible) |v| {
+            if (!v.load(.acquire)) return;
+        }
         try self.renderer_wakeup.notify();
     }
 

--- a/windows/Ghostty.Tests/Wiring/SurfaceOcclusionWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/SurfaceOcclusionWiringTests.cs
@@ -1,0 +1,84 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// The occlusion wiring's polarity is the whole feature: the native
+/// parameter means VISIBILITY (the C entry point spells it "occlusion"
+/// but embedded.zig names it `visible`), so every hand-off has to keep
+/// the sense straight or hiding a tab renders it and showing one parks
+/// it. These pins walk the three hops -- the wrapper's byte mapping, the
+/// PaneHost guard, and SwapActivePane's argument -- because each is one
+/// edit away from inverting silently.
+/// </summary>
+public class SurfaceOcclusionWiringTests
+{
+    private static ShellSource Window() => ShellSource.Load("Ghostty.MainWindow.xaml.cs");
+    private static ShellSource PaneHost() => ShellSource.Load("Panes.PaneHost.cs");
+    private static ShellSource Native() => ShellSource.Load("Interop.Imports.NativeMethods.cs");
+
+    [Fact]
+    public void SwapActivePane_OccludesExactlyTheHiddenHosts()
+    {
+        var swap = Window().Method("SwapActivePane");
+
+        // Receiver included: a call on anything else would match a bare
+        // name and pin the wrong wiring.
+        var calls = swap.DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .Where(i => i.CalleeText() == "host.SetSurfaceVisibility")
+            .ToList();
+        Assert.Single(calls);
+
+        // The ARGUMENT is the polarity: isActive, not !isActive. A guard
+        // that only checks the call exists would pass an inverted hand-off
+        // that renders hidden tabs and parks the visible one.
+        Assert.Equal("isActive", calls[0].ArgumentList.Arguments[0].ToString());
+    }
+
+    [Fact]
+    public void PaneHost_GuardsZeroHandles_AndPassesTheFlagThrough()
+    {
+        var method = PaneHost().Method("SetSurfaceVisibility");
+        var body = method.Body!;
+
+        // The zero-handle guard must precede the native call: surfaces
+        // read IntPtr.Zero before TerminalControl loads and after it is
+        // disposed, and the unguarded call AV'd at startup. Both live
+        // inside the leaf loop, so this is a span comparison, not a
+        // top-level statement index.
+        var guard = body.DescendantNodes()
+            .OfType<IfStatementSyntax>()
+            .Where(i => i.Condition.ToString().Contains("IntPtr.Zero"))
+            .ToList();
+        var call = body.DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .Where(i => i.CalleeText() == "Interop.NativeMethods.SurfaceSetVisible")
+            .ToList();
+        Assert.Single(guard);
+        Assert.Single(call);
+        Assert.True(
+            guard[0].SpanStart < call[0].SpanStart,
+            "the zero-handle guard must precede the native call");
+
+        // The parameter flows through unchanged: the method's own `visible`
+        // is what the wrapper receives, not a negation of it.
+        Assert.Equal("visible", call[0].ArgumentList.Arguments[1].ToString());
+    }
+
+    [Fact]
+    public void Wrapper_MapsVisibleTrueToByteOne()
+    {
+        // The byte mapping is where the C API's parameter meets ours: true
+        // must become 1, which embedded.zig reads as visible=true. An
+        // inverted mapping compiles and hides every visible surface.
+        var method = Native().Method("SurfaceSetVisible");
+        Assert.Contains(
+            method.DescendantNodes().OfType<InvocationExpressionSyntax>(),
+            i => i.ToString().Contains("visible ? (byte)1 : (byte)0"));
+    }
+}

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -579,10 +579,19 @@ internal static partial class NativeMethods
 
     [LibraryImport(Dll, EntryPoint = "ghostty_surface_set_occlusion")]
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
-    private static partial void SurfaceSetOcclusionNative(GhosttySurface surface, byte occluded);
+    private static partial void SurfaceSetOcclusionNative(GhosttySurface surface, byte visible);
 
-    internal static void SurfaceSetOcclusion(GhosttySurface surface, bool occluded)
-        => SurfaceSetOcclusionNative(surface, occluded ? (byte)1 : (byte)0);
+    /// <summary>
+    /// Tell libghostty whether this surface's pixels reach the screen. The
+    /// native parameter means VISIBILITY (the C API spells it "occlusion"
+    /// but passes <c>visible</c>); a hidden surface stops presenting and
+    /// frees its GPU atlas copies until the next frame rebuilds them. The
+    /// wrapper is named for what it means rather than what the entry point
+    /// is called, because the old name's inverted reading ("occluded:
+    /// true" = fully visible) was a trap waiting for the first caller.
+    /// </summary>
+    internal static void SurfaceSetVisible(GhosttySurface surface, bool visible)
+        => SurfaceSetOcclusionNative(surface, visible ? (byte)1 : (byte)0);
 
     [LibraryImport(Dll, EntryPoint = "ghostty_surface_size")]
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -2286,9 +2286,16 @@ public sealed partial class MainWindow : Window
         var active = (PaneHost)_tabManager.ActiveTab.PaneHost;
         foreach (UIElement child in PaneHostContainer.Children)
         {
-            child.Visibility = ReferenceEquals(child, active)
-                ? Visibility.Visible
-                : Visibility.Collapsed;
+            if (child is not PaneHost host) continue;
+            var isActive = ReferenceEquals(host, active);
+            host.Visibility = isActive ? Visibility.Visible : Visibility.Collapsed;
+            // XAML collapse hides the pixels but tells libghostty nothing,
+            // so a busy background tab kept rendering full frames nobody
+            // sees. The surface now learns it is hidden: presenting stops
+            // and the GPU atlas copies are released until the tab returns.
+            // The active tab's OTHER leaves (splits, the zoom-parked tree)
+            // stay visible - they are on screen by design.
+            host.SetSurfaceVisibility(isActive);
         }
     }
 

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -850,6 +850,31 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     }
 
     /// <summary>
+    /// Tell libghostty, per leaf, whether this tab's pixels reach the
+    /// screen. A hidden tab stops presenting and releases its GPU atlas
+    /// copies until it is shown again (the renderer rebuilds them lazily
+    /// on the next frame); occlusion is a surface property, so a split tab
+    /// flips every leaf. Keyed on visibility, never on focus: a background
+    /// tab that never gains focus must still come back rendering.
+    /// </summary>
+    internal void SetSurfaceVisibility(bool visible)
+    {
+        foreach (var leaf in PaneTree.Leaves(_root))
+        {
+            var handle = leaf.Terminal().SurfaceHandle;
+            // Zero before the surface exists (the control has not Loaded
+            // yet - SwapActivePane first runs during construction, ahead
+            // of every surface) or after it is disposed; either way the
+            // native call would dereference a null surface. A surface
+            // that does not exist yet renders nothing and will get its
+            // real state from the next swap.
+            if (handle == IntPtr.Zero) continue;
+            Interop.NativeMethods.SurfaceSetVisible(
+                new Interop.GhosttySurface(handle), visible);
+        }
+    }
+
+    /// <summary>
     /// Tear down every leaf's libghostty surface. Called by
     /// <see cref="MainWindow"/> when the window is closing, since
     /// surface lifetime is decoupled from <c>Unloaded</c> events and


### PR DESCRIPTION
XAML collapse hid a tab's pixels but told libghostty nothing, so a busy background tab rendered full DX12 frames nobody sees and held its GPU atlas copies for life. The occlusion primitive already existed in libghostty, unwired, with a wrapper parameter named for the opposite of what it means.

Two commits:
- **C#**: the wrapper is SurfaceSetVisible (polarity documented; the old 'occluded' spelling inverted at first read), PaneHost.SetSurfaceVisibility flips every leaf behind an IntPtr.Zero guard (surfaces read zero before TerminalControl loads - the unguarded version AV'd at startup and was caught by the smoke boot), and SwapActivePane tells each host's surfaces whether they reach the screen. The active tab's splits and zoom-parked tree stay visible by design; keyed on visibility, never focus.
- **Zig**: a hidden busy surface out-spent a visible one (measured 10.8% vs 8.1% of one core) because the renderer wakeup was the only cost left - Present pacing throttled the visible path and nothing throttled the hidden one. The renderer publishes its visibility as an atomic; the two output-driven wake sites drop their notifies while hidden; the mailbox-consumer wakes (including the deadlock-avoidance wake) are deliberately untouched; the .visible=true transition already rebuilds from terminal state.

Measured after: hidden 13.4% vs visible 12.8% - the regression is gone, parity within noise (the unchanged visible arm itself moved 8.1 to 12.8 between sessions, a larger swing than the gap). The remaining benefits are structural: no presents for invisible pixels, GPU atlases released on hide and rebuilt lazily on show. Switch-back liveness proven twice (one per dll generation): a tab hidden ~60s under continuous output renders dense live content on return (pixel stddev 191/51; blank reads under 10).

Review verdict on the pair: all load-bearing claims verified against sources (polarity confirmed from embedded.zig's export signature; memory ordering sound; the un-hide window covered by the occlusion callback's own wake; the ungated deadlock-avoidance wake confirmed ungated). Findings folded: the duplicated store block removed; this wiring guard added. Known follow-up (filed, not fixed here): restored-session background tabs get no initial occlusion until their first swap - rendering waste only, no blank-on-return risk.