### PR TITLE
terminal: enforce the DCS byte cap on sixel and cap the parameter accumulator

### DIFF
--- a/build.zig.zon.json
+++ b/build.zig.zon.json
@@ -174,10 +174,10 @@
     "url": "git+https://github.com/zigimg/zigimg#d695acd97c02e57bb151e8f659d1280f5cd6ca70",
     "hash": "sha256-0IYATQldT6eJxRR2T/2CsIYZuzomqjvmdVyjmsjguyE="
   },
-  "zioshade-0.7.0-8s3a2hNSTgDA_8j-r4WhyCbfEuhsD6TGlETxwat8Xzz8": {
+  "zioshade-0.8.4-8s3a2kNFVAA2mZkIZq45NvtR1fRSG-tKMIAHaFNZajS1": {
     "name": "zioshade",
-    "url": "https://github.com/zioShade/zioshade/archive/refs/tags/v0.7.0.tar.gz",
-    "hash": "sha256-AB8U+6tn9L+GGqTeTtBN+m3bc11GnrnEcREOTRPXmG4="
+    "url": "https://github.com/zioShade/zioshade/archive/refs/tags/v0.8.4.tar.gz",
+    "hash": "sha256-zVWevb7xPvFCUCbmDALGwL5IDP+rYGon6vLAoeRBRFE="
   },
   "N-V-__8AAB0eQwD-0MdOEBmz7intriBReIsIDNlukNVoNu6o": {
     "name": "zlib",

--- a/build.zig.zon.nix
+++ b/build.zig.zon.nix
@@ -422,11 +422,11 @@ in
       };
     }
     {
-      name = "zioshade-0.7.0-8s3a2hNSTgDA_8j-r4WhyCbfEuhsD6TGlETxwat8Xzz8";
+      name = "zioshade-0.8.4-8s3a2kNFVAA2mZkIZq45NvtR1fRSG-tKMIAHaFNZajS1";
       path = fetchZigArtifact {
         name = "zioshade";
-        url = "https://github.com/zioShade/zioshade/archive/refs/tags/v0.7.0.tar.gz";
-        hash = "sha256-AB8U+6tn9L+GGqTeTtBN+m3bc11GnrnEcREOTRPXmG4=";
+        url = "https://github.com/zioShade/zioshade/archive/refs/tags/v0.8.4.tar.gz";
+        hash = "sha256-zVWevb7xPvFCUCbmDALGwL5IDP+rYGon6vLAoeRBRFE=";
         unpack = false;
       };
     }

--- a/build.zig.zon.txt
+++ b/build.zig.zon.txt
@@ -34,4 +34,4 @@ https://deps.files.ghostty.org/zig_js-3c23860e47fdcdc5af805efb7fd0bdac5fd3e9bc.t
 https://deps.files.ghostty.org/zig_objc-c8de82ff80281215ad92900866dab7103a8efa8b.tar.gz
 https://deps.files.ghostty.org/zlib-1220fed0c74e1019b3ee29edae2051788b080cd96e90d56836eea857b0b966742efb.tar.gz
 https://github.com/vancluever/arocc/archive/ecbc5c799574e0da2758a961b12efa586007f03c.tar.gz
-https://github.com/zioShade/zioshade/archive/refs/tags/v0.7.0.tar.gz
+https://github.com/zioShade/zioshade/archive/refs/tags/v0.8.4.tar.gz

--- a/flatpak/zig-packages.json
+++ b/flatpak/zig-packages.json
@@ -217,8 +217,8 @@
   },
   {
     "type": "archive",
-    "url": "https://github.com/zioShade/zioshade/archive/refs/tags/v0.7.0.tar.gz",
-    "dest": "vendor/p/zioshade-0.7.0-8s3a2hNSTgDA_8j-r4WhyCbfEuhsD6TGlETxwat8Xzz8",
-    "sha256": "001f14fbab67f4bf861aa4de4ed04dfa6ddb735d469eb9c471110e4d13d7986e"
+    "url": "https://github.com/zioShade/zioshade/archive/refs/tags/v0.8.4.tar.gz",
+    "dest": "vendor/p/zioshade-0.8.4-8s3a2kNFVAA2mZkIZq45NvtR1fRSG-tKMIAHaFNZajS1",
+    "sha256": "cd559ebdbef13ef1425026e60c02c6e0be480cffab606a27eaf2c0a1e4414451"
   }
 ]

