### PR TITLE
terminal: fix partial row clone index and pin remap on column growth

### DIFF
--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -2998,23 +2998,29 @@ fn resizeWithoutReflowGrowCols(
                 dst_row,
                 src_row,
             ) catch {
-                // If an error happens, we undo our row copy and break out
-                // into creating a new page.
+                // If an error happens, we undo our row copy and stop
+                // filling. A partial copy can leave managed memory in the
+                // row, and the row is retired back into unused capacity,
+                // which the grow() fast path re-exposes without any
+                // clearing, so it has to go back to the default state.
+                prev_page.resetRow(dst_row);
                 prev_page.size.rows -= 1;
                 copied -= 1;
-                break :prev;
+                break;
             };
         }
 
-        assert(copied == len);
+        assert(copied <= len);
         assert(prev_page.size.rows <= prev_page.capacity.rows);
 
         // Remap any tracked pins that pointed to rows we just copied to prev.
+        // The rows copied before a failure above still moved, and this page
+        // is destroyed at the end, so this has to run for them too.
         const pin_keys = self.tracked_pins.keys();
         for (pin_keys) |p| {
-            if (p.node != chunk.node or p.y >= len) continue;
+            if (p.node != chunk.node or p.y >= copied) continue;
             p.node = prev_node;
-            p.y += prev_page.size.rows - len;
+            p.y += prev_page.size.rows - copied;
         }
     }
 
@@ -3073,7 +3079,10 @@ fn resizeWithoutReflowGrowCols(
                 );
 
                 // We can actually safely handle this though by exiting
-                // this loop early and cutting our copy short.
+                // this loop early and cutting our copy short. The row goes
+                // back into unused capacity so it must be reset, since a
+                // partial copy can leave managed memory behind.
+                new_page.resetRow(dst_row);
                 new_page.size.rows -= 1;
                 break;
             }
@@ -19334,6 +19343,104 @@ test "PageList resize (no reflow) more cols remaps pins in backfill path" {
     // Verify the pin still points to the cell with our marker content.
     const cell = tracked.rowAndCell().cell;
     try testing.expectEqual(.codepoint, cell.content_tag);
+    try testing.expectEqual(marker, cell.content.codepoint.data);
+}
+
+test "PageList resize (no reflow) more cols remaps pins when backfill fails" {
+    // Regression test: the backfill into the previous page can fail partway
+    // through (the destination can't fit the managed memory of a row). The
+    // rows copied before the failure still have to hand over their tracked
+    // pins, because the source page is destroyed at the end of the resize.
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // We start wider than we need and shrink so the first page keeps spare
+    // column capacity and stays in place during the final resize. That
+    // makes it the backfill destination we prepared below.
+    const wide_cols: size.CellCountInt = 80;
+    const cols: size.CellCountInt = wide_cols / 2;
+    const cap = try std_capacity.adjust(.{ .cols = wide_cols });
+    var s = try init(alloc, .{ .cols = wide_cols, .rows = cap.rows });
+    defer s.deinit();
+    try s.resize(.{ .cols = cols, .reflow = false });
+
+    // Grow into a second page and give it a few rows.
+    while (s.pages.first == s.pages.last) _ = try s.grow();
+    const first_node = s.pages.first.?;
+    const second_node = s.pages.last.?;
+    while (second_node.rows() < 4) _ = try s.grow();
+
+    // Free rows in the first page so that the backfill has somewhere to
+    // copy to.
+    s.eraseHistory(.{ .history = .{ .y = 2 } });
+    try testing.expect(first_node.rows() + 2 <= first_node.capacity().rows);
+
+    // Fill the first page's style set so that a styled row can no longer
+    // be cloned into it.
+    {
+        const page = first_node.page();
+        for (0..std_capacity.styles * 2) |i| {
+            _ = page.styles.add(page.memory, .{ .bg_color = .{ .rgb = .{
+                .r = @truncate(i),
+                .g = @truncate(i >> 8),
+                .b = 0,
+            } } }) catch break;
+        }
+
+        if (page.styles.add(
+            page.memory,
+            .{ .flags = .{ .bold = true } },
+        )) |_| return error.StyleSetNotFull else |_| {}
+    }
+
+    // The first row of the second page owns no managed memory so it copies
+    // into the full destination fine. The second row carries a style the
+    // destination can't accept, which aborts the backfill.
+    const marker: u21 = 'X';
+    {
+        const page = second_node.page();
+        {
+            const rac = page.getRowAndCell(0, 0);
+            rac.cell.* = .{
+                .content_tag = .codepoint,
+                .content = .{ .codepoint = .{ .data = marker } },
+            };
+        }
+        {
+            const style_id = try page.styles.add(
+                page.memory,
+                .{ .flags = .{ .bold = true } },
+            );
+            const rac = page.getRowAndCell(0, 1);
+            rac.row.styled = true;
+            rac.cell.* = .{
+                .content_tag = .codepoint,
+                .content = .{ .codepoint = .{ .data = 'Y' } },
+                .style_id = style_id,
+            };
+        }
+    }
+
+    // Track a pin in the row that is copied before the failure.
+    const tracked = try s.trackPin(.{ .node = second_node, .x = 0, .y = 0 });
+    defer s.untrackPin(tracked);
+
+    try s.resize(.{ .cols = cols + 1, .reflow = false });
+
+    // The pin must point at a page that is still in the list.
+    var found = false;
+    var it = s.pages.first;
+    while (it) |node| : (it = node.next) {
+        if (node == tracked.node) {
+            found = true;
+            break;
+        }
+    }
+    try testing.expect(found);
+    try testing.expect(tracked.y < tracked.node.rows());
+
+    // And it must still point at the content it was tracking.
+    const cell = tracked.rowAndCell().cell;
     try testing.expectEqual(marker, cell.content.codepoint.data);
 }
 

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -2896,11 +2896,16 @@ fn resizeWithoutReflow(self: *PageList, opts: Resize) Allocator.Error!void {
     }
 }
 
