### PR TITLE
apprt: C ABI fixes for read_text, inherited config, enum width and null checks

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1279,11 +1279,15 @@ GHOSTTY_API ghostty_surface_t ghostty_surface_new(ghostty_app_t,
 GHOSTTY_API void ghostty_surface_free(ghostty_surface_t);
 GHOSTTY_API void* ghostty_surface_userdata(ghostty_surface_t);
 GHOSTTY_API ghostty_app_t ghostty_surface_app(ghostty_surface_t);
-// The working_directory of the returned config is owned by the surface and
-// stays valid only until the next call for that surface or until the surface
-// is freed, whichever comes first, so copy it before either happens. There is
-// no free for it.
+// The working_directory of the returned config is allocated for the caller,
+// which releases it with ghostty_surface_free_inherited_config. Every call
+// returns its own copy and no call invalidates an earlier one, so a config
+// stays valid until you free it; free it before you free the surface.
 GHOSTTY_API ghostty_surface_config_s ghostty_surface_inherited_config(ghostty_surface_t, ghostty_surface_context_e);
+// Release the memory owned by a config from ghostty_surface_inherited_config,
+// passing the surface it came from. The freed fields are cleared, so calling
+// this twice on the same config is safe.
+GHOSTTY_API void ghostty_surface_free_inherited_config(ghostty_surface_t, ghostty_surface_config_s*);
 GHOSTTY_API void ghostty_surface_update_config(ghostty_surface_t, ghostty_config_t);
 GHOSTTY_API bool ghostty_surface_needs_confirm_quit(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_process_exited(ghostty_surface_t);

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1282,12 +1282,13 @@ GHOSTTY_API ghostty_app_t ghostty_surface_app(ghostty_surface_t);
 // The working_directory of the returned config is allocated for the caller,
 // which releases it with ghostty_surface_free_inherited_config. Every call
 // returns its own copy and no call invalidates an earlier one, so a config
-// stays valid until you free it; free it before you free the surface.
+// stays valid until you free it, including after the surface it came from
+// has been freed.
 GHOSTTY_API ghostty_surface_config_s ghostty_surface_inherited_config(ghostty_surface_t, ghostty_surface_context_e);
-// Release the memory owned by a config from ghostty_surface_inherited_config,
-// passing the surface it came from. The freed fields are cleared, so calling
-// this twice on the same config is safe.
-GHOSTTY_API void ghostty_surface_free_inherited_config(ghostty_surface_t, ghostty_surface_config_s*);
+// Release the memory owned by a config from ghostty_surface_inherited_config.
+// The freed fields are cleared, so calling this twice on the same config is
+// safe, as is calling it on a config that carries no working directory.
+GHOSTTY_API void ghostty_surface_free_inherited_config(ghostty_surface_config_s*);
 GHOSTTY_API void ghostty_surface_update_config(ghostty_surface_t, ghostty_config_t);
 GHOSTTY_API bool ghostty_surface_needs_confirm_quit(ghostty_surface_t);
 GHOSTTY_API bool ghostty_surface_process_exited(ghostty_surface_t);

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1279,6 +1279,9 @@ GHOSTTY_API ghostty_surface_t ghostty_surface_new(ghostty_app_t,
 GHOSTTY_API void ghostty_surface_free(ghostty_surface_t);
 GHOSTTY_API void* ghostty_surface_userdata(ghostty_surface_t);
 GHOSTTY_API ghostty_app_t ghostty_surface_app(ghostty_surface_t);
+// The working_directory of the returned config is owned by the surface and
+// stays valid only until the next call for that surface, so copy it before
+// calling again. There is no free for it.
 GHOSTTY_API ghostty_surface_config_s ghostty_surface_inherited_config(ghostty_surface_t, ghostty_surface_context_e);
 GHOSTTY_API void ghostty_surface_update_config(ghostty_surface_t, ghostty_config_t);
 GHOSTTY_API bool ghostty_surface_needs_confirm_quit(ghostty_surface_t);

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1280,8 +1280,9 @@ GHOSTTY_API void ghostty_surface_free(ghostty_surface_t);
 GHOSTTY_API void* ghostty_surface_userdata(ghostty_surface_t);
 GHOSTTY_API ghostty_app_t ghostty_surface_app(ghostty_surface_t);
 // The working_directory of the returned config is owned by the surface and
-// stays valid only until the next call for that surface, so copy it before
-// calling again. There is no free for it.
+// stays valid only until the next call for that surface or until the surface
+// is freed, whichever comes first, so copy it before either happens. There is
+// no free for it.
 GHOSTTY_API ghostty_surface_config_s ghostty_surface_inherited_config(ghostty_surface_t, ghostty_surface_context_e);
 GHOSTTY_API void ghostty_surface_update_config(ghostty_surface_t, ghostty_config_t);
 GHOSTTY_API bool ghostty_surface_needs_confirm_quit(ghostty_surface_t);

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -725,10 +725,12 @@ pub const Surface = struct {
             }
         }
 
-        // Apply any environment variables that were requested.
-        if (opts.env_var_count > 0) {
+        // Apply any environment variables that were requested. A null
+        // pointer with a non-zero count is a caller bug; read it as "none"
+        // rather than dereferencing the null.
+        if (opts.env_vars) |env_vars| {
             const alloc = config.arenaAlloc();
-            for (opts.env_vars.?[0..opts.env_var_count]) |env_var| {
+            for (env_vars[0..opts.env_var_count]) |env_var| {
                 const key = std.mem.sliceTo(env_var.key, 0);
                 const value = std.mem.sliceTo(env_var.value, 0);
                 try config.env.map.put(

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -517,11 +517,6 @@ pub const Surface = struct {
     /// that getTitle works without the implementer needing to save it.
     title: ?[:0]const u8 = null,
 
-    /// The working directory last handed out by newSurfaceOptions. The
-    /// C API returns that struct by value and has no matching free, so
-    /// the surface keeps ownership of the string.
-    inherited_pwd: ?[:0]const u8 = null,
-
     /// Windows buffers WM_KEYDOWN here so a following WM_CHAR can
     /// attach text before dispatching through key encoding.
     pending_key: if (builtin.os.tag == .windows)
@@ -791,7 +786,6 @@ pub const Surface = struct {
 
         // Free our title
         if (self.title) |v| self.app.core_app.alloc.free(v);
-        if (self.inherited_pwd) |v| self.app.core_app.alloc.free(v);
 
         // Remove ourselves from the list of known surfaces in the app.
         self.app.core_app.deleteSurface(self);
@@ -1376,7 +1370,7 @@ pub const Surface = struct {
         };
     }
 
-    pub fn newSurfaceOptions(self: *Surface, context: apprt.surface.NewSurfaceContext) apprt.Surface.Options {
+    pub fn newSurfaceOptions(self: *const Surface, context: apprt.surface.NewSurfaceContext) apprt.Surface.Options {
         const font_size: f32 = font_size: {
             if (!self.app.config.@"window-inherit-font-size") break :font_size 0;
             break :font_size self.core_surface.font_size.points;
@@ -1387,14 +1381,7 @@ pub const Surface = struct {
             const alloc = self.app.core_app.alloc;
             const cwd = self.core_surface.pwd(alloc) catch null orelse break :wd null;
             defer alloc.free(cwd);
-
-            // The caller only borrows this. Embedders copy the string out
-            // during the call, so we hold on to it until the next one
-            // rather than leaking a fresh copy on every call.
-            const dup = alloc.dupeZ(u8, cwd) catch break :wd null;
-            if (self.inherited_pwd) |old| alloc.free(old);
-            self.inherited_pwd = dup;
-            break :wd dup.ptr;
+            break :wd apprt.surface.dupeInheritedPwd(alloc, cwd);
         };
 
         return .{
@@ -2387,11 +2374,26 @@ pub const CAPI = struct {
     }
 
     /// Returns the config to use for surfaces that inherit from this one.
+    /// The caller owns the working directory in the returned config and
+    /// releases it with ghostty_surface_free_inherited_config.
     export fn ghostty_surface_inherited_config(
         surface: *Surface,
         source: apprt.surface.NewSurfaceContext,
     ) Surface.Options {
         return surface.newSurfaceOptions(source);
+    }
+
+    /// Release the memory owned by a config from
+    /// ghostty_surface_inherited_config. Calling it more than once on the
+    /// same config, or on a config that carries no directory, is safe.
+    export fn ghostty_surface_free_inherited_config(
+        surface: *Surface,
+        config: *Surface.Options,
+    ) void {
+        apprt.surface.freeInheritedPwd(
+            surface.app.core_app.alloc,
+            &config.working_directory,
+        );
     }
 
     /// Update the configuration to the provided config for only this surface.

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -517,6 +517,11 @@ pub const Surface = struct {
     /// that getTitle works without the implementer needing to save it.
     title: ?[:0]const u8 = null,
 
+    /// The working directory last handed out by newSurfaceOptions. The
+    /// C API returns that struct by value and has no matching free, so
+    /// the surface keeps ownership of the string.
+    inherited_pwd: ?[:0]const u8 = null,
+
     /// Windows buffers WM_KEYDOWN here so a following WM_CHAR can
     /// attach text before dispatching through key encoding.
     pending_key: if (builtin.os.tag == .windows)
@@ -784,6 +789,7 @@ pub const Surface = struct {
 
         // Free our title
         if (self.title) |v| self.app.core_app.alloc.free(v);
+        if (self.inherited_pwd) |v| self.app.core_app.alloc.free(v);
 
         // Remove ourselves from the list of known surfaces in the app.
         self.app.core_app.deleteSurface(self);
@@ -1368,7 +1374,7 @@ pub const Surface = struct {
         };
     }
 
-    pub fn newSurfaceOptions(self: *const Surface, context: apprt.surface.NewSurfaceContext) apprt.Surface.Options {
+    pub fn newSurfaceOptions(self: *Surface, context: apprt.surface.NewSurfaceContext) apprt.Surface.Options {
         const font_size: f32 = font_size: {
             if (!self.app.config.@"window-inherit-font-size") break :font_size 0;
             break :font_size self.core_surface.font_size.points;
@@ -1376,9 +1382,17 @@ pub const Surface = struct {
 
         const working_directory: ?[*:0]const u8 = wd: {
             if (!apprt.surface.shouldInheritWorkingDirectory(context, &self.app.config)) break :wd null;
-            const cwd = self.core_surface.pwd(self.app.core_app.alloc) catch null orelse break :wd null;
-            defer self.app.core_app.alloc.free(cwd);
-            break :wd self.app.core_app.alloc.dupeZ(u8, cwd) catch null;
+            const alloc = self.app.core_app.alloc;
+            const cwd = self.core_surface.pwd(alloc) catch null orelse break :wd null;
+            defer alloc.free(cwd);
+
+            // The caller only borrows this. Embedders copy the string out
+            // during the call, so we hold on to it until the next one
+            // rather than leaking a fresh copy on every call.
+            const dup = alloc.dupeZ(u8, cwd) catch break :wd null;
+            if (self.inherited_pwd) |old| alloc.free(old);
+            self.inherited_pwd = dup;
+            break :wd dup.ptr;
         };
 
         return .{

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2390,12 +2390,16 @@ pub const CAPI = struct {
     /// Release the memory owned by a config from
     /// ghostty_surface_inherited_config. Calling it more than once on the
     /// same config, or on a config that carries no directory, is safe.
+    ///
+    /// No surface is needed to free the config: the copy came from the
+    /// process-wide allocator, the same one every other C API allocation
+    /// comes from, so a config stays releasable after the surface it was
+    /// read from is gone.
     export fn ghostty_surface_free_inherited_config(
-        surface: *Surface,
         config: *Surface.Options,
     ) void {
         apprt.surface.freeInheritedPwd(
-            surface.app.core_app.alloc,
+            global.alloc(),
             &config.working_directory,
         );
     }

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2111,7 +2111,6 @@ pub const CAPI = struct {
 
             // Clamp our point to the screen bounds.
             const clamped_x = @min(self.x, screen.pages.cols -| 1);
-            const clamped_y = @min(self.y, screen.pages.rows -| 1);
 
             return switch (self.coord_tag) {
                 // Exact coordinates require a specific pin.
@@ -2125,7 +2124,24 @@ pub const CAPI = struct {
                         inline else => |v| @unionInit(
                             terminal.Point,
                             @tagName(v),
-                            .{ .x = pt_x, .y = clamped_y },
+                            .{
+                                .x = pt_x,
+                                // Only the active and viewport spaces are
+                                // bounded by the screen height. Screen and
+                                // history run the full length of the
+                                // pagelist, and PageList.pin already
+                                // rejects a y past its end, so clamping
+                                // them would answer with the wrong row.
+                                .y = switch (v) {
+                                    .active,
+                                    .viewport,
+                                    => @min(self.y, screen.pages.rows -| 1),
+
+                                    .screen,
+                                    .history,
+                                    => self.y,
+                                },
+                            },
                         ),
                     };
 

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2112,7 +2112,11 @@ pub const CAPI = struct {
                 ),
             };
 
-            // Clamp our point to the screen bounds.
+            // Columns are the same width in every point space, so unlike
+            // y this clamp cannot pick the wrong row. PageList.pin would
+            // reject an out of range x on its own; clamping instead
+            // answers with the last column, which is what the selection
+            // callers who pass a "to the end of the line" x want.
             const clamped_x = @min(self.x, screen.pages.cols -| 1);
 
             return switch (self.coord_tag) {

--- a/src/apprt/structs.zig
+++ b/src/apprt/structs.zig
@@ -65,7 +65,10 @@ pub const ClipboardContent = struct {
     data: [:0]const u8,
 };
 
-pub const ClipboardRequestType = enum(u8) {
+/// This is passed by value across the C ABI to the confirm_read_clipboard
+/// callback, where the embedder reads it as ghostty_clipboard_request_e.
+/// A plain C enum is int sized, so the tag type has to be too.
+pub const ClipboardRequestType = enum(c_int) {
     paste,
     osc_52_read,
     osc_52_write,
@@ -243,3 +246,10 @@ pub const Selection = struct {
     offset_start: u32,
     offset_len: u32,
 };
+
+test "ClipboardRequestType matches the C enum width" {
+    try std.testing.expectEqual(
+        @sizeOf(c_int),
+        @sizeOf(ClipboardRequestType),
+    );
+}

--- a/src/apprt/structs.zig
+++ b/src/apprt/structs.zig
@@ -77,6 +77,12 @@ pub const ClipboardRequestType = enum(c_int) {
     list,
 };
 
+comptime {
+    // The width has to hold in every build, not just the ones that run
+    // tests, because the callback signature is shared with C.
+    std.debug.assert(@sizeOf(ClipboardRequestType) == @sizeOf(c_int));
+}
+
 /// The result of starting a clipboard read request. This only reports
 /// facts about the clipboard; how each state is answered on the wire
 /// (if at all) is up to the protocol handling of the requester.

--- a/src/apprt/surface.zig
+++ b/src/apprt/surface.zig
@@ -369,6 +369,31 @@ pub fn shouldInheritWorkingDirectory(context: NewSurfaceContext, config: *const 
     };
 }
 
+/// Copy a working directory into surface options handed out over the C
+/// API.
+///
+/// The copy belongs to the caller of ghostty_surface_inherited_config,
+/// which releases it with ghostty_surface_free_inherited_config. Giving
+/// the caller its own allocation is what makes the pointer independent
+/// of anything the surface does afterwards: no other call can invalidate
+/// it, so the worst an embedder that ignores the free can do is leak.
+///
+/// Allocation failure yields null, which the config reports as "no
+/// inherited directory" rather than failing the call.
+pub fn dupeInheritedPwd(alloc: Allocator, cwd: []const u8) ?[*:0]const u8 {
+    return alloc.dupeZ(u8, cwd) catch null;
+}
+
+/// Release a working directory produced by dupeInheritedPwd.
+///
+/// Clearing the field as we go keeps a second release a no-op, so an
+/// embedder that frees the same config twice cannot double free.
+pub fn freeInheritedPwd(alloc: Allocator, wd: *?[*:0]const u8) void {
+    const ptr = wd.* orelse return;
+    alloc.free(std.mem.sliceTo(ptr, 0));
+    wd.* = null;
+}
+
 /// Returns a new config for a surface for the given app that should be
 /// used for any new surfaces. The resulting config should be deinitialized
 /// after the surface is initialized.
@@ -394,6 +419,42 @@ pub fn newConfig(
     }
 
     return copy;
+}
+
+test "inherited pwd: the caller owns each copy" {
+    const alloc = std.testing.allocator;
+
+    // Two calls have to hand out two independent allocations, neither of
+    // which the other invalidates. Both are freed here, so the testing
+    // allocator's leak check is what asserts the release reaches all of
+    // the memory we handed out.
+    var first: ?[*:0]const u8 = dupeInheritedPwd(alloc, "/tmp/one");
+    var second: ?[*:0]const u8 = dupeInheritedPwd(alloc, "/tmp/two");
+    try std.testing.expect(first != null);
+    try std.testing.expect(second != null);
+    try std.testing.expect(first.? != second.?);
+    try std.testing.expectEqualStrings("/tmp/one", std.mem.sliceTo(first.?, 0));
+    try std.testing.expectEqualStrings("/tmp/two", std.mem.sliceTo(second.?, 0));
+
+    freeInheritedPwd(alloc, &first);
+
+    // The first release must leave the second copy readable.
+    try std.testing.expectEqualStrings("/tmp/two", std.mem.sliceTo(second.?, 0));
+
+    freeInheritedPwd(alloc, &second);
+    try std.testing.expect(first == null);
+    try std.testing.expect(second == null);
+}
+
+test "inherited pwd: releasing twice is a no-op" {
+    const alloc = std.testing.allocator;
+
+    var wd: ?[*:0]const u8 = dupeInheritedPwd(alloc, "/tmp/one");
+    freeInheritedPwd(alloc, &wd);
+    freeInheritedPwd(alloc, &wd);
+
+    var none: ?[*:0]const u8 = null;
+    freeInheritedPwd(alloc, &none);
 }
 
 test "DesktopNotification init" {

--- a/src/terminal/c/build_info.zig
+++ b/src/terminal/c/build_info.zig
@@ -51,11 +51,13 @@ pub fn get(
         };
     }
 
+    const out_ptr = out orelse return .invalid_value;
+
     return switch (data) {
         .invalid => .invalid_value,
         inline else => |comptime_data| getTyped(
             comptime_data,
-            @ptrCast(@alignCast(out)),
+            @ptrCast(@alignCast(out_ptr)),
         ),
     };
 }
@@ -173,4 +175,8 @@ test "get version_build" {
 
 test "get invalid" {
     try std.testing.expectEqual(Result.invalid_value, get(.invalid, null));
+}
+
+test "get rejects a null out pointer" {
+    try std.testing.expectEqual(Result.invalid_value, get(.simd, null));
 }

--- a/src/terminal/c/cell.zig
+++ b/src/terminal/c/cell.zig
@@ -116,12 +116,14 @@ pub fn get(
         };
     }
 
+    const out_ptr = out orelse return .invalid_value;
+
     return switch (data) {
         .invalid => .invalid_value,
         inline else => |comptime_data| getTyped(
             cell_,
             comptime_data,
-            @ptrCast(@alignCast(out)),
+            @ptrCast(@alignCast(out_ptr)),
         ),
     };
 }
@@ -241,4 +243,9 @@ test "get_multi null values returns invalid_value" {
     const cell: CCell = @bitCast(Cell.init('A'));
     const keys = [_]CellData{.codepoint};
     try testing.expectEqual(Result.invalid_value, get_multi(cell, 1, &keys, null, null));
+}
+
+test "get rejects a null out pointer" {
+    const cell: CCell = @bitCast(Cell.init('A'));
+    try testing.expectEqual(Result.invalid_value, get(cell, .codepoint, null));
 }

--- a/src/terminal/c/osc.zig
+++ b/src/terminal/c/osc.zig
@@ -99,22 +99,24 @@ pub fn commandData(
         };
     }
 
+    const command = command_ orelse return false;
+    const out_ptr = out orelse return false;
+
     return switch (data) {
         .invalid => false,
         inline else => |comptime_data| commandDataTyped(
-            command_,
+            command,
             comptime_data,
-            @ptrCast(@alignCast(out)),
+            @ptrCast(@alignCast(out_ptr)),
         ),
     };
 }
 
 fn commandDataTyped(
-    command_: Command,
+    command: *osc.Command,
     comptime data: CommandData,
     out: *data.OutType(),
 ) bool {
-    const command = command_.?;
     switch (data) {
         .invalid => return false,
         .change_window_title_str => switch (command.*) {
@@ -222,4 +224,23 @@ test "prompt report" {
 
     var shell: [*:0]const u8 = undefined;
     try testing.expect(!commandData(cmd, .prompt_report_shell_str, @ptrCast(&shell)));
+}
+
+test "commandData rejects null arguments" {
+    const testing = std.testing;
+    var p: Parser = undefined;
+    try testing.expectEqual(Result.success, new(
+        &lib.alloc.test_allocator,
+        &p,
+    ));
+    defer free(p);
+
+    next(p, '0');
+    next(p, ';');
+    next(p, 'a');
+    const cmd = end(p, 0);
+
+    var title: [*:0]const u8 = undefined;
+    try testing.expect(!commandData(cmd, .change_window_title_str, null));
+    try testing.expect(!commandData(null, .change_window_title_str, @ptrCast(&title)));
 }

--- a/src/terminal/c/render.zig
+++ b/src/terminal/c/render.zig
@@ -965,13 +965,15 @@ inline fn rowGetDispatch(
         };
     }
 
+    const out_ptr = out orelse return .invalid_value;
+
     return switch (data) {
         .invalid => .invalid_value,
         inline else => |comptime_data| rowGetTyped(
             it,
             y,
             comptime_data,
-            @ptrCast(@alignCast(out)),
+            @ptrCast(@alignCast(out_ptr)),
         ),
     };
 }
@@ -2567,4 +2569,35 @@ test "render: row_cells_get_multi null returns invalid_value" {
     var raw: row.CRow = undefined;
     var values = [_]?*anyopaque{@ptrCast(&raw)};
     try testing.expectEqual(Result.invalid_value, row_cells_get_multi(null, 1, null, &values, null));
+}
+
+test "render: row get rejects a null out pointer" {
+    var terminal: terminal_c.Terminal = null;
+    try testing.expectEqual(Result.success, terminal_c.new(
+        &lib.alloc.test_allocator,
+        &terminal,
+        80,
+        24,
+    ));
+    defer terminal_c.free(terminal);
+
+    var state: RenderState = null;
+    try testing.expectEqual(Result.success, new(
+        &lib.alloc.test_allocator,
+        &state,
+    ));
+    defer free(state);
+
+    try testing.expectEqual(Result.success, update(state, terminal));
+
+    var iterator: RowIterator = null;
+    try testing.expectEqual(Result.success, row_iterator_new(
+        &lib.alloc.test_allocator,
+        &iterator,
+    ));
+    defer row_iterator_free(iterator);
+
+    try testing.expectEqual(Result.success, get(state, .row_iterator, @ptrCast(&iterator)));
+    try testing.expect(row_iterator_next(iterator));
+    try testing.expectEqual(Result.invalid_value, row_get(iterator, .dirty, null));
 }

--- a/src/terminal/c/row.zig
+++ b/src/terminal/c/row.zig
@@ -73,12 +73,14 @@ pub fn get(
         };
     }
 
+    const out_ptr = out orelse return .invalid_value;
+
     return switch (data) {
         .invalid => .invalid_value,
         inline else => |comptime_data| getTyped(
             row_,
             comptime_data,
-            @ptrCast(@alignCast(out)),
+            @ptrCast(@alignCast(out_ptr)),
         ),
     };
 }
@@ -190,4 +192,11 @@ test "get_multi null keys returns invalid_value" {
     var wrap: bool = false;
     var values = [_]?*anyopaque{@ptrCast(&wrap)};
     try testing.expectEqual(Result.invalid_value, get_multi(row_val, 1, null, &values, null));
+}
+
+test "get rejects a null out pointer" {
+    var zig_row: Row = @bitCast(@as(u64, 0));
+    zig_row.wrap = true;
+    const row: CRow = @bitCast(zig_row);
+    try testing.expectEqual(Result.invalid_value, get(row, .wrap, null));
 }

--- a/src/terminal/c/snapshot.zig
+++ b/src/terminal/c/snapshot.zig
@@ -214,6 +214,8 @@ pub fn decoder_get(
     data: DecoderData,
     out: ?*anyopaque,
 ) callconv(lib.calling_conv) Result {
+    const out_ptr = out orelse return .invalid_value;
+
     // Enumerate known keys so each branch recovers the correct output type.
     return switch (data) {
         inline .invalid,
@@ -228,7 +230,7 @@ pub fn decoder_get(
         => |comptime_data| decoderGetTyped(
             decoder_,
             comptime_data,
-            @ptrCast(@alignCast(out)),
+            @ptrCast(@alignCast(out_ptr)),
         ),
         _ => .invalid_value,
     };
@@ -1530,4 +1532,8 @@ test "snapshot incremental decoder exposes READY and page progress" {
     try testing.expectEqual(@as(usize, 0), dropped_rows);
     while (decoder_next(dropped_decoder) == .success) {}
     try testing.expectEqual(Result.no_value, decoder_next(dropped_decoder));
+}
+
+test "decoder_get rejects a null out pointer" {
+    try testing.expectEqual(Result.invalid_value, decoder_get(null, .progress_rows, null));
 }


### PR DESCRIPTION
C ABI hardening found by the audit: null pointer guards in the typed getters, a C
enum width that did not match, a point conversion that clamped a coordinate it
should not have, and the release API the inherited working directory needs.

## What changed

**Null `out` pointers are rejected instead of dereferenced.** `get` in
`terminal/c/{build_info,cell,osc,render,row,snapshot}.zig` took `?*anyopaque` and
`@ptrCast(@alignCast(out))`'d it straight through. Each now returns `invalid_value`.

**`ClipboardRequestType` is `enum(c_int)`.** It is passed by value across the C ABI
to the `confirm_read_clipboard` callback, where the embedder reads it as
`ghostty_clipboard_request_e`. A plain C enum is `int` sized; the tag was `u8`. A
`comptime` assert pins the width in every build, not only the ones that run tests.

**A null env var array is read as "none".** `opts.env_vars.?` was dereferenced
whenever `env_var_count > 0`.

**Screen and history points are no longer clamped to the screen height.** Only the
active and viewport spaces are bounded by it; screen and history run the full length
of the pagelist, and `PageList.pin` already rejects a `y` past its end, so clamping
answered with the wrong row. The `x` clamp stays for every tag and now says why.

**`ghostty_surface_free_inherited_config` is added, and takes no surface.** See below.

## The leak, and what this PR does and does not do about it

`ghostty_surface_inherited_config` hands back a config whose working directory
libghostty allocated. The only live consumer — macOS Swift at three sites in
`Ghostty.App.swift` — copies the string with `String.init(cString:)` and drops the C
pointer, so every new window, tab and split leaks a path.

**This PR does not close that leak.** It adds the release API the fix needs, and
nothing calls it yet. An earlier revision of this branch also wired the three Swift
call sites; that commit was dropped deliberately, because the leak is macOS-only —
`ghostty_surface_inherited_config` has no Windows or C# caller anywhere — and this
fork keeps changes out of `macos/` to avoid conflicts on upstream syncs. The wiring
is a separate macOS-only change.

So `ghostty_surface_free_inherited_config` ships with zero callers. That is
deliberate, not an oversight: it is the prerequisite, and shipping it now while the
signature is still free to change is the cheap moment to get it right.

The free takes no surface. It only ever wanted an allocator, and that
allocator is `global.alloc()` — the app is constructed with it and `App.create`
stores exactly what it is handed. Carrying the surface was the only thing that made
"free the config before you free the surface" a rule. It has no callers outside this
branch yet, so the signature is still free to change; after this it is an ABI break.

## Which gate these tests actually run in — read this before trusting a green

`zig build test` does not cover most of this PR. Two independent mechanisms:

**`zig build test` can never analyse `src/apprt/embedded.zig`.** `Artifact.detect()`
returns `.exe` for any test binary, and `apprt.zig` selects `embedded` only for
`.lib`. The two are mutually exclusive by construction, for every `-Dapp-runtime`
value and every target. Measured: a `@compileError` placed at the top of
`embedded.zig` does not fire under `zig build test -Dapp-runtime=none` — the build
succeeds and runs the suite. The build that does compile it is the lib build,
`zig build -Dapp-runtime=none -Dtarget=x86_64-linux-gnu`, which is green here.

**`zig build test` does not collect `src/terminal/c/*.zig` either.**
`terminal/main.zig:92` resolves `c_api` to `void` unless `c_abi` is set, `c_abi`
defaults to false, it is set true for exactly one module (`vt_c`), that module's test
binary is wired only to `test-lib-vt`, and `build.zig:470` has
`//test_step.dependOn(test_lib_vt_step)` commented out.

So:

| Tests | Gate that runs them |
| --- | --- |
| `apprt/surface.zig` — 2 inherited-pwd tests | `zig build test -Dapp-runtime=none` |
| `apprt/structs.zig` — the enum width test | `zig build test -Dapp-runtime=none` |
| `terminal/c/*.zig` — 6 null-`out` tests | `zig build test-lib-vt` **only** |
| `apprt/embedded.zig` changes | no test; compiled by the lib build only |

Measured, one mutation run in both gates. Reverting the null-`out` guard in
`terminal/c/row.zig` (production site only, test untouched):

```
zig build test-lib-vt -Dtest-filter=rejects
  error: 'terminal.c.row.test.get rejects a null out pointer' exited with code 3
  Build Summary: 43/45 steps succeeded (1 failed); 171/176 tests passed (1 crashed)

zig build test -Dapp-runtime=none -Dtest-filter=rejects
  Build Summary: 87/87 steps succeeded; 134/135 tests passed (1 skipped)
```

The same mutation is invisible to one gate and fatal in the other. Do not accept
`zig build test` alone as a green signal for anything under `src/terminal/c` or
`src/apprt/embedded.zig`.

Gates run for this PR, all green: `zig build test -Dapp-runtime=none`,
`zig build test-lib-vt`, and `zig build -Dapp-runtime=none -Dtarget=x86_64-linux-gnu`.

## Not covered by any gate here

`apprt/embedded.zig`'s changes have no test in any gate — the lib build compiles them
and nothing exercises them. That is the second row of the table above, restated
because it is the weakest coverage in this PR.

`build.zig:470` — uncommenting `test_step.dependOn(test_lib_vt_step)` so
`zig build test` covers the libghostty-vt tests is worth its own PR, and until it
lands the table above is the rule for every PR touching these areas.
