### PR TITLE
termio: don't panic when the resources dir has no parent directory

### DIFF
--- a/src/os/main.zig
+++ b/src/os/main.zig
@@ -68,6 +68,7 @@ test {
     _ = edit;
     _ = i18n;
     _ = path;
+    _ = resourcesdir;
     _ = uri;
     _ = shell;
     _ = windows_shell;

--- a/src/os/resourcesdir.zig
+++ b/src/os/resourcesdir.zig
@@ -3,6 +3,8 @@ const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
 const global = @import("../global.zig");
 
+const log = std.log.scoped(.resources_dir);
+
 pub const ResourcesDir = struct {
     /// Avoid accessing these directly, use the app() and host() methods instead.
     app_path: ?[]const u8 = null,
@@ -54,7 +56,13 @@ pub fn resourcesDir(alloc: Allocator) !ResourcesDir {
             else => return err,
         };
 
-        if (dir.len > 0) return .{ .app_path = dir };
+        if (validResourcesDir(dir)) return .{ .app_path = dir };
+
+        log.warn(
+            "GHOSTTY_RESOURCES_DIR is not an existing absolute directory, ignoring dir={s}",
+            .{dir},
+        );
+        alloc.free(dir);
     }
 
     // This is the sentinel value we look for in the path to know
@@ -112,7 +120,13 @@ pub fn resourcesDir(alloc: Allocator) !ResourcesDir {
     // fallback and use the provided resources dir.
     if (comptime builtin.mode == .Debug) {
         if (global.environ().getAlloc(alloc, "GHOSTTY_RESOURCES_DIR")) |dir| {
-            if (dir.len > 0) return .{ .app_path = dir };
+            if (validResourcesDir(dir)) return .{ .app_path = dir };
+
+            log.warn(
+                "GHOSTTY_RESOURCES_DIR is not an existing absolute directory, ignoring dir={s}",
+                .{dir},
+            );
+            alloc.free(dir);
         } else |err| switch (err) {
             error.InvalidWtf8, error.EnvironmentVariableMissing => {},
             else => return err,
@@ -120,6 +134,23 @@ pub fn resourcesDir(alloc: Allocator) !ResourcesDir {
     }
 
     return .{};
+}
+
+/// Returns true if a GHOSTTY_RESOURCES_DIR value is usable as the resources
+/// directory.
+///
+/// Everything derived from this value assumes a full path to a real
+/// directory: the terminfo database is looked for beside it, and the man
+/// pages and shell integration scripts are looked for inside it. A relative
+/// or missing path produces a broken child environment rather than an
+/// error, so we reject it here and fall back to detection.
+fn validResourcesDir(path: []const u8) bool {
+    if (path.len == 0) return false;
+    if (!std.fs.path.isAbsolute(path)) return false;
+
+    var dir = std.Io.Dir.cwd().openDir(global.io(), path, .{}) catch return false;
+    dir.close(global.io());
+    return true;
 }
 
 /// Little helper to check if the "base/sub/suffix" directory exists and
@@ -145,4 +176,35 @@ pub fn maybeDir(
     }
 
     return null;
+}
+
+test "validResourcesDir rejects a path with no directory component" {
+    const testing = std.testing;
+
+    try testing.expect(!validResourcesDir(""));
+    try testing.expect(!validResourcesDir("ghostty"));
+    try testing.expect(!validResourcesDir("share/ghostty"));
+}
+
+test "validResourcesDir rejects an absolute path that does not exist" {
+    const testing = std.testing;
+
+    const missing = if (comptime builtin.os.tag == .windows)
+        "C:/ghostty-does-not-exist/share/ghostty"
+    else
+        "/ghostty-does-not-exist/share/ghostty";
+
+    try testing.expect(!validResourcesDir(missing));
+}
+
+test "validResourcesDir accepts an existing absolute directory" {
+    const testing = std.testing;
+    const TempDir = @import("TempDir.zig");
+
+    var td = try TempDir.init();
+    defer td.deinit();
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const len = try td.dir.realPath(testing.io, &buf);
+    try testing.expect(validResourcesDir(buf[0..len]));
 }

--- a/src/os/resourcesdir.zig
+++ b/src/os/resourcesdir.zig
@@ -144,6 +144,15 @@ pub fn resourcesDir(alloc: Allocator) !ResourcesDir {
 /// pages and shell integration scripts are looked for inside it. A relative
 /// or missing path produces a broken child environment rather than an
 /// error, so we reject it here and fall back to detection.
+///
+/// This gate applies in release builds too, where the environment value is
+/// otherwise taken on trust. The tradeoff is deliberate and it is not free:
+/// a directory that exists but that we cannot open at startup, such as a
+/// permission-denied or not-yet-mounted share, or on Windows a
+/// rooted-but-driveless path such as `\share\ghostty` that isAbsolute
+/// rejects outright, is now discarded rather than used. Detection then
+/// finds nothing and the child loses terminfo, man pages and shell
+/// integration. Every rejection is logged by the caller with the value.
 fn validResourcesDir(path: []const u8) bool {
     if (path.len == 0) return false;
     if (!std.fs.path.isAbsolute(path)) return false;
@@ -184,6 +193,16 @@ test "validResourcesDir rejects a path with no directory component" {
     try testing.expect(!validResourcesDir(""));
     try testing.expect(!validResourcesDir("ghostty"));
     try testing.expect(!validResourcesDir("share/ghostty"));
+}
+
+test "validResourcesDir rejects a relative path that exists" {
+    const testing = std.testing;
+
+    // The current directory always exists and always opens, which is what
+    // makes it the input that separates the absolute-path check from the
+    // openDir below it. Every other relative path we could name fails to
+    // open anyway and so is rejected either way.
+    try testing.expect(!validResourcesDir("."));
 }
 
 test "validResourcesDir rejects an absolute path that does not exist" {

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -748,19 +748,16 @@ const Subprocess = struct {
         //
         // For now, we just look up a bundled dir but in the future we should
         // also load the terminfo database and look for it.
-        if (cfg.resources_dir) |base| {
+        var terminfo_buf: [std.fs.max_path_bytes]u8 = undefined;
+        if (terminfoDir(&terminfo_buf, cfg.resources_dir)) |dir| {
             try env.put("TERM", cfg.term);
             try env.put("COLORTERM", "truecolor");
-
-            // Assume that the resources directory is adjacent to the terminfo
-            // database
-            var buf: [std.fs.max_path_bytes]u8 = undefined;
-            const dir = try std.fmt.bufPrint(&buf, "{s}/terminfo", .{
-                std.fs.path.dirname(base) orelse unreachable,
-            });
             try env.put("TERMINFO", dir);
         } else {
-            if (comptime builtin.target.os.tag.isDarwin()) {
+            if (cfg.resources_dir) |base| {
+                log.warn("no terminfo dir beside the resources dir base={s}", .{base});
+                log.warn("using xterm-256color, check GHOSTTY_RESOURCES_DIR", .{});
+            } else if (comptime builtin.target.os.tag.isDarwin()) {
                 log.warn("ghostty terminfo not found, using xterm-256color", .{});
                 log.warn("the terminfo SHOULD exist on macos, please ensure", .{});
                 log.warn("you're using a valid app bundle.", .{});
@@ -2370,6 +2367,19 @@ fn execCommand(
             break :shell try args.toOwnedSlice(alloc);
         },
     };
+}
+
+/// Derive the TERMINFO directory from the resources directory, which we
+/// assume sits beside the terminfo database.
+///
+/// Returns null when there is no resources directory, or when it has no
+/// parent directory to look beside. The latter happens when
+/// GHOSTTY_RESOURCES_DIR is a bare name, so the caller falls back to a
+/// TERM that needs none of our terminfo.
+fn terminfoDir(buf: []u8, resources_dir: ?[]const u8) ?[]const u8 {
+    const base = resources_dir orelse return null;
+    const parent = std.fs.path.dirname(base) orelse return null;
+    return std.fmt.bufPrint(buf, "{s}/terminfo", .{parent}) catch null;
 }
 
 /// Append a value to an environment variable such as PATH.
@@ -4425,4 +4435,22 @@ test "maybeWrapGitBashWithWinpty windows: absolute bash with adjacent winpty is 
     try testing.expectEqualStrings(winpty, out[0]);
     try testing.expectEqualStrings(bash, out[1]);
     try testing.expectEqualStrings("--login", out[2]);
+}
+
+test "terminfoDir derives the directory beside the resources dir" {
+    const testing = std.testing;
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    try testing.expectEqualStrings(
+        "/usr/share/terminfo",
+        terminfoDir(&buf, "/usr/share/ghostty").?,
+    );
+}
+
+test "terminfoDir has nothing to derive from a bare resources dir" {
+    const testing = std.testing;
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    try testing.expect(terminfoDir(&buf, null) == null);
+    try testing.expect(terminfoDir(&buf, "ghostty") == null);
 }


### PR DESCRIPTION
`GHOSTTY_RESOURCES_DIR=ghostty` panicked. The TERMINFO derivation did `std.fs.path.dirname(base) orelse unreachable`, and `dirname` returns null for a bare name with no directory component, so a value a user can set reached an `unreachable`: a panic in debug, undefined behaviour in release.

What changed:

- The derivation moved into `terminfoDir`, which returns null when there is no resources directory or when it has no parent to look beside. The caller then takes the branch it already had for "no resources dir at all", setting `TERM=xterm-256color` and `COLORTERM=truecolor`, and two `log.warn` lines name the cause. `GHOSTTY_RESOURCES_DIR` itself is still exported to the child unconditionally, so nothing is silently missing.
- `GHOSTTY_RESOURCES_DIR` is validated before use: non-empty, absolute, and openable as a directory. Both rejection paths free the value, which also closes a small pre-existing leak where an empty value was dropped without being freed.
- `_ = resourcesdir;` in `src/os/main.zig`, so the file is in the `-Dapp-runtime=none` test graph. Without that line the new `validResourcesDir` tests would be collected by nothing.

## This also changes release-build behaviour

The title covers the panic, but roughly half this diff is the new validation, and it applies in the `builtin.mode != .Debug` branch too, where any non-empty `GHOSTTY_RESOURCES_DIR` was previously trusted verbatim.

The consequence, stated plainly: a packaged install that points `GHOSTTY_RESOURCES_DIR` at a directory which exists but which we cannot `openDir` at startup no longer uses it. A permission-denied share, a network path not yet mounted, or on Windows a rooted-but-driveless form such as `\share\ghostty` that `std.fs.path.isAbsolute` rejects outright, all now fall through: the value is logged and discarded, exe-relative detection walks up and finds nothing, and the child gets `TERM=xterm-256color` with no shell integration and no man pages. Before this change that value was used and those worked.

That is a regression class arriving under a panic-fix title, so it is called out here rather than left for a reviewer to find. The validation is still the right default: everything derived from this value assumes a full path to a real directory, and a relative or missing path produces a broken child environment rather than an error. The tradeoff is now also written at `validResourcesDir` so the next reader of the degraded path does not have to derive it.

Test plan:

- [x] `zig build test -Dapp-runtime=none -Dtest-filter=validResourcesDir`: 87/87 steps succeeded, 84/84 tests passed, no leak lines.
- [x] Deleting `if (!std.fs.path.isAbsolute(path)) return false;` fails `os.resourcesdir.test.validResourcesDir rejects a relative path that exists`, and nothing else. The three inputs of the older test are relative paths that do not exist, so `openDir` rejects them with or without that check; `"."` is relative and always opens, which is what separates the two.
- [x] Reverting `dirname(base) orelse return null` to `orelse ""` fails `termio.Exec.test.terminfoDir has nothing to derive from a bare resources dir`.
- [x] Reverting `openDir(...) catch return false` to `catch return true` fails `os.resourcesdir.test.validResourcesDir rejects an absolute path that does not exist`.
- [x] `zig fmt --check` on every touched file.

Known and not fixed here: `terminfoDir` returns null for a `NoSpaceLeft` from `bufPrint` as well as for "no parent", so that case would log the same misleading "no terminfo dir beside the resources dir". `buf` is always `max_path_bytes`, so it is not reachable today.
