### PR TITLE
merge guard: stop deleting head branches on squash

### DIFF
--- a/.agents/scripts/merge_guard.py
+++ b/.agents/scripts/merge_guard.py
@@ -685,7 +685,7 @@ def merge_flow(number, mode="merge", gh=None, git=None, sleep=time.sleep):
                   "body (file it with `--file-only`).")
         else:
             print("merge-guard: would merge with: gh pr merge "
-                  f"{number} --repo {REPO} --squash --delete-branch")
+                  f"{number} --repo {REPO} --squash")
         print(f"merge-guard: would file issue titled: {issue_title(pr, squash)}")
         print("merge-guard: with this body:")
         # The backlog line is in the preview too, so the dry-run body is
@@ -711,7 +711,7 @@ def merge_flow(number, mode="merge", gh=None, git=None, sleep=time.sleep):
 
     # mode == "merge": the real thing. From here on a failure is a 1, not
     # a 2, because the merge may already have landed.
-    out = gh(["pr", "merge", str(number), "--repo", REPO, "--squash", "--delete-branch"])
+    out = gh(["pr", "merge", str(number), "--repo", REPO, "--squash"])
     if out.returncode != 0:
         print(f"merge-guard: the merge command failed (rc={out.returncode}): "
               f"{(out.stderr or out.stdout).strip()}")


### PR DESCRIPTION
The guard squashed with `--delete-branch` unconditionally, and GitHub closes every open PR whose base branch is deleted. Unrecoverably: it refuses to reopen a PR while its base is gone, and refuses to change the base of a closed one. A stacked PR train hit exactly this today: merging the bottom PR deleted its head branch, which was the base of the PR above it, closing it mid-train and forcing a replacement PR for identical commits.

The fix is to stop deleting: the head branch stays, and branch cleanup becomes a deliberate step once nothing is stacked on it, instead of a default that destroys the PRs above it. The dry-run instruction text is updated to match what the guard now runs.

- [x] `--delete-branch` removed from both the dry-run text and the real merge call; no other behavior changed
- [x] Scoped signoff green at the PR head (gates-selftest leg)
- [x] Merged through the patched guard itself, leaving its own head branch in place as the first example
