### PR TITLE
tabs: idle sessions wear the moon

### DIFF
--- a/windows/Ghostty.Core/Panes/IPaneHost.cs
+++ b/windows/Ghostty.Core/Panes/IPaneHost.cs
@@ -71,6 +71,16 @@ internal interface IPaneHost
     event EventHandler? LayoutChanged;
 
     /// <summary>
+    /// The newest activity stamp across every leaf's surface, in
+    /// <see cref="System.Environment.TickCount64"/> milliseconds (0
+    /// until some leaf has loaded). Read by the idle tracker's sweep --
+    /// a tab is idle when no surface under it has seen a keystroke,
+    /// pointer press, or libghostty state-change callback for the idle
+    /// window.
+    /// </summary>
+    long LastActivityTick { get; }
+
+    /// <summary>
     /// Split the active leaf with the given orientation. The new leaf
     /// becomes the active leaf. <paramref name="snapshot"/> is recorded
     /// on the freshly-created leaf.

--- a/windows/Ghostty.Core/Tabs/TabIdleTracker.cs
+++ b/windows/Ghostty.Core/Tabs/TabIdleTracker.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Threading;
+
+namespace Ghostty.Core.Tabs;
+
+/// <summary>
+/// Marks background tabs idle when a session has received no data and no
+/// user interaction for a minute, so the strip can dim them and show the
+/// sleeping state (the moon). It wakes on either: arriving data or a
+/// touch.
+///
+/// The signal is pull-based: every surface keeps its own
+/// <c>TerminalControl.LastActivityTick</c> stamp (keystrokes, pointer
+/// presses, and each callback libghostty fires for arriving data that
+/// changes observable state -- title, cwd, progress, bell, scrollbar),
+/// the pane host aggregates its leaves into
+/// <see cref="IPaneHost.LastActivityTick"/>, and this tracker's periodic
+/// sweep reads the aggregates. No per-tab event subscriptions means
+/// nothing to unwire when a tab closes: a closed tab simply stops being
+/// in <see cref="TabManager.Tabs"/>.
+///
+/// <see cref="TabModel.IsIdle"/> has exactly one writer in the product --
+/// <see cref="Sweep"/> (plus the eager clear when a tab is activated, in
+/// <see cref="Start"/>'s activation handler). The sweep rules:
+/// the active tab is never idle; a tab with an unacknowledged bell is
+/// never idle (the pane just received something worth attention, and the
+/// bell glyph owns the badge slot); a tab whose newest stamp is older
+/// than the threshold is idle. Activation also stamps BOTH tabs involved
+/// -- visiting a tab is interacting with it, so a tab you just read for
+/// ten seconds does not dim seconds after you leave it.
+/// </summary>
+internal sealed class TabIdleTracker : IDisposable
+{
+    /// <summary>
+    /// How long a background session goes without data or interaction
+    /// before it reads as idle. One minute: long enough that an active
+    /// working session never flickers the state on, short enough that a
+    /// tab parked since morning is visibly asleep.
+    /// </summary>
+    internal static readonly TimeSpan DefaultIdleAfter = TimeSpan.FromMinutes(1);
+
+    // The sweep period bounds how stale IsIdle can be: a state change
+    // that arrives through a stamp (rather than an activation) is
+    // reflected on the next sweep, so at most this far behind.
+    private static readonly TimeSpan SweepPeriod = TimeSpan.FromSeconds(30);
+
+    private readonly TabManager _manager;
+    private readonly double _idleAfterMs;
+    private readonly Func<long> _clock;
+    private readonly Action<Action> _marshal;
+    private readonly TimeProvider _time;
+    private readonly object _gate = new();
+    private ITimer? _timer;
+    private TabModel? _lastActive;
+    private bool _disposed;
+
+    /// <param name="manager">The window's tab manager. One tracker per
+    /// manager; the tracker shares the manager's lifetime.</param>
+    /// <param name="marshal">How the sweep reaches the thread that owns
+    /// the models (the UI thread). The timer fires on a threadpool
+    /// thread and the sweep writes INPC properties.</param>
+    /// <param name="idleAfter">Override of <see cref="DefaultIdleAfter"/>,
+    /// for tests.</param>
+    /// <param name="clock">Activity-clock source in
+    /// <see cref="Environment.TickCount64"/> milliseconds, for tests.
+    /// Stamps and reads must share one domain; only differences are
+    /// used, so any monotonic base works.</param>
+    /// <param name="time">Timer provider, for tests.</param>
+    public TabIdleTracker(
+        TabManager manager,
+        Action<Action> marshal,
+        TimeSpan? idleAfter = null,
+        Func<long>? clock = null,
+        TimeProvider? time = null)
+    {
+        _manager = manager;
+        _idleAfterMs = (idleAfter ?? DefaultIdleAfter).TotalMilliseconds;
+        _clock = clock ?? DefaultClock;
+        _marshal = marshal;
+        _time = time ?? TimeProvider.System;
+    }
+
+    private static long DefaultClock() => Environment.TickCount64;
+
+    /// <summary>
+    /// Arm the shared sweep and start tracking activations. Idempotent.
+    /// </summary>
+    public void Start()
+    {
+        lock (_gate)
+        {
+            if (_timer is not null || _disposed) return;
+            _lastActive = _manager.ActiveTab;
+            _manager.ActiveTabChanged += OnActiveTabChanged;
+            _timer = _time.CreateTimer(
+                _ => _marshal(Sweep),
+                null,
+                SweepPeriod,
+                SweepPeriod);
+        }
+        // First pass now, so a window restored onto long-untouched tabs
+        // shows them asleep as soon as it draws rather than after the
+        // first period elapses.
+        _marshal(Sweep);
+    }
+
+    private void OnActiveTabChanged(object? sender, TabModel tab)
+    {
+        // Switching to a tab is the user touching it, and leaving one is
+        // the moment its idle clock should start: stamp both, then clear
+        // the eager way so the moon lifts on activation, not on the next
+        // sweep.
+        if (_lastActive is { } previous) previous.LastActivityTick = _clock();
+        tab.LastActivityTick = _clock();
+        tab.IsIdle = false;
+        _lastActive = tab;
+    }
+
+    /// <summary>
+    /// Recompute <see cref="TabModel.IsIdle"/> for every tab from the
+    /// current stamps. Public entry for the timer via the marshal;
+    /// called directly by tests.
+    /// </summary>
+    internal void Sweep()
+    {
+        if (_disposed) return;
+        var now = _clock();
+        var active = _manager.ActiveTab;
+        foreach (var tab in _manager.Tabs)
+        {
+            // 0 means "no stamp yet" (a leaf that has not loaded, or a
+            // restored tab whose replay has not produced its first
+            // signal): treat as fresh rather than ancient, so nothing
+            // is born asleep.
+            var last = Math.Max(tab.LastActivityTick, tab.PaneHost.LastActivityTick);
+            tab.IsIdle = last != 0
+                && !ReferenceEquals(tab, active)
+                && !tab.BellRinging
+                && now - last >= _idleAfterMs;
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            if (_disposed) return;
+            _disposed = true;
+            _timer?.Dispose();
+            _timer = null;
+            _manager.ActiveTabChanged -= OnActiveTabChanged;
+        }
+    }
+}

--- a/windows/Ghostty.Core/Tabs/TabModel.cs
+++ b/windows/Ghostty.Core/Tabs/TabModel.cs
@@ -159,6 +159,32 @@ internal sealed class TabModel : INotifyPropertyChanged
     }
 
     /// <summary>
+    /// True when nothing has touched this tab for the idle window (see
+    /// <see cref="TabIdleTracker"/>): the strip dims the row and shows a
+    /// moon glyph. Written by the tracker's sweep (and its eager clear on
+    /// activation) -- one writer, so the value is always the computed
+    /// truth, never a stale toggle. Never true for the active tab or a
+    /// tab with an unacknowledged bell. In-memory only.
+    /// </summary>
+    public bool IsIdle
+    {
+        get;
+        set { if (field != value) { field = value; Raise(); } }
+    }
+
+    /// <summary>
+    /// Last time anything touched this tab, in
+    /// <see cref="Environment.TickCount64"/> milliseconds: activation
+    /// stamps here on the model itself, while keystrokes and pane output
+    /// land on the surfaces and read back through
+    /// <see cref="IPaneHost.LastActivityTick"/>. Zero until the first
+    /// stamp. Deliberately not INPC -- it is an input to the idle
+    /// tracker's sweep, not a rendered fact; <see cref="IsIdle"/> is the
+    /// rendered fact.
+    /// </summary>
+    internal long LastActivityTick { get; set; }
+
+    /// <summary>
     /// True while the tab sits in the pinned prefix. Set through
     /// <see cref="TabManager.SetPinned"/>, which relocates the tab to the
     /// zone boundary; writing it directly leaves the order to be repaired

--- a/windows/Ghostty.Tests/Tabs/FakePaneHost.cs
+++ b/windows/Ghostty.Tests/Tabs/FakePaneHost.cs
@@ -24,6 +24,12 @@ internal sealed class FakePaneHost : IPaneHost
     public int CloseActiveCalls { get; private set; }
     public int DisposeAllCalls { get; private set; }
 