--- a/src/terminal/dcs.zig
+++ b/src/terminal/dcs.zig
@@ -19,6 +19,11 @@ pub const Handler = struct {
     /// This is arbitrarily set to 1MB today, increase if needed.
     max_bytes: usize = 1024 * 1024,
 
+    /// Bytes fed to the current sixel sequence. Sixel ops and parameter
+    /// accumulators grow with input, so unlike the fixed-size xtgettcap
+    /// buffer this arm needs its own counter against `max_bytes`.
+    sixel_bytes: usize = 0,
+
     pub fn deinit(self: *Handler) void {
         self.discard();
     }
@@ -48,7 +53,7 @@ pub const Handler = struct {
         command: ?Command = null,
     };
 
-    fn tryHook(self: Handler, alloc: Allocator, dcs: DCS) !?Hook {
+    fn tryHook(self: *Handler, alloc: Allocator, dcs: DCS) !?Hook {
         return switch (dcs.intermediates.len) {
             0 => switch (dcs.final) {
                 // Tmux control mode
@@ -82,6 +87,7 @@ pub const Handler = struct {
                         if (i >= intro.len) break;
                         intro[i] = p;
                     }
+                    self.sixel_bytes = 0;
                     break :sixel_hook .{
                         .state = .{ .sixel = sixel.Parser.init(alloc, intro) },
                     };
@@ -163,7 +169,18 @@ pub const Handler = struct {
                 buffer.len += 1;
             },
 
-            .sixel => |*p| p.put(byte),
+            .sixel => |*p| {
+                // Same budget the xtgettcap arm enforces: sixel is the
+                // one DCS state whose memory grows with input (one op
+                // per paint byte), so an unterminated ESC P q followed
+                // by an endless payload must hit this wall and discard
+                // rather than grow until OOM.
+                if (self.sixel_bytes >= self.max_bytes) {
+                    return error.OutOfMemory;
+                }
+                self.sixel_bytes += 1;
+                p.put(byte);
+            },
         }
 
         return null;
@@ -645,4 +662,45 @@ test "sixel DCS with raster attribs" {
     try testing.expect(cmd == .sixel);
     try testing.expectEqual(@as(u16, 100), cmd.sixel.raster.declared_width);
     try testing.expectEqual(@as(u16, 200), cmd.sixel.raster.declared_height);
+}
+
+test "sixel DCS byte cap discards the sequence" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var h: Handler = .{ .max_bytes = 8 };
+    defer h.deinit();
+
+    try testing.expect(h.hook(alloc, .{ .final = 'q' }) == null);
+    try testing.expect(h.state == .sixel);
+
+    // Nine paint bytes: the ninth must trip max_bytes, discard the
+    // parser, and ignore the rest of the sequence like XTGETTCAP does.
+    for ("????????????????????") |b| _ = h.put(b);
+    try testing.expect(h.state == .ignore);
+    try testing.expect(h.unhook() == null);
+    try testing.expect(h.state == .inactive);
+}
+
+test "sixel DCS accumulator is capped" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var h: Handler = .{};
+    defer h.deinit();
+
+    try testing.expect(h.hook(alloc, .{ .final = 'q' }) == null);
+
+    // A color definition number is never more than a few digits; a
+    // digit-only run is pathological input. The parser must stop
+    // accumulating and ignore the rest rather than grow `accum`
+    // with the whole run. Total fed bytes stay far below max_bytes
+    // so only the accumulator cap can trip here.
+    _ = h.put('#');
+    for ("1" ** 100) |b| _ = h.put(b);
+
+    switch (h.state) {
+        .sixel => |p| try testing.expect(p.state == .ignore),
+        else => return error.TestUnexpectedResult,
+    }
 }

--- a/src/terminal/sixel/parser.zig
+++ b/src/terminal/sixel/parser.zig
@@ -9,6 +9,16 @@ const raster = @import("raster.zig");
 
 const log = std.log.scoped(.terminal_sixel);
 
+/// Upper bound for the parameter accumulator (raster attribs and color
+/// definitions). A real definition is a handful of numbers each a few
+/// digits long -- at most tens of bytes. A run of digits longer than this
+/// is unterminated garbage, and the cap keeps `accum` from tracking an
+/// endless digit stream until the sequence's terminator arrives; the
+/// handler-level max_bytes cannot bound this case, because a digit-only
+/// payload can be far shorter than that budget while still unbounded in
+/// the accumulator.
+const max_accum_bytes: usize = 64;
+
 /// Parser state.
 const State = enum {
     /// Expecting either a `"` prelude (raster attribs) or first
@@ -78,7 +88,9 @@ pub const Parser = struct {
         self.tryPut(byte) catch |err| {
             log.debug("sixel parser error, ignoring rest: {}", .{err});
             // Drop any partially-accumulated state so we don't sit on
-            // up to max_bytes of accum until deinit.
+            // it until deinit. The accumulator is bounded by
+            // max_accum_bytes, but an error can arrive mid-definition,
+            // so this also returns that bounded memory promptly.
             self.accum.clearAndFree(self.alloc);
             self.state = .ignore;
         };
@@ -148,6 +160,9 @@ pub const Parser = struct {
 
             .color_def => switch (byte) {
                 '0'...'9', ';' => {
+                    if (self.accum.items.len >= max_accum_bytes) {
+                        return error.OutOfMemory;
+                    }
                     try self.accum.append(self.alloc, byte);
                 },
                 else => {
@@ -162,6 +177,9 @@ pub const Parser = struct {
 
             .raster_attribs => switch (byte) {
                 '0'...'9', ';' => {
+                    if (self.accum.items.len >= max_accum_bytes) {
+                        return error.OutOfMemory;
+                    }
                     try self.accum.append(self.alloc, byte);
                 },
                 else => {

--- a/src/terminal/sixel/raster.zig
+++ b/src/terminal/sixel/raster.zig
@@ -4,8 +4,9 @@ const Raster = @import("command.zig").Raster;
 
 /// Per-image RGBA byte budget. 48 MiB ≈ 3500×3500 RGBA, the upper
 /// bound we're willing to allocate per inline image. The DCS layer's
-/// 1 MiB source-byte cap (`dcs.Handler.max_bytes`) already bounds
-/// pathological inputs; this catches large *declared* geometries
+/// 1 MiB source-byte cap (`dcs.Handler.max_bytes`, enforced on the
+/// sixel arm itself -- see the "sixel DCS byte cap" test) bounds
+/// pathological payloads; this catches large *declared* geometries
 /// before the decoder allocates.
 pub const MAX_RGBA_BYTES: usize = 48 * 1024 * 1024;
 


### PR DESCRIPTION
The sixel arm of the DCS handler fed bytes into its parser with no budget. The neighboring xtgettcap and decrqss arms check `max_bytes`, but sixel, the one DCS state whose memory grows with input (one op per paint byte), accumulated without bound: a never-terminated `ESC P q` followed by an endless payload grew the heap until OOM. raster.zig's comment claiming the 1 MiB cap already covered this path described a check that did not exist.

Two caps close it. The handler counts sixel bytes against the same `max_bytes` budget as xtgettcap and discards the sequence on overflow, and the parser caps its parameter accumulator at 64 bytes, because a digit-only color/raster payload can stay far under the byte budget while growing the accumulator without limit. The stale comment now points at the mechanism and its test.

- [x] RED first: both new tests failed on exactly the intended assertions (state never reached .ignore)
- [x] GREEN: test-lib-vt 251/251 including the new tests in both the vt and vt-c binaries
- [x] Scoped signoff green (zig-fmt, zig-tests) at the PR head
- [x] No behavior change for well-formed sixel sequences under the cap
