### PR TITLE
build: fixed version and seed for the zig test steps

### DIFF
--- a/.agents/scripts/gate_scope.py
+++ b/.agents/scripts/gate_scope.py
@@ -44,6 +44,7 @@ RECIPE_LEGS = {
     "test-full": (LEG_ZIG,),
     "test-pkg": (LEG_ZIG,),
     "test-reachability": (LEG_ZIG,),
+    "test-configure": (LEG_ZIG,),
     "build-dll": (LEG_ZIG, LEG_WIN),
     "test-win": (LEG_WIN,),
     "build-win": (LEG_WIN,),
@@ -78,15 +79,29 @@ PREFIX_SUFFIX_RULES = (
 PREFIX_RULES = (
     ("src/", ZIG_LEGS),
     ("pkg/", ZIG_LEGS),
-    ("include/", ZIG_LEGS),
+    # The C# suite embeds include/ghostty.h and reads it at test time: the
+    # header parity tests pin the action-tag ordinals and the struct layouts
+    # the shell binds against the header's text, so a header edit with no
+    # C# edit is exactly the case they exist to catch, and it must run
+    # them. The src/ files that same project embeds are listed one by one
+    # in EXACT_RULES below.
+    ("include/", ZIG_LEGS + (LEG_WIN,)),
     ("vendor/", ZIG_LEGS),
     ("test/", ZIG_LEGS),
     ("windows/", (LEG_WIN,)),
+    # `just test-win` runs dist/windows/IconGen.Tests and SplashGen.Tests;
+    # before this line the dist/ rule below said an edit there could affect
+    # nothing, so a broken generator test could merge on a scoped record.
+    ("dist/windows/", (LEG_WIN,)),
     (".agents/scripts/", (LEG_GATES,)),
     (".agents/", ()),
     (".claude/", ()),
     (".github/", ()),
     ("docs/", ()),
+    # IconGen rasterises the launch icon from these masters and its tests,
+    # which `just test-win` runs, read them off the repo tree; the images/
+    # rule below is for the screenshots and marketing art.
+    ("images/icons/", (LEG_WIN,)),
     ("images/", ()),
     ("macos/", ()),
     ("nix/", ()),
@@ -102,6 +117,21 @@ EXACT_RULES = {
     # The check itself. Not a gates-selftest member: that leg runs anywhere,
     # and this one needs a Windows toolchain.
     ".agents/scripts/release_gate_check.ps1": (LEG_RELEASE_GATE,),
+    # Embedded by windows/Ghostty.Tests/Ghostty.Tests.csproj and read by its
+    # parity tests: the exported entry points against main_c.zig, the CLI
+    # aliases against cli/ghostty.zig, the keybind and theme facts against
+    # the config sources. An edit to any of them with no C# edit is a
+    # windows-tests failure the src/ rule alone would never run. Keep this
+    # list equal to the csproj's out-of-tree EmbeddedResource entries;
+    # leg_cache's self-test compares the two.
+    "src/apprt/embedded.zig": ZIG_LEGS + (LEG_WIN,),
+    "src/benchmark/CApi.zig": ZIG_LEGS + (LEG_WIN,),
+    "src/cli/ghostty.zig": ZIG_LEGS + (LEG_WIN,),
+    "src/config/CApi.zig": ZIG_LEGS + (LEG_WIN,),
+    "src/config/Config.zig": ZIG_LEGS + (LEG_WIN,),
+    "src/config/wintty_theme.zig": ZIG_LEGS + (LEG_WIN,),
+    "src/log_bridge.zig": ZIG_LEGS + (LEG_WIN,),
+    "src/main_c.zig": ZIG_LEGS + (LEG_WIN,),
     # The compiled-result half of the shipping gate. It is #if !DEBUG, so
     # editing it proves nothing until a Release run executes it.
     "windows/Ghostty.Tests/Demo/ShippingBuildGateTests.cs": (LEG_WIN, LEG_RELEASE_GATE),

--- a/.agents/scripts/nightly_fuzz.ps1
+++ b/.agents/scripts/nightly_fuzz.ps1
@@ -303,6 +303,12 @@ Write-Host "nightly: running against origin/windows @ $script:sha"
 # counts as a failure, never as a stale green.
 Write-Status 'zig-tests'
 $global:LASTEXITCODE = $null
+# The justfile pins the test seed so signoff runs can hit zig's run cache;
+# the nightly is the run that wants fresh randomness, so it draws one. It
+# rides in the failure issue too, or a seed-dependent red could not be
+# reproduced from the report.
+$env:WINTTY_TEST_SEED = '0x{0:x}' -f (Get-Random -Minimum 1 -Maximum 2147483647)
+Write-Host "nightly: WINTTY_TEST_SEED=$env:WINTTY_TEST_SEED"
 just --justfile (Join-Path $wt 'justfile') --working-directory $wt test
 $testRc = $LASTEXITCODE ?? 1
 $script:status.results['zig-tests'] = $testRc
@@ -315,7 +321,7 @@ $testWinRc = $LASTEXITCODE ?? 1
 $script:status.results['windows-tests'] = $testWinRc
 Write-Host "nightly: windows tests rc=$testWinRc"
 
-if ($testRc -ne 0) { File-Issue '[nightly] zig test suite failed on windows branch' "``just test`` exited $testRc." }
+if ($testRc -ne 0) { File-Issue '[nightly] zig test suite failed on windows branch' "``just test`` exited $testRc (WINTTY_TEST_SEED=$env:WINTTY_TEST_SEED)." }
 if ($testWinRc -ne 0) { File-Issue '[nightly] Windows test suite failed on windows branch' "``just test-win`` exited $testWinRc." }
 
 $wakeLockNote = 'If this machine wakes from hibernation to the lock screen every night (sign-in on wake), the fuzz leg can never run; the appliance flow needs sign-in on wake disabled to get fuzz coverage.'

--- a/.agents/scripts/test_reachability.py
+++ b/.agents/scripts/test_reachability.py
@@ -31,7 +31,7 @@ file that has not been added yet is invisible. And a binary registered with
 running them; what is enforced is the other direction, that no `addTest`
 escapes registration.
 
-Usage: python .agents/scripts/test_reachability.py
+Usage: python .agents/scripts/test_reachability.py [--version-string V]
        python .agents/scripts/test_reachability.py --self-test
 """
 
@@ -54,6 +54,15 @@ REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fi
 # run here. Anything a different `-D` would have compiled instead is out of
 # scope by construction, and is why the exclusions below exist.
 BUILD_ARGS = ["test-binaries", "-Dapp-runtime=none"]
+
+# The version string the justfile's test steps compile with (TEST_VERSION
+# there). The test binaries this builds are the ones `just test-full` just
+# ran, and they are only the same cache entries if build_options matches,
+# which the version is part of; a different string here would compile
+# everything a second time. `--version-string` overrides it and the
+# justfile passes its own value through, so the two cannot drift silently:
+# a mismatch costs a cold build, and gates-selftest compares them.
+TEST_VERSION = "0.0.0-test"
 
 # Directories whose `test` blocks are knowingly not run, with the reason.
 #
@@ -337,7 +346,7 @@ def query_test_names(exe):
             proc.kill()
 
 
-def build_test_binaries(repo, prefix):
+def build_test_binaries(repo, prefix, version=TEST_VERSION):
     """Compile every registered test binary.
 
     Returns [(exe path, module root directory)]. The roots come from the
@@ -347,7 +356,8 @@ def build_test_binaries(repo, prefix):
     """
     if not shutil.which("zig"):
         raise HarnessError("zig is not on PATH")
-    cmd = ["zig", "build"] + BUILD_ARGS + ["-p", prefix.replace("\\", "/")]
+    cmd = ["zig", "build"] + BUILD_ARGS + [f"-Dversion-string={version}",
+                                          "-p", prefix.replace("\\", "/")]
     print("building: " + " ".join(cmd), flush=True)
     proc = subprocess.run(cmd, cwd=repo)
     if proc.returncode != 0:
@@ -471,7 +481,7 @@ def evaluate(files_with_tests, all_files, binaries):
 # --- the check itself ------------------------------------------------------
 
 
-def check(repo):
+def check(repo, version=TEST_VERSION):
     paths = git_zig_files(repo)
     included, excluded = scan_for_test_blocks(repo, paths)
 
@@ -490,7 +500,7 @@ def check(repo):
 
     prefix_dir = tempfile.mkdtemp(prefix="test-reachability-")
     try:
-        binaries = build_test_binaries(repo, prefix_dir)
+        binaries = build_test_binaries(repo, prefix_dir, version)
         registered = registered_test_count(repo)
         if registered != len(binaries):
             raise HarnessError(
@@ -681,6 +691,33 @@ def self_test():
         sorted(set(NOT_BUILT_HERE) & set(NOT_ROOTED)),
         [],
     )
+    # The justfile's TEST_VERSION and this file's default are two spellings
+    # of one value; the recipe passes the justfile's through, so a drift
+    # only shows as a cold second compile that nobody reads as a defect.
+    try:
+        with open(os.path.join(REPO_ROOT, "justfile"), encoding="utf-8") as f:
+            justfile_text = f.read()
+    except OSError:
+        justfile_text = ""
+    m = re.search(r'^TEST_VERSION\s*:=\s*"([^"]*)"', justfile_text, re.M)
+    expect(
+        "the justfile's TEST_VERSION equals this script's default",
+        m.group(1) if m else None,
+        TEST_VERSION,
+    )
+    # The recipe bodies run under `pwsh -Command`, which splits an unquoted
+    # `-Dversion-string=0.0.0-test` at the first dot; an unquoted use here
+    # fails every Zig leg with InvalidVersion two seconds in. Any spelling
+    # counts, a literal as much as the {{TEST_VERSION}} reference.
+    body_lines = [
+        ln for ln in justfile_text.splitlines()
+        if ln[:1].isspace() and not ln.strip().startswith("#")
+    ]
+    expect(
+        "every -Dversion-string in a justfile recipe body is quoted",
+        re.findall(r'''(?<!["'])-Dversion-string=\S*''', "\n".join(body_lines)),
+        [],
+    )
 
     if failures:
         for f in failures:
@@ -694,11 +731,19 @@ def self_test():
 def main(argv):
     if "--self-test" in argv:
         return self_test()
+    version = TEST_VERSION
+    if "--version-string" in argv:
+        i = argv.index("--version-string")
+        if i + 1 >= len(argv) or not argv[i + 1].strip():
+            print("harness: --version-string needs a value", file=sys.stderr)
+            return EXIT_HARNESS
+        version = argv[i + 1]
+        argv = argv[:i] + argv[i + 2:]
     if argv:
         print(__doc__)
         return EXIT_HARNESS
     try:
-        return check(REPO_ROOT)
+        return check(REPO_ROOT, version)
     except HarnessError as e:
         print(f"harness: {e}", file=sys.stderr)
         return EXIT_HARNESS

--- a/justfile
+++ b/justfile
@@ -18,16 +18,60 @@ default: test build-dll
 
 # === Testing ===
 
+# The version the Zig test steps compile with, in place of the one git
+# would report. Without it every test binary carries the branch name and
+# short hash in build_options, which every module imports, so any new
+# commit (an amend, a rebase, a docs-only merge) recompiles every test
+# binary and re-runs every test even though no Zig source moved. Zig
+# already caches a test run against the binary's own hash; a fixed
+# version is what lets that cache see two commits as the same input, and
+# it is also what lets worktrees on different branches share the central
+# cache for src/. Only the test steps use it: the DLL keeps its real
+# version. .agents/scripts/test_reachability.py compiles the same
+# binaries and must pass the same string, or the reachability build is a
+# second cold compile of everything - `gates-selftest` holds them equal.
+TEST_VERSION := "0.0.0-test"
+
+# The seed the test steps run with. `zig build` draws a random one per
+# invocation and hands it to every test binary as `--seed=0x...`, and
+# that argument is part of the run step's cache manifest: measured on
+# this machine, a second `zig build test-lib-vt` at the same commit
+# compiled nothing and still ran both binaries for sixteen minutes. A
+# fixed seed is what makes an unchanged binary's run a cache hit.
+# Override it for a run that wants fresh randomness (the nightly does):
+#   $env:WINTTY_TEST_SEED = '0x1234'; just test
+TEST_SEED := env_var_or_default("WINTTY_TEST_SEED", "0x2a")
+
+# The quotes around the version argument are load-bearing on Windows:
+# the recipe body runs under `pwsh -Command`, whose parser splits an
+# unquoted `-Dversion-string=0.0.0-test` at the first dot into
+# `-Dversion-string=0` and `.0.0-test`, and build.zig then fails with
+# InvalidVersion before compiling anything. `-Dapp-runtime=none` survives
+# only because it has no dot. test_reachability's self-test checks the
+# quotes are still there.
+
 # Run all Zig tests
-test: test-lib-vt test-full test-pkg test-reachability
+test: test-configure test-lib-vt test-full test-pkg test-reachability
+
+# With every test step on the fixed version, nothing in the ladder runs
+# build.zig's own version detection any more, and that path has broken
+# before: Config.init panics on a tag it does not recognise, which is
+# what `gitversion-selftest` guards from the git side. This runs the
+# configure phase alone, with the real git lookup, so a build.zig that
+# cannot configure still fails the Zig leg. Listing the steps is the
+# cheapest thing that forces build() to run to completion.
+#
+# Prove build.zig configures with git version detection.
+test-configure:
+    zig build --list-steps -Dapp-runtime=none
 
 # Test libghostty-vt (fastest feedback loop)
 test-lib-vt:
-    zig build test-lib-vt --summary all
+    zig build test-lib-vt "-Dversion-string={{TEST_VERSION}}" --seed {{TEST_SEED}} --summary all
 
 # Full Zig test suite
 test-full:
-    zig build test -Dapp-runtime=none --summary all
+    zig build test -Dapp-runtime=none "-Dversion-string={{TEST_VERSION}}" --seed {{TEST_SEED}} --summary all
 
 # Tests that live in the vendored packages rather than in src/.
 #
@@ -41,7 +85,7 @@ test-full:
 # under pkg/ carry test blocks; why CI covers just this one is that job's
 # business, and duplicating a different list here would leave two to maintain.
 test-pkg:
-    cd pkg/wuffs && zig build test --summary all
+    cd pkg/wuffs && zig build test --seed {{TEST_SEED}} --summary all
 
 # Zig collects `test` blocks from the files a test binary's own test and
 # comptime blocks reach, so a file can carry assertions that no test step has
@@ -62,7 +106,7 @@ test-pkg:
 #
 # Prove that no file's test blocks are dead.
 test-reachability:
-    python .agents/scripts/test_reachability.py
+    python .agents/scripts/test_reachability.py --version-string {{TEST_VERSION}}
 
 # Cross-platform sanity check (on demand)
 # Uses the cross-platform-test Claude Code skill for native SSH-based testing.


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is stacked!
> - #1008
> - This PR <- **start here and bubble up**

## Summary

The Zig test steps now compile with a fixed `-Dversion-string` and run with a fixed `--seed` (`TEST_VERSION` and `TEST_SEED` in the justfile; `WINTTY_TEST_SEED` overrides the seed, the nightly does). Two scoping holes in `gate_scope.py` are closed.

## Why

Two cache-busters, one level apart:

- `src/build/Config.zig` puts the branch name and short hash into `build_options`, which every module imports, so every new commit, amend or rebase recompiled every test binary, and worktrees on different branches could never share the central cache for `src/`.
- `zig build` draws a random seed per invocation and hands it to every test binary as `--seed=0x...`; that argument is part of the run step's cache manifest (`Step/Run.zig` `enableTestRunnerMode`), so an unchanged binary's tests re-ran on every invocation too.

Only the test steps take the fixed values. The DLL keeps its real version.

## Scoping holes

- `include/` now also selects `windows-tests`: the C# interop parity tests read `ghostty.h` directly, so a header edit with no C# edit is the case they exist to catch.
- `dist/windows/` now selects `windows-tests`: `just test-win` runs `IconGen.Tests` and `SplashGen.Tests`, which the `dist/` rule said could affect nothing.

## Verified

- `just gates-selftest` green; `test_reachability.py --self-test` holds the justfile's `TEST_VERSION` equal to the script's default.
- Spike on the lane, `zig build test-lib-vt` at one commit, before the fix: cold 2332 s (compile 10 min per binary, run 15 min per binary); same commit again 1027 s, both compiles cached in 1 s and both test runs repeated because of the seed.
- Spike after the fix, same step: first run 1444 s (cold compile with the new version, plus the runs); same commit again 6.6 s; a new empty commit 4.7 s, every compile and every test run reported cached.
- Real ladder, twice. First round: `just signoff` on #1008's head paid the Zig leg cold (1674 s), then this head, through the cache-free signoff this branch still has, ran `just test` in 32 s. Final round after review: #1008's head cold again (3200 s, the lane's zig binary had been redeployed in between and the digest noticed), then this head's whole ladder in 653 s. Every leg green, records and GitHub statuses for both heads.
- Reviewed by three persona reviewers over two rounds plus `/code-review high`; every finding fixed or noted in #1008.