+    /// <summary>
+    /// Stand-in for the pane tree's aggregated activity stamp; tests set
+    /// it to simulate a surface receiving data or input.
+    /// </summary>
+    public long LastActivityTick { get; set; }
+
     public PaneOrientation? LastSplitOrientation { get; private set; }
     public ProfileSnapshot? LastSplitSnapshot { get; private set; }
     public int SplitCalls { get; private set; }

--- a/windows/Ghostty.Tests/Tabs/TabIdleTrackerTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabIdleTrackerTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using Ghostty.Core.Tabs;
 using Xunit;
 
@@ -35,8 +36,13 @@ public class TabIdleTrackerTests
 
         public void Start(TimeSpan? idleAfter = null)
         {
+            // The timer provider never arms a real timer: tests drive
+            // Sweep() themselves, and a live TimeProvider.System timer
+            // would keep sweeping this rig from a threadpool thread for
+            // the rest of the test-host process.
             _tracker = new TabIdleTracker(
-                Manager, a => a(), idleAfter ?? TimeSpan.FromSeconds(10), () => Now);
+                Manager, a => a(), idleAfter ?? TimeSpan.FromSeconds(10),
+                () => Now, new NoTimerProvider());
             _tracker.Start();
         }
 
@@ -44,11 +50,35 @@ public class TabIdleTrackerTests
         public void Sweep() => _tracker!.Sweep();
     }
 