+const resizeWithoutReflowGrowCols_tw = tripwire.module(enum {
+    create_page,
+}, resizeWithoutReflowGrowCols);
+
 fn resizeWithoutReflowGrowCols(
     self: *PageList,
     cols: size.CellCountInt,
     chunk: PageIterator.Chunk,
 ) Allocator.Error!void {
+    const tw = resizeWithoutReflowGrowCols_tw;
     assert(cols > self.cols);
     const page = chunk.node.page();
 
@@ -2963,6 +2968,17 @@ fn resizeWithoutReflowGrowCols(
     // we copied exactly our page size.
     var copied: size.CellCountInt = 0;
 
+    // The rows we backfilled into the previous page, if any. The tracked
+    // pins for those rows are only moved once this function can no longer
+    // fail: an error rolls the backfill back, and a pin moved before that
+    // would be left pointing past the restored row count, at a row that
+    // the rollback has reset.
+    var backfill: ?struct {
+        node: *List.Node,
+        base: size.CellCountInt,
+        len: size.CellCountInt,
+    } = null;
+
     // This function has an unfortunate side effect in that it causes memory
     // fragmentation on rows if the columns are increasing in a way that
     // shrinks capacity rows. If we have pages that don't divide evenly then
@@ -3013,25 +3029,21 @@ fn resizeWithoutReflowGrowCols(
         assert(copied <= len);
         assert(prev_page.size.rows <= prev_page.capacity.rows);
 
-        // Remap any tracked pins that pointed to rows we just copied to prev.
-        // The rows copied before a failure above still moved, and this page
-        // is destroyed at the end, so this has to run for them too.
-        const pin_keys = self.tracked_pins.keys();
-        for (pin_keys) |p| {
-            if (p.node != chunk.node or p.y >= copied) continue;
-            p.node = prev_node;
-            p.y += prev_page.size.rows - copied;
-        }
+        if (copied > 0) backfill = .{
+            .node = prev_node,
+            .base = prev_page.size.rows - copied,
+            .len = copied,
+        };
     }
 
     // If we have an error, we clear the rows we just added to our prev page.
-    const prev_copied = copied;
-    errdefer if (prev_copied > 0) {
-        const prev_page = prev.?.page();
-        const prev_size = prev_page.size.rows - prev_copied;
-        const prev_rows = prev_page.rows.ptr(prev_page.memory)[prev_size..prev_page.size.rows];
+    // No tracked pin has been moved onto them yet, so putting the row count
+    // back is a complete undo.
+    errdefer if (backfill) |bf| {
+        const prev_page = bf.node.page();
+        const prev_rows = prev_page.rows.ptr(prev_page.memory)[bf.base..prev_page.size.rows];
         for (prev_rows) |*row| prev_page.resetRow(row);
-        prev_page.size.rows = prev_size;
+        prev_page.size.rows = bf.base;
     };
 
     // We delete any of the nodes we added.
@@ -3048,6 +3060,7 @@ fn resizeWithoutReflowGrowCols(
     // We need to loop because our col growth may force us
     // to split pages.
     while (copied < page.size.rows) {
+        try tw.check(.create_page);
         const new_node = try self.createPage(.{ .cap = cap });
         const new_page = new_node.page();
         defer new_page.assertIntegrity();
@@ -3107,6 +3120,20 @@ fn resizeWithoutReflowGrowCols(
     // Our prior errdeferes are invalid after this point so ensure
     // we don't have any more errors.
     errdefer comptime unreachable;
+
+    // Hand over the tracked pins for the rows we backfilled into the
+    // previous page. This is deliberately last: the rows below were also
+    // moved out of this page, but they went to pages that only exist if we
+    // got here, whereas the backfill destination survives a failure and
+    // would be left holding pins for rows it no longer has.
+    if (backfill) |bf| {
+        const pin_keys = self.tracked_pins.keys();
+        for (pin_keys) |p| {
+            if (p.node != chunk.node or p.y >= bf.len) continue;
+            p.node = bf.node;
+            p.y += bf.base;
+        }
+    }
 
     // Remove the old page.
     // Deallocate the old page.
@@ -19440,6 +19467,74 @@ test "PageList resize (no reflow) more cols remaps pins when backfill fails" {
     try testing.expect(tracked.y < tracked.node.rows());
 
     // And it must still point at the content it was tracking.
+    const cell = tracked.rowAndCell().cell;
+    try testing.expectEqual(marker, cell.content.codepoint.data);
+}
+
+test "PageList resize (no reflow) more cols does not move pins if a later page fails" {
+    // Regression test: the backfill into the previous page is rolled back
+    // when a later allocation fails, so the tracked pins of the backfilled
+    // rows must not have been moved onto it. A pin moved before the
+    // rollback is left with y >= node.rows(), pointing at a row the
+    // rollback has reset.
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const tw = resizeWithoutReflowGrowCols_tw;
+
+    // Same geometry as the backfill test above: start wide and shrink so
+    // the first page keeps spare column capacity and is resized in place,
+    // which leaves it as the backfill destination for the second page.
+    const wide_cols: size.CellCountInt = 80;
+    const cols: size.CellCountInt = wide_cols / 2;
+    const cap = try std_capacity.adjust(.{ .cols = wide_cols });
+    var s = try init(alloc, .{ .cols = wide_cols, .rows = cap.rows });
+    defer s.deinit();
+    try s.resize(.{ .cols = cols, .reflow = false });
+
+    // Grow into a second page and give it a few rows.
+    while (s.pages.first == s.pages.last) _ = try s.grow();
+    const first_node = s.pages.first.?;
+    const second_node = s.pages.last.?;
+    while (second_node.rows() < 4) _ = try s.grow();
+
+    // Free rows in the first page so that the backfill has somewhere to
+    // copy to, but fewer than the second page has, so the resize still has
+    // to allocate a page afterwards.
+    s.eraseHistory(.{ .history = .{ .y = 2 } });
+    const spare = first_node.capacity().rows - first_node.rows();
+    try testing.expect(first_node.capacity().cols >= cols + 1);
+    try testing.expect(spare > 0);
+    try testing.expect(second_node.rows() > spare);
+
+    const marker: u21 = 'X';
+    {
+        const page = second_node.page();
+        const rac = page.getRowAndCell(0, 0);
+        rac.cell.* = .{
+            .content_tag = .codepoint,
+            .content = .{ .codepoint = .{ .data = marker } },
+        };
+    }
+
+    const tracked = try s.trackPin(.{ .node = second_node, .x = 0, .y = 0 });
+    defer s.untrackPin(tracked);
+    const first_rows = first_node.rows();
+
+    // Fail the first page allocation after the backfill has run.
+    tw.errorAlways(.create_page, error.OutOfMemory);
+    try testing.expectError(
+        error.OutOfMemory,
+        s.resize(.{ .cols = cols + 1, .reflow = false }),
+    );
+    // end() reports an error if the point was never reached, which is what
+    // proves we got past the backfill and into the new page loop.
+    try tw.end(.reset);
+
+    // The backfill was undone, so the pin must still be on its original
+    // page, at its original row, holding its original content.
+    try testing.expectEqual(first_rows, first_node.rows());
+    try testing.expectEqual(second_node, tracked.node);
+    try testing.expectEqual(@as(size.CellCountInt, 0), tracked.y);
     const cell = tracked.rowAndCell().cell;
     try testing.expectEqual(marker, cell.content.codepoint.data);
 }

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -3129,10 +3129,18 @@ fn resizeWithoutReflowGrowCols(
     errdefer comptime unreachable;
 
     // Hand over the tracked pins for the rows we backfilled into the
-    // previous page. This is deliberately last: the rows below were also
-    // moved out of this page, but they went to pages that only exist if we
-    // got here, whereas the backfill destination survives a failure and
-    // would be left holding pins for rows it no longer has.
+    // previous page. This is deliberately last: the backfill destination
+    // survives a failure, so remapping onto it any earlier would leave it
+    // holding pins for rows it no longer has.
+    //
+    // The new-page loop above remaps its own pins inline and is NOT safe in
+    // the same way. Its pages do not survive a failure, but the pins moved
+    // onto them are not put back either: if one iteration remaps pins and a
+    // later one fails at createPage, the errdefer destroys the node it
+    // already inserted, and destroyNode zeroes and decommits that page's
+    // memory back to the pool while those pins still point into it. That is
+    // pre-existing, needs two or more new pages plus an allocation failure
+    // to reach, and is tracked separately.
     if (backfill) |bf| {
         const pin_keys = self.tracked_pins.keys();
         for (pin_keys) |p| {

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -3013,12 +3013,18 @@ fn resizeWithoutReflowGrowCols(
                 page,
                 dst_row,
                 src_row,
-            ) catch {
-                // If an error happens, we undo our row copy and stop
-                // filling. A partial copy can leave managed memory in the
-                // row, and the row is retired back into unused capacity,
-                // which the grow() fast path re-exposes without any
-                // clearing, so it has to go back to the default state.
+            ) catch |err| {
+                // Undo the row copy and stop filling. A partial copy can
+                // leave managed memory in the row, and the row is retired
+                // back into unused capacity, which the grow() fast path
+                // re-exposes without any clearing, so the cells have to be
+                // released. resetRow releases only what the cells still
+                // point at, so a reference the failed clone took but had
+                // not yet recorded on a cell stays held by this page.
+                log.warn(
+                    "cloneRowFrom failure backfilling the previous page during resizeWithoutReflowGrowCols: {}",
+                    .{err},
+                );
                 prev_page.resetRow(dst_row);
                 prev_page.size.rows -= 1;
                 copied -= 1;
@@ -3093,8 +3099,9 @@ fn resizeWithoutReflowGrowCols(
 
                 // We can actually safely handle this though by exiting
                 // this loop early and cutting our copy short. The row goes
-                // back into unused capacity so it must be reset, since a
-                // partial copy can leave managed memory behind.
+                // back into unused capacity so it must be reset, with the
+                // same caveat as the backfill above: only what the cells
+                // still point at is released.
                 new_page.resetRow(dst_row);
                 new_page.size.rows -= 1;
                 break;
@@ -19454,16 +19461,12 @@ test "PageList resize (no reflow) more cols remaps pins when backfill fails" {
 
     try s.resize(.{ .cols = cols + 1, .reflow = false });
 
-    // The pin must point at a page that is still in the list.
-    var found = false;
-    var it = s.pages.first;
-    while (it) |node| : (it = node.next) {
-        if (node == tracked.node) {
-            found = true;
-            break;
-        }
-    }
-    try testing.expect(found);
+    // The pin must have gone to the backfill destination. Asserting the
+    // node rather than just "some live node" is what keeps this test tied
+    // to the partial-backfill path: if the geometry ever stops producing a
+    // backfill, the pin is remapped by the new page loop instead and every
+    // other assertion here still holds.
+    try testing.expectEqual(first_node, tracked.node);
     try testing.expect(tracked.y < tracked.node.rows());
 
     // And it must still point at the content it was tracking.

--- a/src/terminal/page.zig
+++ b/src/terminal/page.zig
@@ -1027,9 +1027,15 @@ pub const Page = struct {
         }
 
         // If we are growing columns, then we need to ensure spacer heads
-        // are cleared.
-        if (self.size.cols > other.size.cols) {
-            const last = &cells[other.size.cols - 1];
+        // are cleared. A spacer head only ever sits in the last column of
+        // the source row, so this only applies to a copy that reaches it.
+        // The column is absolute, so it has to be indexed off the row and
+        // not off `cells`, which only covers the copied range.
+        if (self.size.cols > other.size.cols and
+            x_start < x_end and
+            x_end == other.size.cols)
+        {
+            const last = &dst_row.cells.ptr(self.memory)[x_end - 1];
             if (last.wide == .spacer_head) {
                 last.wide = .narrow;
             }
@@ -3659,6 +3665,51 @@ test "Page cloneRowFrom partial hyperlink in same page omit" {
         }
     }
     try testing.expectEqual(@as(usize, 1), page.hyperlinkCount());
+}
+
+test "Page clonePartialRowFrom spacer head into wider page from x_start" {
+    var src = try Page.init(.{ .cols = 5, .rows = 2 });
+    defer src.deinit();
+    var dst = try Page.init(.{ .cols = 8, .rows = 2 });
+    defer dst.deinit();
+
+    // Write a soft-wrapped row that ends with a spacer head, which is
+    // what a wide character that didn't fit leaves behind.
+    {
+        for (0..src.size.cols - 1) |x| {
+            const rac = src.getRowAndCell(x, 0);
+            rac.cell.* = .{
+                .content_tag = .codepoint,
+                .content = .{ .codepoint = .{ .data = @intCast(x + 1) } },
+            };
+        }
+
+        const rac = src.getRowAndCell(src.size.cols - 1, 0);
+        rac.row.wrap = true;
+        rac.cell.wide = .spacer_head;
+    }
+
+    // Clone the tail of the row, including the spacer head.
+    try dst.clonePartialRowFrom(
+        &src,
+        dst.getRow(0),
+        src.getRow(0),
+        2,
+        dst.size.cols,
+    );
+
+    for (2..src.size.cols - 1) |x| {
+        const rac = dst.getRowAndCell(x, 0);
+        try testing.expectEqual(
+            @as(u21, @intCast(x + 1)),
+            rac.cell.content.codepoint.data,
+        );
+    }
+
+    // The spacer head is meaningless in the wider page so it must be
+    // cleared, otherwise it is a spacer head in the middle of a row.
+    const rac = dst.getRowAndCell(src.size.cols - 1, 0);
+    try testing.expectEqual(Cell.Wide.narrow, rac.cell.wide);
 }
 
 test "Page moveCells text-only" {


### PR DESCRIPTION
Growing a `PageList`'s columns without reflow leaves tracked pins on pages that no longer hold their rows when it fails partway, and the row clone it uses indexes a spacer head off the wrong base.

What was wrong:

- `clonePartialRowFrom` clears a spacer head when cloning into a wider page, but it took the last source column off `cells`, the sub-slice covering only the copied range `[x_start, x_end)`. With `x_start = 2` and a 5 column source, `cells` is three long and the absolute column `other.size.cols - 1 = 4` runs off the end of it.
- `resizeWithoutReflowGrowCols` backfills rows into the previous page and hands the tracked pins for those rows over to it, but it did that while the resize could still fail. A later `createPage` failure rolls the rows back out of the destination page and leaves the pins on it, pointing at rows the page no longer has.
- A backfill cut short by a `cloneRowFrom` failure was not recorded at all, so its pins were never handed over and were left on a page that is about to be destroyed. `assertIntegrity` sees this as `error.TrackedPinInvalid`.

What changed:

- The spacer head is indexed off `dst_row` at absolute column `x_end - 1`, guarded by `x_start < x_end` so an empty copy cannot underflow, and by `x_end == other.size.cols` so the fixup only runs when the copy actually reaches the last column, which is the only column a spacer head can occupy. Full row clones pass `x_start = 0` and `x_end_req = self.size.cols` and still satisfy the guard, so existing behaviour is unchanged.
- The backfill pin remap moved below `errdefer comptime unreachable`, so it runs only once the resize can no longer fail. Nothing in between reads those pins: `createPage` (including its `recycle_node` branch), `destroyNode`, `pages.insertBefore` and `cloneRowFrom` never touch `tracked_pins`, and the new page loop's own remap only ever covers rows at or above `backfill.len`.
- A partial backfill is recorded whenever any row was copied, so its pins are handed over like a complete one's. The existing errdefer already resets exactly the backfilled rows and restores `size.rows`, so the rollback stays a complete undo.
- The comment on a rolled back backfill row now says what `resetRow` actually releases, which is only what the cells still point at.

This commit is hardening, not a live crash fix, for the spacer head index. No production caller reaches it: the only `clonePartialRowFrom` callers with `x_start > 0` are the left and right margin scrolls in `Terminal.zig`, where source and destination are pages of the same `PageList` and so have equal `size.cols`, which skips the block entirely. Everything else passes `x_start = 0`.

Not fixed here, all pre-existing and filed separately:

- The new page loop remaps its own pins as it goes. If one iteration remaps pins onto its new page and a later iteration fails at `createPage`, the errdefer destroys the node it already inserted, `destroyNode` zeroes and decommits that page's memory back to the pool, and the pins are left pointing into it. It needs two or more new pages plus an allocation failure, and closing it means deferring a second and larger set of remaps past the safe point, or teaching the errdefer to restore pins. The comment at the deferred remap now names this instead of implying the path is safe.
- `clonePartialRowFrom` takes a hyperlink reference and duplicates its URI bytes before `setHyperlink` records anything on the cell, so a failure in that window strands the reference and its bytes in a page that is not destroyed.
- The new page loop does not advance `copied` when it cuts a row short, so a source row that no fresh page can take makes it append pages until the allocator gives out.
- A `.gt` resize that fails partway leaves `self.cols` at the old value with earlier pages already at the new width.

Test plan:

- [x] `zig build test -Dapp-runtime=none` with single token filters `x_start`, `backfill`, `later`: 87/87 steps succeeded, 83/83 tests passed, no leak lines.
- [x] Restoring the original spacer head expression crashes `terminal.page.test.Page clonePartialRowFrom spacer head into wider page from x_start` with `index out of bounds: index 4, len 3`, which is the predicted defect exactly.
- [x] Moving the deferred remap back into the `prev:` block, and nothing else, crashes `terminal.PageList.test.PageList resize (no reflow) more cols does not move pins if a later page fails`, and only that test.
- [x] Additionally restoring the old `break :prev` semantics, so a partial backfill is never recorded, crashes `terminal.PageList.test.PageList resize (no reflow) more cols remaps pins when backfill fails` on the `error.TrackedPinInvalid` integrity check, so the test fails for the right reason rather than incidentally.
- [x] `zig fmt --check` on every touched file.

Note for whoever runs these: `-Dtest-filter` values containing spaces are silently split at the first space on the way through the lane runner, so a filter of `more cols remaps pins` behaves as `more` and selects 78 tests. Use single token filters and read the failure names rather than the counts.
