### PR TITLE
build: regenerate package manifests for the zioshade 0.8.4 pin

### DIFF
--- a/build.zig.zon.json
+++ b/build.zig.zon.json
@@ -174,10 +174,10 @@
     "url": "git+https://github.com/zigimg/zigimg#d695acd97c02e57bb151e8f659d1280f5cd6ca70",
     "hash": "sha256-0IYATQldT6eJxRR2T/2CsIYZuzomqjvmdVyjmsjguyE="
   },
-  "zioshade-0.7.0-8s3a2hNSTgDA_8j-r4WhyCbfEuhsD6TGlETxwat8Xzz8": {
+  "zioshade-0.8.4-8s3a2kNFVAA2mZkIZq45NvtR1fRSG-tKMIAHaFNZajS1": {
     "name": "zioshade",
-    "url": "https://github.com/zioShade/zioshade/archive/refs/tags/v0.7.0.tar.gz",
-    "hash": "sha256-AB8U+6tn9L+GGqTeTtBN+m3bc11GnrnEcREOTRPXmG4="
+    "url": "https://github.com/zioShade/zioshade/archive/refs/tags/v0.8.4.tar.gz",
+    "hash": "sha256-zVWevb7xPvFCUCbmDALGwL5IDP+rYGon6vLAoeRBRFE="
   },
   "N-V-__8AAB0eQwD-0MdOEBmz7intriBReIsIDNlukNVoNu6o": {
     "name": "zlib",

--- a/build.zig.zon.nix
+++ b/build.zig.zon.nix
@@ -422,11 +422,11 @@ in
       };
     }
     {
-      name = "zioshade-0.7.0-8s3a2hNSTgDA_8j-r4WhyCbfEuhsD6TGlETxwat8Xzz8";
+      name = "zioshade-0.8.4-8s3a2kNFVAA2mZkIZq45NvtR1fRSG-tKMIAHaFNZajS1";
       path = fetchZigArtifact {
         name = "zioshade";
-        url = "https://github.com/zioShade/zioshade/archive/refs/tags/v0.7.0.tar.gz";
-        hash = "sha256-AB8U+6tn9L+GGqTeTtBN+m3bc11GnrnEcREOTRPXmG4=";
+        url = "https://github.com/zioShade/zioshade/archive/refs/tags/v0.8.4.tar.gz";
+        hash = "sha256-zVWevb7xPvFCUCbmDALGwL5IDP+rYGon6vLAoeRBRFE=";
         unpack = false;
       };
     }

--- a/build.zig.zon.txt
+++ b/build.zig.zon.txt
@@ -34,4 +34,4 @@ https://deps.files.ghostty.org/zig_js-3c23860e47fdcdc5af805efb7fd0bdac5fd3e9bc.t
 https://deps.files.ghostty.org/zig_objc-c8de82ff80281215ad92900866dab7103a8efa8b.tar.gz
 https://deps.files.ghostty.org/zlib-1220fed0c74e1019b3ee29edae2051788b080cd96e90d56836eea857b0b966742efb.tar.gz
 https://github.com/vancluever/arocc/archive/ecbc5c799574e0da2758a961b12efa586007f03c.tar.gz
-https://github.com/zioShade/zioshade/archive/refs/tags/v0.7.0.tar.gz
+https://github.com/zioShade/zioshade/archive/refs/tags/v0.8.4.tar.gz

--- a/flatpak/zig-packages.json
+++ b/flatpak/zig-packages.json
@@ -217,8 +217,8 @@
   },
   {
     "type": "archive",
-    "url": "https://github.com/zioShade/zioshade/archive/refs/tags/v0.7.0.tar.gz",
-    "dest": "vendor/p/zioshade-0.7.0-8s3a2hNSTgDA_8j-r4WhyCbfEuhsD6TGlETxwat8Xzz8",
-    "sha256": "001f14fbab67f4bf861aa4de4ed04dfa6ddb735d469eb9c471110e4d13d7986e"
+    "url": "https://github.com/zioShade/zioshade/archive/refs/tags/v0.8.4.tar.gz",
+    "dest": "vendor/p/zioshade-0.8.4-8s3a2kNFVAA2mZkIZq45NvtR1fRSG-tKMIAHaFNZajS1",
+    "sha256": "cd559ebdbef13ef1425026e60c02c6e0be480cffab606a27eaf2c0a1e4414451"
   }
 ]


### PR DESCRIPTION
build.zig.zon moved zioshade to v0.8.4, but the three generated manifests (build.zig.zon.json, build.zig.zon.nix, build.zig.zon.txt) and flatpak/zig-packages.json still carried 0.7.0. Zig resolves packages by the hash-derived directory name, so every offline, Nix and flatpak build failed dependency resolution, on every platform, while local builds kept working from the warm cache.

The entries were regenerated in place from the pinned tarball's digests (cached in the lane's global package cache, same bytes zig fetch verifies against). zioshade 0.8.4 vendors both of its dependencies under vendor/, so the closure needed no other changes; `nix develop -c ./nix/build-support/check-zig-cache.sh` (the nix CI job) is the authoritative verifier that the hand-regenerated output matches what zon2nix produces.

- [x] Only the zioshade entries changed; no other dependency versions touched
- [x] Digests computed from the pinned tarball (sha256 hex for flatpak, SRI for json/nix)
- [x] No source changes; scoped signoff green (zig-fmt, zig-tests) at the PR head