+    /// <summary>
+    /// A TimeProvider whose CreateTimer hands back a timer that never
+    /// fires and cannot be armed -- the null object for the tracker's
+    /// periodic sweep in tests.
+    /// </summary>
+    private sealed class NoTimerProvider : TimeProvider
+    {
+        private sealed class DeadTimer : ITimer
+        {
+            public void Dispose() { }
+            public ValueTask DisposeAsync() => default;
+            public bool Change(TimeSpan dueTime, TimeSpan period) => false;
+        }
+
+        public override ITimer CreateTimer(
+            TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+            => new DeadTimer();
+    }
+
     [Fact]
     public void TheActiveTabIsNeverIdle()
     {
         var rig = new Rig();
         rig.Start();
+        // Stamp the active tab so the elapsed clause of the sweep rule
+        // passes and the active-exemption clause is the only thing left
+        // standing between the tab and the moon: without this the test
+        // passes vacuously through the zero-stamp fresh rule.
+        rig.Manager.Tabs[0].LastActivityTick = rig.Now;
 
         rig.Now += 60_000;
         rig.Sweep();

--- a/windows/Ghostty.Tests/Tabs/TabIdleTrackerTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabIdleTrackerTests.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using Ghostty.Core.Tabs;
+using Xunit;
+
+namespace Ghostty.Tests.Tabs;
+
+/// <summary>
+/// The idle tracker's contract: a session with no data and no
+/// interaction for the window goes idle; arriving data, interaction,
+/// activation, or an unacknowledged bell keep it awake. Everything runs
+/// on a fake clock so the thresholds are exact, and the marshal is
+/// synchronous so the sweep runs where the test can see it.
+/// </summary>
+public class TabIdleTrackerTests
+{
+    private sealed class Rig
+    {
+        public long Now = 5_000;
+        public readonly List<FakePaneHost> Hosts;
+        public readonly TabManager Manager;
+        private TabIdleTracker? _tracker;
+
+        public Rig()
+        {
+            var hosts = new List<FakePaneHost>();
+            Hosts = hosts;
+            Manager = new TabManager(_ =>
+            {
+                var h = new FakePaneHost();
+                hosts.Add(h);
+                return h;
+            });
+        }
+
+        public void Start(TimeSpan? idleAfter = null)
+        {
+            _tracker = new TabIdleTracker(
+                Manager, a => a(), idleAfter ?? TimeSpan.FromSeconds(10), () => Now);
+            _tracker.Start();
+        }
+
+        /// <summary>The product's own sweep entry point, driven directly.</summary>
+        public void Sweep() => _tracker!.Sweep();
+    }
+
+    [Fact]
+    public void TheActiveTabIsNeverIdle()
+    {
+        var rig = new Rig();
+        rig.Start();
+
+        rig.Now += 60_000;
+        rig.Sweep();
+
+        Assert.False(rig.Manager.Tabs[0].IsIdle);
+    }
+
+    [Fact]
+    public void ABackgroundTabWithoutDataOrInteractionGoesIdle()
+    {
+        var rig = new Rig();
+        rig.Start();
+        rig.Manager.NewTab(); // tab 0 is now background; tab 1 is active
+
+        // Below the threshold: awake.
+        rig.Now += 9_000;
+        rig.Sweep();
+        Assert.False(rig.Manager.Tabs[0].IsIdle);
+
+        // Past it: asleep. The switch to the new tab stamped tab 0, so
+        // the clock starts there -- 10s after the switch, not after
+        // construction.
+        rig.Now += 2_000;
+        rig.Sweep();
+        Assert.True(rig.Manager.Tabs[0].IsIdle);
+        Assert.False(rig.Manager.Tabs[1].IsIdle);
+    }
+
+    [Fact]
+    public void DataOnThePaneWakesAnIdleTab()
+    {
+        var rig = new Rig();
+        rig.Start();
+        rig.Manager.NewTab();
+        rig.Now += 60_000;
+        rig.Sweep();
+        Assert.True(rig.Manager.Tabs[0].IsIdle);
+
+        // The pane received data (scrollback grew, a title arrived...):
+        // the aggregate stamp moves to "now", and the tab wakes without
+        // waiting for the user.
+        rig.Hosts[0].LastActivityTick = rig.Now;
+        rig.Sweep();
+        Assert.False(rig.Manager.Tabs[0].IsIdle);
+
+        // And the clock restarts from that data, not from the old stamp.
+        rig.Now += 9_000;
+        rig.Sweep();
+        Assert.False(rig.Manager.Tabs[0].IsIdle);
+        rig.Now += 2_000;
+        rig.Sweep();
+        Assert.True(rig.Manager.Tabs[0].IsIdle);
+    }
+
+    [Fact]
+    public void AnUnacknowledgedBellSuppressesIdle()
+    {
+        var rig = new Rig();
+        rig.Start();
+        rig.Manager.NewTab();
+        rig.Now += 60_000;
+        rig.Sweep();
+        Assert.True(rig.Manager.Tabs[0].IsIdle);
+
+        rig.Manager.Tabs[0].BellRinging = true;
+        rig.Sweep();
+        Assert.False(rig.Manager.Tabs[0].IsIdle);
+
+        rig.Manager.Tabs[0].BellRinging = false;
+        rig.Sweep();
+        Assert.True(rig.Manager.Tabs[0].IsIdle);
+    }
+
+    [Fact]
+    public void ActivatingAnIdleTabClearsItEagerlyAndStampsBothSides()
+    {
+        var rig = new Rig();
+        rig.Start();
+        rig.Manager.NewTab();
+        rig.Now += 60_000;
+        rig.Sweep();
+        Assert.True(rig.Manager.Tabs[0].IsIdle);
+
+        // Going back to the sleeping tab: the moon lifts immediately,
+        // and the switch itself counts as interaction on BOTH tabs --
+        // the one just left must not dim seconds later.
+        rig.Manager.ActivateIndex(0);
+        Assert.False(rig.Manager.Tabs[0].IsIdle);
+
+        rig.Now += 9_000;
+        rig.Sweep();
+        Assert.False(rig.Manager.Tabs[0].IsIdle);
+        Assert.False(rig.Manager.Tabs[1].IsIdle);
+
+        rig.Now += 2_000;
+        rig.Sweep();
+        Assert.False(rig.Manager.Tabs[0].IsIdle);
+        Assert.True(rig.Manager.Tabs[1].IsIdle);
+    }
+
+    [Fact]
+    public void ATabWithNoStampsYetIsNotBornAsleep()
+    {
+        // Tabs that predate the tracker (a restore seeding the manager)
+        // carry no stamps until their first signal: 0 means "fresh",
+        // not "infinitely old".
+        var rig = new Rig();
+        rig.Manager.NewTab();
+
+        rig.Start();
+        rig.Now += 3_600_000;
+        rig.Sweep();
+        Assert.False(rig.Manager.Tabs[0].IsIdle);
+    }
+
+    [Fact]
+    public void ModelSideStampsCountToo()
+    {
+        var rig = new Rig();
+        rig.Start();
+        rig.Manager.NewTab();
+        rig.Now += 60_000;
+        rig.Sweep();
+        Assert.True(rig.Manager.Tabs[0].IsIdle);
+
+        rig.Manager.Tabs[0].LastActivityTick = rig.Now;
+        rig.Sweep();
+        Assert.False(rig.Manager.Tabs[0].IsIdle);
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/TabIdleWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabIdleWiringTests.cs
@@ -83,6 +83,15 @@ public class TabIdleWiringTests
                             .Any(a => a.ToString() == "nameof(TabModel.IsIdle)"))
             .ToList();
         Assert.Equal(2, bindings.Count);
+
+        // The collapsed rail is icon-only: the row's title, bell, and
+        // moon are laid out past the rail's edge and clipped away, so at
+        // rest the item's icon is the only carrier of the state. Without
+        // this write the resting rail shows nothing for an idle tab.
+        Assert.Contains(
+            Strip().Root.DescendantNodes().OfType<AssignmentExpressionSyntax>(),
+            a => a.Left.ToString() == "icon.Opacity"
+                 && a.Right.ToString() == "tab.IsIdle ? IdleIconOpacity : 1.0");
     }
 
     [Fact]

--- a/windows/Ghostty.Tests/Wiring/TabIdleWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabIdleWiringTests.cs
@@ -1,0 +1,161 @@
+using System.Linq;
+using Ghostty.Core.Tabs;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// The idle indicator's wiring, pinned end to end. The state machine
+/// itself is behaviour-tested against Ghostty.Core
+/// (TabIdleTrackerTests); what these guards own is every hop the state
+/// has to survive to reach pixels: the surface stamps its signal paths,
+/// the pane host aggregates the leaves, both strips listen for the
+/// property, the moon yields to the bell, and the window arms and
+/// disposes the one sweep that writes the state.
+/// </summary>
+public class TabIdleWiringTests
+{
+    private static ShellSource Terminal() => ShellSource.Load("Controls.TerminalControl.xaml.cs");
+    private static ShellSource PaneHost() => ShellSource.Load("Panes.PaneHost.cs");
+    private static ShellSource Interface() => ShellSource.Load("Core.Panes.IPaneHost.cs");
+    private static ShellSource Window() => ShellSource.Load("Ghostty.MainWindow.xaml.cs");
+    private static ShellSource TabHost() => ShellSource.Load("Tabs.TabHost.xaml.cs");
+    private static ShellSource NavRow() => ShellSource.Load("Tabs.VerticalTabNavRow.cs");
+    private static ShellSource PinnedRow() => ShellSource.Load("Tabs.VerticalTabPinnedRow.cs");
+    private static ShellSource Strip() => ShellSource.Load("Tabs.VerticalTabStrip.xaml.cs");
+    private static ShellSource Seam() => ShellSource.Load("Testing.TestSeam.cs");
+
+    [Theory]
+    [InlineData("OnKeyDown")]
+    [InlineData("OnPointerPressed")]
+    [InlineData("OnPointerWheelChanged")]
+    [InlineData("QueueScrollbarChanged")]
+    [InlineData("RaiseTitleChanged")]
+    [InlineData("RaiseProgressChanged")]
+    [InlineData("RaisePwdChanged")]
+    [InlineData("RaiseBellRang")]
+    public void TheSurfaceStampsEverySignalPath(string method)
+    {
+        // Each of these is a way a session receives data or interaction.
+        // A stamp dropped from any one of them is a tab that dims while
+        // it is visibly working -- the one failure mode users report.
+        Assert.NotEmpty(Terminal().Method(method).Calls("NoteActivity"));
+    }
+
+    [Fact]
+    public void ThePaneHostAggregatesTheLiveTree()
+    {
+        var property = PaneHost().Root.DescendantNodes()
+            .OfType<PropertyDeclarationSyntax>()
+            .Single(p => p.Identifier.ValueText == "LastActivityTick");
+
+        // The getter walks the tree rather than reading a cached field:
+        // a cache would go stale the day a leaf splits off or closes,
+        // and the sweep would keep reading the dead leaf's stamp.
+        Assert.Contains(
+            property.DescendantNodes().OfType<InvocationExpressionSyntax>(),
+            i => i.CalleeText() == "PaneTree.Leaves");
+        // And it refuses to walk a collapsed tree, the same teardown
+        // rule the other tree walks in this class follow.
+        Assert.Contains("_allLeavesClosed", property.ToString());
+
+        // The hop the sweep actually takes: the interface member the
+        // tracker reads through TabModel.PaneHost.
+        Assert.Contains(
+            Interface().Root.DescendantNodes().OfType<PropertyDeclarationSyntax>(),
+            p => p.Identifier.ValueText == "LastActivityTick");
+    }
+
+    [Fact]
+    public void BothVerticalRowKindsListenForTheProperty()
+    {
+        // The vertical rows refresh through AotBinding property lists,
+        // not the horizontal strip's PropertyChanged chain. A missing
+        // property name here compiles green and the row simply never
+        // hears the state change -- the classic blind wiring guard.
+        var bindings = Strip().Root.DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .Where(i => i.CalleeText() == "AotBinding.Create"
+                        && i.ArgumentList.Arguments
+                            .Any(a => a.ToString() == "nameof(TabModel.IsIdle)"))
+            .ToList();
+        Assert.Equal(2, bindings.Count);
+    }
+
+    [Fact]
+    public void TheHorizontalStripHasAnIsIdleArm()
+    {
+        var arm = TabHost().Method("AddItem").DescendantNodes()
+            .OfType<IfStatementSyntax>()
+            .Where(i => i.Condition.ToString().Contains("nameof(TabModel.IsIdle)"))
+            .ToList();
+        Assert.Single(arm);
+        // The arm does both halves of the visual: the moon and the dim.
+        var text = arm[0].ToString();
+        Assert.Contains("idleGlyph.Visibility", text);
+        Assert.Contains("ApplyIdleInk", text);
+    }
+
+    [Fact]
+    public void TheMoonYieldsToTheBellEverywhere()
+    {
+        // All three badge sites derive visibility from the same shape:
+        // idle AND NOT ringing. Inverted polarity compiles and shows
+        // both badges at once, or neither, so the expression itself is
+        // pinned as parsed, not as a substring.
+        foreach (var source in new[] { TabHost(), NavRow(), PinnedRow() })
+        {
+            var shaped = source.Root.DescendantNodes()
+                .OfType<BinaryExpressionSyntax>()
+                .Where(b => b.IsKind(SyntaxKind.LogicalAndExpression)
+                            && b.Left.ToString() == "tab.IsIdle"
+                            && b.Right.IsKind(SyntaxKind.LogicalNotExpression)
+                            && b.Right.ToString() == "!tab.BellRinging")
+                .ToList();
+            Assert.NotEmpty(shaped);
+        }
+    }
+
+    [Fact]
+    public void TheInkClearPassRestoresTheMoonsQuietInk()
+    {
+        // The moon is born muted; the tab-colour clear pass would strand
+        // it primary-coloured for life without its own case, exactly the
+        // way the bell needed its accent restored.
+        TabHost().Case("ClearHeaderRowForeground", "IdleGlyph");
+    }
+
+    [Fact]
+    public void TheWindowArmsAndDisposesTheSweep()
+    {
+        var window = Window();
+        Assert.Single(window.Root.DescendantNodes()
+            .OfType<ObjectCreationExpressionSyntax>()
+            .Where(o => o.Type.ToString() == "TabIdleTracker"));
+        Assert.Contains(window.Root.DescendantNodes()
+            .OfType<InvocationExpressionSyntax>(),
+            i => i.CalleeText() == "_idleTracker.Start");
+        Assert.Contains(window.Root.DescendantNodes()
+            .OfType<InvocationExpressionSyntax>(),
+            i => i.CalleeText() == "_idleTracker.Dispose");
+    }
+
+    [Fact]
+    public void TheSeamDrivesAndReportsTheProperty()
+    {
+        var seam = Seam();
+        var op = seam.Root.DescendantNodes()
+            .OfType<SwitchSectionSyntax>()
+            .Where(s => s.Labels.ToString().Contains("\"tab-idle\""))
+            .ToList();
+        Assert.Single(op);
+        Assert.Contains(op[0].DescendantNodes().OfType<AssignmentExpressionSyntax>(),
+            a => a.Left.ToString() == "tab.IsIdle");
+        // The state dump answers with the value it read, so a scenario
+        // can assert the round trip, not just the lack of an error.
+        Assert.Contains("WriteBoolean(\"idle\"", seam.Root.ToString());
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/TabIdleWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabIdleWiringTests.cs
@@ -59,8 +59,12 @@ public class TabIdleWiringTests
             property.DescendantNodes().OfType<InvocationExpressionSyntax>(),
             i => i.CalleeText() == "PaneTree.Leaves");
         // And it refuses to walk a collapsed tree, the same teardown
-        // rule the other tree walks in this class follow.
-        Assert.Contains("_allLeavesClosed", property.ToString());
+        // rule the other tree walks in this class follow. The condition
+        // is pinned exactly, as parsed: a negated guard or a comment
+        // that merely mentions the flag would satisfy a substring.
+        Assert.Contains(
+            property.DescendantNodes().OfType<IfStatementSyntax>(),
+            i => i.Condition.ToString() == "_allLeavesClosed");
 
         // The hop the sweep actually takes: the interface member the
         // tracker reads through TabModel.PaneHost.

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Ghostty.Core;
 using Ghostty.Core.Input;
@@ -416,9 +417,23 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     /// </summary>
     public string? CurrentTitle => _userTitleOverride ?? _shellTitle;
 
+    // Latest activity on this surface, in Environment.TickCount64
+    // milliseconds -- keystrokes, pointer presses, and every callback
+    // libghostty fires for a real state change (title, cwd, progress,
+    // bell, scrollbar). Written from both the UI thread and the
+    // libghostty thread, so a plain volatile long; read by the idle
+    // tracker's sweep through PaneHost.LastActivityTick.
+    private long _lastActivityTick;
+    internal long LastActivityTick => Volatile.Read(ref _lastActivityTick);
+    private void NoteActivity() => Volatile.Write(ref _lastActivityTick, Environment.TickCount64);
+
     // Raisers invoked by GhosttyHost after routing an action to this leaf.
     internal void RaiseTitleChanged(string title)
     {
+        // A shell pushing a title is the pane doing something: stamp
+        // before anything else so the idle clock sees this even if a
+        // subscriber below throws.
+        NoteActivity();
         _shellTitle = title;
         TitleChanged?.Invoke(this, CurrentTitle ?? string.Empty);
     }
@@ -435,6 +450,8 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     internal void RaiseCloseRequested() => CloseRequested?.Invoke(this, EventArgs.Empty);
     internal void RaiseProgressChanged(Ghostty.Core.Tabs.TabProgressState state)
     {
+        // OSC 9;4 is pane output; same idle-stamp contract as the title.
+        NoteActivity();
         CurrentProgress = state;
         ProgressChanged?.Invoke(this, state);
     }
@@ -448,7 +465,12 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     /// else with it.
     /// </summary>
     internal event EventHandler<string?>? PwdChanged;
-    internal void RaisePwdChanged(string? pwd) => PwdChanged?.Invoke(this, pwd);
+    internal void RaisePwdChanged(string? pwd)
+    {
+        // OSC 7 / 9;9 is pane output; same idle-stamp contract as the title.
+        NoteActivity();
+        PwdChanged?.Invoke(this, pwd);
+    }
 
     /// <summary>
     /// Hand <paramref name="text"/> to this surface the way committed IME
@@ -494,6 +516,11 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     /// </summary>
     internal void RaiseBellRang(Ghostty.Core.Bell.BellFeatures features)
     {
+        // A bell is the pane demanding attention -- the opposite of
+        // asleep. This is the control-level hook, so it fires for
+        // background surfaces too (the tab-level re-emission is
+        // active-leaf only, but the idle clock must see this one).
+        NoteActivity();
         if (features.Border) ShowBellBorder();
         if (features.Title) _bellTitlePending = true;
         BellRang?.Invoke(this, features);
@@ -567,6 +594,12 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     // cached delegate runs once and reads the most recent values.
     internal void QueueScrollbarChanged(ulong total, ulong offset, ulong len)
     {
+        // Scroll state changes when output moves lines through the
+        // viewport, so this doubles as the streaming-output signal the
+        // idle clock reads: a background tab running a build grows its
+        // scrollback and stays awake without a single keystroke. Runs
+        // on the libghostty thread; the stamp is a volatile write.
+        NoteActivity();
         bool needEnqueue;
         lock (_scrollbarLock)
         {
@@ -1488,6 +1521,11 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     {
         if (BubbledFromChild(sender, e)) return;
 
+        // Any press on the surface is the user touching this pane:
+        // selection drags and scroll-to-read both count, so the idle
+        // clock restarts here rather than waiting for a keystroke.
+        NoteActivity();
+
         // Take focus on the UserControl, not the panel. Guard with the
         // current focus state to avoid generating a Lost+Got pair when
         // we already have focus.
@@ -1621,6 +1659,9 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     {
         if (BubbledFromChild(sender, e)) return;
         if (_surface.Handle == IntPtr.Zero) return;
+        // Scrolling to read is touching the pane; same idle-stamp
+        // contract as a pointer press.
+        NoteActivity();
         var pt = e.GetCurrentPoint(Panel);
         var rawDelta = pt.Properties.MouseWheelDelta;
         var isHorizontal = pt.Properties.IsHorizontalMouseWheel;
@@ -1826,8 +1867,10 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         // Stamp the shared host so VerticalTabHost's hover-expand
         // suppression knows the user is mid-typing and holds back
         // the sidebar pop-open. Unconditional: we want every key
-        // (including chords and IME composition keys) to count.
+        // (including chords and IME composition keys) to count. The
+        // same keydown also stamps this surface's idle clock.
         Host?.NoteKeystroke();
+        NoteActivity();
 
         // Any key reaching the surface acknowledges a pending bell, fading
         // the visual border and clearing the tab indicator (matches macOS).

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -99,6 +99,14 @@ public sealed partial class MainWindow : Window
     private readonly TabManager _tabManager;
     private readonly PaneActionRouter _router;
 
+    // Marks background tabs idle (no data, no interaction, for a minute)
+    // so both strips can dim them and show the moon. Constructed once the
+    // manager exists below; disposed in OnClosedAsync. Subscribes only to
+    // the manager's ActiveTabChanged, and both die with this window, so
+    // like _bellAnnouncer it is an internal cycle, not a cross-object
+    // leak.
+    private readonly TabIdleTracker _idleTracker;
+
     /// <summary>This window's tab manager, exposed for session capture.</summary>
     internal TabManager TabManager => _tabManager;
 
@@ -782,6 +790,14 @@ public sealed partial class MainWindow : Window
             getProfiles: () => App.ProfileRegistry?.Profiles ?? EmptyProfiles,
             openProfile: OpenProfile,
             bindingAction: ExecuteBindingAction);
+        // One shared sweep per window writes TabModel.IsIdle; both strips
+        // render from the property. The sweep must run where the models
+        // live (the UI thread), so the timer's fire is marshalled.
+        // (TryEnqueue wants a DispatcherQueueHandler, not an Action, so
+        // the marshal closes over the conversion rather than fighting it.)
+        _idleTracker = new TabIdleTracker(
+            _tabManager, a => DispatcherQueue.TryEnqueue(() => a()));
+        _idleTracker.Start();
         _windowState = WindowState.Load();
         // Apply the restored window geometry when restoring; otherwise use
         // the window-state.json fallback placement.
@@ -2086,6 +2102,7 @@ public sealed partial class MainWindow : Window
         _slideAnimator?.Dispose();
         _taskbar.Dispose();
         _bellAnnouncer.Dispose();
+        _idleTracker.Dispose();
         // _themeManager was disposed at the top of this method, before the
         // first await, so no theme callback can fire mid-teardown (#208).
 

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -880,6 +880,30 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     /// surface lifetime is decoupled from <c>Unloaded</c> events and
     /// the framework's natural teardown does not free them.
     /// </summary>
+    /// <summary>
+    /// The newest activity stamp across every leaf's surface, for the
+    /// idle tracker's sweep. Computed on demand: the trees are tiny and
+    /// the sweep runs every 30 seconds, so a maintained cached value
+    /// would be write traffic for nothing.
+    /// </summary>
+    public long LastActivityTick
+    {
+        get
+        {
+            // Same teardown guard the other tree walks use: after the
+            // last leaf closes, _root still references it and the walk
+            // would read a terminal CloseLeaf has already torn down.
+            if (_allLeavesClosed) return 0;
+            long latest = 0;
+            foreach (var leaf in PaneTree.Leaves(_root))
+            {
+                var tick = leaf.Terminal().LastActivityTick;
+                if (tick > latest) latest = tick;
+            }
+            return latest;
+        }
+    }
+
     public void DisposeAllLeaves()
     {
         // Tear down any in-flight startup glows first so their timers stop

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -875,12 +875,6 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     }
 
     /// <summary>
-    /// Tear down every leaf's libghostty surface. Called by
-    /// <see cref="MainWindow"/> when the window is closing, since
-    /// surface lifetime is decoupled from <c>Unloaded</c> events and
-    /// the framework's natural teardown does not free them.
-    /// </summary>
-    /// <summary>
     /// The newest activity stamp across every leaf's surface, for the
     /// idle tracker's sweep. Computed on demand: the trees are tiny and
     /// the sweep runs every 30 seconds, so a maintained cached value
@@ -904,6 +898,12 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         }
     }
 
+    /// <summary>
+    /// Tear down every leaf's libghostty surface. Called by
+    /// <see cref="MainWindow"/> when the window is closing, since
+    /// surface lifetime is decoupled from <c>Unloaded</c> events and
+    /// the framework's natural teardown does not free them.
+    /// </summary>
     public void DisposeAllLeaves()
     {
         // Tear down any in-flight startup glows first so their timers stop

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -58,6 +58,14 @@ internal sealed partial class TabHost : UserControl, ITabHost
     // tell the bell from the pin to know which one goes back to the accent.
     private const string BellGlyph = "\uEA8F";
 
+    // Segoe Fluent / MDL2 "QuietHours" moon, shown while TabModel.IsIdle.
+    // Shared with the ink pass for the same reason as the bell.
+    private const string IdleGlyph = "\uE708";
+
+    // How far an idle tab's icon and title fade. Quiet enough to read as
+    // "resting", strong enough to notice in a scan of the strip.
+    private const double IdleOpacity = 0.45;
+
     // One chip per group the projection renders as collapsed-without-the-
     // active-tab. A chip is a real TabViewItem occupying a strip slot, so
     // every slot count and every slot index now includes chips; the maps
@@ -132,11 +140,25 @@ internal sealed partial class TabHost : UserControl, ITabHost
                 // No "pin" part: the pushpin is gone, and the pinned tab's
                 // mark is its own shape -- which a driver reads as the
                 // "row" part's width, not as a glyph inside it.
+                //
+                // Every part must also be VISIBLE. ActualWidth keeps its
+                // last measured value when an element collapses, so a
+                // glyph-visibility gate is what makes "no rect" mean
+                // "not on screen" rather than "hidden but still holding
+                // stale geometry" -- the rect a pixel harness would
+                // sample for ink that is not there.
                 var match = part switch
                 {
-                    "bell" => child is FontIcon bell && bell.Glyph == BellGlyph,
-                    "icon" => child is TabIconPresenter,
-                    "title" => child is TextBlock,
+                    "bell" => child is FontIcon bell
+                        && bell.Glyph == BellGlyph
+                        && bell.Visibility == Visibility.Visible,
+                    "idle" => child is FontIcon moon
+                        && moon.Glyph == IdleGlyph
+                        && moon.Visibility == Visibility.Visible,
+                    "icon" => child is TabIconPresenter icon
+                        && icon.Visibility == Visibility.Visible,
+                    "title" => child is TextBlock title
+                        && title.Visibility == Visibility.Visible,
                     _ => false,
                 };
                 if (match) { target = child as FrameworkElement; break; }
@@ -341,6 +363,28 @@ internal sealed partial class TabHost : UserControl, ITabHost
         };
         iconRow.Children.Add(bellGlyph);
 
+        // Idle indicator: the moon after the bell slot while the tab has
+        // been untouched (TabIdleTracker). Muted, not accent -- idle is a
+        // rest state, not an alert. The bell owns the badge: a ringing tab
+        // is never idle, and the property handler below keeps the moon
+        // hidden while a bell is up even if IsIdle has not caught up.
+        var idleGlyph = new FontIcon
+        {
+            Glyph = IdleGlyph,
+            FontFamily = (Microsoft.UI.Xaml.Media.FontFamily)
+                Application.Current.Resources["SymbolThemeFontFamily"],
+            FontSize = 12,
+            Margin = new Thickness(6, 0, 0, 0),
+            VerticalAlignment = VerticalAlignment.Center,
+            Foreground = IdleGlyphBrush(),
+            Visibility = IdleBadgeVisible(tab) ? Visibility.Visible : Visibility.Collapsed,
+        };
+        iconRow.Children.Add(idleGlyph);
+        // The dim rides the row's own elements rather than the whole
+        // TabViewItem: the close button and the hover chrome stay
+        // full-strength so an idle tab still reads as fully operable.
+        ApplyIdleInk(iconHost, headerText, tab);
+
         // The group rail: a 2px line in the group's color in the header's
         // TOP slot. The progress bar owns the bottom slot; the two
         // never fight. Collapsed until a chrome pass finds a group to
@@ -421,7 +465,19 @@ internal sealed partial class TabHost : UserControl, ITabHost
                 bellGlyph.Visibility = tab.BellRinging
                     ? Visibility.Visible
                     : Visibility.Collapsed;
+                // The bell and the moon share the badge slot; whichever
+                // way the bell moves, the moon re-derives behind it.
+                idleGlyph.Visibility = IdleBadgeVisible(tab)
+                    ? Visibility.Visible
+                    : Visibility.Collapsed;
                 ApplyItemAccessibleText(item, tab);
+            }
+            else if (e.PropertyName == nameof(TabModel.IsIdle))
+            {
+                idleGlyph.Visibility = IdleBadgeVisible(tab)
+                    ? Visibility.Visible
+                    : Visibility.Collapsed;
+                ApplyIdleInk(iconHost, headerText, tab);
             }
             else if (e.PropertyName == nameof(TabModel.IsPinned))
             {
@@ -2131,6 +2187,11 @@ internal sealed partial class TabHost : UserControl, ITabHost
                 case FontIcon bell when bell.Glyph == BellGlyph:
                     bell.Foreground = BellAccentBrush();
                     break;
+                // The idle moon is born muted for the same reason: the
+                // clear pass must put its quiet ink back, not primary.
+                case FontIcon idle when idle.Glyph == IdleGlyph:
+                    idle.Foreground = IdleGlyphBrush();
+                    break;
                 case FontIcon fi:
                     fi.ClearValue(FontIcon.ForegroundProperty);
                     break;
@@ -2153,6 +2214,41 @@ internal sealed partial class TabHost : UserControl, ITabHost
             && c is Windows.UI.Color color)
             return new SolidColorBrush(color);
         return new SolidColorBrush(Microsoft.UI.Colors.OrangeRed);
+    }
+
+    /// <summary>
+    /// Muted brush for the idle moon. Secondary text colour, not the
+    /// accent: sleeping is a rest state, not something demanding a look.
+    /// Resolved against live resources each call so it tracks theme
+    /// changes, same contract as <see cref="BellAccentBrush"/>.
+    /// </summary>
+    private static Brush IdleGlyphBrush()
+    {
+        if (Application.Current.Resources.TryGetValue(
+                "TextFillColorSecondaryBrush", out var b) && b is Brush brush)
+            return brush;
+        return new SolidColorBrush(Microsoft.UI.Colors.Gray);
+    }
+
+    /// <summary>
+    /// Whether the moon is shown for this tab right now. The bell owns
+    /// the badge: while one is up the moon stays hidden even if IsIdle
+    /// has not been recomputed yet, so the slot never shows both.
+    /// </summary>
+    private static bool IdleBadgeVisible(TabModel tab)
+        => tab.IsIdle && !tab.BellRinging;
+
+    /// <summary>
+    /// The idle dim: icon and title fade to <see cref="IdleOpacity"/>.
+    /// Shared by the build pass and the IsIdle property arm so a tab
+    /// created already-idle (a restore landing past the threshold)
+    /// starts dimmed instead of flashing bright first.
+    /// </summary>
+    private static void ApplyIdleInk(TabIconPresenter icon, TextBlock title, TabModel tab)
+    {
+        var opacity = tab.IsIdle ? IdleOpacity : 1.0;
+        icon.Opacity = opacity;
+        title.Opacity = opacity;
     }
 
     /// <summary>

--- a/windows/Ghostty/Tabs/VerticalTabNavRow.cs
+++ b/windows/Ghostty/Tabs/VerticalTabNavRow.cs
@@ -7,12 +7,19 @@ namespace Ghostty.Tabs;
 
 /// <summary>
 /// Expanded-pane row content for a vertical-tab
-/// <see cref="NavigationViewItem"/>: title, optional bell, close.
+/// <see cref="NavigationViewItem"/>: title, optional bell and idle moon,
+/// close.
 /// </summary>
 internal sealed partial class VerticalTabNavRow : Grid
 {
+    // Segoe Fluent / MDL2 "QuietHours" moon. Muted like the horizontal
+    // strip's: sleeping is a rest state, not an alert.
+    private const string IdleGlyph = "\uE708";
+    private const double IdleOpacity = 0.45;
+
     private readonly TextBlock _title;
     private readonly FontIcon _bell;
+    private readonly FontIcon _idle;
     private readonly Button _close;
     private Border? _coDragAccent;
 
@@ -38,6 +45,20 @@ internal sealed partial class VerticalTabNavRow : Grid
             VerticalAlignment = VerticalAlignment.Center,
             Margin = new Thickness(0, 0, 4, 0),
             Visibility = tab.BellRinging ? Visibility.Visible : Visibility.Collapsed,
+        };
+
+        // The idle moon: shown while the tab has been untouched
+        // (TabIdleTracker), hidden whenever a bell is up -- the bell owns
+        // the badge. Muted, not accent, so a resting row does not read
+        // as alerting.
+        _idle = new FontIcon
+        {
+            Glyph = IdleGlyph,
+            FontSize = 9,
+            Foreground = MutedGlyphBrush(),
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(0, 0, 4, 0),
+            Visibility = IdleBadgeVisible(tab),
         };
 
         _close = new Button
@@ -66,10 +87,21 @@ internal sealed partial class VerticalTabNavRow : Grid
         var textRow = new Grid();
         textRow.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
         textRow.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        // Both badges share the one auto column -- moon first, bell
+        // nearest the edge -- so a row carrying both states (idle with a
+        // bell on it, between the sweep hiding the moon and the property
+        // landing) does not reflow the title.
+        var badges = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        badges.Children.Add(_idle);
+        badges.Children.Add(_bell);
         Grid.SetColumn(_title, 0);
-        Grid.SetColumn(_bell, 1);
+        Grid.SetColumn(badges, 1);
         textRow.Children.Add(_title);
-        textRow.Children.Add(_bell);
+        textRow.Children.Add(badges);
 
         Grid.SetColumn(textRow, 0);
         Grid.SetColumn(_close, 1);
@@ -106,7 +138,34 @@ internal sealed partial class VerticalTabNavRow : Grid
         _title.Text = tab.EffectiveTitle;
         ToolTipService.SetToolTip(_title, tab.EffectiveTitle);
         _bell.Visibility = tab.BellRinging ? Visibility.Visible : Visibility.Collapsed;
+        _idle.Visibility = IdleBadgeVisible(tab);
+        // The idle dim rides the title, not the whole row: close stays
+        // full-strength so an idle tab still reads as closable.
+        _title.Opacity = tab.IsIdle ? IdleOpacity : 1.0;
         _close.Tag = tab;
+    }
+
+    /// <summary>
+    /// Whether the moon shows right now: idle, and no bell up (the bell
+    /// owns the badge, and a ringing tab is never idle anyway -- this
+    /// also covers the window where IsIdle has not been recomputed
+    /// since the bell landed).
+    /// </summary>
+    private static Visibility IdleBadgeVisible(TabModel tab)
+        => tab.IsIdle && !tab.BellRinging
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+
+    /// <summary>
+    /// Muted brush for the moon: secondary text colour, resolved against
+    /// live resources so it tracks theme changes.
+    /// </summary>
+    private static Brush MutedGlyphBrush()
+    {
+        if (Application.Current.Resources.TryGetValue(
+                "TextFillColorSecondaryBrush", out var b) && b is Brush brush)
+            return brush;
+        return new SolidColorBrush(Microsoft.UI.Colors.Gray);
     }
 
     /// <summary>

--- a/windows/Ghostty/Tabs/VerticalTabNavRow.cs
+++ b/windows/Ghostty/Tabs/VerticalTabNavRow.cs
@@ -157,8 +157,11 @@ internal sealed partial class VerticalTabNavRow : Grid
             : Visibility.Collapsed;
 
     /// <summary>
-    /// Muted brush for the moon: secondary text colour, resolved against
-    /// live resources so it tracks theme changes.
+    /// Muted brush for the moon: secondary text colour, resolved once at
+    /// row construction. A theme flip after construction leaves the moon
+    /// in the old theme's secondary ink -- the same exposure the bell's
+    /// construction-time accent brush already has in these rows, and the
+    /// row rebuilds that follow a pin or a group change re-resolve it.
     /// </summary>
     private static Brush MutedGlyphBrush()
     {

--- a/windows/Ghostty/Tabs/VerticalTabPinnedRow.cs
+++ b/windows/Ghostty/Tabs/VerticalTabPinnedRow.cs
@@ -228,8 +228,10 @@ internal sealed partial class VerticalTabPinnedRow : Grid
             : Visibility.Collapsed;
 
     /// <summary>
-    /// Muted brush for the moon: secondary text colour, resolved against
-    /// live resources so it tracks theme changes.
+    /// Muted brush for the moon: secondary text colour, resolved once at
+    /// row construction. A theme flip after construction leaves the moon
+    /// in the old theme's secondary ink -- the same exposure the bell's
+    /// construction-time accent brush already has in this square.
     /// </summary>
     private static Brush MutedGlyphBrush()
     {

--- a/windows/Ghostty/Tabs/VerticalTabPinnedRow.cs
+++ b/windows/Ghostty/Tabs/VerticalTabPinnedRow.cs
@@ -36,8 +36,14 @@ internal sealed partial class VerticalTabPinnedRow : Grid
     /// </summary>
     internal const double RowHeight = TabPinBand.ChipSize;
 
+    // Segoe Fluent / MDL2 "QuietHours" moon and the idle dim, matching
+    // the body row's pair.
+    private const string IdleGlyph = "\uE708";
+    private const double IdleOpacity = 0.45;
+
     private readonly Grid _iconSlot;
     private readonly FontIcon _bell;
+    private readonly FontIcon _idle;
     private IconElement? _icon;
     private TextBlock? _iconFallback;
 
@@ -89,6 +95,21 @@ internal sealed partial class VerticalTabPinnedRow : Grid
             Visibility = tab.BellRinging ? Visibility.Visible : Visibility.Collapsed,
         };
         _iconSlot.Children.Add(_bell);
+
+        // The idle moon over the icon's opposite corner: the square
+        // reads as "this icon is asleep" without spending width it does
+        // not have, the same trick the bell plays on its corner. The two
+        // never show together -- a ringing session is not idle.
+        _idle = new FontIcon
+        {
+            Glyph = IdleGlyph,
+            FontSize = 9,
+            Foreground = MutedGlyphBrush(),
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Bottom,
+            Visibility = IdleBadgeVisible(tab),
+        };
+        _iconSlot.Children.Add(_idle);
 
         Refresh(tab);
     }
@@ -189,5 +210,32 @@ internal sealed partial class VerticalTabPinnedRow : Grid
         if (_iconFallback is not null)
             _iconFallback.Text = InitialOf(TabAccessibleText.Name(tab));
         _bell.Visibility = tab.BellRinging ? Visibility.Visible : Visibility.Collapsed;
+        _idle.Visibility = IdleBadgeVisible(tab);
+        // The whole slot dims -- icon and whatever badge is not showing
+        // -- which is the square's only way to whisper "asleep": it has
+        // no title to fade. The bell stays undimmed by never coexisting
+        // with the idle state.
+        _iconSlot.Opacity = tab.IsIdle ? IdleOpacity : 1.0;
+    }
+
+    /// <summary>
+    /// Whether the moon shows right now: idle, and no bell up (the bell
+    /// owns the badge; a ringing session is not idle).
+    /// </summary>
+    private static Visibility IdleBadgeVisible(TabModel tab)
+        => tab.IsIdle && !tab.BellRinging
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+
+    /// <summary>
+    /// Muted brush for the moon: secondary text colour, resolved against
+    /// live resources so it tracks theme changes.
+    /// </summary>
+    private static Brush MutedGlyphBrush()
+    {
+        if (Application.Current.Resources.TryGetValue(
+                "TextFillColorSecondaryBrush", out var b) && b is Brush brush)
+            return brush;
+        return new SolidColorBrush(Microsoft.UI.Colors.Gray);
     }
 }

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -32,6 +32,10 @@ internal sealed partial class VerticalTabStrip : UserControl
 {
     private const double RowInsetLeft = 4;
     private const double RowInsetVertical = 2;
+
+    // The idle dim on the collapsed rail's icons; matches the rows'
+    // title dim so one state reads at one strength everywhere.
+    private const double IdleIconOpacity = 0.45;
     // Where a row's trailing glyph stops. The selected row's fill runs to
     // the pane edge, so this reads as padding inside the fill rather than
     // as a second inset.
@@ -2004,6 +2008,14 @@ internal sealed partial class VerticalTabStrip : UserControl
             if (!_items.TryGetValue(tab, out var navItem)) return;
             if (navItem.Content is VerticalTabNavRow navRow)
                 navRow.Refresh(tab);
+            // The collapsed rail is icon-only: the row's content (title,
+            // bell, moon) is laid out past the rail's right edge and
+            // clipped away, so at rest the item's icon is the ONLY thing
+            // carrying this tab's state. The icon itself dims; the
+            // expanded row fades its own title in Refresh. Same 0.45 as
+            // the rows, one number read across all three shapes.
+            if (navItem.Icon is { } icon)
+                icon.Opacity = tab.IsIdle ? IdleIconOpacity : 1.0;
             ApplyItemTitleChrome(navItem, tab);
         },
         nameof(TabModel.EffectiveTitle),

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -1992,12 +1992,13 @@ internal sealed partial class VerticalTabStrip : UserControl
         };
         ApplyItemTitleChrome(item, tab);
 
