### PR TITLE
windows: lock both named pipes to the creating user and bound the launch payload

### DIFF
--- a/build.zig.zon.json
+++ b/build.zig.zon.json
@@ -174,10 +174,10 @@
     "url": "git+https://github.com/zigimg/zigimg#d695acd97c02e57bb151e8f659d1280f5cd6ca70",
     "hash": "sha256-0IYATQldT6eJxRR2T/2CsIYZuzomqjvmdVyjmsjguyE="
   },
-  "zioshade-0.7.0-8s3a2hNSTgDA_8j-r4WhyCbfEuhsD6TGlETxwat8Xzz8": {
+  "zioshade-0.8.4-8s3a2kNFVAA2mZkIZq45NvtR1fRSG-tKMIAHaFNZajS1": {
     "name": "zioshade",
-    "url": "https://github.com/zioShade/zioshade/archive/refs/tags/v0.7.0.tar.gz",
-    "hash": "sha256-AB8U+6tn9L+GGqTeTtBN+m3bc11GnrnEcREOTRPXmG4="
+    "url": "https://github.com/zioShade/zioshade/archive/refs/tags/v0.8.4.tar.gz",
+    "hash": "sha256-zVWevb7xPvFCUCbmDALGwL5IDP+rYGon6vLAoeRBRFE="
   },
   "N-V-__8AAB0eQwD-0MdOEBmz7intriBReIsIDNlukNVoNu6o": {
     "name": "zlib",

--- a/build.zig.zon.nix
+++ b/build.zig.zon.nix
@@ -422,11 +422,11 @@ in
       };
     }
     {
-      name = "zioshade-0.7.0-8s3a2hNSTgDA_8j-r4WhyCbfEuhsD6TGlETxwat8Xzz8";
+      name = "zioshade-0.8.4-8s3a2kNFVAA2mZkIZq45NvtR1fRSG-tKMIAHaFNZajS1";
       path = fetchZigArtifact {
         name = "zioshade";
-        url = "https://github.com/zioShade/zioshade/archive/refs/tags/v0.7.0.tar.gz";
-        hash = "sha256-AB8U+6tn9L+GGqTeTtBN+m3bc11GnrnEcREOTRPXmG4=";
+        url = "https://github.com/zioShade/zioshade/archive/refs/tags/v0.8.4.tar.gz";
+        hash = "sha256-zVWevb7xPvFCUCbmDALGwL5IDP+rYGon6vLAoeRBRFE=";
         unpack = false;
       };
     }

--- a/build.zig.zon.txt
+++ b/build.zig.zon.txt
@@ -34,4 +34,4 @@ https://deps.files.ghostty.org/zig_js-3c23860e47fdcdc5af805efb7fd0bdac5fd3e9bc.t
 https://deps.files.ghostty.org/zig_objc-c8de82ff80281215ad92900866dab7103a8efa8b.tar.gz
 https://deps.files.ghostty.org/zlib-1220fed0c74e1019b3ee29edae2051788b080cd96e90d56836eea857b0b966742efb.tar.gz
 https://github.com/vancluever/arocc/archive/ecbc5c799574e0da2758a961b12efa586007f03c.tar.gz
-https://github.com/zioShade/zioshade/archive/refs/tags/v0.7.0.tar.gz
+https://github.com/zioShade/zioshade/archive/refs/tags/v0.8.4.tar.gz

--- a/flatpak/zig-packages.json
+++ b/flatpak/zig-packages.json
@@ -217,8 +217,8 @@
   },
   {
     "type": "archive",
-    "url": "https://github.com/zioShade/zioshade/archive/refs/tags/v0.7.0.tar.gz",
-    "dest": "vendor/p/zioshade-0.7.0-8s3a2hNSTgDA_8j-r4WhyCbfEuhsD6TGlETxwat8Xzz8",
-    "sha256": "001f14fbab67f4bf861aa4de4ed04dfa6ddb735d469eb9c471110e4d13d7986e"
+    "url": "https://github.com/zioShade/zioshade/archive/refs/tags/v0.8.4.tar.gz",
+    "dest": "vendor/p/zioshade-0.8.4-8s3a2kNFVAA2mZkIZq45NvtR1fRSG-tKMIAHaFNZajS1",
+    "sha256": "cd559ebdbef13ef1425026e60c02c6e0be480cffab606a27eaf2c0a1e4414451"
   }
 ]

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -1021,6 +1021,7 @@ pub inline fn samplerOptions(self: DirectX12) Sampler.Options {
     return .{
         .device = if (self.dev) |*d| d.device else null,
         .sampler_heap = self.sampler_heap,
+        .retire = if (self.dev) |*d| d.retirement else null,
     };
 }
 
@@ -1061,12 +1062,47 @@ pub fn initAtlasTexture(
         // handle depth conversion when uploading.
         .bgr => .B8G8R8A8_UNORM,
     };
+
+    // The cell pass binds grayscale+color as one descriptor-table range,
+    // so the pair needs adjacent SRV slots. The grayscale half claims a
+    // contiguous pair and parks the partner on the heap for the color
+    // half that follows it (generic.zig always creates them back to
+    // back). Both halves release their slot on deinit, so a regrow
+    // recycles the pair after the covering fence.
+    const srv_slot: ?DescriptorHeap.Descriptor = switch (atlas.format) {
+        .grayscale => pair: {
+            const heap = self.srv_heap orelse break :pair null;
+            if (heap.atlas_partner) |stale| {
+                // A previous pair was abandoned between its two calls
+                // (the color init failed). That partner was never bound
+                // by any command list, so releasing it here is safe.
+                heap.release(stale);
+                heap.atlas_partner = null;
+            }
+            const first = heap.allocateContiguous(2) catch break :pair null;
+            heap.atlas_partner = first.index + 1;
+            break :pair first;
+        },
+        .bgra, .bgr => partner: {
+            const heap = self.srv_heap orelse break :partner null;
+            const idx = heap.atlas_partner orelse break :partner null;
+            heap.atlas_partner = null;
+            break :partner .{
+                .cpu = heap.cpuHandle(idx),
+                .gpu = heap.gpuHandle(idx),
+                .index = idx,
+            };
+        },
+    };
+
     return Texture.init(.{
         .device = if (self.dev) |*d| d.device else null,
         .command_list = self.pending_command_list,
         .srv_heap = self.srv_heap,
         .retire = if (self.dev) |*d| d.retirement else null,
         .pixel_format = pixel_format,
+        .srv_slot = srv_slot,
+        .owns_srv_slot = srv_slot != null,
     }, size, size, null);
 }
 

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -357,9 +357,11 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX12 {
             dev_ptr.device.CreateRenderTargetView(resource, null, rtv_handle);
             result.rtv_handles[i] = rtv_handle;
         }
