### PR TITLE
windows: print both versions in one header, tag releases w*

### DIFF
--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -1,16 +1,35 @@
-# On tag push (v*), fires a repository_dispatch at deblasis/wintty-release so
-# the private release repo can build, pack, and upload without R2 or signing
-# credentials living in this public repo.
+# On a Wintty release tag push, fires a repository_dispatch at
+# deblasis/wintty-release so the private release repo can build, pack, and
+# upload without R2 or signing credentials living in this public repo.
 #
-# Dormant until vars.ENABLE_WINTTY_RELEASE_DISPATCH == 'true', so it stays
-# quiet before the private repo + dispatch PAT are provisioned.
+# Wintty tags are `w<version>`, never `v*`. This fork inherits ghostty's own
+# `v*` tags with every upstream sync, so that namespace names ghostty
+# commits and a `v*` trigger would release one of them under ghostty's
+# version number. The `w` is the same letter `wintty +version` prints in
+# front of the Wintty half of its header
+# (windows/Ghostty.Core/Version/VersionHeader.cs), and the fork's own
+# version detection (src/build/GitVersion.zig) matches `v*` and `tip` only,
+# so a `w*` tag on HEAD never reaches libghostty's version.
+#
+# Accepted shapes, and where they go:
+#   w1.0.0        -> stable (GA)
+#   w1.0.0-rc.2   -> tip    (an RC never reaches stable)
+# Anything else under w* fails the run rather than dispatching a guess.
+# Sandbox rehearsals (-sandbox.N) are deliberately not tags: they go through
+# the private repo's workflow_dispatch and local scripts.
+#
+# Push a release tag on its own. GitHub emits no push event when more than
+# three tags land in one push, so a `w*` tag pushed together with a batch
+# of synced upstream tags never dispatches.
+#
+# Dormant until vars.ENABLE_WINTTY_RELEASE_DISPATCH == 'true'.
 
 name: trigger-release
 
 on:
   push:
     tags:
-      - 'v*'
+      - 'w[0-9]*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,20 +40,36 @@ jobs:
     if: vars.ENABLE_WINTTY_RELEASE_DISPATCH == 'true'
     runs-on: ubuntu-latest
     steps:
-      - name: Derive channel from ref
+      - name: Derive version and channel from the tag
         id: chan
         shell: bash
         run: |
-          case "${{ github.ref }}" in
-            refs/tags/v*) echo "channel=stable" >> "$GITHUB_OUTPUT" ;;
-            *)            echo "channel=tip"    >> "$GITHUB_OUTPUT" ;;
-          esac
+          set -euo pipefail
+          # Components reject leading zeros: vpk and SemVer 2 do too.
+          n='(0|[1-9][0-9]*)'
+          if [[ "$GITHUB_REF" =~ ^refs/tags/w(${n}\.${n}\.${n})$ ]]; then
+            channel=stable
+          elif [[ "$GITHUB_REF" =~ ^refs/tags/w(${n}\.${n}\.${n}-rc\.${n})$ ]]; then
+            channel=tip
+          else
+            echo "::error::$GITHUB_REF is not wX.Y.Z or wX.Y.Z-rc.N; refusing to dispatch"
+            exit 1
+          fi
+          echo "version=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
 
+      # The receiver builds from its own pinned wintty commit, not from
+      # this ref. The sha travels along so it can refuse a cut whose pin
+      # is not the commit that was tagged.
       - name: Dispatch release event to deblasis/wintty-release
         env:
           GH_TOKEN: ${{ secrets.WINTTY_RELEASE_DISPATCH_PAT }}
+          CHANNEL: ${{ steps.chan.outputs.channel }}
+          VERSION: ${{ steps.chan.outputs.version }}
         run: |
           gh api /repos/deblasis/wintty-release/dispatches \
             -f event_type=release \
-            -f "client_payload[channel]=${{ steps.chan.outputs.channel }}" \
-            -f "client_payload[ref]=${{ github.ref }}"
+            -f "client_payload[channel]=$CHANNEL" \
+            -f "client_payload[version]=$VERSION" \
+            -f "client_payload[ref]=$GITHUB_REF" \
+            -f "client_payload[sha]=$GITHUB_SHA"