-        // Title and bell are cheap to reapply, so they share one binding.
-        // Color is separate because it triggers a whole-strip recolor, and
-        // the icon is separate because its spec lives on TabIconViewModel
-        // and changes when the foreground process changes. Folding all
-        // three together would re-decode the icon bitmap and recolor every
-        // row on every OSC 0/2 title the shell emits.
+        // Title, bell, and idle are cheap to reapply, so they share one
+        // binding. Color is separate because it triggers a whole-strip
+        // recolor, and the icon is separate because its spec lives on
+        // TabIconViewModel and changes when the foreground process
+        // changes. Folding them all together would re-decode the icon
+        // bitmap and recolor every row on every OSC 0/2 title the shell
+        // emits.
         var textBinding = AotBinding.Create(tab, _ =>
         {
             if (!_items.TryGetValue(tab, out var navItem)) return;
@@ -2008,7 +2009,8 @@ internal sealed partial class VerticalTabStrip : UserControl
         nameof(TabModel.EffectiveTitle),
         nameof(TabModel.ShellReportedTitle),
         nameof(TabModel.UserOverrideTitle),
-        nameof(TabModel.BellRinging));
+        nameof(TabModel.BellRinging),
+        nameof(TabModel.IsIdle));
 
         var colorBinding = AotBinding.Create(tab, _ => RefreshTabColors(),
             nameof(TabModel.Color));
