### PR TITLE
renderer: recreate the DX12 device after a TDR instead of latching dead

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1308,15 +1308,16 @@ GHOSTTY_API void* ghostty_surface_get_swap_chain_handle(ghostty_surface_t);
 // surface lifetime -- do NOT CloseHandle either of them. The
 // ID3D12Resource and ID3D12Fence returned by OpenSharedHandle on the
 // consumer's device ARE owned by the consumer; Release() them when
-// done, and re-open the resource whenever `version` changes.
+// done, and re-open both handles whenever `version` changes.
 typedef struct {
   // NT HANDLE from CreateSharedHandle on the underlying ID3D12Resource.
   // Consumers open via ID3D12Device::OpenSharedHandle on their own
   // device (cross-device) or on ghostty's device (same-device).
   void* resource_handle;
 
-  // NT HANDLE from CreateSharedHandle on ghostty's ID3D12Fence. Stable
-  // for the surface lifetime (does not change on resize).
+  // NT HANDLE from CreateSharedHandle on ghostty's ID3D12Fence. Does not
+  // change on resize; it does change on device-removed recovery, which
+  // also bumps `version`, so re-open it alongside the resource then.
   void* fence_handle;
 
   // Fence value ghostty will signal after completing the most recently

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1346,6 +1346,8 @@ typedef struct {
 // Returns true on success, false if the surface is not in shared
 // texture mode (in which case `out` is left untouched). The read is
 // atomic -- all fields correspond to the same renderer state snapshot.
+// False is also what a surface returns while its device is being
+// rebuilt after a TDR, so treat it as "poll again", not as a mode change.
 GHOSTTY_API bool ghostty_surface_shared_texture(
     ghostty_surface_t,
     ghostty_surface_shared_texture_s* out);

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1293,7 +1293,9 @@ GHOSTTY_API void ghostty_surface_set_size(ghostty_surface_t, uint32_t, uint32_t)
 // cross-device synchronization issues. Returns NULL on non-DX12 builds or if
 // the renderer device is not yet initialized. Device-removed recovery
 // replaces the device: do not cache this pointer across a `version` change
-// in ghostty_surface_shared_texture_s.
+// in ghostty_surface_shared_texture_s. This and the other surface device
+// queries wait for the renderer's draw lock, so they can block for the
+// length of a frame, or of a device rebuild after a TDR.
 GHOSTTY_API void* ghostty_surface_get_d3d12_device(ghostty_surface_t);
 // Returns the DirectComposition surface handle backing this surface's swap
 // chain in SwapChainPanel mode. Bind it to a WinUI 3 SwapChainPanel via

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1291,7 +1291,9 @@ GHOSTTY_API void ghostty_surface_set_size(ghostty_surface_t, uint32_t, uint32_t)
 // Returns the ID3D12Device* used by this surface's renderer. Shared texture
 // consumers should call OpenSharedResource1 on this device to avoid
 // cross-device synchronization issues. Returns NULL on non-DX12 builds or if
-// the renderer device is not yet initialized.
+// the renderer device is not yet initialized. Device-removed recovery
+// replaces the device: do not cache this pointer across a `version` change
+// in ghostty_surface_shared_texture_s.
 GHOSTTY_API void* ghostty_surface_get_d3d12_device(ghostty_surface_t);
 // Returns the DirectComposition surface handle backing this surface's swap
 // chain in SwapChainPanel mode. Bind it to a WinUI 3 SwapChainPanel via
@@ -1322,7 +1324,8 @@ typedef struct {
 
   // Fence value ghostty will signal after completing the most recently
   // submitted frame. Consumers Wait for this value on their own
-  // command queue before sampling the resource.
+  // command queue before sampling the resource. Restarts from zero on
+  // device-removed recovery, together with the new `fence_handle`.
   uint64_t fence_value;
 
   // Pixel dimensions of the shared resource. These match the size the

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2750,10 +2750,14 @@ pub const CAPI = struct {
     /// null on non-DX12 builds or before the device finishes init.
     export fn ghostty_surface_get_d3d12_device(surface: *Surface) ?*anyopaque {
         if (comptime builtin.os.tag != .windows) return null;
-        const api = surface.core_surface.renderer.api;
+        const r = &surface.core_surface.renderer;
         // Only the DX12 renderer has a `dev` field holding an ID3D12Device.
-        if (comptime !@hasField(@TypeOf(api), "dev")) return null;
-        const dev = api.dev orelse return null;
+        if (comptime !@hasField(@TypeOf(r.api), "dev")) return null;
+        // Device-loss recovery replaces `dev` on the renderer thread under
+        // the draw mutex; reading it anywhere else needs the same lock.
+        r.draw_mutex.lockUncancelable(global.io());
+        defer r.draw_mutex.unlock(global.io());
+        const dev = r.api.dev orelse return null;
         return @ptrCast(dev.device);
     }
 
@@ -2763,9 +2767,12 @@ pub const CAPI = struct {
     /// Returns null on non-DX12 or before the swap chain is created.
     export fn ghostty_surface_get_swap_chain(surface: *Surface) ?*anyopaque {
         if (comptime builtin.os.tag != .windows) return null;
-        const api = surface.core_surface.renderer.api;
-        if (comptime !@hasField(@TypeOf(api), "dev")) return null;
-        const dev = api.dev orelse return null;
+        const r = &surface.core_surface.renderer;
+        if (comptime !@hasField(@TypeOf(r.api), "dev")) return null;
+        // See ghostty_surface_get_d3d12_device for why the lock.
+        r.draw_mutex.lockUncancelable(global.io());
+        defer r.draw_mutex.unlock(global.io());
+        const dev = r.api.dev orelse return null;
         const sc = dev.swap_chain orelse return null;
         return @ptrCast(sc);
     }
@@ -2777,9 +2784,12 @@ pub const CAPI = struct {
     /// SwapChainPanel mode.
     export fn ghostty_surface_get_swap_chain_handle(surface: *Surface) ?*anyopaque {
         if (comptime builtin.os.tag != .windows) return null;
-        const api = surface.core_surface.renderer.api;
-        if (comptime !@hasField(@TypeOf(api), "dev")) return null;
-        const dev = api.dev orelse return null;
+        const r = &surface.core_surface.renderer;
+        if (comptime !@hasField(@TypeOf(r.api), "dev")) return null;
+        // See ghostty_surface_get_d3d12_device for why the lock.
+        r.draw_mutex.lockUncancelable(global.io());
+        defer r.draw_mutex.unlock(global.io());
+        const dev = r.api.dev orelse return null;
         return @ptrCast(dev.swap_chain_surface_handle orelse return null);
     }
 
@@ -2801,10 +2811,15 @@ pub const CAPI = struct {
         out: *SharedTextureSnapshotC,
     ) bool {
         if (comptime builtin.os.tag != .windows) return false;
-        const api_ptr = &surface.core_surface.renderer.api;
-        if (comptime @TypeOf(api_ptr.*) != renderer.DirectX12) return false;
-        if (api_ptr.dev == null) return false;
-        const dev = &api_ptr.dev.?;
+        const r = &surface.core_surface.renderer;
+        if (comptime @TypeOf(r.api) != renderer.DirectX12) return false;
+        // See ghostty_surface_get_d3d12_device for why the lock. It also
+        // means "false" here can mean "the device is being rebuilt": poll
+        // again rather than treating it as a mode change.
+        r.draw_mutex.lockUncancelable(global.io());
+        defer r.draw_mutex.unlock(global.io());
+        if (r.api.dev == null) return false;
+        const dev = &r.api.dev.?;
 
         dev.shared_texture_mutex.lockUncancelable(global.io());
         defer dev.shared_texture_mutex.unlock(global.io());

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2757,7 +2757,7 @@ pub const CAPI = struct {
         // the draw mutex; reading it anywhere else needs the same lock.
         r.draw_mutex.lockUncancelable(global.io());
         defer r.draw_mutex.unlock(global.io());
-        const dev = r.api.dev orelse return null;
+        const dev = if (r.api.dev) |*d| d else return null;
         return @ptrCast(dev.device);
     }
 
@@ -2772,7 +2772,7 @@ pub const CAPI = struct {
         // See ghostty_surface_get_d3d12_device for why the lock.
         r.draw_mutex.lockUncancelable(global.io());
         defer r.draw_mutex.unlock(global.io());
-        const dev = r.api.dev orelse return null;
+        const dev = if (r.api.dev) |*d| d else return null;
         const sc = dev.swap_chain orelse return null;
         return @ptrCast(sc);
     }
@@ -2789,7 +2789,7 @@ pub const CAPI = struct {
         // See ghostty_surface_get_d3d12_device for why the lock.
         r.draw_mutex.lockUncancelable(global.io());
         defer r.draw_mutex.unlock(global.io());
-        const dev = r.api.dev orelse return null;
+        const dev = if (r.api.dev) |*d| d else return null;
         return @ptrCast(dev.swap_chain_surface_handle orelse return null);
     }
 

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -665,11 +665,17 @@ pub fn deviceLost(self: *const DirectX12) bool {
 /// handles, and says so the documented way: `version` keeps counting up
 /// from where it was, so a consumer re-opens both. Composition mode has
 /// no such channel: the embedder holds a raw, un-AddRef'd pointer to the
-/// old swap chain, which this releases, and nothing here can tell it
-/// about the new one. That mode needs a "swap chain changed" notification
-/// before recovery is safe for it.
+/// old swap chain and nothing here can tell it about a new one, so that
+/// mode refuses to recover until a "swap chain changed" notification
+/// exists.
 pub fn recoverDevice(self: *DirectX12) !void {
     var surface = self.surface orelse return error.NoSurface;
+
+    // Composition mode cannot be recovered without a way to hand the
+    // embedder the new swap chain; releasing the one it points at would
+    // turn a frozen surface into a dangling pointer. The caller stops
+    // trying on this error and the surface stays latched, as before.
+    if (surface == .composition) return error.DeviceUnrecoverable;
 
     // The apprt may have resized while the device was down; rebuild at
     // the newest size so the first frame is not immediately a resize.
@@ -687,9 +693,6 @@ pub fn recoverDevice(self: *DirectX12) !void {
     try self.initGpu(surface, width, height);
     self.device_lost = false;
     log.info("DX12 device recreated after loss ({}x{})", .{ width, height });
-    if (surface == .composition) {
-        log.warn("composition-mode swap chain recreated; the embedder still holds the old one and cannot be told", .{});
-    }
 }
 
 /// Execute and release the one-shot init command list.

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -532,8 +532,10 @@ const SurfaceHandleDisposition = enum {
 fn deinitGpu(self: *DirectX12, handle: SurfaceHandleDisposition) void {
     // The apprt-thread exports that read `dev` (device, swap chain,
     // surface handle, shared-texture snapshot) take the renderer's draw
-    // mutex, and every caller of this function holds it, so nothing
-    // observes the Device while it is being released.
+    // mutex. Recovery calls this with that mutex held; final teardown
+    // calls it after the renderer thread is joined and the shell has
+    // stopped asking. Either way nothing observes the Device while it
+    // is being released.
 
     // Wait for GPU to finish before releasing anything. Everything below
     // final-releases resources directly rather than retiring them, so a
@@ -645,16 +647,6 @@ fn deinitGpu(self: *DirectX12, handle: SurfaceHandleDisposition) void {
 /// `recoverDevice` when it is set.
 pub fn deviceLost(self: *const DirectX12) bool {
     return self.device_lost;
-}
-
-/// Whether the device is gone right now, asked of the driver rather than
-/// of the latch. The draw paths set the latch; a loss that lands while
-/// the generic renderer is rebuilding shaders and frames on a device
-/// that was just recreated sets nothing, and this is how that rebuild
-/// learns it has to start over from the device.
-pub fn deviceRemoved(self: *const DirectX12) bool {
-    const dev_ptr = &(self.dev orelse return true);
-    return dev_ptr.removed();
 }
 
 /// Replace a lost device with a new one built for the same surface.

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -6,6 +6,7 @@ pub const DirectX12 = @This();
 
 const builtin = @import("builtin");
 const std = @import("std");
+const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
 
 const configpkg = @import("../config.zig");
@@ -96,6 +97,12 @@ surface: ?Surface = null,
 /// which hands it to the new Device; `deinit` closes it if a rebuild
 /// never succeeds.
 reserved_surface_handle: ?std.os.windows.HANDLE = null,
+
+/// Shared-texture mode: the version the last device published, latched
+/// at teardown so the replacement continues counting from it. Survives
+/// failed rebuild attempts, unlike anything on the device itself. Zero
+/// means no device has published one yet.
+shared_texture_version: u64 = 0,
 
 /// DX12 device owning command queue, fence, and swap chain.
 dev: ?device.Device = null,
@@ -271,7 +278,7 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX12 {
 pub fn initGpu(self: *DirectX12, surface: Surface, width: u32, height: u32) !void {
     self.surface = surface;
 
-    self.dev = device.Device.init(surface, .{
+    var dev = device.Device.init(surface, .{
         .width = width,
         .height = height,
         .surface_handle = self.reserved_surface_handle,
@@ -279,6 +286,13 @@ pub fn initGpu(self: *DirectX12, surface: Surface, width: u32, height: u32) !voi
         log.err("DX12 device init failed: {}", .{err});
         return error.DeviceInitFailed;
     };
+    // Continue the shared-texture version count from the device this one
+    // replaces, before anyone can snapshot it. No lock: the device is not
+    // published yet.
+    if (dev.shared_texture) |*st| {
+        if (self.shared_texture_version != 0) st.version = self.shared_texture_version + 1;
+    }
+    self.dev = dev;
     errdefer {
         // A reused surface handle stays ours until this whole build
         // lands: take it back before Device.deinit would close it, or a
@@ -309,6 +323,7 @@ pub fn initGpu(self: *DirectX12, surface: Surface, width: u32, height: u32) !voi
     }
     errdefer if (self.swap_chain3) |sc3| {
         _ = sc3.Release();
+        self.swap_chain3 = null;
     };
 
     // Create RTV descriptor heap for back buffers plus custom shader
@@ -439,7 +454,10 @@ pub fn initGpu(self: *DirectX12, surface: Surface, width: u32, height: u32) !voi
     }
     errdefer {
         for (&self.gpu_frames) |*gf| {
-            if (gf.*) |*f| f.deinit();
+            if (gf.*) |*f| {
+                f.deinit();
+                gf.* = null;
+            }
         }
     }
 
@@ -509,12 +527,10 @@ const SurfaceHandleDisposition = enum {
 /// stays usable afterwards (unlike `deinit`) so `recoverDevice` can build
 /// again into it.
 fn deinitGpu(self: *DirectX12, handle: SurfaceHandleDisposition) void {
-    // Take the device out of the struct first, so the apprt-thread
-    // exports that read `dev` (swap chain, surface handle, shared-texture
-    // snapshot) see "no device" for the whole teardown instead of a
-    // Device that is being released under them.
-    var dev_opt = self.dev;
-    self.dev = null;
+    // The apprt-thread exports that read `dev` (device, swap chain,
+    // surface handle, shared-texture snapshot) take the renderer's draw
+    // mutex, and every caller of this function holds it, so nothing
+    // observes the Device while it is being released.
 
     // Wait for GPU to finish before releasing anything. Everything below
     // final-releases resources directly rather than retiring them, so a
@@ -527,15 +543,27 @@ fn deinitGpu(self: *DirectX12, handle: SurfaceHandleDisposition) void {
     // retirement queue still has to be emptied HERE, before the heaps
     // below are destroyed: retired descriptor slots point at those heaps,
     // and Device.deinit would otherwise release them into freed memory.
-    if (dev_opt) |*dev_ptr| {
-        if (dev_ptr.removed()) {
-            log.warn("skipping GPU drain before teardown: device removed", .{});
-            dev_ptr.retirement.drainAll();
-        } else {
+    // Whether the device is gone is decided once, AFTER the wait: a TDR
+    // that lands during the wait makes the Signal fail and leaves the
+    // queue full, and the same removal check inside Device.deinit would
+    // then drain it against heaps this function has already freed.
+    if (self.dev) |*dev_ptr| {
+        if (!dev_ptr.removed()) {
             dev_ptr.waitForGpu() catch |err| {
                 log.err("waitForGpu before renderer teardown failed: {}", .{err});
             };
         }
+        if (dev_ptr.removed()) {
+            log.warn("skipping GPU drain before teardown: device removed", .{});
+            dev_ptr.retirement.drainAll();
+        }
+
+        // Shared-texture mode: remember where the version got to, so a
+        // rebuilt device continues the count instead of restarting at 1
+        // (which a consumer keyed on "higher than last" would ignore).
+        dev_ptr.shared_texture_mutex.lockUncancelable(global.io());
+        defer dev_ptr.shared_texture_mutex.unlock(global.io());
+        if (dev_ptr.shared_texture) |st| self.shared_texture_version = st.version;
     }
 
     // Release init command list if never flushed (error during init).
@@ -548,7 +576,10 @@ fn deinitGpu(self: *DirectX12, handle: SurfaceHandleDisposition) void {
         self.init_command_allocator = null;
     }
     self.pending_command_list = null;
-    self.pending_complete = null;
+    // A deferred frameCompleted owes the swap chain a semaphore permit;
+    // dropping one here would deadlock the next SwapChain.deinit. It is
+    // always consumed by drawFrameEnd before anyone can reach this.
+    assert(self.pending_complete == null);
     self.pending_frame_index = 0;
 
     for (&self.gpu_frames) |*gf| {
@@ -564,7 +595,7 @@ fn deinitGpu(self: *DirectX12, handle: SurfaceHandleDisposition) void {
             bb.* = null;
         }
     }
-    self.rtv_handles = .{ .{ .ptr = 0 }, .{ .ptr = 0 }, .{ .ptr = 0 } };
+    self.rtv_handles = @splat(.{ .ptr = 0 });
     self.shared_rtv = null;
     self.rtv_base = 0;
 
@@ -591,12 +622,13 @@ fn deinitGpu(self: *DirectX12, handle: SurfaceHandleDisposition) void {
         self.swap_chain3 = null;
     }
 
-    if (dev_opt) |*dev_ptr| {
+    if (self.dev) |*dev_ptr| {
         if (handle == .keep_surface_handle) {
             self.reserved_surface_handle = dev_ptr.swap_chain_surface_handle;
             dev_ptr.swap_chain_surface_handle = null;
         }
         dev_ptr.deinit();
+        self.dev = null;
     }
 }
 
@@ -637,23 +669,13 @@ pub fn recoverDevice(self: *DirectX12) !void {
         surface.shared_texture = .{ .width = width, .height = height };
     }
 
-    // Carry the shared-texture version across the rebuild: a fresh Device
-    // starts it at 1, and a consumer that only re-opens on a higher number
-    // would keep the dead handles forever.
-    const last_version: u64 = if (self.dev) |*dev_ptr| version: {
-        const st = dev_ptr.shared_texture orelse break :version 0;
-        break :version st.version;
-    } else 0;
+    if (surface == .composition) {
+        log.warn("composition-mode swap chain recreated; the embedder still holds the old one and cannot be told", .{});
+    }
 
     if (self.dev != null) self.deinitGpu(.keep_surface_handle);
 
     try self.initGpu(surface, width, height);
-    if (last_version != 0) {
-        const dev_ptr = &self.dev.?;
-        dev_ptr.shared_texture_mutex.lockUncancelable(global.io());
-        defer dev_ptr.shared_texture_mutex.unlock(global.io());
-        if (dev_ptr.shared_texture) |*st| st.version = last_version + 1;
-    }
     self.device_lost = false;
     log.info("DX12 device recreated after loss ({}x{})", .{ width, height });
 }
@@ -706,6 +728,9 @@ pub fn flushInitCommands(self: *DirectX12) void {
 /// and every frame's resources at teardown.
 pub fn waitGpu(self: *DirectX12) void {
     if (self.dev) |*dev_ptr| {
+        // A removed device cannot signal and is not executing anything;
+        // the caller is about to rebuild it.
+        if (dev_ptr.removed()) return;
         dev_ptr.waitForGpu() catch |err| {
             log.err("waitForGpu failed: {}; GPU state may still be in use", .{err});
         };
@@ -1010,7 +1035,11 @@ pub inline fn beginFrame(
             // counter so consumers re-open their handle.
             dev_ptr.recreateSharedTexture(want.width, want.height) catch |err| {
                 log.err("recreateSharedTexture failed: {}", .{err});
-                api.device_lost = true;
+                // Only a removed device earns the recovery path: it tears
+                // down without a GPU drain, which is wrong for a live
+                // device that merely failed to allocate. That one just
+                // retries the resize next frame.
+                if (dev_ptr.removed()) api.handleDeviceRemoved();
                 return error.ResizeFailed;
             };
             // Refresh the single RTV to point at the new resource.

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -31,6 +31,7 @@ pub const Buffer = bufferpkg.Buffer;
 pub const shaders = @import("directx12/shaders.zig");
 
 const DescriptorHeap = @import("directx12/descriptor_heap.zig").DescriptorHeap;
+const Surface = @import("directx12/surface.zig").Surface;
 
 // --- Sub-module re-exports: low-level D3D12/DXGI/COM bindings ---
 
@@ -80,8 +81,20 @@ blending: configpkg.Config.AlphaBlending = .native,
 
 /// Set to true when a device-loss error is detected (DEVICE_REMOVED,
 /// DEVICE_HUNG, or DEVICE_RESET). Prevents further GPU submissions
-/// until device recovery.
+/// until `recoverDevice` has built a replacement, which is the only
+/// thing that clears it.
 device_lost: bool = false,
+
+/// What `init` built the device for, kept so `recoverDevice` can build
+/// the same thing again after a TDR or a driver upgrade takes it away.
+surface: ?Surface = null,
+
+/// SwapChainPanel mode: the DirectComposition surface handle carried
+/// from a torn-down device to its replacement. Owned here only between
+/// `deinitGpu(.keep_surface_handle)` and the next successful `initGpu`,
+/// which hands it to the new Device; `deinit` closes it if a rebuild
+/// never succeeds.
+reserved_surface_handle: ?std.os.windows.HANDLE = null,
 
 /// DX12 device owning command queue, fence, and swap chain.
 dev: ?device.Device = null,
@@ -208,10 +221,9 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX12 {
         return result;
     }
 
-    const surface_pkg = @import("directx12/surface.zig");
     const w = opts.rt_surface.platform.windows;
 
-    const surface: surface_pkg.Surface = if (w.hwnd) |hwnd|
+    const surface: Surface = if (w.hwnd) |hwnd|
         .{ .hwnd = hwnd }
     else if (w.swap_chain_panel != null)
         // Presence of the panel pointer selects SwapChainPanel mode. The
@@ -232,20 +244,49 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX12 {
         break :comp .composition;
     };
 
+    // For shared-texture mode, use the texture dimensions as the initial
+    // applied size so beginFrame doesn't trigger a redundant recreate on
+    // the first frame. For swap-chain modes, use the screen size.
     const size = opts.size.screen;
-    result.dev = device.Device.init(surface, .{
-        .width = size.width,
-        .height = size.height,
+    const init_width = if (w.shared_texture.enabled) w.shared_texture.width else size.width;
+    const init_height = if (w.shared_texture.enabled) w.shared_texture.height else size.height;
+
+    try result.initGpu(surface, init_width, init_height);
+    result.desired_size.store(packSize(init_width, init_height), .monotonic);
+
+    return result;
+}
+
+/// Build the device and everything that lives on it: swap chain, heaps,
+/// back buffers, per-frame command lists, and the one-shot init command
+/// list. Shared by `init` and `recoverDevice`, which is why it takes the
+/// surface and size explicitly rather than reading them off the options.
+/// Public so the GPU tests can build a headless instance without a
+/// renderer.Options.
+///
+/// Leaves `pending_command_list` pointing at the init command list so the
+/// generic renderer's atlas placeholders can record their barriers; the
+/// caller runs `flushInitCommands` once those exist.
+pub fn initGpu(self: *DirectX12, surface: Surface, width: u32, height: u32) !void {
+    self.surface = surface;
+
+    self.dev = device.Device.init(surface, .{
+        .width = width,
+        .height = height,
+        .surface_handle = self.reserved_surface_handle,
     }) catch |err| {
         log.err("DX12 device init failed: {}", .{err});
         return error.DeviceInitFailed;
     };
+    // The device owns the surface handle from here; if anything below
+    // fails, the errdefer's Device.deinit closes it with the rest.
+    self.reserved_surface_handle = null;
     errdefer {
-        result.dev.?.deinit();
-        result.dev = null;
+        self.dev.?.deinit();
+        self.dev = null;
     }
 
-    const dev_ptr = &result.dev.?;
+    const dev_ptr = &self.dev.?;
 
     // Get SwapChain3 for GetCurrentBackBufferIndex.
     if (dev_ptr.swap_chain) |sc| {
@@ -259,9 +300,9 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX12 {
             log.err("QueryInterface for IDXGISwapChain3 failed: 0x{x}", .{@as(u32, @bitCast(hr))});
             return error.SwapChain3QueryFailed;
         }
-        result.swap_chain3 = sc3;
+        self.swap_chain3 = sc3;
     }
-    errdefer if (result.swap_chain3) |sc3| {
+    errdefer if (self.swap_chain3) |sc3| {
         _ = sc3.Release();
     };
 
@@ -271,8 +312,8 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX12 {
     //   frame_count (swap chain) + frame_count * 2 (custom shader)
     const rtv_heap_capacity = device.Device.frame_count + device.Device.frame_count * 2;
     {
-        const ptr = try alloc.create(DescriptorHeap);
-        errdefer alloc.destroy(ptr);
+        const ptr = try self.allocator.create(DescriptorHeap);
+        errdefer self.allocator.destroy(ptr);
         ptr.* = DescriptorHeap.init(
             dev_ptr.device,
             .RTV,
@@ -282,20 +323,20 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX12 {
             log.err("RTV descriptor heap creation failed: {}", .{err});
             return error.DescriptorHeapCreationFailed;
         };
-        result.rtv_heap = ptr;
+        self.rtv_heap = ptr;
     }
     errdefer {
-        if (result.rtv_heap) |h| {
+        if (self.rtv_heap) |h| {
             h.deinit();
-            alloc.destroy(h);
-            result.rtv_heap = null;
+            self.allocator.destroy(h);
+            self.rtv_heap = null;
         }
     }
 
     // Shader-visible CBV/SRV/UAV heap for texture SRVs.
     {
-        const ptr = try alloc.create(DescriptorHeap);
-        errdefer alloc.destroy(ptr);
+        const ptr = try self.allocator.create(DescriptorHeap);
+        errdefer self.allocator.destroy(ptr);
         ptr.* = DescriptorHeap.init(
             dev_ptr.device,
             .CBV_SRV_UAV,
@@ -305,20 +346,20 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX12 {
             log.err("SRV descriptor heap creation failed: {}", .{err});
             return error.DescriptorHeapCreationFailed;
         };
-        result.srv_heap = ptr;
+        self.srv_heap = ptr;
     }
     errdefer {
-        if (result.srv_heap) |h| {
+        if (self.srv_heap) |h| {
             h.deinit();
-            alloc.destroy(h);
-            result.srv_heap = null;
+            self.allocator.destroy(h);
+            self.srv_heap = null;
         }
     }
 
     // Shader-visible sampler heap for texture sampling.
     {
-        const ptr = try alloc.create(DescriptorHeap);
-        errdefer alloc.destroy(ptr);
+        const ptr = try self.allocator.create(DescriptorHeap);
+        errdefer self.allocator.destroy(ptr);
         ptr.* = DescriptorHeap.init(
             dev_ptr.device,
             .SAMPLER,
@@ -328,18 +369,18 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX12 {
             log.err("Sampler descriptor heap creation failed: {}", .{err});
             return error.DescriptorHeapCreationFailed;
         };
-        result.sampler_heap = ptr;
+        self.sampler_heap = ptr;
     }
     errdefer {
-        if (result.sampler_heap) |h| {
+        if (self.sampler_heap) |h| {
             h.deinit();
-            alloc.destroy(h);
-            result.sampler_heap = null;
+            self.allocator.destroy(h);
+            self.sampler_heap = null;
         }
     }
 
     // Get back buffer resources and create RTVs.
-    if (result.swap_chain3) |sc3| {
+    if (self.swap_chain3) |sc3| {
         for (0..device.Device.frame_count) |i| {
             var resource: ?*d3d12.ID3D12Resource = null;
             const hr = sc3.GetBuffer(
@@ -351,32 +392,32 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX12 {
                 log.err("GetBuffer({}) failed: 0x{x}", .{ i, @as(u32, @bitCast(hr)) });
                 return error.GetBufferFailed;
             }
-            result.back_buffers[i] = resource;
+            self.back_buffers[i] = resource;
 
-            const rtv_handle = result.rtv_heap.?.cpuHandle(@intCast(i));
+            const rtv_handle = self.rtv_heap.?.cpuHandle(@intCast(i));
             dev_ptr.device.CreateRenderTargetView(resource, null, rtv_handle);
-            result.rtv_handles[i] = rtv_handle;
+            self.rtv_handles[i] = rtv_handle;
         }
         // Advance the allocator past the swap chain slots so custom
         // shader textures get their own RTV descriptors. claimFirst (not
         // a raw allocated write) so the free mask agrees and recycling
         // cannot hand these slots out again.
-        result.rtv_heap.?.claimFirst(device.Device.frame_count);
-        result.rtv_base = result.rtv_heap.?.allocated;
+        self.rtv_heap.?.claimFirst(device.Device.frame_count);
+        self.rtv_base = self.rtv_heap.?.allocated;
     } else if (dev_ptr.shared_texture != null) {
         // Shared-texture mode: one RTV pointing at the shared resource.
         // Use RTV heap slot 0 -- we only ever need one slot because
         // the shared resource is the sole render target and is never
         // rotated with a back-buffer cycle.
         const st = &dev_ptr.shared_texture.?;
-        const rtv_handle = result.rtv_heap.?.cpuHandle(0);
+        const rtv_handle = self.rtv_heap.?.cpuHandle(0);
         dev_ptr.device.CreateRenderTargetView(st.resource, null, rtv_handle);
-        result.shared_rtv = rtv_handle;
-        result.rtv_heap.?.claimFirst(1);
-        result.rtv_base = 1;
+        self.shared_rtv = rtv_handle;
+        self.rtv_heap.?.claimFirst(1);
+        self.rtv_base = 1;
     }
     errdefer {
-        for (&result.back_buffers) |*bb| {
+        for (&self.back_buffers) |*bb| {
             if (bb.*) |r| {
                 _ = r.Release();
                 bb.* = null;
@@ -385,14 +426,14 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX12 {
     }
 
     // Create per-frame command allocators and command lists.
-    for (&result.gpu_frames) |*gf| {
+    for (&self.gpu_frames) |*gf| {
         gf.* = Frame.init(dev_ptr.device) catch |err| {
             log.err("Frame init failed: {}", .{err});
             return error.FrameInitFailed;
         };
     }
     errdefer {
-        for (&result.gpu_frames) |*gf| {
+        for (&self.gpu_frames) |*gf| {
             if (gf.*) |*f| f.deinit();
         }
     }
@@ -430,32 +471,53 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX12 {
         }
         errdefer _ = init_cl.?.Release();
 
-        result.init_command_allocator = init_alloc;
-        result.init_command_list = init_cl;
-        result.pending_command_list = init_cl;
+        self.init_command_allocator = init_alloc;
+        self.init_command_list = init_cl;
+        self.pending_command_list = init_cl;
     }
 
-    // For shared-texture mode, use the texture dimensions as the initial
-    // applied size so beginFrame doesn't trigger a redundant recreate on
-    // the first frame. For swap-chain modes, use the screen size.
-    const init_width = if (w.shared_texture.enabled) w.shared_texture.width else size.width;
-    const init_height = if (w.shared_texture.enabled) w.shared_texture.height else size.height;
-    result.desired_size.store(packSize(init_width, init_height), .monotonic);
-    result.applied_width = init_width;
-    result.applied_height = init_height;
-
-    return result;
+    self.applied_width = width;
+    self.applied_height = height;
 }
 
 pub fn deinit(self: *DirectX12) void {
+    self.deinitGpu(.close_surface_handle);
+    if (self.reserved_surface_handle) |h| {
+        _ = d3d12.CloseHandle(h);
+        self.reserved_surface_handle = null;
+    }
+    self.* = undefined;
+}
+
+const SurfaceHandleDisposition = enum {
+    /// Let Device.deinit close the DirectComposition surface handle.
+    close_surface_handle,
+    /// Move the handle into `reserved_surface_handle` so the next
+    /// `initGpu` binds a new swap chain to the surface the embedder
+    /// already composites.
+    keep_surface_handle,
+};
+
+/// Release everything `initGpu` built, in dependency order. The struct
+/// stays usable afterwards (unlike `deinit`) so `recoverDevice` can build
+/// again into it.
+fn deinitGpu(self: *DirectX12, handle: SurfaceHandleDisposition) void {
     // Wait for GPU to finish before releasing anything. Everything below
     // final-releases resources directly rather than retiring them, so a
     // failed drain has to be visible: it means the back buffers and frame
     // command allocators go away while the GPU may still be using them.
+    //
+    // A removed device is the one case where skipping the wait is right
+    // rather than merely tolerated: its queue cannot signal a fence, and
+    // nothing on it is executing, so there is nothing to drain.
     if (self.dev) |*dev_ptr| {
-        dev_ptr.waitForGpu() catch |err| {
-            log.err("waitForGpu before renderer teardown failed: {}", .{err});
-        };
+        if (dev_ptr.removed()) {
+            log.warn("skipping GPU drain before teardown: device removed", .{});
+        } else {
+            dev_ptr.waitForGpu() catch |err| {
+                log.err("waitForGpu before renderer teardown failed: {}", .{err});
+            };
+        }
     }
 
     // Release init command list if never flushed (error during init).
@@ -467,6 +529,9 @@ pub fn deinit(self: *DirectX12) void {
         _ = alloc.Release();
         self.init_command_allocator = null;
     }
+    self.pending_command_list = null;
+    self.pending_complete = null;
+    self.pending_frame_index = 0;
 
     for (&self.gpu_frames) |*gf| {
         if (gf.*) |*f| {
@@ -481,6 +546,9 @@ pub fn deinit(self: *DirectX12) void {
             bb.* = null;
         }
     }
+    self.rtv_handles = .{ .{ .ptr = 0 }, .{ .ptr = 0 }, .{ .ptr = 0 } };
+    self.shared_rtv = null;
+    self.rtv_base = 0;
 
     if (self.sampler_heap) |h| {
         h.deinit();
@@ -506,11 +574,53 @@ pub fn deinit(self: *DirectX12) void {
     }
 
     if (self.dev) |*dev_ptr| {
+        if (handle == .keep_surface_handle) {
+            self.reserved_surface_handle = dev_ptr.swap_chain_surface_handle;
+            dev_ptr.swap_chain_surface_handle = null;
+        }
         dev_ptr.deinit();
         self.dev = null;
     }
+}
 
-    self.* = undefined;
+/// Whether a device-loss error has been seen and not yet recovered from.
+/// The generic renderer polls this at the top of every draw and calls
+/// `recoverDevice` when it is set.
+pub fn deviceLost(self: *const DirectX12) bool {
+    return self.device_lost;
+}
+
+/// Replace a lost device with a new one built for the same surface.
+///
+/// Everything the generic renderer created on the old device (shaders,
+/// frame buffers, textures, samplers) is dead and must be gone before this
+/// runs, because their retirement queue is destroyed with the device. The
+/// caller rebuilds them afterwards. `device_lost` clears only on success:
+/// a failure (a driver still installing, no adapter yet) leaves the
+/// struct torn down with the flag set, and the next call tries again.
+///
+/// SwapChainPanel mode keeps its DirectComposition surface handle across
+/// the swap, so the panel the embedder bound once keeps compositing the
+/// new swap chain without being told. Shared-texture mode cannot do the
+/// same: its resource and fence handles are minted by the device, so the
+/// consumer sees a new snapshot with `version` back at 1.
+pub fn recoverDevice(self: *DirectX12) !void {
+    var surface = self.surface orelse return error.NoSurface;
+
+    // The apprt may have resized while the device was down; rebuild at
+    // the newest size so the first frame is not immediately a resize.
+    const want = unpackSize(self.desired_size.load(.monotonic));
+    const width = if (want.width != 0) want.width else self.applied_width;
+    const height = if (want.height != 0) want.height else self.applied_height;
+    if (surface == .shared_texture) {
+        surface.shared_texture = .{ .width = width, .height = height };
+    }
+
+    if (self.dev != null) self.deinitGpu(.keep_surface_handle);
+
+    try self.initGpu(surface, width, height);
+    self.device_lost = false;
+    log.info("DX12 device recreated after loss ({}x{})", .{ width, height });
 }
 
 /// Execute and release the one-shot init command list.

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -399,7 +399,17 @@ pub fn initGpu(self: *DirectX12, surface: Surface, width: u32, height: u32) !voi
         }
     }
 
-    // Get back buffer resources and create RTVs.
+    // Get back buffer resources and create RTVs. The errdefer goes
+    // before the loop so a failure part way releases what it got: this
+    // runs again on every recovery attempt, and a leak here compounds.
+    errdefer {
+        for (&self.back_buffers) |*bb| {
+            if (bb.*) |r| {
+                _ = r.Release();
+                bb.* = null;
+            }
+        }
+    }
     if (self.swap_chain3) |sc3| {
         for (0..device.Device.frame_count) |i| {
             var resource: ?*d3d12.ID3D12Resource = null;
@@ -436,22 +446,9 @@ pub fn initGpu(self: *DirectX12, surface: Surface, width: u32, height: u32) !voi
         self.rtv_heap.?.claimFirst(1);
         self.rtv_base = 1;
     }
-    errdefer {
-        for (&self.back_buffers) |*bb| {
-            if (bb.*) |r| {
-                _ = r.Release();
-                bb.* = null;
-            }
-        }
-    }
 
-    // Create per-frame command allocators and command lists.
-    for (&self.gpu_frames) |*gf| {
-        gf.* = Frame.init(dev_ptr.device) catch |err| {
-            log.err("Frame init failed: {}", .{err});
-            return error.FrameInitFailed;
-        };
-    }
+    // Create per-frame command allocators and command lists. Same
+    // errdefer-before-loop shape as the back buffers, for the same reason.
     errdefer {
         for (&self.gpu_frames) |*gf| {
             if (gf.*) |*f| {
@@ -459,6 +456,12 @@ pub fn initGpu(self: *DirectX12, surface: Surface, width: u32, height: u32) !voi
                 gf.* = null;
             }
         }
+    }
+    for (&self.gpu_frames) |*gf| {
+        gf.* = Frame.init(dev_ptr.device) catch |err| {
+            log.err("Frame init failed: {}", .{err});
+            return error.FrameInitFailed;
+        };
     }
 
     // Create a one-shot command list for init-time texture work.
@@ -685,15 +688,16 @@ pub fn recoverDevice(self: *DirectX12) !void {
         surface.shared_texture = .{ .width = width, .height = height };
     }
 
-    if (surface == .composition) {
-        log.warn("composition-mode swap chain recreated; the embedder still holds the old one and cannot be told", .{});
-    }
-
-    if (self.dev != null) self.deinitGpu(.keep_surface_handle);
+    // Unconditional: with no device this sweeps whatever a failed
+    // attempt built before it stopped.
+    self.deinitGpu(.keep_surface_handle);
 
     try self.initGpu(surface, width, height);
     self.device_lost = false;
     log.info("DX12 device recreated after loss ({}x{})", .{ width, height });
+    if (surface == .composition) {
+        log.warn("composition-mode swap chain recreated; the embedder still holds the old one and cannot be told", .{});
+    }
 }
 
 /// Execute and release the one-shot init command list.

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -10,6 +10,7 @@ const Allocator = std.mem.Allocator;
 
 const configpkg = @import("../config.zig");
 const font = @import("../font/main.zig");
+const global = @import("../global.zig");
 const rendererpkg = @import("../renderer.zig");
 const Renderer = rendererpkg.GenericRenderer(DirectX12);
 const shadertoy = @import("shadertoy.zig");
@@ -278,10 +279,14 @@ pub fn initGpu(self: *DirectX12, surface: Surface, width: u32, height: u32) !voi
         log.err("DX12 device init failed: {}", .{err});
         return error.DeviceInitFailed;
     };
-    // The device owns the surface handle from here; if anything below
-    // fails, the errdefer's Device.deinit closes it with the rest.
-    self.reserved_surface_handle = null;
     errdefer {
+        // A reused surface handle stays ours until this whole build
+        // lands: take it back before Device.deinit would close it, or a
+        // failure below would cost the panel the surface it is bound to
+        // and the next attempt would mint one nothing composites.
+        if (self.reserved_surface_handle != null) {
+            self.dev.?.swap_chain_surface_handle = null;
+        }
         self.dev.?.deinit();
         self.dev = null;
     }
@@ -478,6 +483,8 @@ pub fn initGpu(self: *DirectX12, surface: Surface, width: u32, height: u32) !voi
 
     self.applied_width = width;
     self.applied_height = height;
+    // Only now does the device own a reused surface handle.
+    self.reserved_surface_handle = null;
 }
 
 pub fn deinit(self: *DirectX12) void {
@@ -502,6 +509,13 @@ const SurfaceHandleDisposition = enum {
 /// stays usable afterwards (unlike `deinit`) so `recoverDevice` can build
 /// again into it.
 fn deinitGpu(self: *DirectX12, handle: SurfaceHandleDisposition) void {
+    // Take the device out of the struct first, so the apprt-thread
+    // exports that read `dev` (swap chain, surface handle, shared-texture
+    // snapshot) see "no device" for the whole teardown instead of a
+    // Device that is being released under them.
+    var dev_opt = self.dev;
+    self.dev = null;
+
     // Wait for GPU to finish before releasing anything. Everything below
     // final-releases resources directly rather than retiring them, so a
     // failed drain has to be visible: it means the back buffers and frame
@@ -509,10 +523,14 @@ fn deinitGpu(self: *DirectX12, handle: SurfaceHandleDisposition) void {
     //
     // A removed device is the one case where skipping the wait is right
     // rather than merely tolerated: its queue cannot signal a fence, and
-    // nothing on it is executing, so there is nothing to drain.
-    if (self.dev) |*dev_ptr| {
+    // nothing on it is executing, so there is nothing to wait for. The
+    // retirement queue still has to be emptied HERE, before the heaps
+    // below are destroyed: retired descriptor slots point at those heaps,
+    // and Device.deinit would otherwise release them into freed memory.
+    if (dev_opt) |*dev_ptr| {
         if (dev_ptr.removed()) {
             log.warn("skipping GPU drain before teardown: device removed", .{});
+            dev_ptr.retirement.drainAll();
         } else {
             dev_ptr.waitForGpu() catch |err| {
                 log.err("waitForGpu before renderer teardown failed: {}", .{err});
@@ -573,13 +591,12 @@ fn deinitGpu(self: *DirectX12, handle: SurfaceHandleDisposition) void {
         self.swap_chain3 = null;
     }
 
-    if (self.dev) |*dev_ptr| {
+    if (dev_opt) |*dev_ptr| {
         if (handle == .keep_surface_handle) {
             self.reserved_surface_handle = dev_ptr.swap_chain_surface_handle;
             dev_ptr.swap_chain_surface_handle = null;
         }
         dev_ptr.deinit();
-        self.dev = null;
     }
 }
 
@@ -599,11 +616,15 @@ pub fn deviceLost(self: *const DirectX12) bool {
 /// a failure (a driver still installing, no adapter yet) leaves the
 /// struct torn down with the flag set, and the next call tries again.
 ///
-/// SwapChainPanel mode keeps its DirectComposition surface handle across
-/// the swap, so the panel the embedder bound once keeps compositing the
-/// new swap chain without being told. Shared-texture mode cannot do the
-/// same: its resource and fence handles are minted by the device, so the
-/// consumer sees a new snapshot with `version` back at 1.
+/// What the embedder sees depends on the surface mode. SwapChainPanel
+/// keeps its DirectComposition surface handle across the swap, so the
+/// panel the embedder bound once keeps compositing the new swap chain
+/// without being told. Shared-texture mode mints new resource and fence
+/// handles, and says so the documented way: `version` keeps counting up
+/// from where it was, so a consumer re-opens both. Composition mode has
+/// no such channel: the embedder holds a raw pointer to the old swap
+/// chain and nothing here can tell it about the new one, so that mode
+/// comes back blank until a "swap chain changed" notification exists.
 pub fn recoverDevice(self: *DirectX12) !void {
     var surface = self.surface orelse return error.NoSurface;
 
@@ -616,9 +637,23 @@ pub fn recoverDevice(self: *DirectX12) !void {
         surface.shared_texture = .{ .width = width, .height = height };
     }
 
+    // Carry the shared-texture version across the rebuild: a fresh Device
+    // starts it at 1, and a consumer that only re-opens on a higher number
+    // would keep the dead handles forever.
+    const last_version: u64 = if (self.dev) |*dev_ptr| version: {
+        const st = dev_ptr.shared_texture orelse break :version 0;
+        break :version st.version;
+    } else 0;
+
     if (self.dev != null) self.deinitGpu(.keep_surface_handle);
 
     try self.initGpu(surface, width, height);
+    if (last_version != 0) {
+        const dev_ptr = &self.dev.?;
+        dev_ptr.shared_texture_mutex.lockUncancelable(global.io());
+        defer dev_ptr.shared_texture_mutex.unlock(global.io());
+        if (dev_ptr.shared_texture) |*st| st.version = last_version + 1;
+    }
     self.device_lost = false;
     log.info("DX12 device recreated after loss ({}x{})", .{ width, height });
 }
@@ -703,6 +738,11 @@ pub fn drawFrameEnd(self: *DirectX12) void {
 
     const dev_ptr = &(self.dev orelse return);
     const cl = self.pending_command_list orelse return;
+    // The init command list is still recording until flushInitCommands
+    // closes it. A draw that fails between a device rebuild and that
+    // flush lands here with it pending; executing an open list is an
+    // invalid call that would remove the device all over again.
+    if (cl == self.init_command_list) return;
     self.pending_command_list = null;
 
     // Execute the command list.

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -557,6 +557,11 @@ fn deinitGpu(self: *DirectX12, handle: SurfaceHandleDisposition) void {
             log.warn("skipping GPU drain before teardown: device removed", .{});
             dev_ptr.retirement.drainAll();
         }
+        // Whatever the wait left behind (a live device whose fence wait
+        // failed) must not keep pointing at the heaps destroyed below.
+        // Slots are dropped; resources keep the leak-rather-than-corrupt
+        // policy Device.deinit applies to them.
+        dev_ptr.retirement.forgetSlots();
 
         // Shared-texture mode: remember where the version got to, so a
         // rebuilt device continues the count instead of restarting at 1
@@ -639,6 +644,16 @@ pub fn deviceLost(self: *const DirectX12) bool {
     return self.device_lost;
 }
 
+/// Whether the device is gone right now, asked of the driver rather than
+/// of the latch. The draw paths set the latch; a loss that lands while
+/// the generic renderer is rebuilding shaders and frames on a device
+/// that was just recreated sets nothing, and this is how that rebuild
+/// learns it has to start over from the device.
+pub fn deviceRemoved(self: *const DirectX12) bool {
+    const dev_ptr = &(self.dev orelse return true);
+    return dev_ptr.removed();
+}
+
 /// Replace a lost device with a new one built for the same surface.
 ///
 /// Everything the generic renderer created on the old device (shaders,
@@ -654,9 +669,10 @@ pub fn deviceLost(self: *const DirectX12) bool {
 /// without being told. Shared-texture mode mints new resource and fence
 /// handles, and says so the documented way: `version` keeps counting up
 /// from where it was, so a consumer re-opens both. Composition mode has
-/// no such channel: the embedder holds a raw pointer to the old swap
-/// chain and nothing here can tell it about the new one, so that mode
-/// comes back blank until a "swap chain changed" notification exists.
+/// no such channel: the embedder holds a raw, un-AddRef'd pointer to the
+/// old swap chain, which this releases, and nothing here can tell it
+/// about the new one. That mode needs a "swap chain changed" notification
+/// before recovery is safe for it.
 pub fn recoverDevice(self: *DirectX12) !void {
     var surface = self.surface orelse return error.NoSurface;
 

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -555,6 +555,11 @@ fn drawNowCallback(
     const t = self_.?;
     t.drawFrame(true);
 
+    // A draw can leave the renderer wanting another wake (a device
+    // rebuild that failed and is due to retry), and this path was the
+    // only draw that did not ask.
+    t.armAnimationTimer();
+
     return .rearm;
 }
 

--- a/src/renderer/directx12/d3d12.zig
+++ b/src/renderer/directx12/d3d12.zig
@@ -1467,6 +1467,43 @@ pub const ID3D12Device = extern struct {
     }
 };
 
+/// ID3D12Device5, bound only for RemoveDevice: the documented way to put
+/// a device into the removed state on demand, so device-loss recovery can
+/// be exercised by a test instead of waiting for a real TDR. Every other
+/// slot is reserved; the renderer talks to the device through ID3D12Device.
+pub const ID3D12Device5 = extern struct {
+    vtable: *const VTable,
+    pub const IID = GUID{
+        .data1 = 0x8b4f173b,
+        .data2 = 0x2fea,
+        .data3 = 0x4b80,
+        .data4 = .{ 0x8f, 0x58, 0x43, 0x07, 0x19, 0x1a, 0xb9, 0x5d },
+    };
+
+    pub const VTable = extern struct {
+        /// IUnknown (3) + ID3D12Object (4) + ID3D12Device (37) +
+        /// ID3D12Device1 (3) + ID3D12Device2 (1) + ID3D12Device3 (3) +
+        /// ID3D12Device4 (6) + ID3D12Device5.CreateLifetimeTracker (1).
+        /// RemoveDevice is the second ID3D12Device5 method. Counting the
+        /// SDK header is a trap: the four struct-returning methods are
+        /// declared twice there, once per ABI, and only one of each is
+        /// a slot.
+        base: [58]Reserved,
+        RemoveDevice: *const fn (*ID3D12Device5) callconv(.winapi) void,
+        /// EnumerateMetaCommands through CheckDriverMatchingIdentifier.
+        tail: [6]Reserved,
+    };
+
+    pub inline fn RemoveDevice(self: *ID3D12Device5) void {
+        self.vtable.RemoveDevice(self);
+    }
+
+    pub inline fn Release(self: *ID3D12Device5) u32 {
+        const unknown: *IUnknown = @ptrCast(self);
+        return unknown.vtable.Release(unknown);
+    }
+};
+
 // --- Extern functions ---
 
 pub extern "d3d12" fn D3D12CreateDevice(
@@ -1923,6 +1960,19 @@ test "DxcBuffer is extern struct with expected field order" {
 test "DXC_OUT_KIND has OBJECT and ERRORS variants" {
     try std.testing.expectEqual(@as(u32, 1), @intFromEnum(DXC_OUT_KIND.OBJECT));
     try std.testing.expectEqual(@as(u32, 2), @intFromEnum(DXC_OUT_KIND.ERRORS));
+}
+
+test "ID3D12Device5 RemoveDevice sits at slot 58 of 65" {
+    // Counted from ID3D12Device5Vtbl in the Windows SDK d3d12.h (minus its
+    // per-ABI duplicate declarations): the slot has to match or
+    // RemoveDevice would call CreateLifetimeTracker or CreateStateObject
+    // instead, and the first symptom of that was a fast-fail crash.
+    try std.testing.expectEqual(@sizeOf(*anyopaque), @sizeOf(ID3D12Device5));
+    try std.testing.expectEqual(65 * @sizeOf(*anyopaque), @sizeOf(ID3D12Device5.VTable));
+    try std.testing.expectEqual(58 * @sizeOf(*anyopaque), @offsetOf(ID3D12Device5.VTable, "RemoveDevice"));
+    // ID3D12Device5 extends ID3D12Device, so the shared prefix must agree.
+    try std.testing.expectEqual(44 * @sizeOf(*anyopaque), @sizeOf(ID3D12Device.VTable));
+    try std.testing.expectEqual(37 * @sizeOf(*anyopaque), @offsetOf(ID3D12Device.VTable, "GetDeviceRemovedReason"));
 }
 
 test "IDxcBlobUtf8 has expected vtable field count" {

--- a/src/renderer/directx12/device.zig
+++ b/src/renderer/directx12/device.zig
@@ -204,6 +204,13 @@ pub const InitOptions = struct {
     width: u32 = 800,
     /// Initial back buffer height. Ignored for SharedTexture (uses its own size).
     height: u32 = 600,
+    /// SwapChainPanel mode only: bind the new swap chain to this existing
+    /// DirectComposition surface handle instead of minting one. The handle
+    /// outlives the D3D12 device that presented into it, so a device
+    /// recreated after a TDR can keep presenting into the surface the
+    /// embedder already bound with SetSwapChainHandle, and the panel never
+    /// has to be told. Ownership transfers to the Device on success.
+    surface_handle: ?std.os.windows.HANDLE = null,
 };
 
 pub fn init(surface: @import("surface.zig").Surface, opts: InitOptions) !Device {
@@ -363,6 +370,7 @@ pub fn init(surface: @import("surface.zig").Surface, opts: InitOptions) !Device 
                 command_queue.?,
                 opts.width,
                 opts.height,
+                opts.surface_handle,
             );
             swap_chain = result.swap_chain;
             swap_chain_surface_handle = result.handle;
@@ -399,7 +407,8 @@ pub fn init(surface: @import("surface.zig").Surface, opts: InitOptions) !Device 
     // errdefer is a no-op for the other surface variants.
     errdefer if (swap_chain_surface_handle) |h| {
         _ = swap_chain.?.Release();
-        _ = d3d12.CloseHandle(h);
+        // A handle the caller passed in stays the caller's to close.
+        if (opts.surface_handle == null) _ = d3d12.CloseHandle(h);
     };
     errdefer if (result_shared_texture) |st| {
         _ = d3d12.CloseHandle(st.fence_handle);
@@ -443,24 +452,34 @@ pub fn deinit(self: *Device) void {
     // reading anything) from a live device whose fence we failed to
     // signal. What the retirement queue holds DOES have an alternative;
     // see below.
+    //
+    // A removed device is the benign case made explicit: its queue can no
+    // longer signal, so the wait cannot succeed, but nothing on it is
+    // executing either, so there is nothing left to drain and every
+    // release below is safe. This is the path a device-loss recovery
+    // takes, once per lost device, so it must not leak.
     var drained = true;
-    self.waitForGpu() catch |err| {
+    if (self.removed()) {
+        log.warn(
+            "device removed (reason 0x{x}); tearing down without a GPU drain",
+            .{@as(u32, @bitCast(self.device.GetDeviceRemovedReason()))},
+        );
+    } else self.waitForGpu() catch |err| {
         drained = false;
-        const reason = self.device.GetDeviceRemovedReason();
         log.err(
-            "waitForGpu before device teardown failed: {}, device removed reason 0x{x}; releasing GPU resources without a drain, and leaking {d} retired resource(s) rather than freeing them under a live GPU",
-            .{ err, @as(u32, @bitCast(reason)), self.retirement.count() },
+            "waitForGpu before device teardown failed: {}; releasing GPU resources without a drain, and leaking {d} retired resource(s) rather than freeing them under a live GPU",
+            .{ err, self.retirement.count() },
         );
     };
 
     // Free anything the retirement queue is still holding -- but only when
-    // the drain above actually succeeded. Device.deinit runs per surface,
-    // on every tab and split close, in a process that keeps running, so
-    // "the process is going away" is not available as a justification. On
-    // a failed wait the GPU may still be reading these, and leaking them
-    // is strictly safer than releasing them; the back-buffer and frame
-    // releases below have no such option, which is why the asymmetry is
-    // worth taking here.
+    // the drain above actually succeeded or was unnecessary. Device.deinit
+    // runs per surface, on every tab and split close, in a process that
+    // keeps running, so "the process is going away" is not available as a
+    // justification. On a failed wait against a live device the GPU may
+    // still be reading these, and leaking them is strictly safer than
+    // releasing them; the back-buffer and frame releases below have no
+    // such option, which is why the asymmetry is worth taking here.
     if (drained) self.retirement.drainAll();
     self.retirement.deinit();
     std.heap.c_allocator.destroy(self.retirement);
@@ -487,6 +506,12 @@ pub fn deinit(self: *Device) void {
     _ = self.device.Release();
 
     self.* = undefined;
+}
+
+/// Whether the device has been removed (TDR, driver upgrade, adapter
+/// gone). Cheap: no GPU round trip, just the driver's recorded reason.
+pub fn removed(self: *const Device) bool {
+    return FAILED(self.device.GetDeviceRemovedReason());
 }
 
 /// Signal the fence from the command queue and block until the GPU catches up.
@@ -665,21 +690,24 @@ const SurfaceHandleSwapChain = struct {
     handle: std.os.windows.HANDLE,
 };
 
-/// Create a DirectComposition surface handle and a composition swap chain
-/// bound to it. The caller owns both: Release the swap chain and
-/// CloseHandle the handle. Used by SwapChainPanel mode so the embedder
-/// can bind the handle via ISwapChainPanelNative2::SetSwapChainHandle.
+/// Create a composition swap chain bound to a DirectComposition surface
+/// handle, minting the handle unless the caller passes one in. The caller
+/// owns both on return: Release the swap chain and CloseHandle the handle.
+/// Used by SwapChainPanel mode so the embedder can bind the handle via
+/// ISwapChainPanelNative2::SetSwapChainHandle.
 ///
-/// Each call mints a fresh surface handle. The embedder binds the handle
-/// to the panel exactly once after surface creation, so any future
-/// device-removed (TDR) recovery that recreates the swap chain must also
-/// mint a new handle here AND have the embedder re-bind it via
-/// SetSwapChainHandle, or the panel would composite a dead handle.
+/// The embedder binds the handle to the panel exactly once after surface
+/// creation, and the handle is a composition primitive that does not
+/// belong to any D3D12 device. That is what lets a device recreated after
+/// a TDR present into the panel without the embedder rebinding: it passes
+/// the old handle in `existing` and gets a new swap chain on the same
+/// surface. On failure a passed-in handle stays the caller's to close.
 fn createSurfaceHandleSwapChain(
     factory: *dxgi.IDXGIFactory2,
     queue: *d3d12.ID3D12CommandQueue,
     width: u32,
     height: u32,
+    existing: ?std.os.windows.HANDLE,
 ) !SurfaceHandleSwapChain {
     // The composition-surface-handle entry point lives on IDXGIFactoryMedia,
     // which the factory we already created supports via QueryInterface.
@@ -697,19 +725,23 @@ fn createSurfaceHandleSwapChain(
     }
     defer _ = media.?.Release();
 
-    var handle: std.os.windows.HANDLE = undefined;
-    {
+    const handle: std.os.windows.HANDLE = existing orelse minted: {
+        var fresh: std.os.windows.HANDLE = undefined;
         const hr = dcomp.DCompositionCreateSurfaceHandle(
             dcomp.COMPOSITIONOBJECT_ALL_ACCESS,
             null,
-            &handle,
+            &fresh,
         );
         if (FAILED(hr)) {
             log.err("DCompositionCreateSurfaceHandle failed: 0x{x}", .{@as(u32, @bitCast(hr))});
             return error.SurfaceHandleCreationFailed;
         }
-    }
-    errdefer _ = d3d12.CloseHandle(handle);
+        break :minted fresh;
+    };
+    // Only a handle minted here is ours to close on failure.
+    errdefer if (existing == null) {
+        _ = d3d12.CloseHandle(handle);
+    };
 
     const desc = compositionSwapChainDesc(width, height);
 

--- a/src/renderer/directx12/device.zig
+++ b/src/renderer/directx12/device.zig
@@ -85,12 +85,14 @@ pub const SharedTextureState = struct {
     /// Device. Closed and reborn on resize.
     resource_handle: std.os.windows.HANDLE,
     /// NT HANDLE from CreateSharedHandle on the Device's fence. Owned
-    /// by Device. Stable for the surface lifetime.
+    /// by Device. Survives resize; a device-removed recovery replaces
+    /// the fence and so this handle too, under a bumped `version`.
     fence_handle: std.os.windows.HANDLE,
     /// Pixel dimensions of `resource`.
     width: u32,
     height: u32,
-    /// Monotonically increasing; bumped by recreateSharedTexture.
+    /// Monotonically increasing; bumped by recreateSharedTexture and
+    /// carried across a device recreation so it never goes backwards.
     version: u64,
 
     /// Create a shared committed ID3D12Resource and NT handles for both

--- a/src/renderer/directx12/gpu_test.zig
+++ b/src/renderer/directx12/gpu_test.zig
@@ -1755,6 +1755,7 @@ test "DirectX12: rebuilds every device-bound object after the device is removed"
         return error.SkipZigTest;
     defer api.deinit();
     api.flushInitCommands();
+    const version_before = api.dev.?.shared_texture.?.version;
 
     try removeDevice(api.dev.?.device);
     // What handleDeviceRemoved records when Present or Signal reports it.
@@ -1766,7 +1767,10 @@ test "DirectX12: rebuilds every device-bound object after the device is removed"
     try std.testing.expect(!api.deviceLost());
     const dev = &(api.dev orelse return error.NoDevice);
     try std.testing.expect(!dev.removed());
-    try std.testing.expect(dev.shared_texture != null);
+    // A consumer re-opens the shared handles on a version it has not
+    // seen; a fresh device would have restarted the count at 1.
+    const st = dev.shared_texture orelse return error.NoSharedTexture;
+    try std.testing.expectEqual(version_before + 1, st.version);
     try std.testing.expect(api.srv_heap != null);
     try std.testing.expect(api.rtv_heap != null);
     try std.testing.expect(api.sampler_heap != null);

--- a/src/renderer/directx12/gpu_test.zig
+++ b/src/renderer/directx12/gpu_test.zig
@@ -1693,3 +1693,90 @@ test "Texture: deinit recycles its SRV slot" {
     defer tex2.deinit();
     try std.testing.expectEqual(@as(u32, 0), tex2.srv.index);
 }
+
+// ---- Device-loss recovery ----
+
+/// Put a live device into the removed state, the way a TDR or a driver
+/// upgrade would, without waiting for either. Needs ID3D12Device5
+/// (Windows 10 1809+); skips where the runtime cannot hand it out.
+fn removeDevice(dev: *d3d12.ID3D12Device) !void {
+    var dev5: ?*d3d12.ID3D12Device5 = null;
+    const hr = dev.vtable.QueryInterface(dev, &d3d12.ID3D12Device5.IID, @ptrCast(&dev5));
+    if (com.FAILED(hr) or dev5 == null) return error.SkipZigTest;
+    defer _ = dev5.?.Release();
+    dev5.?.RemoveDevice();
+    if (!com.FAILED(dev.GetDeviceRemovedReason())) return error.DeviceNotRemoved;
+}
+
+test "Device: SwapChainPanel surface handle outlives the device that presented into it" {
+    // The WinUI shell binds the DirectComposition surface handle to its
+    // SwapChainPanel exactly once. A device recreated after a TDR must
+    // present into that same surface, or the panel keeps compositing a
+    // handle nothing writes to.
+    if (!hasInteractiveDesktop()) return error.SkipZigTest;
+
+    var first = Device.init(.swap_chain_panel, .{ .width = 64, .height = 64 }) catch
+        return error.SkipZigTest;
+    const handle = first.swap_chain_surface_handle orelse return error.NoSurfaceHandle;
+
+    try removeDevice(first.device);
+
+    // Keep the handle across the teardown; the renderer does the same.
+    first.swap_chain_surface_handle = null;
+    first.deinit();
+
+    var second = try Device.init(.swap_chain_panel, .{
+        .width = 64,
+        .height = 64,
+        .surface_handle = handle,
+    });
+    defer second.deinit();
+
+    try std.testing.expectEqual(handle, second.swap_chain_surface_handle.?);
+    try std.testing.expect(!com.FAILED(second.device.GetDeviceRemovedReason()));
+
+    // The proof is a Present into the reused surface from the new device.
+    const sc = second.swap_chain orelse return error.NoSwapChain;
+    try std.testing.expect(!com.FAILED(sc.Present(0, 0)));
+}
+
+test "DirectX12: rebuilds every device-bound object after the device is removed" {
+    if (comptime builtin.os.tag != .windows) return;
+
+    const DirectX12 = @import("../DirectX12.zig");
+
+    // Shared-texture mode: a real device and command queue with no window
+    // or swap chain, so this runs headless.
+    var api: DirectX12 = .{ .allocator = std.testing.allocator };
+    api.initGpu(.{ .shared_texture = .{ .width = 64, .height = 64 } }, 64, 64) catch
+        return error.SkipZigTest;
+    defer api.deinit();
+    api.flushInitCommands();
+
+    try removeDevice(api.dev.?.device);
+    // What handleDeviceRemoved records when Present or Signal reports it.
+    api.device_lost = true;
+    try std.testing.expect(api.deviceLost());
+
+    try api.recoverDevice();
+
+    try std.testing.expect(!api.deviceLost());
+    const dev = &(api.dev orelse return error.NoDevice);
+    try std.testing.expect(!dev.removed());
+    try std.testing.expect(dev.shared_texture != null);
+    try std.testing.expect(api.srv_heap != null);
+    try std.testing.expect(api.rtv_heap != null);
+    try std.testing.expect(api.sampler_heap != null);
+    try std.testing.expect(api.shared_rtv != null);
+    for (api.gpu_frames) |gf| try std.testing.expect(gf != null);
+    try std.testing.expectEqual(@as(u32, 64), api.applied_width);
+    try std.testing.expectEqual(@as(u32, 64), api.applied_height);
+
+    // The rebuilt queue accepts and completes work: the fresh init
+    // command list goes through Close, ExecuteCommandLists and a fence
+    // wait, none of which the old device could do.
+    try std.testing.expect(api.init_command_list != null);
+    api.flushInitCommands();
+    try std.testing.expect(api.init_command_list == null);
+    try dev.waitForGpu();
+}

--- a/src/renderer/directx12/gpu_test.zig
+++ b/src/renderer/directx12/gpu_test.zig
@@ -1744,7 +1744,7 @@ test "Device: SwapChainPanel surface handle outlives the device that presented i
 }
 
 test "DirectX12: rebuilds every device-bound object after the device is removed" {
-    if (comptime builtin.os.tag != .windows) return;
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
 
     const DirectX12 = @import("../DirectX12.zig");
 

--- a/src/renderer/directx12/gpu_test.zig
+++ b/src/renderer/directx12/gpu_test.zig
@@ -1717,6 +1717,8 @@ test "Device: SwapChainPanel surface handle outlives the device that presented i
 
     var first = Device.init(.swap_chain_panel, .{ .width = 64, .height = 64 }) catch
         return error.SkipZigTest;
+    var first_alive = true;
+    errdefer if (first_alive) first.deinit();
     const handle = first.swap_chain_surface_handle orelse return error.NoSurfaceHandle;
 
     try removeDevice(first.device);
@@ -1724,6 +1726,7 @@ test "Device: SwapChainPanel surface handle outlives the device that presented i
     // Keep the handle across the teardown; the renderer does the same.
     first.swap_chain_surface_handle = null;
     first.deinit();
+    first_alive = false;
 
     var second = try Device.init(.swap_chain_panel, .{
         .width = 64,

--- a/src/renderer/directx12/gpu_test.zig
+++ b/src/renderer/directx12/gpu_test.zig
@@ -1727,6 +1727,8 @@ test "Device: SwapChainPanel surface handle outlives the device that presented i
     first.swap_chain_surface_handle = null;
     first.deinit();
     first_alive = false;
+    // Ours until the second device takes it.
+    errdefer _ = d3d12.CloseHandle(handle);
 
     var second = try Device.init(.swap_chain_panel, .{
         .width = 64,

--- a/src/renderer/directx12/gpu_test.zig
+++ b/src/renderer/directx12/gpu_test.zig
@@ -1728,13 +1728,17 @@ test "Device: SwapChainPanel surface handle outlives the device that presented i
     first.deinit();
     first_alive = false;
     // Ours until the second device takes it.
-    errdefer _ = d3d12.CloseHandle(handle);
+    var handle_owned = true;
+    errdefer if (handle_owned) {
+        _ = d3d12.CloseHandle(handle);
+    };
 
     var second = try Device.init(.swap_chain_panel, .{
         .width = 64,
         .height = 64,
         .surface_handle = handle,
     });
+    handle_owned = false;
     defer second.deinit();
 
     try std.testing.expectEqual(handle, second.swap_chain_surface_handle.?);

--- a/src/renderer/directx12/retire.zig
+++ b/src/renderer/directx12/retire.zig
@@ -177,6 +177,29 @@ pub const Retirement = struct {
         self.staged.clearRetainingCapacity();
     }
 
+    /// Drop every descriptor-slot retirement without recycling it. For
+    /// the moment right before the heaps themselves are destroyed: a
+    /// slot entry is a pointer into a heap, so once the heaps go it can
+    /// only ever be released into freed memory. Resources are kept; they
+    /// still follow the drain-or-leak rule.
+    pub fn forgetSlots(self: *Self) void {
+        var kept: usize = 0;
+        for (self.pending.items) |entry| {
+            if (entry.item == .slot) continue;
+            self.pending.items[kept] = entry;
+            kept += 1;
+        }
+        self.pending.shrinkRetainingCapacity(kept);
+
+        kept = 0;
+        for (self.staged.items) |item| {
+            if (item == .slot) continue;
+            self.staged.items[kept] = item;
+            kept += 1;
+        }
+        self.staged.shrinkRetainingCapacity(kept);
+    }
+
     fn releaseItem(item: Item) void {
         switch (item) {
             .resource => |resource| _ = resource.Release(),
@@ -402,4 +425,27 @@ test "Retirement: drainAll frees staged slots without a fence" {
 
     const d1 = try heap.allocate();
     try std.testing.expectEqual(@as(u32, 0), d1.index);
+}
+
+test "Retirement: forgetSlots drops slots, staged and sealed, and keeps nothing pointing at a heap" {
+    var q = Retirement.init(std.testing.allocator);
+    defer q.deinit();
+    defer q.drainAll();
+
+    var heap = testHeap(2);
+    const d0 = try heap.allocate();
+    const d1 = try heap.allocate();
+
+    // One sealed, one staged: both kinds have to go.
+    q.retireSlot(&heap, d0.index);
+    q.seal(1);
+    q.retireSlot(&heap, d1.index);
+    try std.testing.expectEqual(@as(usize, 2), q.count());
+
+    q.forgetSlots();
+    try std.testing.expectEqual(@as(usize, 0), q.count());
+
+    // Forgotten means not recycled: the heap still thinks both are taken,
+    // which is the point when the heap is about to be destroyed anyway.
+    try std.testing.expectError(error.DescriptorHeapFull, heap.allocate());
 }

--- a/src/renderer/directx12/retire.zig
+++ b/src/renderer/directx12/retire.zig
@@ -183,6 +183,7 @@ pub const Retirement = struct {
     /// only ever be released into freed memory. Resources are kept; they
     /// still follow the drain-or-leak rule.
     pub fn forgetSlots(self: *Self) void {
+        const before_pending = self.pending.items.len;
         var kept: usize = 0;
         for (self.pending.items) |entry| {
             if (entry.item == .slot) continue;
@@ -191,6 +192,7 @@ pub const Retirement = struct {
         }
         self.pending.shrinkRetainingCapacity(kept);
 
+        const before_staged = self.staged.items.len;
         kept = 0;
         for (self.staged.items) |item| {
             if (item == .slot) continue;
@@ -198,6 +200,13 @@ pub const Retirement = struct {
             kept += 1;
         }
         self.staged.shrinkRetainingCapacity(kept);
+
+        // Normally nothing: a drain ahead of this empties the queue. A
+        // count here is a fence wait that failed on a live device.
+        const dropped = (before_pending - self.pending.items.len) + (before_staged - kept);
+        if (dropped != 0) {
+            log.warn("dropped {d} descriptor slot retirement(s) ahead of heap teardown", .{dropped});
+        }
     }
 
     fn releaseItem(item: Item) void {

--- a/src/renderer/directx12/shaders.zig
+++ b/src/renderer/directx12/shaders.zig
@@ -353,6 +353,13 @@ comptime {
 }
 
 pub const Shaders = struct {
+    /// What the generic renderer holds between deiniting a set and
+    /// building the next one, so a failure in between leaves something
+    /// safe to deinit again rather than `undefined`. Defunct, so a draw
+    /// that reaches it is caught by the same assert a failed reinit
+    /// always tripped.
+    pub const empty: Shaders = .{ .defunct = true };
+
     /// Shared root signature owned by this struct. Pipelines reference it
     /// for draw-time binding but do not own it -- deinit releases it here.
     root_signature: ?*d3d12.ID3D12RootSignature = null,

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1236,6 +1236,27 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         ///
         /// Must be called on the render thread.
         pub fn animationWake(self: *const Self) ?AnimationWake {
+            // A device rebuild that failed is retried from a draw, and
+            // nothing else guarantees one on an idle surface. Until the
+            // retry lands no other wake can paint anything, so it wins
+            // outright. An update wake, so the pass that re-uploads the
+            // images dropped with the device runs on the same tick.
+            if (self.device_recovery_retry_at) |at| {
+                const now: std.Io.Timestamp = .now(global.io(), .awake);
+                const remaining_ns = now.durationTo(at).nanoseconds;
+                const remaining_ms: u64 = if (remaining_ns > 0)
+                    @intCast(@divTrunc(remaining_ns, std.time.ns_per_ms))
+                else
+                    0;
+                return .{
+                    .delay_ms = @max(remaining_ms, draw_interval_ms),
+                    .kind = .update,
+                };
+            }
+            if (self.images_lost) {
+                return .{ .delay_ms = draw_interval_ms, .kind = .update };
+            }
+
             // Custom shaders animate by redrawing on a fixed cadence,
             // gated by configuration and focus.
             const shader_delay: ?u64 = shader: {
@@ -2402,6 +2423,9 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
             self.device_recovery_pending = false;
             self.device_recovery_retry_at = null;
+            // The shaders were just built from the current config; a
+            // reload queued before the loss has nothing left to redo.
+            self.reinitialize_shaders = false;
             // New frame states start with 1x1 targets and empty buffers;
             // the draw path below resizes and resyncs them, but nothing
             // in it forces a draw when the cells are unchanged, and

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -232,7 +232,9 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         /// A health change the surface has not been told about yet
         /// because the mailbox was full at the time. Retried from the
         /// draw path; the value to send is always the current `health`.
-        health_report_pending: bool = false,
+        /// Atomic because Metal reports health from its completion
+        /// thread, not the renderer thread.
+        health_report_pending: std.atomic.Value(bool) = .{ .raw = false },
 
         /// True when we have a graphics context that can create GPU
         /// resources. Creating any GPU resource while this is false is invalid.
@@ -1919,11 +1921,11 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
             // A health change that found the mailbox full: same instant
             // push, same retry-next-draw shape as the two above.
-            defer if (self.health_report_pending) {
+            defer if (self.health_report_pending.load(.acquire)) {
                 if (self.surface_mailbox.push(
                     .{ .renderer_health = self.health.load(.seq_cst) },
                     .instant,
-                ) > 0) self.health_report_pending = false;
+                ) > 0) self.health_report_pending.store(false, .release);
             };
 
             // Emit any pending custom-shader failure on the same mailbox path
@@ -2366,9 +2368,10 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // draw mutex, which the apprt thread takes in the surface
             // device queries, and the apprt thread is also what drains the
             // mailbox. A full mailbox is retried from the next draw.
-            self.health_report_pending = self.surface_mailbox.push(.{
+            const delivered = self.surface_mailbox.push(.{
                 .renderer_health = health,
-            }, .instant) == 0;
+            }, .instant) > 0;
+            self.health_report_pending.store(!delivered, .release);
         }
 
         /// How long to leave a device alone after a rebuild fails before

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -247,6 +247,24 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         /// this is set to true so that we can do that whenever possible.
         reinitialize_shaders: bool = false,
 
+        /// Set once `recoverDevice` has torn down the state that died
+        /// with a lost GPU device, and cleared when the rebuild lands.
+        /// A rebuild that fails (a driver still installing) is retried
+        /// on a later frame, and this is what stops the retry tearing
+        /// down twice. Only backends with a `recoverDevice` decl set it.
+        device_recovery_pending: bool = false,
+
+        /// Earliest time the next device rebuild may be attempted after
+        /// a failed one. Draws before then return without touching the
+        /// GPU, so a driver that needs a few seconds to come back is not
+        /// hammered at the draw rate.
+        device_recovery_retry_at: ?std.Io.Timestamp = null,
+
+        /// The kitty image textures went down with a lost device and
+        /// must be rebuilt from the terminal's image storage on the next
+        /// update, whether or not that storage thinks anything changed.
+        images_lost: bool = false,
+
         /// Whether or not we have custom shaders.
         has_custom_shaders: bool = false,
 
@@ -956,10 +974,22 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
         /// Why shaders are being (re)built. Only `startup` and
         /// `config_reload` arm the user-facing custom-shader notice: a
-        /// display realize rebuilds GPU resources for something the user did
-        /// not ask for, and must not re-raise a failure they have already
-        /// been told about.
-        const ShaderInitCause = enum { startup, config_reload, display_realized };
+        /// display realize or a device recovery rebuilds GPU resources for
+        /// something the user did not ask for, and must not re-raise a
+        /// failure they have already been told about.
+        const ShaderInitCause = enum {
+            startup,
+            config_reload,
+            display_realized,
+            device_recovered,
+
+            fn armsNotice(self: ShaderInitCause) bool {
+                return switch (self) {
+                    .startup, .config_reload => true,
+                    .display_realized, .device_recovered => false,
+                };
+            }
+        };
 
         fn initShaders(self: *Self, cause: ShaderInitCause) !void {
             var arena = ArenaAllocator.init(self.alloc);
@@ -998,7 +1028,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // translation above failing, and the backend building zero post
             // pipelines. Both leave the terminal rendering normally, so a
             // `log.warn` nobody reads is otherwise the only trace.
-            if (cause != .display_realized and configured) {
+            if (cause.armsNotice() and configured) {
                 if (!has_custom_shaders) {
                     self.custom_shader_failure = .load_failed;
                 } else if (shaders.post_pipelines.len == 0) {
@@ -1567,11 +1597,12 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 // If we have any virtual references, we must also rebuild our
                 // kitty state on every frame because any cell change can move
                 // an image.
-                if (self.images.kittyRequiresUpdate(state.terminal)) {
+                if (self.images_lost or self.images.kittyRequiresUpdate(state.terminal)) {
                     // We need to grab the draw mutex since this updates
                     // our image state that drawFrame uses.
                     self.draw_mutex.lockUncancelable(global.io());
                     defer self.draw_mutex.unlock(global.io());
+                    self.images_lost = false;
                     self.images.kittyUpdate(
                         self.alloc,
                         state.terminal,
@@ -1861,6 +1892,16 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // only the case while unrealized (GTK); displayRealized
             // rebuilds the swap chain.
             if (!self.display_realized) return;
+
+            // A lost GPU device (TDR, driver upgrade) takes every
+            // resource built on it down with it. Rebuild before touching
+            // the swap chain below; a device that cannot be rebuilt yet
+            // leaves us here until the next attempt is due.
+            if (comptime @hasDecl(GraphicsAPI, "recoverDevice")) {
+                if (self.api.deviceLost() or self.device_recovery_pending) {
+                    try self.recoverDevice();
+                }
+            }
 
             // Get our swap chain, rebuilding it if it was released
             // while we were hidden. Rebuilding is deferred to draw
@@ -2226,23 +2267,114 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             self: *Self,
             health: Health,
         ) void {
-            // If our health value hasn't changed, then we do nothing. We don't
-            // do a cmpxchg here because strict atomicity isn't important.
-            if (self.health.load(.seq_cst) != health) {
-                self.health.store(health, .seq_cst);
-
-                // Our health value changed, so we notify the surface so that it
-                // can do something about it.
-                _ = self.surface_mailbox.push(.{
-                    .renderer_health = health,
-                }, .{ .forever = {} });
-            }
+            self.reportHealth(health);
 
             // Always release our semaphore. The swap chain is
             // guaranteed to exist here: it is only torn down after
             // waiting for all in-flight frames to complete, and this
             // callback is what signals that completion.
             self.swap_chain.?.releaseFrame();
+        }
+
+        /// Record the renderer's health and tell the surface when it
+        /// changes. Also reached from device recovery, which reports
+        /// unhealthy the moment the device is found gone (a frame that
+        /// cannot begin never reaches `frameCompleted`) and healthy again
+        /// once the rebuild lands.
+        fn reportHealth(self: *Self, health: Health) void {
+            // If our health value hasn't changed, then we do nothing. We don't
+            // do a cmpxchg here because strict atomicity isn't important.
+            if (self.health.load(.seq_cst) == health) return;
+            self.health.store(health, .seq_cst);
+
+            // Our health value changed, so we notify the surface so that it
+            // can do something about it.
+            _ = self.surface_mailbox.push(.{
+                .renderer_health = health,
+            }, .{ .forever = {} });
+        }
+
+        /// How long to leave a device alone after a rebuild fails before
+        /// trying again. A driver upgrade takes seconds to install; a
+        /// retry per draw would only fill the log.
+        const device_recovery_retry_delay: std.Io.Duration = .fromNanoseconds(
+            std.time.ns_per_s,
+        );
+
+        /// Rebuild everything on a replacement GPU device after the old
+        /// one was lost. Caller holds the draw mutex.
+        ///
+        /// Two halves, so that a failure in the second can be retried
+        /// without repeating the first: tear down all state that lived on
+        /// the dead device (once, guarded by `device_recovery_pending`),
+        /// then rebuild the device, the shaders, the swap chain and the
+        /// background image. Kitty images are not rebuilt here; they are
+        /// dropped and `images_lost` makes the next update re-upload them
+        /// from the terminal's storage.
+        ///
+        /// Returns `error.DeviceLost` while the device stays gone, which
+        /// the renderer thread logs like any other failed draw.
+        fn recoverDevice(self: *Self) !void {
+            const now: std.Io.Timestamp = .now(global.io(), .awake);
+            if (self.device_recovery_retry_at) |at| {
+                if (now.durationTo(at).nanoseconds > 0) return error.DeviceLost;
+            }
+
+            if (!self.device_recovery_pending) {
+                self.device_recovery_pending = true;
+                log.warn("GPU device lost; rebuilding renderer state", .{});
+                self.reportHealth(.unhealthy);
+
+                // Everything below was created on the dead device. The
+                // order matters only in that the backend's device goes
+                // last, inside `api.recoverDevice`: these objects retire
+                // into a queue the device owns.
+                if (self.swap_chain) |*sc| sc.deinit();
+                self.swap_chain = null;
+                self.shaders.deinit(self.alloc);
+                const upload_budget = self.images.upload_budget_bytes;
+                self.images.deinit(self.alloc);
+                self.images = .empty;
+                self.images.upload_budget_bytes = upload_budget;
+                self.images_lost = true;
+                if (self.bg_image) |img| img.deinit(self.alloc);
+                self.bg_image = null;
+            }
+
+            errdefer self.device_recovery_retry_at = now.addDuration(
+                device_recovery_retry_delay,
+            );
+
+            if (self.api.deviceLost()) try self.api.recoverDevice();
+
+            // From here the device is good; only the rebuild on top of it
+            // can still fail, and a retry must start from bare shaders.
+            try self.initShaders(.device_recovered);
+            errdefer self.shaders.deinit(self.alloc);
+            self.swap_chain = try SwapChain.init(
+                self.alloc,
+                self.api,
+                self.has_custom_shaders,
+            );
+            if (@hasDecl(GraphicsAPI, "flushInitCommands")) {
+                self.api.flushInitCommands();
+            }
+            self.prepBackgroundImage() catch |err| {
+                // Not worth failing the recovery over: the terminal
+                // comes back without its wallpaper, same as at startup.
+                log.warn("background image not restored after device recovery: {}", .{err});
+            };
+
+            self.device_recovery_pending = false;
+            self.device_recovery_retry_at = null;
+            // New frame states start with 1x1 targets and empty buffers;
+            // the draw path below resizes and resyncs them, but nothing
+            // in it forces a draw when the cells are unchanged, and
+            // presenting a never-drawn back buffer would flash black.
+            self.cells_rebuilt = true;
+            self.markDirty();
+            self.reportHealth(.healthy);
+            log.info("GPU device recovered; renderer state rebuilt", .{});
         }
 
         /// Call this any time the background image path changes.

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1981,6 +1981,9 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 self.reinitialize_shaders = false;
                 self.api.waitGpu();
                 self.shaders.deinit(self.alloc);
+                // Deinit-safe while the rebuild below can still fail
+                // (a device removed mid-reload fails every PSO).
+                self.shaders = .{};
                 try self.initShaders(.config_reload);
             }
 
@@ -2309,9 +2312,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         /// How long to leave a device alone after a rebuild fails before
         /// trying again. A driver upgrade takes seconds to install; a
         /// retry per draw would only fill the log.
-        const device_recovery_retry_delay: std.Io.Duration = .fromNanoseconds(
-            std.time.ns_per_s,
-        );
+        const device_recovery_retry_delay: std.Io.Duration = .fromSeconds(1);
 
         /// Rebuild everything on a replacement GPU device after the old
         /// one was lost. Caller holds the draw mutex.
@@ -2345,6 +2346,11 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 // into a queue the device owns. Each field is left in a
                 // state that is safe to deinit again, because a tab can
                 // close while the rebuild is still failing.
+                //
+                // The drain is a no-op on a removed device. It is here for
+                // a backend that flagged the device lost while it was
+                // still executing: shaders are not retired, only released.
+                self.api.waitGpu();
                 if (self.swap_chain) |*sc| sc.deinit();
                 self.swap_chain = null;
                 self.shaders.deinit(self.alloc);
@@ -2371,6 +2377,10 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
             // From here the device is good; only the rebuild on top of it
             // can still fail, and a retry must start from bare shaders.
+            // A failed rebuild retires the descriptor slots of whatever
+            // it did build; on a live device only a drain hands them
+            // back, and without it each retry eats another six.
+            errdefer self.api.waitGpu();
             try self.initShaders(.device_recovered);
             errdefer {
                 self.shaders.deinit(self.alloc);

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -229,6 +229,11 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         /// Health of the most recently completed frame.
         health: std.atomic.Value(Health) = .{ .raw = .healthy },
 
+        /// A health change the surface has not been told about yet
+        /// because the mailbox was full at the time. Retried from the
+        /// draw path; the value to send is always the current `health`.
+        health_report_pending: bool = false,
+
         /// True when we have a graphics context that can create GPU
         /// resources. Creating any GPU resource while this is false is invalid.
         display_realized: bool = true,
@@ -1890,6 +1895,15 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     self.first_render_sent = true;
             };
 
+            // A health change that found the mailbox full: same instant
+            // push, same retry-next-draw shape as the two above.
+            defer if (self.health_report_pending) {
+                if (self.surface_mailbox.push(
+                    .{ .renderer_health = self.health.load(.seq_cst) },
+                    .instant,
+                ) > 0) self.health_report_pending = false;
+            };
+
             // Emit any pending custom-shader failure on the same mailbox path
             // as `.first_render` above. A defer so it also catches a failure
             // armed by the shader re-init further down this same frame.
@@ -2002,9 +2016,11 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 self.reinitialize_shaders = false;
                 self.api.waitGpu();
                 self.shaders.deinit(self.alloc);
-                // Deinit-safe while the rebuild below can still fail
-                // (a device removed mid-reload fails every PSO).
-                self.shaders = .{};
+                // Backends that can be rebuilt after a device loss keep
+                // something deinit-safe here, because that rebuild will
+                // deinit again if the reload below fails (a device
+                // removed mid-reload fails every PSO).
+                if (comptime @hasDecl(Shaders, "empty")) self.shaders = .empty;
                 try self.initShaders(.config_reload);
             }
 
@@ -2324,10 +2340,13 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             self.health.store(health, .seq_cst);
 
             // Our health value changed, so we notify the surface so that it
-            // can do something about it.
-            _ = self.surface_mailbox.push(.{
+            // can do something about it. Never block: this runs under the
+            // draw mutex, which the apprt thread takes in the surface
+            // device queries, and the apprt thread is also what drains the
+            // mailbox. A full mailbox is retried from the next draw.
+            self.health_report_pending = self.surface_mailbox.push(.{
                 .renderer_health = health,
-            }, .{ .forever = {} });
+            }, .instant) == 0;
         }
 
         /// How long to leave a device alone after a rebuild fails before
@@ -2375,7 +2394,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 if (self.swap_chain) |*sc| sc.deinit();
                 self.swap_chain = null;
                 self.shaders.deinit(self.alloc);
-                self.shaders = .{};
+                self.shaders = .empty;
                 // Kitty and overlay textures alike. The overlay needs no
                 // flag: updateFrame rebuilds it from `self.overlay` on
                 // every pass, and markDirty below forces that pass.
@@ -2412,7 +2431,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             try self.initShaders(.device_recovered);
             errdefer {
                 self.shaders.deinit(self.alloc);
-                self.shaders = .{};
+                self.shaders = .empty;
             }
             self.swap_chain = try SwapChain.init(
                 self.alloc,

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -270,6 +270,13 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         /// update, whether or not that storage thinks anything changed.
         images_lost: bool = false,
 
+        /// One update pass is owed for `images_lost`, so an idle surface
+        /// gets it without waiting for the terminal to change. Cleared
+        /// by the first update pass that runs, whatever it does: a pass
+        /// that bails on synchronized output leaves the images to the
+        /// terminal's own next wake rather than spinning until then.
+        images_wake_pending: bool = false,
+
         /// Whether or not we have custom shaders.
         has_custom_shaders: bool = false,
 
@@ -1248,17 +1255,14 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // images dropped with the device runs on the same tick.
             if (self.device_recovery_retry_at) |at| {
                 const now: std.Io.Timestamp = .now(global.io(), .awake);
-                const remaining_ns = now.durationTo(at).nanoseconds;
-                const remaining_ms: u64 = if (remaining_ns > 0)
-                    @intCast(@divTrunc(remaining_ns, std.time.ns_per_ms))
-                else
-                    0;
+                const remaining_ms = now.durationTo(at).toMilliseconds();
+                const due: u64 = if (remaining_ms > 0) @intCast(remaining_ms) else 0;
                 return .{
-                    .delay_ms = @max(remaining_ms, draw_interval_ms),
+                    .delay_ms = @max(due, draw_interval_ms),
                     .kind = .update,
                 };
             }
-            if (self.images_lost) {
+            if (self.images_wake_pending) {
                 return .{ .delay_ms = draw_interval_ms, .kind = .update };
             }
 
@@ -1497,6 +1501,10 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // the course of a frame. Always flush those objects, including
             // when rebuilding the frame fails due to memory pressure.
             defer self.font_shaper.endFrame();
+
+            // This is the pass a device recovery asked for; whether it
+            // gets as far as the images is up to the terminal state.
+            self.images_wake_pending = false;
 
             // We fully deinit and reset the terminal state every so often
             // so that a particularly large terminal state doesn't cause
@@ -2413,21 +2421,16 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 .awake,
             ).addDuration(device_recovery_retry_delay);
 
-            // The latch says a draw path saw the loss. The second check
-            // covers a loss that landed while the previous attempt was
-            // rebuilding on a device it had just created: no draw ran,
-            // so nothing latched, and the device would otherwise be
-            // built on forever.
-            if (self.api.deviceLost() or self.api.deviceRemoved()) {
-                try self.api.recoverDevice();
-            }
+            // Every attempt rebuilds the device, not only the first. A
+            // loss that lands while the previous attempt was building
+            // shaders and frames on the device it had just created sets
+            // no latch (no draw ran), and that attempt's init command
+            // list still holds barriers naming textures it has since
+            // released; rebuilding the device discards both.
+            try self.api.recoverDevice();
 
             // From here the device is good; only the rebuild on top of it
             // can still fail, and a retry must start from bare shaders.
-            // A failed rebuild retires the descriptor slots of whatever
-            // it did build; on a live device only a drain hands them
-            // back, and without it each retry eats another six.
-            errdefer self.api.waitGpu();
             try self.initShaders(.device_recovered);
             errdefer {
                 self.shaders.deinit(self.alloc);
@@ -2438,7 +2441,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 self.api,
                 self.has_custom_shaders,
             );
-            if (@hasDecl(GraphicsAPI, "flushInitCommands")) {
+            if (comptime @hasDecl(GraphicsAPI, "flushInitCommands")) {
                 self.api.flushInitCommands();
             }
             self.prepBackgroundImage() catch |err| {
@@ -2449,6 +2452,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
             self.device_recovery_pending = false;
             self.device_recovery_retry_at = null;
+            self.images_wake_pending = true;
             // The shaders were just built from the current config; a
             // reload queued before the loss has nothing left to redo.
             self.reinitialize_shaders = false;

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -265,6 +265,11 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         /// hammered at the draw rate.
         device_recovery_retry_at: ?std.Io.Timestamp = null,
 
+        /// The backend said this surface cannot be rebuilt (it has no
+        /// way to hand the embedder a new swap chain). The surface stays
+        /// dark and unhealthy, as it always did, and nothing retries.
+        device_recovery_abandoned: bool = false,
+
         /// The kitty image textures went down with a lost device and
         /// must be rebuilt from the terminal's image storage on the next
         /// update, whether or not that storage thinks anything changed.
@@ -1248,19 +1253,28 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         ///
         /// Must be called on the render thread.
         pub fn animationWake(self: *const Self) ?AnimationWake {
-            // A device rebuild that failed is retried from a draw, and
-            // nothing else guarantees one on an idle surface. Until the
-            // retry lands no other wake can paint anything, so it wins
-            // outright. An update wake, so the pass that re-uploads the
-            // images dropped with the device runs on the same tick.
-            if (self.device_recovery_retry_at) |at| {
-                const now: std.Io.Timestamp = .now(global.io(), .awake);
-                const remaining_ms = now.durationTo(at).toMilliseconds();
-                const due: u64 = if (remaining_ms > 0) @intCast(remaining_ms) else 0;
-                return .{
-                    .delay_ms = @max(due, draw_interval_ms),
-                    .kind = .update,
-                };
+            // A device rebuild runs from a draw, and nothing else
+            // guarantees one on an idle surface: the draw that saw the
+            // loss returns normally, and a rebuild that failed only arms
+            // a deadline. Until the rebuild lands no other wake can paint
+            // anything, so these win outright. Update wakes, so the pass
+            // that re-uploads the images dropped with the device runs on
+            // the same tick.
+            if (comptime @hasDecl(GraphicsAPI, "recoverDevice")) {
+                if (!self.device_recovery_abandoned) {
+                    if (self.device_recovery_retry_at) |at| {
+                        const now: std.Io.Timestamp = .now(global.io(), .awake);
+                        const remaining_ms = now.durationTo(at).toMilliseconds();
+                        const due: u64 = if (remaining_ms > 0) @intCast(remaining_ms) else 0;
+                        return .{
+                            .delay_ms = @max(due, draw_interval_ms),
+                            .kind = .update,
+                        };
+                    }
+                    if (self.api.deviceLost() or self.device_recovery_pending) {
+                        return .{ .delay_ms = draw_interval_ms, .kind = .update };
+                    }
+                }
             }
             if (self.images_wake_pending) {
                 return .{ .delay_ms = draw_interval_ms, .kind = .update };
@@ -2378,6 +2392,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         /// the attempt's own error when one fails, which the renderer
         /// thread logs like any other failed draw.
         fn recoverDevice(self: *Self) !void {
+            if (self.device_recovery_abandoned) return error.DeviceRecoveryPending;
             if (self.device_recovery_retry_at) |at| {
                 const now: std.Io.Timestamp = .now(global.io(), .awake);
                 if (now.durationTo(at).nanoseconds > 0) return error.DeviceRecoveryPending;
@@ -2427,7 +2442,14 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // no latch (no draw ran), and that attempt's init command
             // list still holds barriers naming textures it has since
             // released; rebuilding the device discards both.
-            try self.api.recoverDevice();
+            self.api.recoverDevice() catch |err| switch (err) {
+                error.DeviceUnrecoverable => {
+                    log.warn("GPU device lost and this surface cannot be rebuilt; it stays dark", .{});
+                    self.device_recovery_abandoned = true;
+                    return error.DeviceRecoveryPending;
+                },
+                else => return err,
+            };
 
             // From here the device is good; only the rebuild on top of it
             // can still fail, and a retry must start from bare shaders.

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -2394,7 +2394,14 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 .awake,
             ).addDuration(device_recovery_retry_delay);
 
-            if (self.api.deviceLost()) try self.api.recoverDevice();
+            // The latch says a draw path saw the loss. The second check
+            // covers a loss that landed while the previous attempt was
+            // rebuilding on a device it had just created: no draw ran,
+            // so nothing latched, and the device would otherwise be
+            // built on forever.
+            if (self.api.deviceLost() or self.api.deviceRemoved()) {
+                try self.api.recoverDevice();
+            }
 
             // From here the device is good; only the rebuild on top of it
             // can still fail, and a retry must start from bare shaders.

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -325,9 +325,16 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             ) !SwapChain {
                 var result: SwapChain = .{ .frames = undefined };
 
-                // Initialize all of our frame state.
+                // Initialize all of our frame state. A failure part way
+                // through must release the frames already built: this
+                // runs again after a device recovery, where one frame
+                // failing and the next attempt succeeding is the
+                // expected shape.
+                var built: usize = 0;
+                errdefer for (result.frames[0..built]) |*frame| frame.deinit();
                 for (&result.frames) |*frame| {
                     frame.* = try FrameState.init(alloc, api, custom_shaders);
+                    built += 1;
                 }
 
                 return result;
@@ -1899,7 +1906,12 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // leaves us here until the next attempt is due.
             if (comptime @hasDecl(GraphicsAPI, "recoverDevice")) {
                 if (self.api.deviceLost() or self.device_recovery_pending) {
-                    try self.recoverDevice();
+                    self.recoverDevice() catch |err| switch (err) {
+                        // Between attempts there is nothing to draw and
+                        // nothing new to say; the failed attempt logged.
+                        error.DeviceRecoveryPending => return,
+                        else => return err,
+                    };
                 }
             }
 
@@ -2312,12 +2324,14 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         /// dropped and `images_lost` makes the next update re-upload them
         /// from the terminal's storage.
         ///
-        /// Returns `error.DeviceLost` while the device stays gone, which
-        /// the renderer thread logs like any other failed draw.
+        /// Fails with `error.DeviceRecoveryPending` while a retry is not
+        /// yet due (the caller draws nothing and says nothing), and with
+        /// the attempt's own error when one fails, which the renderer
+        /// thread logs like any other failed draw.
         fn recoverDevice(self: *Self) !void {
-            const now: std.Io.Timestamp = .now(global.io(), .awake);
             if (self.device_recovery_retry_at) |at| {
-                if (now.durationTo(at).nanoseconds > 0) return error.DeviceLost;
+                const now: std.Io.Timestamp = .now(global.io(), .awake);
+                if (now.durationTo(at).nanoseconds > 0) return error.DeviceRecoveryPending;
             }
 
             if (!self.device_recovery_pending) {
@@ -2328,29 +2342,40 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 // Everything below was created on the dead device. The
                 // order matters only in that the backend's device goes
                 // last, inside `api.recoverDevice`: these objects retire
-                // into a queue the device owns.
+                // into a queue the device owns. Each field is left in a
+                // state that is safe to deinit again, because a tab can
+                // close while the rebuild is still failing.
                 if (self.swap_chain) |*sc| sc.deinit();
                 self.swap_chain = null;
                 self.shaders.deinit(self.alloc);
-                const upload_budget = self.images.upload_budget_bytes;
+                self.shaders = .{};
+                // Kitty and overlay textures alike. The overlay needs no
+                // flag: updateFrame rebuilds it from `self.overlay` on
+                // every pass, and markDirty below forces that pass.
                 self.images.deinit(self.alloc);
                 self.images = .empty;
-                self.images.upload_budget_bytes = upload_budget;
+                self.images.upload_budget_bytes = self.config.image_upload_budget_bytes;
                 self.images_lost = true;
                 if (self.bg_image) |img| img.deinit(self.alloc);
                 self.bg_image = null;
             }
 
-            errdefer self.device_recovery_retry_at = now.addDuration(
-                device_recovery_retry_delay,
-            );
+            // Measured from the end of the attempt: creating a device on
+            // an adapter mid driver-install can itself take seconds.
+            errdefer self.device_recovery_retry_at = std.Io.Timestamp.now(
+                global.io(),
+                .awake,
+            ).addDuration(device_recovery_retry_delay);
 
             if (self.api.deviceLost()) try self.api.recoverDevice();
 
             // From here the device is good; only the rebuild on top of it
             // can still fail, and a retry must start from bare shaders.
             try self.initShaders(.device_recovered);
-            errdefer self.shaders.deinit(self.alloc);
+            errdefer {
+                self.shaders.deinit(self.alloc);
+                self.shaders = .{};
+            }
             self.swap_chain = try SwapChain.init(
                 self.alloc,
                 self.api,


### PR DESCRIPTION
A device-lost error (TDR, driver upgrade) set `device_lost` and nothing ever cleared it, so the surface stayed blank until the tab was closed, and the shell never heard about it because health only travels through a completed frame.

The DX12 backend can now rebuild its device in place, and the generic renderer rebuilds shaders, swap chain and images on top of it, retrying once a second while the driver is still coming back. SwapChainPanel mode keeps its DirectComposition surface handle across the swap, so the panel the shell bound once needs no rebinding. Shared-texture mode carries its version counter across, so consumers re-open both handles. A removed device drains its retirement queue at teardown instead of leaking it, and the surface device queries take the draw lock so they cannot observe a device mid-teardown.

Composition mode refuses to recover: the embedder holds a raw pointer to the old swap chain and there is no way to hand it a new one, so that mode stays latched as before. Left for follow-ups: a rebind signal for composition mode, WARP fallback and a TDR-frequency cap, the inspector surface's own device, the C# shell dropping the renderer-health action, and the pre-existing double release of the frame semaphore after an error past beginFrame.

Test plan:
- new: `ID3D12Device5 RemoveDevice sits at slot 58 of 65`, `Device: SwapChainPanel surface handle outlives the device that presented into it`, `DirectX12: rebuilds every device-bound object after the device is removed` (the last two remove a real device through ID3D12Device5 and the third checks the version carry), `Retirement: forgetSlots ...`
- Windows: `zig build test -Dapp-runtime=none` full run green on the first revision; targeted device/vtable/retirement filters 127/127 on the final one; `zig build -Dapp-runtime=none` green
- Linux (OpenGL, the shared generic.zig path): `zig build test -Dapp-runtime=none` 4084/4201, 117 skipped, 0 failed
- Mac: not run, no zig on the host at the moment
- three rounds of subagent review (ghostty-reviewer, zig-check-learnings, code-review high, DX12 resilience), all confirmed findings fixed

Size-override: the recovery path and the three rounds of review hardening on it cannot ship separately; every later commit closes a use-after-free or a deadlock in the code the first one adds, so a stack would land the hazard before its fix.
