### PR TITLE
terminal: reject oversized PNGs before decoding and bound kitty placements

### DIFF
--- a/src/terminal/kitty/graphics_exec.zig
+++ b/src/terminal/kitty/graphics_exec.zig
@@ -463,7 +463,22 @@ fn transmitAnimationFrame(
         // Not the first frame, so continue loading similar to transmit
         // but this is for a subsequent frame.
         var result = loading.response;
+
+        // A payload that has already outgrown everything storage could ever
+        // hold can only fail at the end, so stop accumulating it now.
+        if (loading.data.items.len +| cmd.data.len > storage.total_limit) {
+            loading.destroy(alloc);
+            storage.loading = null;
+            encodeError(&result, error.OutOfMemory);
+            return result;
+        }
+
         loading.addData(alloc, cmd.data) catch |err| {
+            // A rejected chunk ends the transmission: every later chunk
+            // fails the same way, so the buffered payload would stay
+            // resident until the client happened to send a delete.
+            loading.destroy(alloc);
+            storage.loading = null;
             encodeError(&result, err);
             return result;
         };
@@ -999,9 +1014,24 @@ fn loadAndAddImage(
 
     // Determine our image. This also handles chunking and early exit.
     var loading: LoadingImage = if (storage.loading) |loading| loading: {
+        // A payload that has already outgrown everything storage could ever
+        // hold can only fail at the end, so stop accumulating it now.
+        if (loading.data.items.len +| cmd.data.len > storage.total_limit) {
+            loading.destroy(alloc);
+            storage.loading = null;
+            return error.OutOfMemory;
+        }
+
         // Note: we do NOT want to call "cmd.toOwnedData" here because
         // we're _copying_ the data. We want the command data to be freed.
-        try loading.addData(alloc, cmd.data);
+        loading.addData(alloc, cmd.data) catch |err| {
+            // A rejected chunk ends the transmission: every later chunk
+            // fails the same way, so the buffered payload would stay
+            // resident until the client happened to send a delete.
+            loading.destroy(alloc);
+            storage.loading = null;
+            return err;
+        };
 
         // If we have more then we're done
         if (t.more_chunks) return .{ .image = loading.image, .more = true };
@@ -1741,6 +1771,84 @@ test "kittygfx more chunks with chunk increasing q" {
         const resp = execute(io, alloc, &t, &cmd);
         try testing.expect(resp == null);
     }
+}
+
+test "kittygfx rejected chunk drops the partial image load" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var t = try Terminal.init(io, alloc, .{ .rows = 5, .cols = 5 });
+    defer t.deinit(alloc);
+    const storage = &t.screens.active.kitty_images;
+
+    // A storage budget smaller than the payload. The upload can never
+    // complete, so the chunk that passes the budget is rejected.
+    storage.total_limit = 8;
+
+    {
+        const cmd = try command.Parser.parseString(
+            alloc,
+            "a=t,f=24,s=4,v=1,i=1,m=1;AAAA",
+        );
+        defer cmd.deinit(alloc);
+        try testing.expect(execute(io, alloc, &t, &cmd) == null);
+    }
+    try testing.expect(storage.loading != null);
+
+    {
+        const cmd = try command.Parser.parseString(
+            alloc,
+            "a=t,m=1;AAAAAAAAAAAA",
+        );
+        defer cmd.deinit(alloc);
+        const resp = execute(io, alloc, &t, &cmd);
+        try testing.expect(resp != null and !resp.?.ok());
+    }
+    try testing.expect(storage.loading == null);
+}
+
+test "kittygfx rejected animation frame chunk drops the partial load" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var t = try Terminal.init(io, alloc, .{ .rows = 5, .cols = 5 });
+    defer t.deinit(alloc);
+    const storage = &t.screens.active.kitty_images;
+
+    // A 2x1 RGB white image to hang the animation frames off of.
+    {
+        const cmd = try command.Parser.parseString(
+            alloc,
+            "a=t,f=24,s=2,v=1,i=1;////////",
+        );
+        defer cmd.deinit(alloc);
+        try testing.expect(execute(io, alloc, &t, &cmd).?.ok());
+    }
+
+    storage.total_limit = 8;
+
+    {
+        const cmd = try command.Parser.parseString(
+            alloc,
+            "a=f,i=1,f=24,s=2,v=1,m=1;/wAA",
+        );
+        defer cmd.deinit(alloc);
+        try testing.expect(execute(io, alloc, &t, &cmd) == null);
+    }
+    try testing.expect(storage.loading != null);
+
+    {
+        const cmd = try command.Parser.parseString(
+            alloc,
+            "a=f,m=1;AAAAAAAAAAAA",
+        );
+        defer cmd.deinit(alloc);
+        const resp = execute(io, alloc, &t, &cmd);
+        try testing.expect(resp != null and !resp.?.ok());
+    }
+    try testing.expect(storage.loading == null);
 }
 
 test "kittygfx delete aborts chunked image load" {

--- a/src/terminal/kitty/graphics_image.zig
+++ b/src/terminal/kitty/graphics_image.zig
@@ -640,9 +640,37 @@ pub const LoadingImage = struct {
         self.image.compression = .none;
     }
 
+    /// Reads the image dimensions out of a PNG header, or null if the data
+    /// doesn't begin with a well formed header. The dimensions live in the
+    /// IHDR chunk, which the format requires to come first: an 8 byte
+    /// signature, a 4 byte chunk length, the 4 byte chunk type, and then
+    /// the width and height as big endian u32s.
+    fn pngHeaderDimensions(data: []const u8) ?struct { width: u32, height: u32 } {
+        const signature = "\x89PNG\r\n\x1a\n";
+        if (data.len < 24) return null;
+        if (!std.mem.eql(u8, data[0..signature.len], signature)) return null;
+        if (!std.mem.eql(u8, data[12..16], "IHDR")) return null;
+        return .{
+            .width = std.mem.readInt(u32, data[16..20], .big),
+            .height = std.mem.readInt(u32, data[20..24], .big),
+        };
+    }
+
     /// Decode the data as PNG. This will also updated the image dimensions.
     fn decodePng(self: *LoadingImage, alloc: Allocator) !void {
         assert(self.image.format == .png);
+
+        // Decoders size their destination buffer from the header before
+        // they inflate a single pixel, so a couple dozen header bytes are
+        // enough to make one allocate hundreds of megabytes. `complete`
+        // rejects these dimensions too, but only once that has happened.
+        if (pngHeaderDimensions(self.data.items)) |dimensions| {
+            if (dimensions.width > max_dimension or
+                dimensions.height > max_dimension)
+            {
+                return error.DimensionsTooLarge;
+            }
+        }
 
         const decode_png_fn = sys.decode_png orelse
             return error.UnsupportedFormat;
@@ -1835,8 +1863,8 @@ test "image load: png rejects oversized Wuffs image before allocation" {
     const alloc = testing.allocator;
 
     // Turn the small test PNG into a 32768x32767 image. Its decoded RGBA
-    // size is just under Wuffs' 4 GiB package limit but over Kitty's 400 MiB
-    // limit, which previously allowed the large allocation to happen first.
+    // size is just under Wuffs' 4 GiB package limit, so nothing inside the
+    // decoder stops it; the header dimensions are what reject it.
     var data = @embedFile("testdata/image-png-none-50x76-2147483647-raw.data").*;
     std.mem.writeInt(u32, data[16..20], 32768, .big);
     std.mem.writeInt(u32, data[20..24], 32767, .big);
@@ -1852,7 +1880,62 @@ test "image load: png rejects oversized Wuffs image before allocation" {
     var loading = try LoadingImage.init(testing.io, alloc, &cmd, .direct);
     defer loading.deinit(alloc);
 
-    try testing.expectError(error.InvalidData, loading.complete(alloc));
+    try testing.expectError(error.DimensionsTooLarge, loading.complete(alloc));
+}
+
+test "image load: png rejects oversized header dimensions before decoding" {
+    const testing = std.testing;
+
+    // A decoder sizes its destination buffer from the header, exactly as
+    // Wuffs does, so reaching it at all means the allocation happens.
+    const header_decoder = struct {
+        fn decode(
+            alloc: Allocator,
+            data: []const u8,
+        ) sys.DecodeError!sys.Image {
+            const width = std.mem.readInt(u32, data[16..20], .big);
+            const height = std.mem.readInt(u32, data[20..24], .big);
+            return .{
+                .width = width,
+                .height = height,
+                .data = try alloc.alloc(
+                    u8,
+                    @as(usize, width) * @as(usize, height) * 4,
+                ),
+            };
+        }
+    }.decode;
+
+    const original_decode_png = sys.decode_png;
+    defer sys.decode_png = original_decode_png;
+    sys.decode_png = &header_decoder;
+
+    // 10001x10001 is over the dimension limit but its decoded size is
+    // still under max_size, so the size limiter lets it through.
+    var header: [24]u8 = undefined;
+    @memcpy(header[0..16], "\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR");
+    std.mem.writeInt(u32, header[16..20], max_dimension + 1, .big);
+    std.mem.writeInt(u32, header[20..24], max_dimension + 1, .big);
+
+    // Fail any allocation which reaches the underlying allocator. Nothing
+    // should be allocated for an image we already know is too large.
+    var failing = testing.FailingAllocator.init(testing.allocator, .{
+        .fail_index = 0,
+    });
+
+    var loading: LoadingImage = .{
+        .image = .{ .format = .png },
+        .quiet = .no,
+        .temporary_directory = null,
+    };
+    defer loading.deinit(testing.allocator);
+    try loading.data.appendSlice(testing.allocator, &header);
+
+    try testing.expectError(
+        error.DimensionsTooLarge,
+        loading.complete(failing.allocator()),
+    );
+    try testing.expect(!failing.has_induced_failure);
 }
 
 test "limits: direct medium always allowed" {

--- a/src/terminal/kitty/graphics_storage.zig
+++ b/src/terminal/kitty/graphics_storage.zig
@@ -73,6 +73,15 @@ pub const ImageStorage = struct {
     const ImageMap = std.AutoHashMapUnmanaged(u32, Image);
     const PlacementMap = std.AutoHashMapUnmanaged(PlacementKey, Placement);
 
+    /// Maximum number of placements a storage will hold, and the maximum
+    /// number that may reference a single image. A placement holds no
+    /// image bytes, so the byte budget doesn't limit them at all; without
+    /// these a client can spend unbounded memory on display commands for
+    /// one tiny image. The values are far above what a screen can usefully
+    /// show at once.
+    const max_placements = 4096;
+    const max_placements_per_image = 1024;
+
     /// Dirty is set to true if placements or images change. This is
     /// purely informational for the renderer and doesn't affect the
     /// correctness of the program. The renderer must set this to false
@@ -402,14 +411,13 @@ pub const ImageStorage = struct {
             gop.value_ptr.deinit(s);
         } else {
             const img = self.images.getPtr(image_id).?;
-            img.metadata.placement_count = std.math.add(
-                @TypeOf(img.metadata.placement_count),
-                img.metadata.placement_count,
-                1,
-            ) catch {
+            if (self.placements.count() > max_placements or
+                img.metadata.placement_count >= max_placements_per_image)
+            {
                 self.placements.removeByPtr(gop.key_ptr);
                 return error.OutOfMemory;
-            };
+            }
+            img.metadata.placement_count += 1;
         }
         gop.value_ptr.* = p;
 
@@ -2248,6 +2256,82 @@ test "storage: placement count limit permits replacement" {
         s.addPlacement(io, alloc, t.screens.active, 1, 2, .{ .location = .{ .virtual = {} } }),
     );
     try testing.expectEqual(@as(usize, 1), s.placements.count());
+}
+
+test "storage: placements for one image are capped" {
+    const testing = std.testing;
+    const io = testing.io;
+    const alloc = testing.allocator;
+    var t = try terminal.Terminal.init(io, alloc, .{ .rows = 3, .cols = 3 });
+    defer t.deinit(alloc);
+
+    var s: ImageStorage = .{};
+    defer s.deinit(alloc, t.screens.active);
+    try s.addImage(io, alloc, t.screens.active, .{ .id = 1 });
+
+    const cap = ImageStorage.max_placements_per_image;
+    for (0..cap) |i| try s.addPlacement(
+        io,
+        alloc,
+        t.screens.active,
+        1,
+        @intCast(i + 1),
+        .{ .location = .{ .virtual = {} } },
+    );
+
+    try testing.expectError(error.OutOfMemory, s.addPlacement(
+        io,
+        alloc,
+        t.screens.active,
+        1,
+        cap + 1,
+        .{ .location = .{ .virtual = {} } },
+    ));
+    try testing.expectEqual(@as(usize, cap), s.placements.count());
+}
+
+test "storage: placements across images are capped" {
+    const testing = std.testing;
+    const io = testing.io;
+    const alloc = testing.allocator;
+    var t = try terminal.Terminal.init(io, alloc, .{ .rows = 3, .cols = 3 });
+    defer t.deinit(alloc);
+
+    var s: ImageStorage = .{};
+    defer s.deinit(alloc, t.screens.active);
+
+    // Enough images to reach the total cap without any one of them
+    // reaching the per-image cap, plus one more to place onto.
+    const cap = ImageStorage.max_placements;
+    const per_image = ImageStorage.max_placements_per_image;
+    const image_count = cap / per_image;
+    for (1..image_count + 2) |id| try s.addImage(
+        io,
+        alloc,
+        t.screens.active,
+        .{ .id = @intCast(id) },
+    );
+    for (1..image_count + 1) |id| {
+        for (0..per_image) |i| try s.addPlacement(
+            io,
+            alloc,
+            t.screens.active,
+            @intCast(id),
+            @intCast(i + 1),
+            .{ .location = .{ .virtual = {} } },
+        );
+    }
+    try testing.expectEqual(@as(usize, cap), s.placements.count());
+
+    try testing.expectError(error.OutOfMemory, s.addPlacement(
+        io,
+        alloc,
+        t.screens.active,
+        image_count + 1,
+        1,
+        .{ .location = .{ .virtual = {} } },
+    ));
+    try testing.expectEqual(@as(usize, cap), s.placements.count());
 }
 
 test "storage: delete all visible placements and matching images" {


### PR DESCRIPTION
Two hardening fixes in the kitty graphics path.

- PNG uploads were only checked against `max_dimension` after wuffs had allocated and decoded the image, so a few KB of PNG declaring 30000x30000 forced a multi-hundred-MB allocation on the IO thread. The IHDR width and height are now read before decoding and oversized images are rejected with `EINVAL: dimensions too large`. The test uses a failing allocator to prove no allocation happens.
- A chunked upload that ran over the storage budget left the partial image resident in `storage.loading`, and placements had no real cap. The abandoned upload is now freed on the rejected-chunk path, and placements are capped at 4096 total and 1024 per image (garbage placements are reaped first), replying `ENOMEM` when hit.

Already handled on this branch and left alone: placement parameter clamping and the per-command APC payload limit.

Test plan:
- [x] `zig build test -Dapp-runtime=none -Dtest-filter=kitty` (626/630, 4 skipped)
- [x] `zig fmt --check` on the three files

Known follow-ups (not in this PR): JPEG and GIF decode paths still have no header pre-check and only the 4 GiB wuffs ceiling; the placement cap is a constant rather than grid-derived.