@@ -2057,10 +2059,10 @@ internal sealed partial class VerticalTabStrip : UserControl
         row.SetIcon(TabIconElementFactory.Create(tab.TabIcon));
 
         // The same three subscriptions a body row takes, pointed at the
-        // pinned row instead: title and bell feed the tooltip and the a11y
-        // chrome, color re-inks the whole strip, and the icon rebuilds when
-        // the foreground process changes. (AddBodyRow carries the long
-        // version of the split rationale.)
+        // pinned row instead: title, bell, and idle feed the tooltip and
+        // the badges, color re-inks the whole strip, and the icon rebuilds
+        // when the foreground process changes. (AddBodyRow carries the
+        // long version of the split rationale.)
         var textBinding = AotBinding.Create(tab, _ =>
         {
             if (_pinnedRows.TryGetValue(tab, out var pinnedRow))
@@ -2069,7 +2071,8 @@ internal sealed partial class VerticalTabStrip : UserControl
         nameof(TabModel.EffectiveTitle),
         nameof(TabModel.ShellReportedTitle),
         nameof(TabModel.UserOverrideTitle),
-        nameof(TabModel.BellRinging));
+        nameof(TabModel.BellRinging),
+        nameof(TabModel.IsIdle));
 
         var colorBinding = AotBinding.Create(tab, _ => RefreshTabColors(),
             nameof(TabModel.Color));