--- a/windows/Ghostty.Core/Version/VersionHeader.cs
+++ b/windows/Ghostty.Core/Version/VersionHeader.cs
@@ -1,0 +1,89 @@
+using System.Text;
+
+namespace Ghostty.Core.Version;
+
+/// <summary>
+/// The one-line identity of a build, both versions each under its own
+/// prefix: <c>Wintty w1.0.0-rc.1 (tip) on libghostty v1.3.2-dev</c>.
+///
+/// The libghostty half is upstream's <c>build.zig.zon</c> value, which
+/// upstream bumps to <c>X.Y.Z-dev</c> right after each release, so between
+/// releases it reads as "after vX.Y.(Z-1)". The Wintty half is the cut
+/// version; this public tree hardcodes it to 0.0.0 (it has no release
+/// path), and the release build stamps the real one in.
+///
+/// Display only. <see cref="BuildInfo.WinttyVersionString"/> keeps its
+/// <c>&lt;version&gt;-&lt;cadence&gt;+&lt;commit&gt;</c> shape because the release
+/// scripts read it back and assert on it.
+/// </summary>
+public static class VersionHeader
+{
+    /// <summary>
+    /// The letter in front of the Wintty half. Rendered here, enforced by
+    /// the release tag trigger: Wintty tags are <c>w*</c> because the fork
+    /// inherits ghostty's <c>v*</c> tags and cannot share that namespace.
+    /// </summary>
+    public const string TagPrefix = "w";
+
+    /// <summary>
+    /// The cadence word the build was stamped with (<c>stable</c> or
+    /// <c>tip</c>), recovered from <paramref name="winttyVersionString"/>,
+    /// which is <c>&lt;winttyVersion&gt;-&lt;cadence&gt;+&lt;commit&gt;</c>.
+    /// Empty when the string does not have that shape, so a caller renders
+    /// nothing rather than a guess. The version itself may carry a
+    /// prerelease (<c>1.0.0-rc.1</c>), which is why this anchors on the
+    /// whole version rather than the last dash.
+    /// </summary>
+    public static string Cadence(string winttyVersion, string winttyVersionString)
+    {
+        if (string.IsNullOrEmpty(winttyVersion) || string.IsNullOrEmpty(winttyVersionString))
+            return string.Empty;
+
+        var plus = winttyVersionString.IndexOf('+');
+        var prerelease = plus >= 0 ? winttyVersionString[..plus] : winttyVersionString;
+
+        var prefix = winttyVersion + "-";
+        if (!prerelease.StartsWith(prefix, StringComparison.Ordinal))
+            return string.Empty;
+
+        var cadence = prerelease[prefix.Length..];
+        // A cadence is a bare word (stable, tip). Anything with digits or
+        // punctuation is a prerelease identifier that leaked past the
+        // version, and rendering it as "(rc.1)" would be a lie.
+        if (cadence.Length == 0) return string.Empty;
+        foreach (var c in cadence)
+        {
+            if (!char.IsAsciiLetterLower(c)) return string.Empty;
+        }
+        return cadence;
+    }
+
+    /// <summary>
+    /// <c>w1.0.0-rc.1 (tip) on libghostty v1.3.2-dev</c>. The cadence is
+    /// omitted when it cannot be recovered, the libghostty half when the
+    /// library reports no version.
+    /// </summary>
+    public static string ComposeVersion(VersionInfo info)
+    {
+        var sb = new StringBuilder();
+        sb.Append(TagPrefix).Append(info.WinttyVersion);
+
+        var cadence = Cadence(info.WinttyVersion, info.WinttyVersionString);
+        if (cadence.Length > 0)
+            sb.Append(" (").Append(cadence).Append(')');
+
+        if (!string.IsNullOrEmpty(info.LibGhostty.Version))
+            sb.Append(" on libghostty v").Append(info.LibGhostty.Version);
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// <see cref="ComposeVersion"/> with the product name in front, for the
+    /// places that stand alone: the <c>+version</c> header, log headers, the
+    /// Version dialog title. The About window uses the bare form because
+    /// its heading already carries the name.
+    /// </summary>
+    public static string Compose(VersionInfo info)
+        => AppIdentity.ProductName + " " + ComposeVersion(info);
+}

--- a/windows/Ghostty.Core/Version/VersionRenderer.cs
+++ b/windows/Ghostty.Core/Version/VersionRenderer.cs
@@ -52,9 +52,10 @@ public static class VersionRenderer
 
     /// <summary>Plain rendering of just the Version + Build Config blocks
     /// (no header, no commit URL line). The dialog uses this because the
-    /// dialog's title bar already shows "Wintty &lt;version&gt;" and the
-    /// commit URL is rendered as a clickable HyperlinkButton above the text,
-    /// making the header redundant.</summary>
+    /// dialog's title bar already shows the one-line header
+    /// (<see cref="VersionHeader.Compose"/>) and the commit URL is rendered
+    /// as a clickable HyperlinkButton above the text, making the header
+    /// redundant.</summary>
     public static string RenderPlainBody(VersionInfo info)
     {
         var sb = new StringBuilder();
@@ -85,16 +86,20 @@ public static class VersionRenderer
     private static void AppendHeader(StringBuilder sb, VersionInfo info, bool ansi)
     {
         var hasCommit = !string.IsNullOrEmpty(info.WinttyCommit) && info.WinttyCommit != "unknown";
+        // Both halves of the identity on the first line, each under its own
+        // prefix (see VersionHeader). One commit line serves both, because
+        // libghostty is built from this same tree.
+        var header = VersionHeader.Compose(info);
         if (ansi && hasCommit)
         {
             sb.Append(Osc8Open).Append(CommitUrlPrefix).Append(info.WinttyCommit).Append(St);
-            sb.Append(AppIdentity.ProductName).Append(' ').Append(info.WinttyVersionString);
+            sb.Append(header);
             sb.Append(Osc8Close);
             sb.Append('\n');
         }
         else
         {
-            sb.Append(AppIdentity.ProductName).Append(' ').Append(info.WinttyVersionString).Append('\n');
+            sb.Append(header).Append('\n');
         }
         if (hasCommit)
         {

--- a/windows/Ghostty.Tests/Version/VersionHeaderTests.cs
+++ b/windows/Ghostty.Tests/Version/VersionHeaderTests.cs
@@ -1,0 +1,96 @@
+using Ghostty.Core;
+using Ghostty.Core.Version;
+using Xunit;
+
+namespace Ghostty.Tests.Version;
+
+public sealed class VersionHeaderTests
+{
+    // Distinct numbers on purpose: the header exists so the two versions
+    // cannot be read as one, and a fixture where they agree proves nothing.
+    // The product name is read from AppIdentity, not spelled, because the
+    // packaged flavours rebind it (Wintty Pro) and run these same tests.
+    private static readonly string Product = AppIdentity.ProductName;
+
+    private static VersionInfo Sample() => new(
+        WinttyVersion:       "1.0.0-rc.1",
+        BuildLabel:          "",
+        WinttyVersionString: "1.0.0-rc.1-tip+abc1234",
+        WinttyCommit:        "abc1234",
+        Edition:             Edition.Oss,
+        LibGhostty: new LibGhosttyBuildInfo(
+            Version:       "1.3.2-dev",
+            VersionString: "1.3.2-dev+abc1234",
+            Commit:        "abc1234",
+            Channel:       "tip",
+            ZigVersion:    "0.16.0",
+            BuildMode:     "ReleaseFast"),
+        DotnetRuntime:   "10.0.0",
+        MsbuildConfig:   "Release",
+        AppRuntime:      "WinUI 3",
+        Renderer:        "DX12",
+        FontEngine:      "DirectWrite",
+        WindowsVersion:  "11.0.26200",
+        Architecture:    "x64");
+
+    [Fact]
+    public void Compose_BothHalves_EachUnderItsOwnPrefix()
+    {
+        Assert.Equal(
+            $"{Product} w1.0.0-rc.1 (tip) on libghostty v1.3.2-dev",
+            VersionHeader.Compose(Sample()));
+    }
+
+    [Fact]
+    public void ComposeVersion_OmitsProductName()
+    {
+        Assert.Equal(
+            "w1.0.0-rc.1 (tip) on libghostty v1.3.2-dev",
+            VersionHeader.ComposeVersion(Sample()));
+    }
+
+    [Fact]
+    public void Compose_StableCadence_ReadsStable()
+    {
+        var info = Sample() with { WinttyVersion = "1.0.0", WinttyVersionString = "1.0.0-stable+abc1234" };
+        Assert.Equal(
+            $"{Product} w1.0.0 (stable) on libghostty v1.3.2-dev",
+            VersionHeader.Compose(info));
+    }
+
+    [Fact]
+    public void Compose_NoLibghosttyVersion_OmitsThatHalf()
+    {
+        var sample = Sample();
+        var info = sample with { LibGhostty = sample.LibGhostty with { Version = "" } };
+        Assert.Equal($"{Product} w1.0.0-rc.1 (tip)", VersionHeader.Compose(info));
+    }
+
+    [Fact]
+    public void Compose_UnrecoverableCadence_OmitsParens()
+    {
+        // A version string that does not extend the version with a cadence
+        // word is rendered without a guess, not with a wrong one.
+        var info = Sample() with { WinttyVersionString = "0.0.0" };
+        Assert.Equal($"{Product} w1.0.0-rc.1 on libghostty v1.3.2-dev", VersionHeader.Compose(info));
+    }
+
+    [Theory]
+    [InlineData("1.0.0-rc.1", "1.0.0-rc.1-tip+abc1234", "tip")]
+    [InlineData("1.0.0", "1.0.0-stable+abc1234", "stable")]
+    [InlineData("1.0.0", "1.0.0-stable", "stable")]
+    // The shape a dirty dev tree produces: the suffix sits after '+'.
+    [InlineData("0.0.0", "0.0.0-tip+abc1234-dirty", "tip")]
+    // The rc identifier must not be mistaken for the cadence, whichever
+    // side of the version it ends up on.
+    [InlineData("1.0.0", "1.0.0-rc.1-tip+abc1234", "")]
+    [InlineData("1.0.0", "1.0.0-rc.1+abc1234", "")]
+    [InlineData("1.0.0-rc.1", "1.0.0-rc.1+abc1234", "")]
+    [InlineData("1.0.0-rc.1", "1.0.0-rc.1-tip-debug+abc1234", "")]
+    [InlineData("", "1.0.0-tip+abc1234", "")]
+    [InlineData("1.0.0", "", "")]
+    public void Cadence_RecoversOnlyTheStampedWord(string version, string versionString, string expected)
+    {
+        Assert.Equal(expected, VersionHeader.Cadence(version, versionString));
+    }
+}

--- a/windows/Ghostty.Tests/Version/VersionRendererTests.cs
+++ b/windows/Ghostty.Tests/Version/VersionRendererTests.cs
@@ -30,7 +30,7 @@ public sealed class VersionRendererTests
     public void RenderPlain_OssFixture_MatchesExpected()
     {
         var expected =
-            "Wintty 1.2.0-tip+abc1234\n" +
+            $"{Ghostty.Core.AppIdentity.ProductName} w1.2.0 (tip) on libghostty v1.2.0\n" +
             "  https://github.com/deblasis/wintty/commit/abc1234\n" +
             "\n" +
             "Version\n" +
@@ -62,7 +62,7 @@ public sealed class VersionRendererTests
         };
 
         var output = VersionRenderer.RenderPlain(info);
-        Assert.StartsWith("Wintty 1.2.0-tip+unknown\n\n", output);
+        Assert.StartsWith($"{Ghostty.Core.AppIdentity.ProductName} w1.2.0 (tip) on libghostty v1.2.0\n\n", output);
         Assert.DoesNotContain("github.com/deblasis/wintty/commit", output);
     }
 
@@ -71,7 +71,7 @@ public sealed class VersionRendererTests
     {
         var output = VersionRenderer.RenderAnsi(Sample());
         Assert.Contains(
-            "\x1b]8;;https://github.com/deblasis/wintty/commit/abc1234\x1b\\Wintty 1.2.0-tip+abc1234\x1b]8;;\x1b\\",
+            $"\x1b]8;;https://github.com/deblasis/wintty/commit/abc1234\x1b\\{Ghostty.Core.AppIdentity.ProductName} w1.2.0 (tip) on libghostty v1.2.0\x1b]8;;\x1b\\",
             output);
     }
 

--- a/windows/Ghostty/Dialogs/AboutWindow.xaml
+++ b/windows/Ghostty/Dialogs/AboutWindow.xaml
@@ -63,6 +63,8 @@
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                     <TextBlock x:Name="VersionValue" Grid.Row="0" Grid.Column="1"
                                FontFamily="Cascadia Mono, Consolas"
+                               TextWrapping="Wrap"
+                               MaxWidth="290"
                                IsTextSelectionEnabled="True" />
 
                     <TextBlock Grid.Row="1" Grid.Column="0" Text="Label"

--- a/windows/Ghostty/Dialogs/AboutWindow.xaml.cs
+++ b/windows/Ghostty/Dialogs/AboutWindow.xaml.cs
@@ -69,16 +69,14 @@ internal sealed partial class AboutWindow : Window
         CopyrightText.Text = AboutContent.Copyright;
 
         var info = VersionRenderer.Build();
-        VersionValue.Text = info.WinttyVersion;
+        // Both versions, each under its own prefix, the way `+version` opens.
+        // The product name is already the heading above, so only the version
+        // half goes in the row.
+        VersionValue.Text = VersionHeader.ComposeVersion(info);
 
-        // The Version row already carries the semantic version, so the Build
-        // row surfaces the distribution identity instead: edition, plus the
-        // libghostty channel (tip/stable) when reported. Mirrors the split in
-        // `wintty +version`.
-        var edition = EditionLabel.Format(info.Edition);
-        BuildValue.Text = string.IsNullOrEmpty(info.LibGhostty.Channel)
-            ? edition
-            : $"{edition} ({info.LibGhostty.Channel})";
+        // The Version row now carries the cadence too, so the Build row is
+        // the edition alone; repeating the channel here read as a duplicate.
+        BuildValue.Text = EditionLabel.Format(info.Edition);
 
         // Free-form build identifier. Empty by default, in which case the row
         // collapses (both cells hidden) just like the Commit row below.

--- a/windows/Ghostty/Dialogs/VersionDialog.xaml
+++ b/windows/Ghostty/Dialogs/VersionDialog.xaml
@@ -13,6 +13,8 @@
                    Height="40"
                    VerticalAlignment="Center"/>
             <TextBlock x:Name="TitleText"
+                       TextWrapping="Wrap"
+                       MaxWidth="440"
                        VerticalAlignment="Center"/>
         </StackPanel>
     </ContentDialog.Title>

--- a/windows/Ghostty/Dialogs/VersionDialog.xaml.cs
+++ b/windows/Ghostty/Dialogs/VersionDialog.xaml.cs
@@ -26,14 +26,15 @@ internal sealed partial class VersionDialog : ContentDialog
         // bug-report use case still has everything when pasted elsewhere.
         _output = VersionRenderer.RenderPlain(info);
         // The dialog itself shows the body without the header/URL line --
-        // the title bar carries "Wintty <version>" and the URL is rendered
+        // the title bar carries the one-line header and the URL is rendered
         // as a clickable HyperlinkButton above the body.
         VersionText.Text = VersionRenderer.RenderPlainBody(info);
 
-        // Title bar: app icon + "Wintty <version>". Icon URI is the
-        // canonical AppIconSource so packaging changes propagate here.
+        // Title bar: app icon + the same one-line identity `+version` prints
+        // first. Icon URI is the canonical AppIconSource so packaging changes
+        // propagate here.
         TitleIcon.Source = new BitmapImage(AppIconSource.Current);
-        TitleText.Text = $"{Ghostty.Core.AppIdentity.ProductName} {info.WinttyVersionString}";
+        TitleText.Text = VersionHeader.Compose(info);
 
         var commitUrl = VersionRenderer.CommitUrl(info);
         if (commitUrl is null)


### PR DESCRIPTION
`wintty +version`, the Version dialog and the About window now open with both versions on one line, each under its own prefix:

```
Wintty w1.0.0-rc.1 (tip) on libghostty v1.3.2-dev
```

The compiled version string is untouched; the release scripts read it back. The About window's Build row drops the channel (the Version row carries it now) and both text blocks wrap.

Release tags move to `w*`. The fork inherits ghostty's `v*` tags on every sync, so the old trigger could have dispatched a stable release of a ghostty commit under ghostty's number. The trigger now fires on `w[0-9]*` only, routes `wX.Y.Z` to stable and `wX.Y.Z-rc.N` to tip, refuses anything else (leading zeros included), and sends the tagged sha. Companion change on the release side (receivers).

Tested: Version namespace tests (33) pass, the app project builds, the tag routing was exercised against good and bad refs. The header tests read the product name from `AppIdentity` so the Pro flavours, which rebind it, run them unchanged.