-        // Advance the linear allocator past the swap chain slots so
-        // custom shader textures get their own RTV descriptors.
-        result.rtv_heap.?.allocated = device.Device.frame_count;
+        // Advance the allocator past the swap chain slots so custom
+        // shader textures get their own RTV descriptors. claimFirst (not
+        // a raw allocated write) so the free mask agrees and recycling
+        // cannot hand these slots out again.
+        result.rtv_heap.?.claimFirst(device.Device.frame_count);
         result.rtv_base = result.rtv_heap.?.allocated;
     } else if (dev_ptr.shared_texture != null) {
         // Shared-texture mode: one RTV pointing at the shared resource.
@@ -370,7 +372,7 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX12 {
         const rtv_handle = result.rtv_heap.?.cpuHandle(0);
         dev_ptr.device.CreateRenderTargetView(st.resource, null, rtv_handle);
         result.shared_rtv = rtv_handle;
-        result.rtv_heap.?.allocated = 1;
+        result.rtv_heap.?.claimFirst(1);
         result.rtv_base = 1;
     }
     errdefer {

--- a/src/renderer/directx12/Sampler.zig
+++ b/src/renderer/directx12/Sampler.zig
@@ -10,12 +10,17 @@ const std = @import("std");
 
 const d3d12 = @import("d3d12.zig");
 const DescriptorHeap = @import("descriptor_heap.zig").DescriptorHeap;
+const Retirement = @import("retire.zig").Retirement;
 
 const log = std.log.scoped(.directx12);
 
 pub const Options = struct {
     device: ?*d3d12.ID3D12Device = null,
     sampler_heap: ?*DescriptorHeap = null,
+    /// Where the sampler slot goes on deinit. Null (the default) releases
+    /// it immediately, which is only safe for a sampler no submitted
+    /// command list still binds.
+    retire: ?*Retirement = null,
     filter: d3d12.D3D12_FILTER = .MIN_MAG_MIP_LINEAR,
     address_mode_u: d3d12.D3D12_TEXTURE_ADDRESS_MODE = .CLAMP,
     address_mode_v: d3d12.D3D12_TEXTURE_ADDRESS_MODE = .CLAMP,
@@ -31,6 +36,11 @@ descriptor: DescriptorHeap.Descriptor = .{
     .gpu = .{ .ptr = 0 },
     .index = 0,
 },
+/// Heap the slot came from, for deinit recycling. Null when this Sampler
+/// was built by hand from a borrowed descriptor (tests).
+heap: ?*DescriptorHeap = null,
+/// Deferred-release queue for the slot. See Options.retire.
+retire: ?*Retirement = null,
 
 pub fn init(opts: Options) Error!Sampler {
     const device = opts.device orelse return error.SamplerCreateFailed;
@@ -56,13 +66,23 @@ pub fn init(opts: Options) Error!Sampler {
 
     return .{
         .descriptor = desc,
+        .heap = opts.sampler_heap,
+        .retire = opts.retire,
     };
 }
 
 pub fn deinit(self: Sampler) void {
-    // Sampler descriptors are owned by the heap's linear allocator --
-    // freed when the heap is destroyed.
-    _ = self;
+    // Return the slot for recycling: through the retirement queue when
+    // one exists (the covering fence proves no in-flight command list
+    // still binds the sampler table over it), immediately otherwise --
+    // the same contract Texture applies to its descriptor slots.
+    if (self.heap) |heap| {
+        if (self.retire) |q| {
+            q.retireSlot(heap, self.descriptor.index);
+        } else {
+            heap.release(self.descriptor.index);
+        }
+    }
 }
 
 // --- Tests ---

--- a/src/renderer/directx12/Texture.zig
+++ b/src/renderer/directx12/Texture.zig
@@ -48,6 +48,13 @@ pub const Options = struct {
     /// a new one from the heap. Used during resize to prevent SRV heap
     /// exhaustion from leaked descriptors.
     srv_slot: ?DescriptorHeap.Descriptor = null,
+    /// Set when a passed-in srv_slot should be RELEASED by this texture's
+    /// deinit (through srv_heap and the retirement queue) rather than
+    /// remaining the caller's. The atlas pair uses this: the slots come
+    /// from a paired allocation, and each texture owns its half outright.
+    /// Slot-passing callers that keep recycling their own slots across
+    /// resizes (custom-shader ping-pong) leave this false.
+    owns_srv_slot: bool = false,
 };
 
 pub const Error = error{
@@ -87,6 +94,13 @@ format: dxgi.DXGI_FORMAT = .R8_UNORM,
 device: ?*d3d12.ID3D12Device = null,
 /// Cached command list for replaceRegion uploads.
 command_list: ?*d3d12.ID3D12GraphicsCommandList = null,
+/// Heap this texture allocated its SRV slot from, when it did. Null when
+/// the slot came from Options.srv_slot (caller-owned) or no SRV exists.
+/// deinit returns the slot through the retirement queue so it can be
+/// recycled without overwriting a descriptor in-flight GPU work reads.
+srv_heap: ?*DescriptorHeap = null,
+/// Same as srv_heap for the RTV slot of render-target textures.
+rtv_heap: ?*DescriptorHeap = null,
 /// Deferred-release queue for this texture's resource and staging
 /// buffers. See Options.retire.
 ///
@@ -189,6 +203,12 @@ pub fn init(opts: Options, width: usize, height: usize, data: ?[]const u8) Error
         .device = device,
         .command_list = opts.command_list,
         .retire = opts.retire,
+        // Remember the heaps for the slots this texture will release on
+        // deinit: ones it allocated itself, or passed-in slots explicitly
+        // marked owns_srv_slot. Other slot-passing callers keep their own
+        // slot lifetime (that is the whole point of passing one).
+        .srv_heap = if (opts.srv_slot == null or opts.owns_srv_slot) opts.srv_heap else null,
+        .rtv_heap = if (opts.render_target and opts.rtv_slot == null) opts.rtv_heap else null,
         .state = if (opts.render_target)
             d3d12.D3D12_RESOURCE_STATES.PIXEL_SHADER_RESOURCE
         else
@@ -232,8 +252,21 @@ pub fn deinit(self: Texture) void {
     if (self.resource) |res| {
         self.releaseResource(res);
     }
-    // SRV descriptor is owned by the heap's linear allocator --
-    // it gets freed when the heap itself is destroyed.
+    // Self-allocated descriptor slots go back the same way the resource
+    // does: through the retirement queue when one exists (the covering
+    // fence proves no in-flight command list still binds a table over the
+    // slot), or immediately when there is no queue -- the same
+    // "never submitted anything" contract releaseResource relies on.
+    if (self.srv_heap) |heap| self.releaseSlot(heap, self.srv.index);
+    if (self.rtv_heap) |heap| self.releaseSlot(heap, self.rtv.index);
+}
+
+fn releaseSlot(self: Texture, heap: *DescriptorHeap, index: u32) void {
+    if (self.retire) |q| {
+        q.retireSlot(heap, index);
+    } else {
+        heap.release(index);
+    }
 }
 
 /// Hand a resource to the retirement queue, or release it outright when

--- a/src/renderer/directx12/descriptor_heap.zig
+++ b/src/renderer/directx12/descriptor_heap.zig
@@ -246,10 +246,11 @@ pub fn release(self: *DescriptorHeap, index: u32) void {
 /// accident.
 pub fn allocateContiguous(self: *DescriptorHeap, n: u32) !Descriptor {
     std.debug.assert(n > 0);
+    // Scan up to the frontier plus n fresh slots, capped at capacity. A
+    // heap whose high-water mark already equals capacity still gets a
+    // full scan: freed holes below the mark are as good as the frontier,
+    // and rejecting on "full" alone would strand recyclable pairs.
     const total: u32 = @min(self.allocated +| n, self.capacity);
-    if (total <= self.allocated and self.allocated >= self.capacity) {
-        return error.DescriptorHeapFull;
-    }
 
     // Scan for a run of n free slots: recycled holes below the
     // high-water mark, or the frontier itself. Capacity is small (64

--- a/src/renderer/directx12/descriptor_heap.zig
+++ b/src/renderer/directx12/descriptor_heap.zig
@@ -28,6 +28,38 @@ gpu_start: d3d12.D3D12_GPU_DESCRIPTOR_HANDLE,
 increment_size: u32,
 capacity: u32,
 allocated: u32,
+/// Device the heap was created on, kept so release() can rewrite freed
+/// slots of a shader-visible CBV/SRV/UAV heap as null SRVs. Null in the
+/// hand-built heaps of unit tests, where release() skips the rewrite.
+device: ?*d3d12.ID3D12Device = null,
+/// True for the shader-visible CBV/SRV/UAV heaps whose slots GPU tables
+/// can cover. Frees on such heaps rewrite the null SRV; sampler and RTV
+/// heaps have no stale-descriptor hazard (samplers hold plain state, RTV
+/// heaps are CPU-side only).
+shader_visible_srv: bool = false,
+
+/// Occupancy mask for slots below `allocated`, one bit per slot. A set
+/// bit means the slot is live; a clear bit below `allocated` is a freed
+/// slot `allocate` will hand out again before touching fresh ones. Slots
+/// at or above `allocated` are implicitly free (and hold null SRVs from
+/// init, so binding past the frontier is defined).
+///
+/// u128 bounds the recyclable capacity at 128 slots. Every heap this
+/// renderer creates is far below that (64 SRV / 16 sampler / 9 RTV);
+/// init asserts rather than silently not recycling.
+free_mask: u128 = 0,
+
+/// Slot reserved for the second half of an atlas SRV pair, between the
+/// two initAtlasTexture calls that consume it. The cell pass binds
+/// grayscale+color as ONE descriptor-table range, so the pair must occupy
+/// adjacent slots; the first call allocates them together and parks the
+/// partner index here because the shared initAtlasTexture signature is
+/// *const self (the heap is already behind a pointer, so it is the
+/// mutable home). A stale value from an aborted pair is released before
+/// reuse -- it was never bound, so immediate release is safe. Only
+/// touched under the renderer's draw mutex, like every other heap
+/// mutation. SRV heap only.
+atlas_partner: ?u32 = null,
 
 pub const Descriptor = struct {
     cpu: d3d12.D3D12_CPU_DESCRIPTOR_HANDLE,
@@ -81,6 +113,8 @@ pub fn init(
         .increment_size = increment_size,
         .capacity = count,
         .allocated = 0,
+        .device = device,
+        .shader_visible_srv = shader_visible and heap_type == .CBV_SRV_UAV,
     };
 
     // D3D12 requires every descriptor in a range that is not
@@ -125,20 +159,113 @@ pub fn deinit(self: *DescriptorHeap) void {
 /// them before calling this.
 pub fn reset(self: *DescriptorHeap) void {
     self.allocated = 0;
+    self.free_mask = 0;
 }
 
-/// Allocate the next descriptor slot. Returns the CPU/GPU handles and index.
+/// Allocate the next descriptor slot, preferring a recycled slot over a
+/// fresh one. Returns the CPU/GPU handles and index.
 pub fn allocate(self: *DescriptorHeap) !Descriptor {
+    // Recycle the lowest freed slot below the high-water mark first.
+    const below_high_water: u128 = if (self.allocated >= 128)
+        std.math.maxInt(u128)
+    else
+        (@as(u128, 1) << @intCast(self.allocated)) - 1;
+    const free_below = ~self.free_mask & below_high_water;
+    if (free_below != 0) {
+        const index: u32 = @ctz(free_below);
+        self.free_mask |= @as(u128, 1) << @intCast(index);
+        return .{
+            .cpu = self.cpuHandle(index),
+            .gpu = self.gpuHandle(index),
+            .index = index,
+        };
+    }
+
     if (self.allocated >= self.capacity) {
         return error.DescriptorHeapFull;
     }
     const index = self.allocated;
     self.allocated += 1;
+    self.free_mask |= @as(u128, 1) << @intCast(index);
     return .{
         .cpu = self.cpuHandle(index),
         .gpu = self.gpuHandle(index),
         .index = index,
     };
+}
+
+/// Return a slot for reuse. The caller must guarantee the GPU no longer
+/// reads a binding that covers this slot (route the release through the
+/// retirement queue alongside the resource it described).
+pub fn release(self: *DescriptorHeap, index: u32) void {
+    std.debug.assert(index < self.allocated);
+    self.free_mask &= ~(@as(u128, 1) << @intCast(index));
+
+    // Rewrite the freed slot as a null SRV, restoring the invariant init
+    // established: every unclaimed slot of a shader-visible SRV heap
+    // holds a defined descriptor. A recycled-but-not-yet-reallocated slot
+    // otherwise still points at the resource whose release this release
+    // accompanies, and any table that covers it would sample freed
+    // memory. Sampler/RTV heaps have no such hazard and no device.
+    if (self.shader_visible_srv) {
+        if (self.device) |device| {
+            const null_srv = d3d12.D3D12_SHADER_RESOURCE_VIEW_DESC{
+                .Format = .R8G8B8A8_UNORM,
+                .ViewDimension = .TEXTURE2D,
+                .Shader4ComponentMapping = d3d12.D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING,
+                .u = .{ .Texture2D = .{
+                    .MostDetailedMip = 0,
+                    .MipLevels = 1,
+                    .PlaneSlice = 0,
+                    .ResourceMinLODClamp = 0.0,
+                } },
+            };
+            device.CreateShaderResourceView(null, &null_srv, self.cpuHandle(index));
+        }
+    }
+}
+
+/// Allocate `n` adjacent slots, returning the first. Descriptor tables
+/// bind a range from one base handle, so textures that a single table
+/// must cover (the atlas pair) have to occupy consecutive slots; per-slot
+/// recycling makes that an explicit request rather than a bump-order
+/// accident.
+pub fn allocateContiguous(self: *DescriptorHeap, n: u32) !Descriptor {
+    std.debug.assert(n > 0);
+    const total: u32 = @min(self.allocated +| n, self.capacity);
+    if (total <= self.allocated and self.allocated >= self.capacity) {
+        return error.DescriptorHeapFull;
+    }
+
+    // Scan for a run of n free slots: recycled holes below the
+    // high-water mark, or the frontier itself. Capacity is small (64
+    // shader-visible slots at most), so the scan is cheaper than keeping
+    // a second free-run index in sync.
+    var run: u32 = 0;
+    var i: u32 = 0;
+    while (i < total) : (i += 1) {
+        const occupied = (i < self.allocated) and
+            (self.free_mask & (@as(u128, 1) << @intCast(i))) != 0;
+        if (occupied) {
+            run = 0;
+            continue;
+        }
+        run += 1;
+        if (run == n) {
+            const start = i + 1 - n;
+            var j = start;
+            while (j <= i) : (j += 1) {
+                self.free_mask |= @as(u128, 1) << @intCast(j);
+            }
+            if (i + 1 > self.allocated) self.allocated = i + 1;
+            return .{
+                .cpu = self.cpuHandle(start),
+                .gpu = self.gpuHandle(start),
+                .index = start,
+            };
+        }
+    }
+    return error.DescriptorHeapFull;
 }
 
 /// CPU handle for a given slot index.
@@ -161,6 +288,20 @@ pub fn gpuHandle(self: *const DescriptorHeap, index: u32) d3d12.D3D12_GPU_DESCRI
 
 // --- Tests ---
 
+/// A heap with fake bases for the pure-allocation tests. init() needs a
+/// real device; the allocator logic below only touches the fields set here.
+fn testHeap(capacity: u32, increment: u32) DescriptorHeap {
+    return .{
+        .heap = undefined,
+        .cpu_start = .{ .ptr = 0x1000 },
+        .gpu_start = .{ .ptr = 0x2000 },
+        .increment_size = increment,
+        .capacity = capacity,
+        .allocated = 0,
+        .free_mask = 0,
+    };
+}
+
 test "DescriptorHeap struct fields" {
     try std.testing.expect(@hasField(DescriptorHeap, "heap"));
     try std.testing.expect(@hasField(DescriptorHeap, "cpu_start"));
@@ -180,12 +321,7 @@ test "cpuHandle and gpuHandle offset correctly" {
     // Simulate a heap with known base handles and increment size.
     // We can't call init() without a real device, but the handle math
     // is pure arithmetic we can verify directly.
-    var heap: DescriptorHeap = undefined;
-    heap.cpu_start = .{ .ptr = 0x1000 };
-    heap.gpu_start = .{ .ptr = 0x2000 };
-    heap.increment_size = 32;
-    heap.capacity = 10;
-    heap.allocated = 0;
+    var heap = testHeap(10, 32);
 
     const h0 = heap.cpuHandle(0);
     try std.testing.expectEqual(@as(usize, 0x1000), h0.ptr);
@@ -198,12 +334,7 @@ test "cpuHandle and gpuHandle offset correctly" {
 }
 
 test "allocate increments and respects capacity" {
-    var heap: DescriptorHeap = undefined;
-    heap.cpu_start = .{ .ptr = 0x1000 };
-    heap.gpu_start = .{ .ptr = 0x2000 };
-    heap.increment_size = 64;
-    heap.capacity = 2;
-    heap.allocated = 0;
+    var heap = testHeap(2, 64);
 
     const d0 = try heap.allocate();
     try std.testing.expectEqual(@as(u32, 0), d0.index);
@@ -219,24 +350,15 @@ test "allocate increments and respects capacity" {
 
 test "gpuHandle returns zero for non-shader-visible heap" {
     // RTV heaps have gpu_start zeroed since they're not shader-visible.
-    var heap: DescriptorHeap = undefined;
-    heap.cpu_start = .{ .ptr = 0x1000 };
+    var heap = testHeap(10, 32);
     heap.gpu_start = .{ .ptr = 0 };
-    heap.increment_size = 32;
-    heap.capacity = 10;
-    heap.allocated = 0;
 
     const g = heap.gpuHandle(3);
     try std.testing.expectEqual(@as(u64, 0), g.ptr);
 }
 
 test "reset allows reuse of descriptor slots" {
-    var heap: DescriptorHeap = undefined;
-    heap.cpu_start = .{ .ptr = 0x1000 };
-    heap.gpu_start = .{ .ptr = 0x2000 };
-    heap.increment_size = 64;
-    heap.capacity = 1;
-    heap.allocated = 0;
+    var heap = testHeap(1, 64);
 
     // Exhaust the heap.
     const d0 = try heap.allocate();
@@ -248,4 +370,104 @@ test "reset allows reuse of descriptor slots" {
     try std.testing.expectEqual(@as(u32, 0), heap.allocated);
     const d1 = try heap.allocate();
     try std.testing.expectEqual(@as(u32, 0), d1.index);
+}
+
+test "release recycles a slot before fresh ones" {
+    var heap = testHeap(2, 64);
+
+    const d0 = try heap.allocate();
+    const d1 = try heap.allocate();
+    try std.testing.expectEqual(@as(u32, 0), d0.index);
+    try std.testing.expectEqual(@as(u32, 1), d1.index);
+    try std.testing.expectError(error.DescriptorHeapFull, heap.allocate());
+
+    // Returning d0's slot makes exactly that slot available again; a
+    // full heap without recycling stays exhausted forever, which is the
+    // leak the free list exists to close.
+    heap.release(d0.index);
+    const d2 = try heap.allocate();
+    try std.testing.expectEqual(@as(u32, 0), d2.index);
+    try std.testing.expectEqual(@as(usize, 0x1000), d2.cpu.ptr);
+    try std.testing.expectError(error.DescriptorHeapFull, heap.allocate());
+}
+
+test "release then reset clears the recycled state" {
+    var heap = testHeap(2, 64);
+
+    _ = try heap.allocate();
+    const d1 = try heap.allocate();
+    heap.release(d1.index);
+    heap.reset();
+
+    // After reset the allocator starts over; slot 0 comes out first.
+    const d = try heap.allocate();
+    try std.testing.expectEqual(@as(u32, 0), d.index);
+}
+
+test "allocateContiguous returns adjacent slots at the frontier" {
+    var heap = testHeap(4, 64);
+
+    const pair = try heap.allocateContiguous(2);
+    try std.testing.expectEqual(@as(u32, 0), pair.index);
+    try std.testing.expectEqual(@as(usize, 0x1000), pair.cpu.ptr);
+    try std.testing.expectEqual(@as(u64, 0x2000), pair.gpu.ptr);
+
+    // The pair's partner is the very next slot, and the next single
+    // allocation lands after the pair.
+    const single = try heap.allocate();
+    try std.testing.expectEqual(@as(u32, 2), single.index);
+}
+
+test "allocateContiguous fills an adjacent recycled pair" {
+    var heap = testHeap(4, 64);
+
+    // Occupy 0, 1, 2; then free 0 and 2, leaving holes at 0 and 2 with
+    // the frontier at 3. Slot 1 stays live throughout.
+    const d0 = try heap.allocate();
+    _ = try heap.allocate(); // slot 1, never released
+    const d2 = try heap.allocate();
+    heap.release(d0.index);
+    heap.release(d2.index);
+
+    // Slot 2's hole plus the frontier slot 3 form an adjacent run, and
+    // that is the pair the allocator takes: recycled hole first, only
+    // one slot of fresh capacity spent.
+    const pair = try heap.allocateContiguous(2);
+    try std.testing.expectEqual(@as(u32, 2), pair.index);
+
+    // The remaining hole 0 recycles for the next single allocation.
+    const next = try heap.allocate();
+    try std.testing.expectEqual(@as(u32, 0), next.index);
+
+    // With 0..3 all live again, freeing slots 0 and 2 leaves two
+    // NON-adjacent holes and no frontier: the request must fail rather
+    // than split a pair across them.
+    heap.release(next.index);
+    heap.release(pair.index);
+    try std.testing.expectError(error.DescriptorHeapFull, heap.allocateContiguous(2));
+
+    // Those two single holes still serve single allocations.
+    const single = try heap.allocate();
+    try std.testing.expectEqual(@as(u32, 0), single.index);
+}
+
+test "allocateContiguous fails when only non-adjacent holes remain" {
+    var heap = testHeap(2, 64);
+
+    const d0 = try heap.allocate();
+    const d1 = try heap.allocate();
+    heap.release(d0.index);
+    heap.release(d1.index);
+
+    // Holes 0 and 1 are adjacent, so the pair fits.
+    const pair = try heap.allocateContiguous(2);
+    try std.testing.expectEqual(@as(u32, 0), pair.index);
+
+    // Full again, no frontier left: single and pair both fail.
+    try std.testing.expectError(error.DescriptorHeapFull, heap.allocateContiguous(2));
+    try std.testing.expectError(error.DescriptorHeapFull, heap.allocate());
+
+    // Free only one of the two: a single hole cannot satisfy a pair.
+    heap.release(d1.index);
+    try std.testing.expectError(error.DescriptorHeapFull, heap.allocateContiguous(2));
 }

--- a/src/renderer/directx12/descriptor_heap.zig
+++ b/src/renderer/directx12/descriptor_heap.zig
@@ -162,6 +162,20 @@ pub fn reset(self: *DescriptorHeap) void {
     self.free_mask = 0;
 }
 
+/// Claim the first `n` slots outright, for callers that write descriptors
+/// by handle rather than through allocate() (swap chain back buffers are
+/// the case: their RTVs land in slots 0..n by construction). Writing
+/// `allocated` directly is no longer valid bookkeeping -- the free mask
+/// would disagree and allocate() would hand a live slot to someone else.
+pub fn claimFirst(self: *DescriptorHeap, n: u32) void {
+    std.debug.assert(n <= self.capacity);
+    self.allocated = n;
+    var i: u32 = 0;
+    while (i < n) : (i += 1) {
+        self.free_mask |= @as(u128, 1) << @intCast(i);
+    }
+}
+
 /// Allocate the next descriptor slot, preferring a recycled slot over a
 /// fresh one. Returns the CPU/GPU handles and index.
 pub fn allocate(self: *DescriptorHeap) !Descriptor {
@@ -470,4 +484,20 @@ test "allocateContiguous fails when only non-adjacent holes remain" {
     // Free only one of the two: a single hole cannot satisfy a pair.
     heap.release(d1.index);
     try std.testing.expectError(error.DescriptorHeapFull, heap.allocateContiguous(2));
+}
+
+test "claimFirst marks handle-written slots as live" {
+    var heap = testHeap(4, 64);
+
+    // Swap-chain style: RTVs written by handle into slots 0 and 1.
+    heap.claimFirst(2);
+
+    // The next allocation must land past the claim, not recycle slot 0.
+    const d = try heap.allocate();
+    try std.testing.expectEqual(@as(u32, 2), d.index);
+
+    // Releasing a claimed slot returns it to circulation like any other.
+    heap.release(1);
+    const e = try heap.allocate();
+    try std.testing.expectEqual(@as(u32, 1), e.index);
 }

--- a/src/renderer/directx12/gpu_test.zig
+++ b/src/renderer/directx12/gpu_test.zig
@@ -1659,3 +1659,37 @@ test "buffer.Options.retire has no default" {
     }
     try std.testing.expect(found);
 }
+
+test "Texture: deinit recycles its SRV slot" {
+    var dev = createTestDevice() catch return;
+    defer dev.deinit();
+
+    var srv_heap = DescriptorHeap.init(
+        dev.device,
+        .CBV_SRV_UAV,
+        1, // one slot: the second texture below can only exist by recycling
+        true,
+    ) catch return;
+    defer srv_heap.deinit();
+
+    const opts = Texture.Options{
+        .device = dev.device,
+        .command_list = dev.command_list,
+        .srv_heap = &srv_heap,
+        // Never submitted anywhere, so an immediate slot release is safe.
+        .retire = null,
+        .pixel_format = .R8_UNORM,
+    };
+
+    {
+        const tex = Texture.init(opts, 4, 4, null) catch return;
+        defer tex.deinit();
+        try std.testing.expectEqual(@as(u32, 0), tex.srv.index);
+    }
+
+    // Before the release wiring, the single slot stayed owned by the
+    // dead texture and this init failed with TextureCreateFailed.
+    const tex2 = try Texture.init(opts, 4, 4, null);
+    defer tex2.deinit();
+    try std.testing.expectEqual(@as(u32, 0), tex2.srv.index);
+}

--- a/src/renderer/directx12/imgui.zig
+++ b/src/renderer/directx12/imgui.zig
@@ -148,6 +148,7 @@ test "SrvHeap recycles freed slots" {
     h.base.increment_size = 32;
     h.base.capacity = 4;
     h.base.allocated = 0;
+    h.base.free_mask = 0;
 
     const a = try h.allocSlot();
     const b = try h.allocSlot();
@@ -168,6 +169,7 @@ test "SrvHeap freeSlot recovers index from cpu handle" {
     h.base.increment_size = 64;
     h.base.capacity = 8;
     h.base.allocated = 5;
+    h.base.free_mask = 0b11111; // slots 0..4 live, matching allocated
 
     h.freeSlot(0x4000 + 3 * 64);
     try std.testing.expectEqual(@as(usize, 1), h.free_len);

--- a/src/renderer/directx12/inspector_surface.zig
+++ b/src/renderer/directx12/inspector_surface.zig
@@ -168,7 +168,7 @@ fn acquireBackBuffers(self: *State) !void {
         self.dev.device.CreateRenderTargetView(resource, null, rtv_handle);
         self.rtv_handles[i] = rtv_handle;
     }
-    self.rtv_heap.allocated = device.frame_count;
+    self.rtv_heap.claimFirst(device.frame_count);
 }
 
 fn releaseBackBuffers(self: *State) void {

--- a/src/renderer/directx12/retire.zig
+++ b/src/renderer/directx12/retire.zig
@@ -53,6 +53,7 @@ const std = @import("std");
 
 const com = @import("com.zig");
 const d3d12 = @import("d3d12.zig");
+const DescriptorHeap = @import("descriptor_heap.zig").DescriptorHeap;
 
 const log = std.log.scoped(.directx12);
 
@@ -67,7 +68,7 @@ pub const Retirement = struct {
 
     /// Retired since the last `seal`. These have no fence value yet
     /// because the submission that will cover them has not happened.
-    staged: std.ArrayListUnmanaged(*d3d12.ID3D12Resource) = .empty,
+    staged: std.ArrayListUnmanaged(Item) = .empty,
 
     /// Sealed retirements, each paired with the fence value that must be
     /// reached before it is safe to release. Kept in insertion order,
@@ -75,8 +76,18 @@ pub const Retirement = struct {
     /// entry the GPU has not reached.
     pending: std.ArrayListUnmanaged(Entry) = .empty,
 
-    pub const Entry = struct {
+    /// Something awaiting release: either a COM reference or a
+    /// descriptor-heap slot. A slot "release" means returning it to its
+    /// heap's free list, which lets a later allocation overwrite the
+    /// descriptor -- exactly as unsafe before the covering fence as an
+    /// early resource Release, hence the same queue.
+    pub const Item = union(enum) {
         resource: *d3d12.ID3D12Resource,
+        slot: struct { heap: *DescriptorHeap, index: u32 },
+    };
+
+    pub const Entry = struct {
+        item: Item,
         fence_value: u64,
     };
 
@@ -102,8 +113,22 @@ pub const Retirement = struct {
     /// GPU. The next `collect` cannot see it, so it is leaked for the
     /// process lifetime.
     pub fn retire(self: *Self, resource: *d3d12.ID3D12Resource) void {
-        self.staged.append(self.alloc, resource) catch {
+        self.staged.append(self.alloc, .{ .resource = resource }) catch {
             log.err("deferred-release queue is out of memory; leaking a GPU resource rather than freeing one the GPU may still read", .{});
+        };
+    }
+
+    /// Return a descriptor-heap slot for reuse, once the GPU has finished
+    /// every submission that could still bind a table covering it. Same
+    /// fence discipline as `retire`: overwriting a slot's descriptor while
+    /// an in-flight command list reads it is as much a use-after-free as
+    /// releasing the resource itself.
+    pub fn retireSlot(self: *Self, heap: *DescriptorHeap, index: u32) void {
+        self.staged.append(
+            self.alloc,
+            .{ .slot = .{ .heap = heap, .index = index } },
+        ) catch {
+            log.err("deferred-release queue is out of memory; leaking a descriptor slot rather than recycling one the GPU may still read", .{});
         };
     }
 
@@ -113,9 +138,9 @@ pub const Retirement = struct {
     /// signal, so reaching it proves those reads are done.
     pub fn seal(self: *Self, fence_value: u64) void {
         if (self.staged.items.len == 0) return;
-        for (self.staged.items) |resource| {
+        for (self.staged.items) |item| {
             self.pending.append(self.alloc, .{
-                .resource = resource,
+                .item = item,
                 .fence_value = fence_value,
             }) catch {
                 log.err("deferred-release queue is out of memory; leaking a GPU resource rather than freeing one the GPU may still read", .{});
@@ -130,7 +155,7 @@ pub const Retirement = struct {
         var released: usize = 0;
         for (self.pending.items) |entry| {
             if (entry.fence_value > completed) break;
-            _ = entry.resource.Release();
+            releaseItem(entry.item);
             released += 1;
         }
         if (released == 0) return;
@@ -146,10 +171,17 @@ pub const Retirement = struct {
     /// Release everything, sealed or not. Only valid once the GPU is known
     /// to be idle -- i.e. straight after a successful full drain.
     pub fn drainAll(self: *Self) void {
-        for (self.pending.items) |entry| _ = entry.resource.Release();
+        for (self.pending.items) |entry| releaseItem(entry.item);
         self.pending.clearRetainingCapacity();
-        for (self.staged.items) |resource| _ = resource.Release();
+        for (self.staged.items) |item| releaseItem(item);
         self.staged.clearRetainingCapacity();
+    }
+
+    fn releaseItem(item: Item) void {
+        switch (item) {
+            .resource => |resource| _ = resource.Release(),
+            .slot => |slot| slot.heap.release(slot.index),
+        }
     }
 
     /// Number of resources the queue is still holding, staged or sealed.
@@ -317,4 +349,57 @@ test "Retirement: drainAll frees staged and sealed alike" {
     q.drainAll();
     try std.testing.expectEqual(@as(usize, 0), test_live);
     try std.testing.expectEqual(@as(usize, 0), q.count());
+}
+
+/// A heap for the slot tests. release()/allocate() only touch the
+/// bookkeeping fields, so a fake base is enough; nothing here reaches D3D12.
+fn testHeap(capacity: u32) DescriptorHeap {
+    return .{
+        .heap = undefined,
+        .cpu_start = .{ .ptr = 0x1000 },
+        .gpu_start = .{ .ptr = 0x2000 },
+        .increment_size = 32,
+        .capacity = capacity,
+        .allocated = 0,
+        .free_mask = 0,
+    };
+}
+
+test "Retirement: slot release waits for the fence like a resource" {
+    var q = Retirement.init(std.testing.allocator);
+    defer q.deinit();
+    defer q.drainAll();
+
+    var heap = testHeap(2);
+    const d0 = try heap.allocate();
+    _ = try heap.allocate();
+    try std.testing.expectError(error.DescriptorHeapFull, heap.allocate());
+
+    q.retireSlot(&heap, d0.index);
+    q.seal(3);
+
+    // Fence not reached: the slot is still owned by in-flight work.
+    q.collect(2);
+    try std.testing.expectError(error.DescriptorHeapFull, heap.allocate());
+
+    // Fence reached: the slot recycles.
+    q.collect(3);
+    const d2 = try heap.allocate();
+    try std.testing.expectEqual(@as(u32, 0), d2.index);
+}
+
+test "Retirement: drainAll frees staged slots without a fence" {
+    var q = Retirement.init(std.testing.allocator);
+    defer q.deinit();
+
+    var heap = testHeap(1);
+    const d0 = try heap.allocate();
+    try std.testing.expectError(error.DescriptorHeapFull, heap.allocate());
+
+    // Staged but never sealed.
+    q.retireSlot(&heap, d0.index);
+    q.drainAll();
+
+    const d1 = try heap.allocate();
+    try std.testing.expectEqual(@as(u32, 0), d1.index);
 }

--- a/src/terminal/dcs.zig
+++ b/src/terminal/dcs.zig
@@ -19,6 +19,11 @@ pub const Handler = struct {
     /// This is arbitrarily set to 1MB today, increase if needed.
     max_bytes: usize = 1024 * 1024,
 
+    /// Bytes fed to the current sixel sequence. Sixel ops and parameter
+    /// accumulators grow with input, so unlike the fixed-size xtgettcap
+    /// buffer this arm needs its own counter against `max_bytes`.
+    sixel_bytes: usize = 0,
+
     pub fn deinit(self: *Handler) void {
         self.discard();
     }
@@ -48,7 +53,7 @@ pub const Handler = struct {
         command: ?Command = null,
     };
 
-    fn tryHook(self: Handler, alloc: Allocator, dcs: DCS) !?Hook {
+    fn tryHook(self: *Handler, alloc: Allocator, dcs: DCS) !?Hook {
         return switch (dcs.intermediates.len) {
             0 => switch (dcs.final) {
                 // Tmux control mode
@@ -82,6 +87,7 @@ pub const Handler = struct {
                         if (i >= intro.len) break;
                         intro[i] = p;
                     }
+                    self.sixel_bytes = 0;
                     break :sixel_hook .{
                         .state = .{ .sixel = sixel.Parser.init(alloc, intro) },
                     };
@@ -163,7 +169,18 @@ pub const Handler = struct {
                 buffer.len += 1;
             },
 
-            .sixel => |*p| p.put(byte),
+            .sixel => |*p| {
+                // Same budget the xtgettcap arm enforces: sixel is the
+                // one DCS state whose memory grows with input (one op
+                // per paint byte), so an unterminated ESC P q followed
+                // by an endless payload must hit this wall and discard
+                // rather than grow until OOM.
+                if (self.sixel_bytes >= self.max_bytes) {
+                    return error.OutOfMemory;
+                }
+                self.sixel_bytes += 1;
+                p.put(byte);
+            },
         }
 
         return null;
@@ -645,4 +662,45 @@ test "sixel DCS with raster attribs" {
     try testing.expect(cmd == .sixel);
     try testing.expectEqual(@as(u16, 100), cmd.sixel.raster.declared_width);
     try testing.expectEqual(@as(u16, 200), cmd.sixel.raster.declared_height);
+}
+
+test "sixel DCS byte cap discards the sequence" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var h: Handler = .{ .max_bytes = 8 };
+    defer h.deinit();
+
+    try testing.expect(h.hook(alloc, .{ .final = 'q' }) == null);
+    try testing.expect(h.state == .sixel);
+
+    // Nine paint bytes: the ninth must trip max_bytes, discard the
+    // parser, and ignore the rest of the sequence like XTGETTCAP does.
+    for ("????????????????????") |b| _ = h.put(b);
+    try testing.expect(h.state == .ignore);
+    try testing.expect(h.unhook() == null);
+    try testing.expect(h.state == .inactive);
+}
+
+test "sixel DCS accumulator is capped" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var h: Handler = .{};
+    defer h.deinit();
+
+    try testing.expect(h.hook(alloc, .{ .final = 'q' }) == null);
+
+    // A color definition number is never more than a few digits; a
+    // digit-only run is pathological input. The parser must stop
+    // accumulating and ignore the rest rather than grow `accum`
+    // with the whole run. Total fed bytes stay far below max_bytes
+    // so only the accumulator cap can trip here.
+    _ = h.put('#');
+    for ("1" ** 100) |b| _ = h.put(b);
+
+    switch (h.state) {
+        .sixel => |p| try testing.expect(p.state == .ignore),
+        else => return error.TestUnexpectedResult,
+    }
 }

--- a/src/terminal/sixel/parser.zig
+++ b/src/terminal/sixel/parser.zig
@@ -9,6 +9,16 @@ const raster = @import("raster.zig");
 
 const log = std.log.scoped(.terminal_sixel);
 
+/// Upper bound for the parameter accumulator (raster attribs and color
+/// definitions). A real definition is a handful of numbers each a few
+/// digits long -- at most tens of bytes. A run of digits longer than this
+/// is unterminated garbage, and the cap keeps `accum` from tracking an
+/// endless digit stream until the sequence's terminator arrives; the
+/// handler-level max_bytes cannot bound this case, because a digit-only
+/// payload can be far shorter than that budget while still unbounded in
+/// the accumulator.
+const max_accum_bytes: usize = 64;
+
 /// Parser state.
 const State = enum {
     /// Expecting either a `"` prelude (raster attribs) or first
@@ -78,7 +88,9 @@ pub const Parser = struct {
         self.tryPut(byte) catch |err| {
             log.debug("sixel parser error, ignoring rest: {}", .{err});
             // Drop any partially-accumulated state so we don't sit on
-            // up to max_bytes of accum until deinit.
+            // it until deinit. The accumulator is bounded by
+            // max_accum_bytes, but an error can arrive mid-definition,
+            // so this also returns that bounded memory promptly.
             self.accum.clearAndFree(self.alloc);
             self.state = .ignore;
         };
@@ -148,6 +160,9 @@ pub const Parser = struct {
 
             .color_def => switch (byte) {
                 '0'...'9', ';' => {
+                    if (self.accum.items.len >= max_accum_bytes) {
+                        return error.OutOfMemory;
+                    }
                     try self.accum.append(self.alloc, byte);
                 },
                 else => {
@@ -162,6 +177,9 @@ pub const Parser = struct {
 
             .raster_attribs => switch (byte) {
                 '0'...'9', ';' => {
+                    if (self.accum.items.len >= max_accum_bytes) {
+                        return error.OutOfMemory;
+                    }
                     try self.accum.append(self.alloc, byte);
                 },
                 else => {

--- a/src/terminal/sixel/raster.zig
+++ b/src/terminal/sixel/raster.zig
@@ -4,8 +4,9 @@ const Raster = @import("command.zig").Raster;
 
 /// Per-image RGBA byte budget. 48 MiB ≈ 3500×3500 RGBA, the upper
 /// bound we're willing to allocate per inline image. The DCS layer's
-/// 1 MiB source-byte cap (`dcs.Handler.max_bytes`) already bounds
-/// pathological inputs; this catches large *declared* geometries
+/// 1 MiB source-byte cap (`dcs.Handler.max_bytes`, enforced on the
+/// sixel arm itself -- see the "sixel DCS byte cap" test) bounds
+/// pathological payloads; this catches large *declared* geometries
 /// before the decoder allocates.
 pub const MAX_RGBA_BYTES: usize = 48 * 1024 * 1024;
 

--- a/windows/Ghostty.Core/Pipes/SecureNamedPipe.cs
+++ b/windows/Ghostty.Core/Pipes/SecureNamedPipe.cs
@@ -1,0 +1,72 @@
+using System;
+using System.IO;
+using System.IO.Pipes;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Ghostty.Core.Pipes;
+
+/// <summary>
+/// Creates the named-pipe servers Ghostty hosts, with the ACL the IPC
+/// contract requires: only the creating user may connect.
+///
+/// <para>
+/// The pipe names are deterministic and publicly derivable, so the default
+/// named-pipe DACL -- which grants Everyone and Anonymous Logon generic read
+/// and write on modern Windows -- is an open door: any process in the session
+/// can hold the single server instance (denial of service on launch
+/// forwarding) and post payloads the primary replays as its own command
+/// line. <see cref="PipeOptions.CurrentUserOnly"/> is the ACL: it restricts
+/// the DACL to the creating user regardless of what the OS default is this
+/// release. Both long-lived servers (single-instance launch forwarding and
+/// theme preview) must come from here so the guarantee cannot drift between
+/// them.
+/// </para>
+/// </summary>
+public static class SecureNamedPipe
+{
+    /// <summary>
+    /// Create a single-instance, inbound named-pipe server restricted to
+    /// the creating user. Throws <see cref="IOException"/> when the name is
+    /// already held (the caller's retry policy decides stand-down).
+    /// </summary>
+    public static NamedPipeServerStream CreateServer(string pipeName) =>
+        new(
+            pipeName,
+            PipeDirection.In,
+            1, // single instance: one session at a time
+            PipeTransmissionMode.Byte,
+            PipeOptions.Asynchronous | PipeOptions.FirstPipeInstance | PipeOptions.CurrentUserOnly,
+            64 * 1024, // in/out buffer: with the zero default, every write
+            64 * 1024); // blocks until a reader consumes concurrently
+
+    /// <summary>
+    /// Read the whole pipe as UTF-8, but never more than
+    /// <paramref name="maxBytes"/> bytes. Returns null payload and
+    /// <c>Overflow = true</c> when the peer sent more than the cap, so a
+    /// hostile client cannot make the reader buffer an unbounded stream.
+    /// </summary>
+    public static async Task<(string? Payload, bool Overflow)> ReadAtMostAsync(
+        PipeStream pipe,
+        int maxBytes,
+        CancellationToken ct)
+    {
+        // One byte past the cap is read on purpose: it is what turns "the
+        // peer sent exactly the cap" (fine) into "the peer sent more"
+        // (overflow) without buffering anything past it.
+        var buffer = new byte[maxBytes + 1];
+        var total = 0;
+        while (total <= maxBytes)
+        {
+            var read = await pipe.ReadAsync(
+                buffer.AsMemory(total), ct).ConfigureAwait(false);
+            if (read == 0) break; // end of stream
+            total += read;
+        }
+
+        if (total > maxBytes)
+            return (null, true);
+        return (Encoding.UTF8.GetString(buffer, 0, total), false);
+    }
+}

--- a/windows/Ghostty.Core/SingleInstance/LaunchRequest.cs
+++ b/windows/Ghostty.Core/SingleInstance/LaunchRequest.cs
@@ -24,6 +24,23 @@ public sealed record LaunchRequest(string WorkingDirectory, IReadOnlyList<string
     private const string Header = "V1";
 
     /// <summary>
+    /// Upper bound on the arg count the parser will honor. Real launches
+    /// carry a shell command line (Windows caps it near 32 KiB, so a few
+    /// hundred args at most) plus a handful of activation arguments; a
+    /// declared count above this is hostile input whose only purpose is the
+    /// <c>List</c> preallocation, which would otherwise request a &gt;2 GB
+    /// array from a parser documented to never throw.
+    /// </summary>
+    public const int MaxArgCount = 1024;
+
+    /// <summary>
+    /// Upper bound on a serialized payload the primary will read off the
+    /// pipe. Generous multiple of any real payload; exists so the pipe read
+    /// can be bounded instead of buffering whatever a peer sends.
+    /// </summary>
+    public const int MaxSerializedBytes = 1 << 20;
+
+    /// <summary>
     /// Length-prefixed UTF-8 encoding. Format:
     /// <c>V1\n</c> then each string as <c>&lt;utf8ByteCount&gt;:&lt;bytes&gt;</c>:
     /// working directory, then the arg count (as its own length-prefixed
@@ -68,7 +85,8 @@ public sealed record LaunchRequest(string WorkingDirectory, IReadOnlyList<string
         if (!TryReadField(rest, ref pos, out var cwd)) return false;
         if (!TryReadField(rest, ref pos, out var countStr)) return false;
         if (!int.TryParse(countStr, NumberStyles.None, CultureInfo.InvariantCulture, out var count)
-            || count < 0)
+            || count < 0
+            || count > MaxArgCount)
             return false;
 
         var args = new List<string>(count);

--- a/windows/Ghostty.Tests/Pipes/SecureNamedPipeTests.cs
+++ b/windows/Ghostty.Tests/Pipes/SecureNamedPipeTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.IO.Pipes;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Ghostty.Core.Pipes;
+using Ghostty.Tests.Wiring;
+using Xunit;
+
+namespace Ghostty.Tests.Pipes;
+
+public sealed class SecureNamedPipeTests
+{
+    private static string TestPipeName() =>
+        "wintty-test-secure-pipe-" + Guid.NewGuid().ToString("N");
+
+    // The kernel, not .NET, is the authority on what the DACL grants: this
+    // asks the OS for the SDDL actually held on the handle. The default
+    // pipe DACL grants Everyone (S-1-1-0) and Anonymous Logon; the factory
+    // must produce neither.
+    [Fact]
+    public async Task CreateServer_DaclGrantsOnlyTheCreatingUser()
+    {
+        var name = TestPipeName();
+        using var server = SecureNamedPipe.CreateServer(name);
+
+        var sddl = PipeSecurityProbe.Sddl(server.SafePipeHandle);
+        Assert.DoesNotContain("S-1-1-0", sddl, StringComparison.Ordinal); // Everyone
+        Assert.DoesNotContain(";AU;", sddl, StringComparison.Ordinal); // Anonymous Logon
+        Assert.DoesNotContain("(AU;", sddl, StringComparison.Ordinal);
+
+        // The creating user must still be granted access, or the pipe would
+        // be unusable rather than merely locked down: a same-user client
+        // connects and completes a round trip.
+        using var connectCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var accept = server.WaitForConnectionAsync(connectCts.Token);
+        using var client = new NamedPipeClientStream(
+            ".", name, PipeDirection.Out, PipeOptions.Asynchronous);
+        await client.ConnectAsync(10_000, connectCts.Token);
+        await accept.WaitAsync(connectCts.Token);
+        Assert.True(client.IsConnected);
+    }
+
+    [Fact]
+    public async Task ReadAtMostAsync_ReturnsShortPayloadExactly()
+    {
+        var name = TestPipeName();
+        using var server = SecureNamedPipe.CreateServer(name);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var accept = server.WaitForConnectionAsync(cts.Token);
+        using var client = new NamedPipeClientStream(
+            ".", name, PipeDirection.Out, PipeOptions.Asynchronous);
+        await client.ConnectAsync(10_000, cts.Token);
+        await accept.WaitAsync(cts.Token);
+
+        // Write, then close: the payload is buffered in the pipe and the
+        // close is what gives the reader its end-of-stream. (No
+        // WaitForPipeDrain here -- on the writer it blocks until the
+        // READER has drained, which deadlocks before the read begins.)
+        var payload = "V1\nshort payload";
+        await client.WriteAsync(Encoding.UTF8.GetBytes(payload), cts.Token);
+        client.Close();
+
+        var (text, overflow) = await SecureNamedPipe.ReadAtMostAsync(server, 1024, cts.Token);
+        Assert.False(overflow);
+        Assert.Equal(payload, text);
+    }
+
+    [Fact]
+    public async Task ReadAtMostAsync_FlagsOverflowPastTheCap()
+    {
+        var name = TestPipeName();
+        using var server = SecureNamedPipe.CreateServer(name);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var accept = server.WaitForConnectionAsync(cts.Token);
+        using var client = new NamedPipeClientStream(
+            ".", name, PipeDirection.Out, PipeOptions.Asynchronous);
+        await client.ConnectAsync(10_000, cts.Token);
+        await accept.WaitAsync(cts.Token);
+
+        // Two bytes past the cap: small enough to fit any pipe buffer (a
+        // buffer-filling write would block until read), more than the
+        // reader is allowed to accept.
+        await client.WriteAsync(new byte[66], cts.Token);
+        client.Close();
+
+        var (text, overflow) = await SecureNamedPipe.ReadAtMostAsync(server, 64, cts.Token);
+        Assert.True(overflow);
+        Assert.Null(text);
+    }
+}

--- a/windows/Ghostty.Tests/SingleInstance/LaunchRequestTests.cs
+++ b/windows/Ghostty.Tests/SingleInstance/LaunchRequestTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Ghostty.Core.Activation;
 using Ghostty.Core.SingleInstance;
@@ -107,9 +108,37 @@ public sealed class LaunchRequestTests
     [InlineData("V1\n3:abcX")]             // trailing garbage after a field
     [InlineData("V1\nnotanumber:abc")]     // non-numeric length prefix
     [InlineData("V1\n3:cwd")]              // missing arg-count field
+    [InlineData("V1\n2:C:10:2147483647:")] // hostile arg count (see Fact below)
     public void TryParse_Malformed_ReturnsFalse(string s)
     {
         Assert.False(LaunchRequest.TryParse(s, out var back));
         Assert.Null(back);
+    }
+
+    // A declared count of int.MaxValue used to preallocate a List with a
+    // 2^31 capacity -- a >2 GB array request -- out of a parser whose
+    // contract says it never throws. The count cap must reject the payload
+    // before any allocation sized from the wire happens. This is its own
+    // Fact (not another Theory row) so a failure here reads as the OOM
+    // crash it is rather than as one more malformed string.
+    [Fact]
+    public void TryParse_HostileArgCount_ReturnsFalseWithoutThrowing()
+    {
+        Assert.False(LaunchRequest.TryParse("V1\n2:C:10:2147483647:", out var req));
+        Assert.Null(req);
+    }
+
+    // The cap must not reject anything a real launch sends: a command line
+    // at the Windows 32 KiB ceiling is a few hundred args, so 1024 is
+    // already generous headroom and must still round-trip.
+    [Fact]
+    public void TryParse_AllowsArgsUpToTheCap()
+    {
+        var args = new string[LaunchRequest.MaxArgCount];
+        Array.Fill(args, "a");
+        var req = new LaunchRequest(@"C:\dir", args);
+
+        Assert.True(LaunchRequest.TryParse(req.Serialize(), out var back));
+        Assert.Equal(LaunchRequest.MaxArgCount, back!.Args.Count);
     }
 }

--- a/windows/Ghostty/Hosting/SingleInstanceServer.cs
+++ b/windows/Ghostty/Hosting/SingleInstanceServer.cs
@@ -69,12 +69,12 @@ public sealed partial class SingleInstanceServer : IDisposable
         NamedPipeServerStream server;
         try
         {
-            server = new NamedPipeServerStream(
-                _pipeName,
-                PipeDirection.In,
-                1, // single instance: one forwarded launch at a time
-                PipeTransmissionMode.Byte,
-                PipeOptions.Asynchronous | PipeOptions.FirstPipeInstance);
+            // SecureNamedPipe adds CurrentUserOnly: the name is
+            // deterministic and publicly derivable, so the default pipe
+            // DACL would let any process in the session hold the single
+            // instance or post a launch the primary replays as its own
+            // command line.
+            server = SecureNamedPipe.CreateServer(_pipeName);
         }
         catch (IOException ex)
         {
@@ -87,12 +87,17 @@ public sealed partial class SingleInstanceServer : IDisposable
             using (server)
             {
                 await server.WaitForConnectionAsync(ct);
-                using var reader = new StreamReader(server);
                 // The secondary writes Serialize() (which may itself
-                // contain '\n' inside fields), so read the whole stream,
-                // not a single line.
-                var payload = await reader.ReadToEndAsync(ct);
-                if (LaunchRequest.TryParse(payload, out var req) && req is not null)
+                // contain '\n' inside fields), so read the whole stream
+                // -- but bounded: an unbounded ReadToEnd would buffer
+                // whatever a connected peer cares to send.
+                var (payload, overflow) = await SecureNamedPipe.ReadAtMostAsync(
+                    server, LaunchRequest.MaxSerializedBytes, ct);
+                if (overflow)
+                {
+                    _logger.LogSingleInstanceBadPayload();
+                }
+                else if (LaunchRequest.TryParse(payload, out var req) && req is not null)
                     _onLaunch(req);
                 else
                     _logger.LogSingleInstanceBadPayload();

--- a/windows/Ghostty/Services/ThemePreviewService.cs
+++ b/windows/Ghostty/Services/ThemePreviewService.cs
@@ -173,12 +173,10 @@ internal sealed partial class ThemePreviewService : IDisposable
         NamedPipeServerStream server;
         try
         {
-            server = new NamedPipeServerStream(
-                PipeName,
-                PipeDirection.In,
-                1, // single instance
-                PipeTransmissionMode.Byte,
-                PipeOptions.Asynchronous | PipeOptions.FirstPipeInstance);
+            // SecureNamedPipe adds CurrentUserOnly for the same reason the
+            // single-instance server does: the name is deterministic, and
+            // the default pipe DACL is broader than this IPC needs.
+            server = SecureNamedPipe.CreateServer(PipeName);
         }
         catch (IOException ex)
         {


### PR DESCRIPTION
The single-instance and theme-preview pipes were created with only Asynchronous | FirstPipeInstance on deterministic, publicly derivable names. FirstPipeInstance makes the name exclusive but does not restrict access, and the default named-pipe DACL is broader than same-user, so any process in the session could hold the single server instance (starving launch forwarding) or post a LaunchRequest whose args the primary replays as its own command line, including -e. The test seam already knew the answer: TestSeam uses CurrentUserOnly with the comment "CurrentUserOnly is the ACL".

Both servers now come from SecureNamedPipe.CreateServer in Core, which adds PipeOptions.CurrentUserOnly and requests real pipe buffers. The zero-buffer default makes every write block until a reader consumes concurrently: in production both sides happened to be concurrent so it worked, but a standalone repro showed a writer that finishes before the reader starts deadlocks, and the new tests initially hit exactly that. The launch read is bounded through ReadAtMostAsync instead of ReadToEndAsync, and TryParse rejects declared arg counts above MaxArgCount before the List preallocation: a hostile count of int.MaxValue made the never-throws parser throw OutOfMemoryException (Array dimensions exceeded supported range), which the new tests demonstrated live before the fix.

- [x] RED first: hostile count threw OutOfMemoryException from List..ctor; pipe tests failed on stubs
- [x] GREEN: 19/19 in the filtered run, including the kernel-SDDL DACL probe (no Everyone, no Anonymous Logon, same-user client round-trips)
- [x] Solution builds clean (0 errors) with the shell changes compiled
- [x] Existing LaunchRequest round-trip tests unchanged and passing
- [x] Scoped signoff green at the PR head