--- a/windows/Ghostty/Testing/TestSeam.cs
+++ b/windows/Ghostty/Testing/TestSeam.cs
@@ -938,6 +938,22 @@ internal static class TestSeam
                 return OkWithState(window, manager, op);
             }
 
+            case "tab-idle":
+            {
+                var index = ArgInt(args, "index", -1);
+                var tab = TabAt(manager, index);
+                if (tab is null) return Error(op, $"no tab at index {index}");
+                // Writes the property the idle tracker's sweep owns, so a
+                // harness can verify every strip's reaction to the idle
+                // state (moon glyph + dim, both orientations, pinned and
+                // body rows) without waiting out the one-minute
+                // threshold. The next sweep overwrites this with the
+                // computed truth -- the honest race a scenario must
+                // finish inside.
+                tab.IsIdle = ArgBool(args, "idle", true);
+                return OkWithState(window, manager, op);
+            }
+
             case "header-rect":
             {
                 var index = ArgInt(args, "index", -1);
@@ -1266,6 +1282,7 @@ internal static class TestSeam
             json.WriteNumber("index", i);
             json.WriteString("title", tab.EffectiveTitle);
             json.WriteBoolean("pinned", tab.IsPinned);
+            json.WriteBoolean("idle", tab.IsIdle);
             // Per-tab pane memory: the leaf each tab would come back to.
             if (tab.PaneHost is Ghostty.Panes.PaneHost host)
             {

--- a/windows/scripts/idle-badge-check.ps1
+++ b/windows/scripts/idle-badge-check.ps1
@@ -1,0 +1,230 @@
+#requires -Version 7
+<#
+    The idle badge, checked against the running app.
+
+    TabIdleTrackerTests prove the state machine and TabIdleWiringTests
+    pin the hops, but "the moon is painted and the row is dim" is a
+    claim about pixels, and pixels are only observable on a live window.
+    The `tab-idle` seam op writes the property the sweep owns, so this
+    harness drives the exact INPC chain the product's one-minute sweep
+    drives -- without waiting a minute per leg.
+
+    The oracle is layered, because no one signal survives every theme:
+
+      - state readback: the op answers with tabs[n].idle, proving the
+        property round trip;
+      - geometry: `header-rect` part "idle" returns the moon's screen
+        rect only when the glyph is laid out, so hidden <=> no rect is a
+        real signal in the horizontal strip;
+      - pixels: the moon's rect is cropped from a settled screenshot and
+        must hold glyph ink when idle and none when awake; the title
+        rect's mean luminance must drop when the row dims.
+
+    The vertical strips have no header-rect equivalent for the moon, so
+    their legs capture settled screenshots for image analysis and keep
+    the seam readback as the machine oracle.
+
+    Seam-driven throughout; no synthesized input. Exits 0 clean, 2
+    findings, 1 could-not-run.
+#>
+param(
+    [Parameter(Mandatory)][string]$ExePath,
+    [Parameter(Mandatory)][string]$OutDir
+)
+. (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
+. (Join-Path $PSScriptRoot 'lib/seam-client.ps1')
+$ErrorActionPreference = 'Stop'
+
+New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
+Add-Type -AssemblyName System.Drawing
+[void][SeamWin]::SetProcessDpiAwarenessContext([IntPtr](-4))
+
+$Config = @'
+windows-single-instance = true
+window-save-state = never
+vertical-tabs = false
+profile.pwsh.name = PowerShell
+profile.pwsh.command = pwsh.exe -NoProfile
+default-profile = pwsh
+'@
+
+$script:Findings = [System.Collections.Generic.List[string]]::new()
+$harnessError = ''
+$session = $null
+
+function Shot([string]$Name) {
+    $rc = [SeamWin]::RectOf($session.Hwnd64)
+    if ($null -eq $rc) { throw "HARVEST_MISS: degenerate rect for $Name" }
+    $bmp = New-Object System.Drawing.Bitmap $rc.W, $rc.Hh
+    $g = [System.Drawing.Graphics]::FromImage($bmp)
+    $g.CopyFromScreen($rc.L, $rc.T, 0, 0, $bmp.Size)
+    $p = Join-Path $OutDir "shots\$Name.png"
+    $bmp.Save($p); $g.Dispose(); $bmp.Dispose()
+    return $p
+}
+
+# Std-dev of luminance over a screen rect cropped out of a full-window
+# shot. The rect arrives in screen px from the seam; the shot starts at
+# the window's left/top, so the crop origin is rect - window.
+#
+# Std-dev, not the mean, because the mean's direction under the dim
+# depends on the theme: fading dark text over a light strip BRIGHTENS
+# the region, fading light text over a dark strip darkens it. What the
+# dim always does is compress the contrast between the text ink and the
+# strip background, and the region's spread measures exactly that.
+function StdDev-Luminance([string]$pngPath, [double]$sx, [double]$sy, [double]$sw, [double]$sh) {
+    $bmp = [System.Drawing.Bitmap]::FromFile($pngPath)
+    try {
+        $rc = [SeamWin]::RectOf($session.Hwnd64)
+        $x0 = [int][Math]::Max(0, $sx - $rc.L); $y0 = [int][Math]::Max(0, $sy - $rc.T)
+        $x1 = [int][Math]::Min($bmp.Width, $x0 + [Math]::Max(1, $sw))
+        $y1 = [int][Math]::Min($bmp.Height, $y0 + [Math]::Max(1, $sh))
+        $sum = 0.0; $sumSq = 0.0; $n = 0
+        for ($y = $y0; $y -lt $y1; $y++) {
+            for ($x = $x0; $x -lt $x1; $x++) {
+                $c = $bmp.GetPixel($x, $y)
+                $l = 0.299 * $c.R + 0.587 * $c.G + 0.114 * $c.B
+                $sum += $l; $sumSq += $l * $l; $n++
+            }
+        }
+        if ($n -eq 0) { return -1.0 }
+        $mean = $sum / $n
+        return [Math]::Sqrt([Math]::Max(0.0, $sumSq / $n - $mean * $mean))
+    } finally { $bmp.Dispose() }
+}
+
+function Rect-Has-Ink([string]$pngPath, [double]$sx, [double]$sy, [double]$sw, [double]$sh) {
+    $bmp = [System.Drawing.Bitmap]::FromFile($pngPath)
+    try {
+        $rc = [SeamWin]::RectOf($session.Hwnd64)
+        $x0 = [int][Math]::Max(0, $sx - $rc.L); $y0 = [int][Math]::Max(0, $sy - $rc.T)
+        $x1 = [int][Math]::Min($bmp.Width, $x0 + [Math]::Max(1, $sw))
+        $y1 = [int][Math]::Min($bmp.Height, $y0 + [Math]::Max(1, $sh))
+        $minL = 255.0; $maxL = 0.0
+        for ($y = $y0; $y -lt $y1; $y++) {
+            for ($x = $x0; $x -lt $x1; $x++) {
+                $c = $bmp.GetPixel($x, $y)
+                $l = 0.299 * $c.R + 0.587 * $c.G + 0.114 * $c.B
+                if ($l -lt $minL) { $minL = $l }
+                if ($l -gt $maxL) { $maxL = $l }
+            }
+        }
+        # Ink means contrast: a glyph has bright and dark pixels; an
+        # empty background patch does not. 30 is comfortably above
+        # antialiasing on a flat fill and below any real glyph.
+        return ($maxL - $minL) -ge 30.0
+    } finally { $bmp.Dispose() }
+}
+
+function Get-IdleRect([int]$Index) {
+    # Absence is the answer this exists to detect, but the seam (and
+    # Invoke-SeamCommand) treats an error reply as fatal so a caller
+    # cannot miss one. "No rect" arrives as a throw; catch it here and
+    # translate to null, which is what the callers below reason about.
+    try {
+        $r = Invoke-SeamCommand $session @{ op = 'header-rect'; index = $Index; part = 'idle' }
+    }
+    catch { return $null }
+    if (-not $r.ok) { return $null }
+    return $r
+}
+
+# ---- run --------------------------------------------------------------
+
+# The machine-wide seam lock, same contract as every capture harness:
+# PlaceOnTop plus screenshots are window-global side effects, and two
+# harnesses doing them at once corrupt both films.
+$ownLock = $null
+if (-not $env:WINTTY_SEAM_LOCK_HELD) {
+    . C:\temp\seam-lock.ps1
+    $ownLock = Enter-SeamLock -Owner 'idle-badge-check'
+}
+
+try {
+    Assert-NoWintty -Context 'the idle badge check'
+    $session = Start-SeamSession -ExePath $ExePath -ConfigText $Config
+    if (-not (Wait-SeamReady $session.Proc)) { throw 'SEAM_REFUSED: app never announced the pipe' }
+
+    # One deterministic window rect so the shots are comparable leg to
+    # leg regardless of what the desktop did before.
+    [void][SeamWin]::MoveWindow([SeamWin]::P([int64]$session.Hwnd64), 60, 60, 1000, 700, $true)
+    Start-Sleep -Milliseconds 500
+
+    # Three tabs: 0 active, 1 and 2 the audience.
+    [void](Invoke-SeamCommand $session @{ op = 'seed-tabs'; count = 3 })
+    Start-Sleep -Milliseconds 800
+
+    # ---- horizontal strip -------------------------------------------
+    # Awake baseline: no moon rect, full-contrast title.
+    if ($null -ne (Get-IdleRect 1)) {
+        $script:Findings.Add('horizontal: the moon reports a rect while the tab is awake')
+    }
+    $awake = Shot('h-awake')
+    $titleRect = Invoke-SeamCommand $session @{ op = 'header-rect'; index = 1; part = 'title' }
+    $awakeSpread = StdDev-Luminance $awake $titleRect.x $titleRect.y $titleRect.w $titleRect.h
+
+    # Idle: property round trip, moon rect exists and holds ink.
+    $st = Invoke-SeamCommand $session @{ op = 'tab-idle'; index = 1; idle = $true }
+    if (-not $st.state.tabs[1].idle) {
+        $script:Findings.Add('horizontal: tab-idle op did not report the property back')
+    }
+    $moon = Get-IdleRect 1
+    if ($null -eq $moon) {
+        $script:Findings.Add('horizontal: no idle rect while the tab is idle (glyph not laid out)')
+    } else {
+        $idleShot = Shot('h-idle')
+        if (-not (Rect-Has-Ink $idleShot $moon.x $moon.y $moon.w $moon.h)) {
+            $script:Findings.Add('horizontal: the moon rect holds no ink (glyph not painted)')
+        }
+        $dimSpread = StdDev-Luminance $idleShot $titleRect.x $titleRect.y $titleRect.w $titleRect.h
+        # The title dims to 0.45 opacity, which compresses the ink-vs-
+        # background contrast the region's spread measures. 0.8 leaves
+        # room for antialiasing and is far above noise on a settled
+        # frame.
+        if ($dimSpread -ge 0.0 -and $awakeSpread -ge 0.0 -and $dimSpread -gt ($awakeSpread * 0.8)) {
+            $script:Findings.Add("horizontal: title contrast did not compress (awake=$awakeSpread idle=$dimSpread)")
+        }
+    }
+
+    # Awake again: the moon rect must be gone.
+    [void](Invoke-SeamCommand $session @{ op = 'tab-idle'; index = 1; idle = $false })
+    Start-Sleep -Milliseconds 300
+    if ($null -ne (Get-IdleRect 1)) {
+        $script:Findings.Add('horizontal: the moon rect survives clearing the idle state')
+    }
+
+    # ---- vertical strip ---------------------------------------------
+    [void](Invoke-SeamCommand $session @{ op = 'toggle-layout'; await = $true })
+    Start-Sleep -Milliseconds 600
+    [void](Shot('v-awake'))
+    $st = Invoke-SeamCommand $session @{ op = 'tab-idle'; index = 1; idle = $true }
+    if (-not $st.state.tabs[1].idle) {
+        $script:Findings.Add('vertical: tab-idle op did not report the property back')
+    }
+    Start-Sleep -Milliseconds 300
+    [void](Shot('v-idle-body'))
+
+    # A pinned idle square: pin tab 2, idle it, shoot the band.
+    [void](Invoke-SeamCommand $session @{ op = 'pin'; index = 2 })
+    [void](Invoke-SeamCommand $session @{ op = 'tab-idle'; index = 2; idle = $true })
+    Start-Sleep -Milliseconds 300
+    [void](Shot('v-idle-pinned'))
+}
+catch {
+    $harnessError = $_.Exception.Message
+}
+finally {
+    if ($null -ne $session) { Stop-SeamSession $session }
+    if ($ownLock) { Exit-SeamLock $ownLock }
+}
+
+if ($harnessError) {
+    Write-Host "HARNESS-ERROR: $harnessError"
+    exit 1
+}
+if ($script:Findings.Count -gt 0) {
+    $script:Findings | ForEach-Object { Write-Host "FINDING: $_" }
+    exit 2
+}
+Write-Host 'idle-badge-check: clean (moon, dim, and state round trip verified)'
+exit 0

--- a/windows/scripts/idle-badge-check.ps1
+++ b/windows/scripts/idle-badge-check.ps1
@@ -204,9 +204,25 @@ try {
     Start-Sleep -Milliseconds 300
     [void](Shot('v-idle-body'))
 
-    # A pinned idle square: pin tab 2, idle it, shoot the band.
+    # A pinned idle square. Pinning RELOCATES the tab to the front of
+    # the strip, so the index the pin was issued against is stale the
+    # moment it returns -- ask the state which index holds the pinned
+    # tab before driving the idle property at it.
     [void](Invoke-SeamCommand $session @{ op = 'pin'; index = 2 })
-    [void](Invoke-SeamCommand $session @{ op = 'tab-idle'; index = 2; idle = $true })
+    $st = Invoke-SeamCommand $session @{ op = 'get-state' }
+    $pinnedIndex = -1
+    foreach ($t in $st.state.tabs) {
+        if ($t.pinned) { $pinnedIndex = $t.index; break }
+    }
+    if ($pinnedIndex -lt 0) {
+        $script:Findings.Add('vertical pinned: no tab reports pinned after the pin op')
+    }
+    else {
+        $st = Invoke-SeamCommand $session @{ op = 'tab-idle'; index = $pinnedIndex; idle = $true }
+        if (-not $st.state.tabs[$pinnedIndex].idle) {
+            $script:Findings.Add('vertical pinned: tab-idle op did not report the property back')
+        }
+    }
     Start-Sleep -Milliseconds 300
     [void](Shot('v-idle-pinned'))
 }

--- a/windows/scripts/idle-badge-check.ps1
+++ b/windows/scripts/idle-badge-check.ps1
@@ -186,10 +186,18 @@ try {
         }
     }
 
-    # Awake again: the moon rect must be gone.
-    [void](Invoke-SeamCommand $session @{ op = 'tab-idle'; index = 1; idle = $false })
+    # Awake again: the moon rect must be gone. A slow run can push past
+    # the real one-minute threshold here, and the product's own sweep
+    # re-idling the tab is correct behavior, not a finding -- so the
+    # state is read first and only a tab the harness itself left idle
+    # counts against the clear.
+    $st = Invoke-SeamCommand $session @{ op = 'tab-idle'; index = 1; idle = $false }
     Start-Sleep -Milliseconds 300
-    if ($null -ne (Get-IdleRect 1)) {
+    $check = Invoke-SeamCommand $session @{ op = 'get-state' }
+    if ($check.state.tabs[1].idle) {
+        Write-Host 'note: the real sweep re-idled tab 1 (slow run); clear-check skipped'
+    }
+    elseif ($null -ne (Get-IdleRect 1)) {
         $script:Findings.Add('horizontal: the moon rect survives clearing the idle state')
     }
 


### PR DESCRIPTION
A terminal session is idle when it has received no data and no user interaction for one minute. It wakes on either.

**Signal** (pull-based, no per-tab event wiring): each `TerminalControl` keeps a volatile activity tick stamped on keydown, pointer press, wheel, and every libghostty state-change callback (title, cwd, progress, bell, scrollbar -- the scrollbar growth is the streaming-output signal, so a background build stays awake without a keystroke). `PaneHost` aggregates its leaves on demand; `TabIdleTracker` sweeps every 30s and is the single product writer of `TabModel.IsIdle`. The active tab never idles; an unacknowledged bell suppresses (the pane just received something, and the bell owns the badge); switching tabs stamps both sides, so a tab you read for ten seconds does not dim moments after you leave it.

**Render**: all three row kinds -- horizontal header, vertical expanded row, vertical pinned square -- show a muted QuietHours moon (the bell wins the slot while up) and a 0.45 dim on title/icon, leaving close affordances full-strength. The collapsed vertical rail is icon-only, so the rail icon itself carries the dim; measured on live frames at alpha ~0.45 with the whole-frame diff confined to that glyph.

**Verification**: 7 tracker behavior tests (fake clock); 8 mutation-verified wiring guards; `idle-badge-check.ps1` drives the live app through the seam (`tab-idle` op writes the property the sweep owns) and checks state round trip, moon ink, and contrast-compressing dim -- clean run, plus Sonnet image analysis of the captured frames. `header-rect` parts now require visibility (ActualWidth keeps stale values through a collapse, so hidden glyphs were handing out rects of ink that is not there).

Known v1 gaps, targeted by the native idle tier: in-place-redraw output (\r spinners, alt-screen TUIs) leaves no shell-observable callback, so such a tab can moon while visibly updating; collapsed group chips render no idle state.