### PR TITLE
input, config: paste CR safety, keybind chain close, config line limit and clamps

### DIFF
--- a/include/ghostty/vt/paste.h
+++ b/include/ghostty/vt/paste.h
@@ -193,7 +193,7 @@ GHOSTTY_API GhosttyResult ghostty_terminal_paste(
  * Check if paste data is safe to paste into the terminal.
  *
  * Data is considered unsafe if it contains:
- * - Newlines (`\n`) which can inject commands
+ * - Line breaks (`\n`, `\r`, or U+0085) which can inject commands
  * - The bracketed paste end sequence (`\x1b[201~`) which can be used
  *   to exit bracketed paste mode and inject commands
  *

--- a/src/App.zig
+++ b/src/App.zig
@@ -493,6 +493,11 @@ pub fn performAllChainedAction(
                 err,
             });
         };
+
+        // This slice is owned by the keybind set of the surface the
+        // binding came from, and that surface is now gone, so there is
+        // nothing left to read.
+        if (action.closesSurface()) break;
     }
 }
 

--- a/src/App.zig
+++ b/src/App.zig
@@ -404,6 +404,11 @@ pub fn keyEvent(
     // be processed by Surface.keyEvent. For chained actions, all
     // actions must be app-scoped.
     for (actions) |action| if (action.scoped(.app) == null) return false;
+
+    // Unlike performAllChainedAction this loop has no endsChain break.
+    // It does not need one: appendChain refuses to append after an action
+    // that ends the chain, so an action that frees this slice is always
+    // the last one and the loop stops without reading the slice again.
     for (actions) |action| {
         self.performAction(
             rt_app,

--- a/src/App.zig
+++ b/src/App.zig
@@ -495,9 +495,9 @@ pub fn performAllChainedAction(
         };
 
         // This slice is owned by the keybind set of the surface the
-        // binding came from, and that surface is now gone, so there is
-        // nothing left to read.
-        if (action.closesSurface()) break;
+        // binding came from, and that set has just been freed, so there
+        // is nothing left to read.
+        if (action.endsChain()) break;
     }
 }
 

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3095,10 +3095,23 @@ fn maybeHandleBinding(
         leaf.flags,
         actions,
     });
+    // Set if we ran an action that closes the surface. Our "self" pointer
+    // and the action slice (owned by the keybind set) are both dead after
+    // that, so nothing may touch either of them.
+    var closed: bool = false;
     const performed = performed: {
         // If this is a global or all action, then we perform it on
         // the app and it applies to every surface.
         if (leaf.flags.global or leaf.flags.all) {
+            // These run on every surface, ours included, so decide before
+            // performing whether we are about to lose it.
+            for (actions) |action| {
+                if (action.closesSurface()) {
+                    closed = true;
+                    break;
+                }
+            }
+
             self.app.performAllChainedAction(
                 self.rt_app,
                 actions,
@@ -3112,28 +3125,33 @@ fn maybeHandleBinding(
         // actions perform.
         var performed: bool = false;
         for (actions) |action| {
-            if (self.performBindingAction(action)) |v| {
-                performed = performed or v;
-            } else |err| {
+            const action_performed = self.performBindingAction(action) catch |err| act: {
                 log.info(
                     "key binding action failed action={t} err={}",
                     .{ action, err },
                 );
+                break :act false;
+            };
+            performed = performed or action_performed;
+
+            // Stop the chain at a closing action. The config parser
+            // rejects a chain that continues past one, but a keybind set
+            // built any other way must not run into freed memory.
+            if (action.closesSurface()) {
+                closed = action_performed;
+                break;
             }
         }
 
         break :performed performed;
     };
 
-    if (performed) {
-        // If we performed an action and it was a closing action,
-        // our "self" pointer is not safe to use anymore so we need to
-        // just exit immediately.
-        for (actions) |action| if (closingAction(action)) {
-            log.debug("key binding is a closing binding, halting key event processing", .{});
-            return .closed;
-        };
+    if (closed) {
+        log.debug("key binding is a closing binding, halting key event processing", .{});
+        return .closed;
+    }
 
+    if (performed) {
         // If our action was "ignore" then we return the special input
         // effect of "ignored".
         for (actions) |action| if (action == .ignore) {
@@ -5892,20 +5910,6 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
     }
 
     return true;
-}
-
-/// Returns true if performing the given action result in closing
-/// the surface. This is used to determine if our self pointer is
-/// still valid after performing some binding action.
-fn closingAction(action: input.Binding.Action) bool {
-    return switch (action) {
-        .close_surface,
-        .close_window,
-        .close_tab,
-        => true,
-
-        else => false,
-    };
 }
 
 /// The portion of the screen to write for writeScreenFile.

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3300,10 +3300,12 @@ fn catchAllIsIgnore(self: *Surface) bool {
 /// End the key sequence ahead of a chain that can close the surface.
 ///
 /// `maybeHandleBinding` answers `.closed` for such a chain and returns
-/// straight away, so it never reaches the tail where all of its
-/// `endKeySequence` calls live, and `endKeySequence` is the only drain
-/// for `keyboard.sequence_queued` outside `deinit`. The sequence has to
-/// end before the chain runs, while `self` is certainly still ours.
+/// straight away, so it never reaches its own tail, which is where every
+/// `endKeySequence` call it makes lives — two that drop and two that
+/// flush. `endKeySequence` is the only drain for `keyboard.sequence_queued`
+/// outside `deinit`, and it is called from elsewhere in this file too. The
+/// sequence has to end before the chain runs, while `self` is certainly
+/// still ours.
 ///
 /// This is not housekeeping for a surface that is about to die. No apprt
 /// in this tree has been shown to free the core surface inside the call,
@@ -3313,12 +3315,39 @@ fn catchAllIsIgnore(self: *Surface) bool {
 /// holding the leader key's encoded write, which the next unrelated
 /// sequence then flushes into the pty out of order.
 ///
-/// `.drop` is what every other path that matched a binding does. The one
-/// path that would rather flush is `performable` with nothing performed,
-/// and whether a chain performs is not knowable until it has run, by
-/// which time the surface may be gone. So a `performable` binding whose
-/// chain closes the surface drops its queued leader keys rather than
-/// encoding them.
+/// `.drop` is what every path that matched a binding and then consumed
+/// or ignored the event does. The cost falls on a chain that *contains* a
+/// closing action but turns out not to close, because whether a chain
+/// performs is not knowable until it has run, by which time the surface
+/// may be gone. Such a chain goes on to reach a path that would rather
+/// flush the queued leader keys, and finds the queue already dropped.
+/// All three of those paths are defeated, not just one:
+///
+///   * `performable` with nothing performed.
+///
+///   * The non-consumed tail. `consumed` defaults true, so this needs the
+///     `unconsumed:` prefix, which is legal on a sequence: the parser
+///     rejects only `global`/`all` there. `unconsumed:ctrl+a>u=undo` on a
+///     runtime that answers `undo` with false used to encode the leader
+///     key and then `u`; it now silently swallows the leader keystroke.
+///
+///   * The `end_key_sequence` binding action itself, whose whole stated
+///     purpose is to flush. It does not end a chain, so pairing it with a
+///     closing action in one chain is legal, and it then has nothing left
+///     to flush.
+///
+/// No shipped default is a key sequence at all, so none of this is
+/// reachable without user config. Draining later would not help either:
+/// the cost is in what the drain does (`.drop`), not in when it runs.
+/// Keeping both behaviours means detaching the queue before the chain and
+/// handing it back only if the surface survived, which is a larger change
+/// than this one.
+///
+/// One more consequence, for the same chains: `endKeySequence` notifies
+/// the apprt that the key sequence ended before its own empty-queue early
+/// return, so a closing chain that does not close notifies twice. The
+/// notification is idempotent everywhere it is handled, and the Windows
+/// host does not handle it at all.
 fn endKeySequenceBeforeClose(
     self: *Surface,
     actions: []const input.Binding.Action,

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3090,6 +3090,15 @@ fn maybeHandleBinding(
     // Setup our actions
     const actions = leaf.actionsSlice();
 
+    // Only a chain reads its actions out of the keybind set; a single
+    // action was copied into `leaf`, which is ours, so nothing an action
+    // does can take it away.
+    const borrowed = leaf.actionsBorrowed();
+
+    // Anything we need to know about the actions themselves has to be
+    // decided now, while they are certainly still there.
+    const ignored = leaf.hasIgnore();
+
     // Attempt to perform the action
     log.debug("key event binding flags={} action={any}", .{
         leaf.flags,
@@ -3099,11 +3108,11 @@ fn maybeHandleBinding(
     // is dead after that, so nothing may touch it.
     var closed: bool = false;
 
-    // Set if we ran an action that frees the keybind set. That is a
-    // larger set of actions than the ones that close us, because a config
-    // reload replaces the set while leaving the surface alive, and the
-    // action slice lives in the set, so nothing may read it afterwards.
-    var chain_ended: bool = false;
+    // Set if we ran an action that freed the actions we are iterating.
+    // That is a larger set of actions than the ones that close us,
+    // because a config reload replaces the keybind set while leaving the
+    // surface alive.
+    var actions_freed: bool = false;
     const performed = performed: {
         // If this is a global or all action, then we perform it on
         // the app and it applies to every surface.
@@ -3112,7 +3121,7 @@ fn maybeHandleBinding(
             // performing what we are about to lose.
             for (actions) |action| {
                 if (action.closesSurface()) closed = true;
-                if (action.endsChain()) chain_ended = true;
+                if (borrowed and action.endsChain()) actions_freed = true;
             }
 
             self.app.performAllChainedAction(
@@ -3143,7 +3152,7 @@ fn maybeHandleBinding(
             // must not run into freed memory.
             if (action.endsChain()) {
                 if (action.closesSurface()) closed = performed;
-                chain_ended = true;
+                if (borrowed) actions_freed = true;
                 break;
             }
         }
@@ -3156,17 +3165,13 @@ fn maybeHandleBinding(
         return .closed;
     }
 
-    // Everything below reads the action slice again, so it is only safe
-    // while the keybind set that owns it is still alive.
-    if (performed and !chain_ended) {
-        // If our action was "ignore" then we return the special input
-        // effect of "ignored".
-        for (actions) |action| if (action == .ignore) {
-            // If we're in a sequence, clear it.
-            self.endKeySequence(.drop, .retain);
+    // If our action was "ignore" then we return the special input
+    // effect of "ignored".
+    if (performed and ignored) {
+        // If we're in a sequence, clear it.
+        self.endKeySequence(.drop, .retain);
 
-            return .ignored;
-        };
+        return .ignored;
     }
 
     // If we have the performable flag and the action was not performed,
@@ -3190,7 +3195,9 @@ fn maybeHandleBinding(
         // Store our last trigger so we don't encode the release event
         self.keyboard.last_trigger = event.bindingHash();
 
-        if (!chain_ended) if (insp_ev) |ev| {
+        // The inspector wants the actions themselves, so it only gets
+        // them while they are still there to copy.
+        if (!actions_freed) if (insp_ev) |ev| {
             ev.binding = self.alloc.dupe(
                 input.Binding.Action,
                 actions,

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -398,7 +398,11 @@ const DerivedConfig = struct {
             .cursor_click_to_move = config.@"cursor-click-to-move",
             .desktop_notifications = config.@"desktop-notifications",
             .font = try font.SharedGridSet.DerivedConfig.init(alloc, config),
-            .mouse_interval = config.@"click-repeat-interval" * 1_000_000, // 500ms
+            // Widened before the multiply: the config value is in
+            // milliseconds and anything over ~4.3s overflows a u32 of
+            // nanoseconds.
+            .mouse_interval = @as(u64, config.@"click-repeat-interval") *
+                std.time.ns_per_ms,
             .mouse_hide_while_typing = config.@"mouse-hide-while-typing",
             .mouse_reporting = config.@"mouse-reporting",
             .mouse_scroll_multiplier = config.@"mouse-scroll-multiplier",
@@ -6748,6 +6752,25 @@ fn presentSurface(self: *Surface) !void {
 /// not available on a particular platform.
 pub fn getProcessInfo(self: *Surface, comptime info: ProcessInfo) ?ProcessInfo.Type(info) {
     return self.io.getProcessInfo(info);
+}
+
+test "DerivedConfig: a long click-repeat-interval does not overflow" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    try oni.testing.ensureInit();
+
+    var config = try configpkg.Config.default(alloc);
+    defer config.deinit();
+    config.@"click-repeat-interval" = 5000;
+
+    var derived = try DerivedConfig.init(alloc, &config);
+    defer derived.deinit();
+
+    try testing.expectEqual(
+        @as(u64, 5000 * std.time.ns_per_ms),
+        derived.mouse_interval,
+    );
 }
 
 test "queueIo frees allocated writes in readonly mode" {

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3151,6 +3151,11 @@ fn maybeHandleBinding(
             // continues past one, but a keybind set built any other way
             // must not run into freed memory.
             if (action.endsChain()) {
+                // performBindingAction answers false only when the apprt
+                // did nothing at all, so a false here means the surface
+                // is still ours. quit and close_all_windows always answer
+                // true; undo and redo answer the apprt, which is what the
+                // performable flag below needs.
                 if (action.closesSurface()) closed = performed;
                 if (borrowed) actions_freed = true;
                 break;

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3096,20 +3096,23 @@ fn maybeHandleBinding(
         actions,
     });
     // Set if we ran an action that closes the surface. Our "self" pointer
-    // and the action slice (owned by the keybind set) are both dead after
-    // that, so nothing may touch either of them.
+    // is dead after that, so nothing may touch it.
     var closed: bool = false;
+
+    // Set if we ran an action that frees the keybind set. That is a
+    // larger set of actions than the ones that close us, because a config
+    // reload replaces the set while leaving the surface alive, and the
+    // action slice lives in the set, so nothing may read it afterwards.
+    var chain_ended: bool = false;
     const performed = performed: {
         // If this is a global or all action, then we perform it on
         // the app and it applies to every surface.
         if (leaf.flags.global or leaf.flags.all) {
             // These run on every surface, ours included, so decide before
-            // performing whether we are about to lose it.
+            // performing what we are about to lose.
             for (actions) |action| {
-                if (action.closesSurface()) {
-                    closed = true;
-                    break;
-                }
+                if (action.closesSurface()) closed = true;
+                if (action.endsChain()) chain_ended = true;
             }
 
             self.app.performAllChainedAction(
@@ -3134,11 +3137,13 @@ fn maybeHandleBinding(
             };
             performed = performed or action_performed;
 
-            // Stop the chain at a closing action. The config parser
-            // rejects a chain that continues past one, but a keybind set
-            // built any other way must not run into freed memory.
-            if (action.closesSurface()) {
-                closed = performed;
+            // Stop the chain at an action that freed the set we are
+            // reading from. The config parser rejects a chain that
+            // continues past one, but a keybind set built any other way
+            // must not run into freed memory.
+            if (action.endsChain()) {
+                if (action.closesSurface()) closed = performed;
+                chain_ended = true;
                 break;
             }
         }
@@ -3151,7 +3156,9 @@ fn maybeHandleBinding(
         return .closed;
     }
 
-    if (performed) {
+    // Everything below reads the action slice again, so it is only safe
+    // while the keybind set that owns it is still alive.
+    if (performed and !chain_ended) {
         // If our action was "ignore" then we return the special input
         // effect of "ignored".
         for (actions) |action| if (action == .ignore) {
@@ -3183,7 +3190,7 @@ fn maybeHandleBinding(
         // Store our last trigger so we don't encode the release event
         self.keyboard.last_trigger = event.bindingHash();
 
-        if (insp_ev) |ev| {
+        if (!chain_ended) if (insp_ev) |ev| {
             ev.binding = self.alloc.dupe(
                 input.Binding.Action,
                 actions,
@@ -3194,7 +3201,7 @@ fn maybeHandleBinding(
                 );
                 break :binding &.{};
             };
-        }
+        };
         return .consumed;
     }
 

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3138,7 +3138,7 @@ fn maybeHandleBinding(
             // rejects a chain that continues past one, but a keybind set
             // built any other way must not run into freed memory.
             if (action.closesSurface()) {
-                closed = action_performed;
+                closed = performed;
                 break;
             }
         }

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3104,6 +3104,12 @@ fn maybeHandleBinding(
         leaf.flags,
         actions,
     });
+
+    // Anything a closing chain owes the sequence has to be paid now,
+    // before the chain runs, because `return .closed` below leaves
+    // without touching the tail this function normally ends in.
+    self.endKeySequenceBeforeClose(actions);
+
     // Set if we ran an action that closes the surface. Our "self" pointer
     // is dead after that, so nothing may touch it.
     var closed: bool = false;
@@ -3118,7 +3124,10 @@ fn maybeHandleBinding(
         // the app and it applies to every surface.
         if (leaf.flags.global or leaf.flags.all) {
             // These run on every surface, ours included, so decide before
-            // performing what we are about to lose.
+            // performing what we are about to lose. The per-surface arm
+            // below can afford to wait for the result and set `closed`
+            // from it; here there is no result to wait for, since this
+            // arm ends in an unconditional `break :performed true`.
             for (actions) |action| {
                 if (action.closesSurface()) closed = true;
                 if (borrowed and action.endsChain()) actions_freed = true;
@@ -3151,11 +3160,23 @@ fn maybeHandleBinding(
             // continues past one, but a keybind set built any other way
             // must not run into freed memory.
             if (action.endsChain()) {
-                // performBindingAction answers false only when the apprt
-                // did nothing at all, so a false here means the surface
-                // is still ours. quit and close_all_windows always answer
-                // true; undo and redo answer the apprt, which is what the
-                // performable flag below needs.
+                // Read this as "no action in this chain did anything",
+                // not as "this action did nothing": `performed` is the
+                // chain accumulator, so an earlier action that performed
+                // already forces `closed`. That direction is the safe
+                // one, and a `false` still means nothing ran at all.
+                //
+                // Do not read a `true` as evidence that a runtime tore
+                // anything down. It is only that for `undo` and `redo`,
+                // which return the apprt's own boolean, and that is what
+                // the `performable` flag below needs. For `quit` and
+                // `close_all_windows` the valve is stuck open on every
+                // runtime: `performBindingAction` takes its `else` arm
+                // and returns an unconditional `true`, and
+                // `App.performAction` has already thrown the runtime's
+                // answer away with `_ =`. On the embedded apprt that is
+                // exactly where those two land whether the embedder
+                // implements them or not.
                 if (action.closesSurface()) closed = performed;
                 if (borrowed) actions_freed = true;
                 break;
@@ -3274,6 +3295,39 @@ fn catchAllIsIgnore(self: *Surface) bool {
             if (action == .ignore) break :chained true;
         } else false,
     };
+}
+
+/// End the key sequence ahead of a chain that can close the surface.
+///
+/// `maybeHandleBinding` answers `.closed` for such a chain and returns
+/// straight away, so it never reaches the tail where all of its
+/// `endKeySequence` calls live, and `endKeySequence` is the only drain
+/// for `keyboard.sequence_queued` outside `deinit`. The sequence has to
+/// end before the chain runs, while `self` is certainly still ours.
+///
+/// This is not housekeeping for a surface that is about to die. No apprt
+/// in this tree has been shown to free the core surface inside the call,
+/// and the embedded apprt demonstrably does not: it hands the action to
+/// the embedder and returns. The Windows host does not implement `quit`
+/// at all, so `keybind = ctrl+a>q=quit` there leaves a live surface
+/// holding the leader key's encoded write, which the next unrelated
+/// sequence then flushes into the pty out of order.
+///
+/// `.drop` is what every other path that matched a binding does. The one
+/// path that would rather flush is `performable` with nothing performed,
+/// and whether a chain performs is not knowable until it has run, by
+/// which time the surface may be gone. So a `performable` binding whose
+/// chain closes the surface drops its queued leader keys rather than
+/// encoding them.
+fn endKeySequenceBeforeClose(
+    self: *Surface,
+    actions: []const input.Binding.Action,
+) void {
+    for (actions) |action| {
+        if (!action.closesSurface()) continue;
+        self.endKeySequence(.drop, .retain);
+        return;
+    }
 }
 
 const KeySequenceQueued = enum { flush, drop };
@@ -6775,6 +6829,74 @@ fn presentSurface(self: *Surface) !void {
 /// not available on a particular platform.
 pub fn getProcessInfo(self: *Surface, comptime info: ProcessInfo) ?ProcessInfo.Type(info) {
     return self.io.getProcessInfo(info);
+}
+
+/// A Surface with only the fields under test initialized. Building a real
+/// one needs a live apprt, an IO thread and a renderer, none of which the
+/// unit test binary has: it is built with `-Dapp-runtime=none`, whose
+/// `App` is an empty struct. Only touch fields a test has set.
+fn testSurface(alloc: Allocator, rt_app: *apprt.App) !*Surface {
+    const surface = try alloc.create(Surface);
+    surface.alloc = alloc;
+    surface.rt_app = rt_app;
+    surface.readonly = false;
+    surface.keyboard = .{};
+    return surface;
+}
+
+test "endKeySequenceBeforeClose: a closing action drops the queued sequence" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var rt_app: apprt.App = undefined;
+    const surface = try testSurface(alloc, &rt_app);
+    defer alloc.destroy(surface);
+    defer surface.keyboard.sequence_queued.deinit(alloc);
+
+    // The leader key's encoded write, queued the way maybeHandleBinding
+    // queues it for `ctrl+a` in `ctrl+a>q=quit`.
+    try surface.keyboard.sequence_queued.append(alloc, .{ .alloc = .{
+        .alloc = alloc,
+        .data = try alloc.dupe(u8, "\x01"),
+    } });
+
+    surface.endKeySequenceBeforeClose(&.{.{ .quit = {} }});
+
+    // `.closed` returns before any other drain, so if this write is
+    // still queued it stays queued, and the next unrelated sequence
+    // flushes it into the pty. The testing allocator also fails the test
+    // if it was left owned by nobody.
+    try testing.expectEqual(
+        @as(usize, 0),
+        surface.keyboard.sequence_queued.items.len,
+    );
+}
+
+test "endKeySequenceBeforeClose: an ordinary action leaves the sequence alone" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var rt_app: apprt.App = undefined;
+    const surface = try testSurface(alloc, &rt_app);
+    defer alloc.destroy(surface);
+    defer {
+        for (surface.keyboard.sequence_queued.items) |req| req.deinit();
+        surface.keyboard.sequence_queued.deinit(alloc);
+    }
+
+    try surface.keyboard.sequence_queued.append(alloc, .{ .alloc = .{
+        .alloc = alloc,
+        .data = try alloc.dupe(u8, "\x01"),
+    } });
+
+    // Nothing here can free the surface, so the tail of
+    // maybeHandleBinding still owns the decision to flush or drop.
+    surface.endKeySequenceBeforeClose(&.{.{ .new_tab = {} }});
+
+    try testing.expectEqual(
+        @as(usize, 1),
+        surface.keyboard.sequence_queued.items.len,
+    );
 }
 
 test "DerivedConfig: a long click-repeat-interval does not overflow" {

--- a/src/apprt/none.zig
+++ b/src/apprt/none.zig
@@ -15,6 +15,21 @@ pub const App = struct {
     /// it at all.
     pub fn wakeup(_: *const App) void {}
 
+    /// Always return false: there is no apprt here to hand an action to,
+    /// so nothing is ever performed. It exists for the same reason
+    /// `wakeup` does. Without it any core code path that notifies the
+    /// apprt fails to compile under this runtime, and since this is the
+    /// runtime the unit test binary is built with, no test could reach
+    /// one -- `Surface.endKeySequence` among them.
+    pub fn performAction(
+        _: *App,
+        _: apprt.Target,
+        comptime action: apprt.Action.Key,
+        _: apprt.Action.Value(action),
+    ) !bool {
+        return false;
+    }
+
     /// Always return false as there is no apprt to communicate with.
     pub fn performIpc(
         _: Allocator,

--- a/src/cli/args.zig
+++ b/src/cli/args.zig
@@ -61,6 +61,11 @@ pub fn parse(
     const info = @typeInfo(T);
     assert(info == .@"struct");
 
+    const Iter = switch (@typeInfo(@TypeOf(iter))) {
+        .pointer => |v| v.child,
+        else => @TypeOf(iter),
+    };
+
     // Make an arena for all our allocations if we support it. Otherwise,
     // use an allocator that always fails. If the arena is already set on
     // the config, then we reuse that. See memory note in parse docs.
@@ -85,7 +90,20 @@ pub fn parse(
         dst._arena = null;
     };
 
-    while (iter.next()) |arg| {
+    while (true) {
+        const next_ = iter.next();
+
+        // An iterator can drop an input it couldn't read, such as a
+        // config line that is too long. Report those alongside the
+        // errors from the args we did get.
+        if (comptime canTrackDiags(T) and @hasDecl(Iter, "skippedDiagnostic")) {
+            if (try iter.skippedDiagnostic(arena_alloc)) |d| {
+                try dst._diagnostics.append(arena_alloc, d);
+            }
+        }
+
+        const arg = next_ orelse break;
+
         // Do manual parsing if we have a hook for it.
         if (@hasDecl(T, "parseManuallyHook")) {
             if (!try dst.parseManuallyHook(
@@ -1526,6 +1544,12 @@ pub const LineIterator = struct {
     /// is formatted to be compatible with the parse function.
     entry: [MAX_LINE_SIZE]u8 = [_]u8{ '-', '-' } ++ ([_]u8{0} ** (MAX_LINE_SIZE - 2)),
 
+    /// The line number of a line we skipped because it was too long to
+    /// fit in `entry`. Read (and cleared) by `skippedDiagnostic` so that
+    /// the parser can report it. Every skip is also logged, so nothing is
+    /// lost if several lines are skipped before it is read.
+    skipped_line: ?usize = null,
+
     pub fn init(reader: *std.Io.Reader) Self {
         return .{ .r = reader };
     }
@@ -1551,9 +1575,30 @@ pub const LineIterator = struct {
             // Reset write head
             writer.end = 0;
 
-            _ = self.r.streamDelimiterEnding(&writer, '\n') catch |e| {
-                log.warn("cannot read from \"{s}\": {}", .{ self.filepath, e });
-                return null;
+            _ = self.r.streamDelimiterEnding(&writer, '\n') catch |e| switch (e) {
+                // The line doesn't fit in our entry buffer so it can't be
+                // a valid argument. Skip past it and keep reading: treating
+                // this as end of input would silently drop the rest of the
+                // file.
+                error.WriteFailed => {
+                    self.line += 1;
+                    self.skipped_line = self.line;
+                    log.warn(
+                        "{s}:{}: line exceeds the {} byte maximum, ignoring",
+                        .{ self.filepath, self.line, MAX_LINE_SIZE },
+                    );
+
+                    _ = self.r.discardDelimiterInclusive('\n') catch {};
+                    if (self.r.seek == self.r.end) {
+                        self.r.fillMore() catch {};
+                    }
+                    continue;
+                },
+
+                else => {
+                    log.warn("cannot read from \"{s}\": {}", .{ self.filepath, e });
+                    return null;
+                },
             };
             _ = self.r.discardDelimiterInclusive('\n') catch {};
 
@@ -1624,6 +1669,25 @@ pub const LineIterator = struct {
             .path = try alloc.dupe(u8, self.filepath),
             .line = self.line,
         } };
+    }
+
+    /// Returns a diagnostic for a line that was skipped since the last
+    /// call, if there was one. `parse` calls this so that a skipped line
+    /// is reported to the user and not just to the log.
+    pub fn skippedDiagnostic(
+        self: *Self,
+        alloc: Allocator,
+    ) Allocator.Error!?diags.Diagnostic {
+        const line = self.skipped_line orelse return null;
+        self.skipped_line = null;
+
+        return .{
+            .message = "line exceeds the maximum length and was ignored",
+            .location = if (self.filepath.len == 0) .none else .{ .file = .{
+                .path = try alloc.dupe(u8, self.filepath),
+                .line = line,
+            } },
+        };
     }
 };
 
@@ -1777,6 +1841,31 @@ test "LineIterator with buffered and primed reader" {
     try testing.expectEqualStrings("--B=C", iter.next().?);
     try testing.expectEqual(@as(?[]const u8, null), iter.next());
     try testing.expectEqual(@as(?[]const u8, null), iter.next());
+}
+
+test "LineIterator skips a line that is too long" {
+    const testing = std.testing;
+
+    const long = "A=" ++ ("x" ** LineIterator.MAX_LINE_SIZE);
+
+    // Over-long line in the middle of the file.
+    {
+        var reader: std.Io.Reader = .fixed("A\n" ++ long ++ "\nB=42\n");
+        var iter: LineIterator = .{ .r = &reader, .filepath = "test" };
+        try testing.expectEqualStrings("--A", iter.next().?);
+        try testing.expectEqualStrings("--B=42", iter.next().?);
+        try testing.expectEqual(@as(?usize, 2), iter.skipped_line);
+        try testing.expectEqual(@as(?[]const u8, null), iter.next());
+    }
+
+    // Over-long line at the end of the file, with no trailing newline.
+    {
+        var reader: std.Io.Reader = .fixed("A\n" ++ long);
+        var iter: LineIterator = .{ .r = &reader, .filepath = "test" };
+        try testing.expectEqualStrings("--A", iter.next().?);
+        try testing.expectEqual(@as(?[]const u8, null), iter.next());
+        try testing.expectEqual(@as(?usize, 2), iter.skipped_line);
+    }
 }
 
 test "LineIterator refills after ignored line at buffer boundary" {

--- a/src/cli/args.zig
+++ b/src/cli/args.zig
@@ -96,7 +96,10 @@ pub fn parse(
         // An iterator can drop an input it couldn't read, such as a
         // config line that is too long. Report those alongside the
         // errors from the args we did get.
-        if (comptime canTrackDiags(T) and @hasDecl(Iter, "skippedDiagnostic")) {
+        if (comptime canTrackDiags(T) and
+            @typeInfo(Iter) == .@"struct" and
+            @hasDecl(Iter, "skippedDiagnostic"))
+        {
             if (try iter.skippedDiagnostic(arena_alloc)) |d| {
                 try dst._diagnostics.append(arena_alloc, d);
             }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -4211,6 +4211,32 @@ test "handle bom in config files" {
     }
 }
 
+test "config file with an over-long line keeps reading" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const data = "title = " ++
+        ("x" ** cli.args.LineIterator.MAX_LINE_SIZE) ++
+        "\nfont-size = 20\n";
+    var reader: std.Io.Reader = .fixed(data);
+    var cfg = try Config.default(alloc);
+    defer cfg.deinit();
+    try cfg.loadReader(
+        alloc,
+        &reader,
+        "/home/ghostty/.config/ghostty/config.ghostty",
+    );
+
+    // The rest of the file is still applied and the user is told about
+    // the line we dropped.
+    try testing.expectEqual(20, cfg.@"font-size");
+    try testing.expectEqual(1, cfg._diagnostics.items().len);
+    try testing.expectEqual(
+        @as(usize, 1),
+        cfg._diagnostics.items()[0].location.file.line,
+    );
+}
+
 pub const OptionalFileAction = enum { loaded, not_found, @"error" };
 
 /// Load optional configuration file from `path`. All errors are ignored.

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -57,6 +57,23 @@ const terminal = struct {
 
 const log = std.log.scoped(.config);
 
+const default_font_size: f32 = switch (builtin.os.tag) {
+    // On macOS we default a little bigger since this tends to look better.
+    // This is purely subjective but this is easy to modify.
+    .macos => 13,
+    else => 12,
+};
+
+/// The range a font size is allowed to be in. The same range is applied
+/// to font size changes at runtime (see the font size keybind actions).
+const min_font_size: f32 = 1;
+const max_font_size: f32 = 255;
+
+/// The largest window size we accept, in cells. The terminal addresses
+/// its grid with a u16, and the value is multiplied by the cell size to
+/// get pixels, so anything larger only overflows.
+const max_window_size_cells: u32 = std.math.maxInt(u16);
+
 /// Used on Unixes for some defaults.
 const c = @cImport({
     @cInclude("unistd.h");
@@ -271,12 +288,7 @@ language: ?[:0]const u8 = null,
 /// On Linux with GTK, font size is scaled according to both display-wide and
 /// text-specific scaling factors, which are often managed by your desktop
 /// environment (e.g. the GNOME display scale and large text settings).
-@"font-size": f32 = switch (builtin.os.tag) {
-    // On macOS we default a little bigger since this tends to look better. This
-    // is purely subjective but this is easy to modify.
-    .macos => 13,
-    else => 12,
-},
+@"font-size": f32 = default_font_size,
 
 /// A repeatable configuration to set one or more font variations values for
 /// a variable font. A variable font is a single font, usually with a filename
@@ -5035,6 +5047,13 @@ pub fn finalize(self: *Config) !void {
     {
         self.@"click-repeat-interval" = internal_os.clickInterval() orelse 500;
     }
+
+    // Clamp our font size. A font size is turned into integer metrics,
+    // so a value that isn't a real number can't be used at all.
+    self.@"font-size" = if (std.math.isNan(self.@"font-size"))
+        default_font_size
+    else
+        std.math.clamp(self.@"font-size", min_font_size, max_font_size);
 
     // Clamp our mouse scroll multiplier
     self.@"mouse-scroll-multiplier".precision = @min(10_000.0, @max(0.01, self.@"mouse-scroll-multiplier".precision));
@@ -11136,6 +11155,52 @@ test "clone default" {
 
     // I want to do this but this doesn't work (the API doesn't work)
     // try testing.expectEqualDeep(dest, source);
+}
+
+test "finalize clamps font-size" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    {
+        var reader: std.Io.Reader = .fixed("font-size = nan\n");
+        var cfg = try Config.default(alloc);
+        defer cfg.deinit();
+        try cfg.loadReader(
+            alloc,
+            &reader,
+            "/home/ghostty/.config/ghostty/config.ghostty",
+        );
+        try testing.expect(std.math.isNan(cfg.@"font-size"));
+
+        try cfg.finalize();
+        try testing.expectEqual(default_font_size, cfg.@"font-size");
+    }
+
+    {
+        var reader: std.Io.Reader = .fixed("font-size = inf\n");
+        var cfg = try Config.default(alloc);
+        defer cfg.deinit();
+        try cfg.loadReader(
+            alloc,
+            &reader,
+            "/home/ghostty/.config/ghostty/config.ghostty",
+        );
+        try cfg.finalize();
+        try testing.expectEqual(max_font_size, cfg.@"font-size");
+    }
+
+    {
+        var reader: std.Io.Reader = .fixed("font-size = 0\n");
+        var cfg = try Config.default(alloc);
+        defer cfg.deinit();
+        try cfg.loadReader(
+            alloc,
+            &reader,
+            "/home/ghostty/.config/ghostty/config.ghostty",
+        );
+        try cfg.finalize();
+        try testing.expectEqual(min_font_size, cfg.@"font-size");
+    }
 }
 
 test "default mouse-hide-while-typing is true" {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -4442,7 +4442,16 @@ pub fn loadCliArgs(self: *Config, alloc_gpa: Allocator) !void {
             }
 
             self.@"_xdg-terminal-exec" = true;
-            self.@"initial-command" = .{ .direct = try builder.toOwnedSlice(arena_alloc) };
+
+            // Invoked with no command at all. Leave the initial command
+            // unset so we start the default shell; an empty argv has no
+            // program to execute.
+            if (builder.items.len > 0) {
+                self.@"initial-command" = .{
+                    .direct = try builder.toOwnedSlice(arena_alloc),
+                };
+            }
+
             return;
         }
     }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -5065,9 +5065,17 @@ pub fn finalize(self: *Config) !void {
     // Clamp our contrast
     self.@"minimum-contrast" = @min(21, @max(1, self.@"minimum-contrast"));
 
-    // Minimum window size
-    if (self.@"window-width" > 0) self.@"window-width" = @max(10, self.@"window-width");
-    if (self.@"window-height" > 0) self.@"window-height" = @max(4, self.@"window-height");
+    // Window size, in cells
+    if (self.@"window-width" > 0) self.@"window-width" = std.math.clamp(
+        self.@"window-width",
+        10,
+        max_window_size_cells,
+    );
+    if (self.@"window-height" > 0) self.@"window-height" = std.math.clamp(
+        self.@"window-height",
+        4,
+        max_window_size_cells,
+    );
 
     // When link-url-style = always, switch the default URL matcher's
     // highlight to .always so the URL matcher behaves like the OSC 8
@@ -11211,6 +11219,28 @@ test "default mouse-hide-while-typing is true" {
     defer cfg.deinit();
 
     try testing.expectEqual(true, cfg.@"mouse-hide-while-typing");
+}
+
+test "finalize clamps window size" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var reader: std.Io.Reader = .fixed(
+        \\window-width = 4000000000
+        \\window-height = 1
+        \\
+    );
+    var cfg = try Config.default(alloc);
+    defer cfg.deinit();
+    try cfg.loadReader(
+        alloc,
+        &reader,
+        "/home/ghostty/.config/ghostty/config.ghostty",
+    );
+    try cfg.finalize();
+
+    try testing.expectEqual(max_window_size_cells, cfg.@"window-width");
+    try testing.expectEqual(4, cfg.@"window-height");
 }
 
 test "clone preserves conditional state" {

--- a/src/config/string.zig
+++ b/src/config/string.zig
@@ -69,6 +69,11 @@ pub const CodepointIterator = struct {
             else => |start| {
                 const cp_len = std.unicode.utf8ByteSequenceLength(start) catch
                     return error.InvalidString;
+
+                // A truncated sequence at the end of the value is just an
+                // invalid string; there are no bytes left to decode.
+                if (self.bytes.len - self.i < cp_len) return error.InvalidString;
+
                 defer self.i += cp_len;
                 return std.unicode.utf8Decode(self.bytes[self.i..][0..cp_len]) catch
                     return error.InvalidString;
@@ -146,6 +151,20 @@ test "codepointIterator: escape sequences" {
     try std.testing.expectEqual(@as(u21, '\n'), (try it.next()).?);
     try std.testing.expectEqual(@as(u21, '\\'), (try it.next()).?);
     try std.testing.expectEqual(null, try it.next());
+}
+
+test "codepointIterator: truncated utf8" {
+    // A multi-byte sequence that runs off the end of the value.
+    {
+        var it = codepointIterator("a\xf0");
+        try std.testing.expectEqual(@as(u21, 'a'), (try it.next()).?);
+        try std.testing.expectError(error.InvalidString, it.next());
+    }
+
+    {
+        var it = codepointIterator("\xe2\x94");
+        try std.testing.expectError(error.InvalidString, it.next());
+    }
 }
 
 test "codepointIterator: unicode escape" {

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -1367,6 +1367,21 @@ pub const Action = union(enum) {
         return Error.InvalidAction;
     }
 
+    /// Returns true if performing this action can close the surface it
+    /// was performed on. The surface (and anything owned by it, such as
+    /// the keybind set an action chain lives in) is gone once one of
+    /// these is performed, so nothing may run after it.
+    pub fn closesSurface(self: Action) bool {
+        return switch (self) {
+            .close_surface,
+            .close_window,
+            .close_tab,
+            => true,
+
+            else => false,
+        };
+    }
+
     /// The scope of an action. The scope is the context in which an action
     /// must be executed.
     pub const Scope = enum {
@@ -2714,12 +2729,13 @@ pub const Set = struct {
 
     /// Append a chained action to the prior set action.
     ///
-    /// It is an error if there is no valid prior chain parent.
+    /// It is an error if there is no valid prior chain parent or if the
+    /// prior action closes the surface, since nothing can run after that.
     pub fn appendChain(
         self: *Set,
         alloc: Allocator,
         action: Action,
-    ) (Allocator.Error || error{NoChainParent})!void {
+    ) (Allocator.Error || error{ NoChainParent, InvalidChainAction })!void {
         // Unbind is not a valid chain action; callers must check this.
         assert(action != .unbind);
 
@@ -2731,16 +2747,23 @@ pub const Set = struct {
 
             // If it is already a chained action, we just append the
             // action. Easy!
-            .leaf_chained => |*leaf| try leaf.actions.append(
-                alloc,
-                action,
-            ),
+            .leaf_chained => |*leaf| {
+                if (leaf.actions.getLast().closesSurface()) {
+                    return error.InvalidChainAction;
+                }
+
+                try leaf.actions.append(alloc, action);
+            },
 
             // If it is a leaf, we need to convert it to a leaf_chained.
             // We also need to be careful to remove any prior reverse
             // mappings for this action since chained actions are not
             // part of the reverse mapping.
             .leaf => |leaf| {
+                if (leaf.action.closesSurface()) {
+                    return error.InvalidChainAction;
+                }
+
                 // Setup our failable actions list first.
                 var actions: std.ArrayList(Action) = .empty;
                 try actions.ensureTotalCapacity(alloc, 2);
@@ -4837,6 +4860,60 @@ test "set: appendChain multiple times" {
     try testing.expect(chained.actions.items[2] == .close_surface);
 }
 
+test "set: appendChain after a closing leaf is an error" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s: Set = .{};
+    defer s.deinit(alloc);
+
+    try s.put(alloc, .{ .key = .{ .unicode = 'a' } }, .{ .close_surface = {} });
+    try testing.expectError(
+        error.InvalidChainAction,
+        s.appendChain(alloc, .{ .new_tab = {} }),
+    );
+
+    // The binding is left as it was.
+    const entry = s.get(.{ .key = .{ .unicode = 'a' } }).?;
+    try testing.expect(entry.value_ptr.* == .leaf);
+    try testing.expect(entry.value_ptr.*.leaf.action == .close_surface);
+}
+
+test "set: appendChain after a closing action in a chain is an error" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s: Set = .{};
+    defer s.deinit(alloc);
+
+    try s.put(alloc, .{ .key = .{ .unicode = 'a' } }, .{ .new_window = {} });
+    try s.appendChain(alloc, .{ .close_tab = .this });
+    try testing.expectError(
+        error.InvalidChainAction,
+        s.appendChain(alloc, .{ .new_tab = {} }),
+    );
+
+    const chained = s.get(.{ .key = .{ .unicode = 'a' } }).?.value_ptr.*.leaf_chained;
+    try testing.expectEqual(@as(usize, 2), chained.actions.items.len);
+}
+
+test "set: parseAndPut chain after a closing action is invalid" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s: Set = .{};
+    defer s.deinit(alloc);
+
+    try s.parseAndPut(alloc, "a=close_surface");
+    try testing.expectError(
+        error.InvalidFormat,
+        s.parseAndPut(alloc, "chain=new_tab"),
+    );
+
+    const entry = s.get(.{ .key = .{ .unicode = 'a' } }).?;
+    try testing.expect(entry.value_ptr.* == .leaf);
+}
+
 test "set: appendChain removes reverse mapping" {
     const testing = std.testing;
     const alloc = testing.allocator;
@@ -4871,12 +4948,12 @@ test "set: appendChain with performable does not affect reverse mapping" {
     try s.putFlags(
         alloc,
         .{ .key = .{ .unicode = 'a' } },
-        .{ .close_surface = {} },
+        .{ .reset = {} },
         .{ .performable = true },
     );
 
-    // close_surface was performable, so not in reverse map
-    try testing.expect(s.getTrigger(.{ .close_surface = {} }) == null);
+    // reset was performable, so not in reverse map
+    try testing.expect(s.getTrigger(.{ .reset = {} }) == null);
 
     // Chaining the performable binding should not crash or affect anything
     try s.appendChain(alloc, .{ .new_tab = {} });

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -1369,11 +1369,22 @@ pub const Action = union(enum) {
 
     /// Returns true if performing this action can close the surface it
     /// was performed on, so the surface pointer is dead afterwards.
+    ///
+    /// `quit` and `close_all_windows` take every surface with them, and
+    /// `undo`/`redo` can replay the teardown of whatever created this
+    /// one. Some runtimes defer that work to their event loop, but gtk
+    /// does it inline: `quit` destroys every window before it returns,
+    /// and the surface is freed on the way. A caller still holding the
+    /// surface has to assume it is gone.
     pub fn closesSurface(self: Action) bool {
         return switch (self) {
             .close_surface,
             .close_window,
             .close_tab,
+            .close_all_windows,
+            .quit,
+            .undo,
+            .redo,
             => true,
 
             else => false,
@@ -1384,20 +1395,11 @@ pub const Action = union(enum) {
     /// that a chain of actions is being read from, so no action after it
     /// in the chain may be looked at.
     ///
-    /// Closing the surface frees the config it derived, and so does
-    /// reloading: a config reload replaces every surface's derived
-    /// config, which owns the keybind set, without closing anything.
-    /// `quit` and `close_all_windows` take every surface with them, and
-    /// `undo`/`redo` can replay the teardown of whatever created this
-    /// one.
+    /// Reloading the config replaces every surface's derived config,
+    /// which owns the keybind set, without closing anything.
     pub fn endsChain(self: Action) bool {
         return switch (self) {
-            .reload_config,
-            .close_all_windows,
-            .quit,
-            .undo,
-            .redo,
-            => true,
+            .reload_config => true,
 
             // Every action that takes the surface away takes its keybind
             // set with it.
@@ -4977,18 +4979,20 @@ test "action: endsChain" {
     try testing.expect((Action{ .close_window = {} }).endsChain());
     try testing.expect((Action{ .close_tab = .this }).endsChain());
 
-    // These do not close the surface but do free the keybind set.
+    // A reload frees the keybind set but leaves the surface open.
     try testing.expect(!(Action{ .reload_config = {} }).closesSurface());
-    try testing.expect(!(Action{ .close_all_windows = {} }).closesSurface());
-    try testing.expect(!(Action{ .quit = {} }).closesSurface());
     try testing.expect((Action{ .reload_config = {} }).endsChain());
+
+    // These take every surface with them, ours included.
+    try testing.expect((Action{ .close_all_windows = {} }).closesSurface());
     try testing.expect((Action{ .close_all_windows = {} }).endsChain());
+    try testing.expect((Action{ .quit = {} }).closesSurface());
     try testing.expect((Action{ .quit = {} }).endsChain());
 
     // Undoing whatever created this surface takes the surface with it.
-    try testing.expect(!(Action{ .undo = {} }).closesSurface());
-    try testing.expect(!(Action{ .redo = {} }).closesSurface());
+    try testing.expect((Action{ .undo = {} }).closesSurface());
     try testing.expect((Action{ .undo = {} }).endsChain());
+    try testing.expect((Action{ .redo = {} }).closesSurface());
     try testing.expect((Action{ .redo = {} }).endsChain());
 
     // An ordinary action does neither.

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -1368,9 +1368,7 @@ pub const Action = union(enum) {
     }
 
     /// Returns true if performing this action can close the surface it
-    /// was performed on. The surface (and anything owned by it, such as
-    /// the keybind set an action chain lives in) is gone once one of
-    /// these is performed, so nothing may run after it.
+    /// was performed on, so the surface pointer is dead afterwards.
     pub fn closesSurface(self: Action) bool {
         return switch (self) {
             .close_surface,
@@ -1379,6 +1377,27 @@ pub const Action = union(enum) {
             => true,
 
             else => false,
+        };
+    }
+
+    /// Returns true if performing this action can free the keybind set
+    /// that a chain of actions is being read from, so no action after it
+    /// in the chain may be looked at.
+    ///
+    /// Closing the surface frees the config it derived, and so does
+    /// reloading: a config reload replaces every surface's derived
+    /// config, which owns the keybind set, without closing anything.
+    /// `quit` and `close_all_windows` take every surface with them.
+    pub fn endsChain(self: Action) bool {
+        return switch (self) {
+            .reload_config,
+            .close_all_windows,
+            .quit,
+            => true,
+
+            // Every action that takes the surface away takes its keybind
+            // set with it.
+            else => self.closesSurface(),
         };
     }
 
@@ -2730,7 +2749,8 @@ pub const Set = struct {
     /// Append a chained action to the prior set action.
     ///
     /// It is an error if there is no valid prior chain parent or if the
-    /// prior action closes the surface, since nothing can run after that.
+    /// prior action frees the set this chain lives in, since nothing can
+    /// run after that.
     pub fn appendChain(
         self: *Set,
         alloc: Allocator,
@@ -2748,7 +2768,7 @@ pub const Set = struct {
             // If it is already a chained action, we just append the
             // action. Easy!
             .leaf_chained => |*leaf| {
-                if (leaf.actions.getLast().closesSurface()) {
+                if (leaf.actions.getLast().endsChain()) {
                     return error.InvalidChainAction;
                 }
 
@@ -2760,7 +2780,7 @@ pub const Set = struct {
             // mappings for this action since chained actions are not
             // part of the reverse mapping.
             .leaf => |leaf| {
-                if (leaf.action.closesSurface()) {
+                if (leaf.action.endsChain()) {
                     return error.InvalidChainAction;
                 }
 
@@ -4895,6 +4915,55 @@ test "set: appendChain after a closing action in a chain is an error" {
 
     const chained = s.get(.{ .key = .{ .unicode = 'a' } }).?.value_ptr.*.leaf_chained;
     try testing.expectEqual(@as(usize, 2), chained.actions.items.len);
+}
+
+test "set: appendChain after an action that frees the set is an error" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // None of these close the surface, but each one can replace or tear
+    // down the config that owns this set, which frees the action slice a
+    // chain is read from.
+    const actions: []const Action = &.{
+        .{ .reload_config = {} },
+        .{ .close_all_windows = {} },
+        .{ .quit = {} },
+    };
+
+    for (actions) |action| {
+        var s: Set = .{};
+        defer s.deinit(alloc);
+
+        try s.put(alloc, .{ .key = .{ .unicode = 'a' } }, action);
+        try testing.expectError(
+            error.InvalidChainAction,
+            s.appendChain(alloc, .{ .new_tab = {} }),
+        );
+
+        const entry = s.get(.{ .key = .{ .unicode = 'a' } }).?;
+        try testing.expect(entry.value_ptr.* == .leaf);
+    }
+}
+
+test "action: endsChain" {
+    const testing = std.testing;
+
+    // Every action that closes the surface also ends the chain.
+    try testing.expect((Action{ .close_surface = {} }).endsChain());
+    try testing.expect((Action{ .close_window = {} }).endsChain());
+    try testing.expect((Action{ .close_tab = .this }).endsChain());
+
+    // These do not close the surface but do free the keybind set.
+    try testing.expect(!(Action{ .reload_config = {} }).closesSurface());
+    try testing.expect(!(Action{ .close_all_windows = {} }).closesSurface());
+    try testing.expect(!(Action{ .quit = {} }).closesSurface());
+    try testing.expect((Action{ .reload_config = {} }).endsChain());
+    try testing.expect((Action{ .close_all_windows = {} }).endsChain());
+    try testing.expect((Action{ .quit = {} }).endsChain());
+
+    // An ordinary action does neither.
+    try testing.expect(!(Action{ .new_tab = {} }).closesSurface());
+    try testing.expect(!(Action{ .new_tab = {} }).endsChain());
 }
 
 test "set: parseAndPut chain after a closing action is invalid" {

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -1368,14 +1368,25 @@ pub const Action = union(enum) {
     }
 
     /// Returns true if performing this action can close the surface it
-    /// was performed on, so the surface pointer is dead afterwards.
+    /// was performed on, so a caller still holding that surface has to
+    /// treat the pointer as dead once the action has run.
     ///
-    /// `quit` and `close_all_windows` take every surface with them, and
+    /// "Can", not "does", and the difference matters: no runtime in this
+    /// tree has been shown to free the core surface before
+    /// `performAction` returns. The embedded apprt calls straight out to
+    /// the embedder and returns, and every embedder here defers the
+    /// close to its own UI loop; gtk's `quit` destroys its windows
+    /// inline, but the core surface is freed in GObject `finalize`,
+    /// which runs at last unref and not necessarily before the key
+    /// handler that triggered it returns.
+    ///
+    /// The list is deliberately wider than any of that: `quit` and
+    /// `close_all_windows` take every surface with them, and
     /// `undo`/`redo` can replay the teardown of whatever created this
-    /// one. Some runtimes defer that work to their event loop, but gtk
-    /// does it inline: `quit` destroys every window before it returns,
-    /// and the surface is freed on the way. A caller still holding the
-    /// surface has to assume it is gone.
+    /// one. A caller cannot check afterwards whether it survived, and
+    /// being wrong in the other direction is a use-after-free, so
+    /// membership is a claim about what an apprt is allowed to do, not a
+    /// measurement of what any of them currently does.
     pub fn closesSurface(self: Action) bool {
         return switch (self) {
             .close_surface,

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -4947,13 +4947,14 @@ test "set: appendChain after an action that frees the set is an error" {
     const testing = std.testing;
     const alloc = testing.allocator;
 
-    // None of these close the surface, but each one can replace or tear
-    // down the config that owns this set, which frees the action slice a
-    // chain is read from.
+    // Each one can replace or tear down the config that owns this set,
+    // which frees the action slice a chain is read from.
     const actions: []const Action = &.{
         .{ .reload_config = {} },
         .{ .close_all_windows = {} },
         .{ .quit = {} },
+        .{ .undo = {} },
+        .{ .redo = {} },
     };
 
     for (actions) |action| {

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -1387,12 +1387,16 @@ pub const Action = union(enum) {
     /// Closing the surface frees the config it derived, and so does
     /// reloading: a config reload replaces every surface's derived
     /// config, which owns the keybind set, without closing anything.
-    /// `quit` and `close_all_windows` take every surface with them.
+    /// `quit` and `close_all_windows` take every surface with them, and
+    /// `undo`/`redo` can replay the teardown of whatever created this
+    /// one.
     pub fn endsChain(self: Action) bool {
         return switch (self) {
             .reload_config,
             .close_all_windows,
             .quit,
+            .undo,
+            .redo,
             => true,
 
             // Every action that takes the surface away takes its keybind
@@ -2363,6 +2367,26 @@ pub const Set = struct {
                 .single => |*arr| arr,
                 .many => |slice| slice,
             };
+        }
+
+        /// Returns true if `actionsSlice` points into the keybind set this
+        /// leaf came from instead of into the leaf itself. Only a borrowed
+        /// slice can be freed by an action that ends the chain; a single
+        /// action is copied into the leaf, so it lives as long as the
+        /// caller's own copy of it.
+        pub fn actionsBorrowed(self: *const GenericLeaf) bool {
+            return self.actions == .many;
+        }
+
+        /// Returns true if any action in this leaf is `ignore`. Ask before
+        /// performing anything: performing an action can free the slice
+        /// this reads.
+        pub fn hasIgnore(self: *const GenericLeaf) bool {
+            for (self.actionsSlice()) |action| {
+                if (action == .ignore) return true;
+            }
+
+            return false;
         }
     };
 
@@ -4961,9 +4985,63 @@ test "action: endsChain" {
     try testing.expect((Action{ .close_all_windows = {} }).endsChain());
     try testing.expect((Action{ .quit = {} }).endsChain());
 
+    // Undoing whatever created this surface takes the surface with it.
+    try testing.expect(!(Action{ .undo = {} }).closesSurface());
+    try testing.expect(!(Action{ .redo = {} }).closesSurface());
+    try testing.expect((Action{ .undo = {} }).endsChain());
+    try testing.expect((Action{ .redo = {} }).endsChain());
+
     // An ordinary action does neither.
     try testing.expect(!(Action{ .new_tab = {} }).closesSurface());
     try testing.expect(!(Action{ .new_tab = {} }).endsChain());
+}
+
+test "leaf: only a chain borrows its action slice" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s: Set = .{};
+    defer s.deinit(alloc);
+
+    // A single action that ends the chain, and a chain that does not.
+    try s.parseAndPut(alloc, "a=reload_config");
+    try s.parseAndPut(alloc, "b=new_tab");
+    try s.appendChain(alloc, .{ .new_window = {} });
+
+    const single = genericLeaf(&s, 'a');
+    const many = genericLeaf(&s, 'b');
+
+    try testing.expect(!single.actionsBorrowed());
+    try testing.expect(many.actionsBorrowed());
+
+    // The single leaf's slice is inside the leaf we are holding, so it
+    // is readable no matter what performing the action did.
+    try testing.expectEqual(@as(usize, 1), single.actionsSlice().len);
+    try testing.expect(single.actionsSlice()[0] == .reload_config);
+}
+
+test "leaf: hasIgnore sees past an action that ends the chain" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s: Set = .{};
+    defer s.deinit(alloc);
+
+    try s.parseAndPut(alloc, "a=ignore");
+    try s.appendChain(alloc, .{ .reload_config = {} });
+    try s.parseAndPut(alloc, "b=new_tab");
+    try s.appendChain(alloc, .{ .reload_config = {} });
+
+    try testing.expect(genericLeaf(&s, 'a').hasIgnore());
+    try testing.expect(!genericLeaf(&s, 'b').hasIgnore());
+}
+
+fn genericLeaf(s: *const Set, cp: u21) Set.GenericLeaf {
+    const entry = s.get(.{ .key = .{ .unicode = cp } }).?;
+    return switch (entry.value_ptr.*) {
+        .leader => unreachable,
+        inline .leaf, .leaf_chained => |leaf| leaf.generic(),
+    };
 }
 
 test "set: parseAndPut chain after a closing action is invalid" {

--- a/src/input/paste.zig
+++ b/src/input/paste.zig
@@ -164,6 +164,10 @@ pub fn encodeWriter(
 /// unsafe if it contains any of the following:
 ///
 /// - `\n`: Newlines can be used to inject commands.
+/// - `\r`: Line editors accept the current line on carriage return, so
+///   it injects commands the same way a newline does. `encode` also
+///   turns every newline into one for an unbracketed paste.
+/// - U+0085 (NEL): Some programs treat it as a line break.
 /// - `\x1b[201~`: This is the end of a bracketed paste. This cane be used
 ///   to exit a bracketed paste and inject commands.
 ///
@@ -173,7 +177,8 @@ pub fn encodeWriter(
 /// should raise suspicion that the producer of the paste data is
 /// acting strangely.
 pub fn isSafe(data: []const u8) bool {
-    return std.mem.indexOf(u8, data, "\n") == null and
+    return std.mem.indexOfAny(u8, data, "\n\r") == null and
+        std.mem.indexOf(u8, data, "\u{0085}") == null and
         std.mem.indexOf(u8, data, "\x1b[201~") == null;
 }
 
@@ -199,6 +204,15 @@ test isSafe {
     try testing.expect(!isSafe("hello\n"));
     try testing.expect(!isSafe("hello\nworld"));
     try testing.expect(!isSafe("he\x1b[201~llo"));
+
+    // A carriage return accepts the line just like a newline does.
+    try testing.expect(!isSafe("hello\r"));
+    try testing.expect(!isSafe("hello\rworld"));
+    try testing.expect(!isSafe("hello\r\nworld"));
+    try testing.expect(!isSafe("hello\u{0085}world"));
+
+    // A codepoint that merely contains the NEL continuation byte is fine.
+    try testing.expect(isSafe("hello \u{2745} world"));
 }
 
 test isSafeWith {
@@ -207,12 +221,14 @@ test isSafeWith {
     // Bracketed: newlines are fine, the frame terminator is not.
     try testing.expect(isSafeWith("hello", .{ .bracketed = true }));
     try testing.expect(isSafeWith("hello\nworld", .{ .bracketed = true }));
+    try testing.expect(isSafeWith("hello\rworld", .{ .bracketed = true }));
     try testing.expect(!isSafeWith("he\x1b[201~llo", .{ .bracketed = true }));
     try testing.expect(!isSafeWith("hello\n\x1b[201~", .{ .bracketed = true }));
 
     // Unbracketed: the conservative rule.
     try testing.expect(isSafeWith("hello", .{ .bracketed = false }));
     try testing.expect(!isSafeWith("hello\nworld", .{ .bracketed = false }));
+    try testing.expect(!isSafeWith("hello\rworld", .{ .bracketed = false }));
     try testing.expect(!isSafeWith("he\x1b[201~llo", .{ .bracketed = false }));
 }
 

--- a/src/renderer/link.zig
+++ b/src/renderer/link.zig
@@ -100,17 +100,36 @@ pub const Set = struct {
 
         const str = builder.writer.buffered();
 
+        // Bound the backtracking work per search. This runs on every frame
+        // update and a link regex can backtrack catastrophically on some
+        // viewport contents, so use the same budget as the click path.
+        var match_param = try oni.MatchParam.init();
+        defer match_param.deinit();
+        try match_param.setRetryLimitInSearch(
+            terminal.StringMap.oni_search_retry_limit,
+        );
+
         // Go through each link and see if we have any matches.
         for (self.links) |*link| {
             if (!link.active(mouse_viewport, mouse_mods)) continue;
 
             var offset: usize = 0;
             while (offset < str.len) {
-                var region = link.regex.search(
+                var region = link.regex.searchWithParam(
                     str[offset..],
                     .{},
+                    &match_param,
                 ) catch |err| switch (err) {
-                    error.Mismatch => break,
+                    // A budget overrun is treated the same as no match:
+                    // we stop looking at the rest of the viewport for
+                    // this link.
+                    error.Mismatch,
+                    error.RetryLimitInMatchOver,
+                    error.RetryLimitInSearchOver,
+                    error.MatchStackLimitOver,
+                    error.SubexpCallLimitInSearchOver,
+                    => break,
+
                     else => return err,
                 };
                 defer region.deinit();
@@ -195,6 +214,53 @@ test "renderCellMap" {
     try testing.expect(!result.contains(.{ .x = 3, .y = 0 }));
     try testing.expect(result.contains(.{ .x = 1, .y = 1 }));
     try testing.expect(!result.contains(.{ .x = 1, .y = 2 }));
+}
+
+test "renderCellMap bounds regex backtracking" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // A URL followed by a long run of trailing punctuation. The default
+    // URL regex has to consider every way of splitting that run between
+    // its repeated groups, which is exponential work, so this only
+    // finishes because the search has a retry budget.
+    const url = "https://x.com/";
+    const trailing = "." ** 40;
+
+    var t: terminal.Terminal = try .init(testing.io, alloc, .{
+        .cols = url.len + trailing.len,
+        .rows = 2,
+    });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    s.nextSlice("https://a.com\r\n" ++ url ++ trailing);
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var set = try Set.fromConfig(alloc, &.{.{
+        .regex = @import("../config/url.zig").regex,
+        .action = .{ .open = {} },
+        .highlight = .{ .always = {} },
+    }});
+    defer set.deinit(alloc);
+
+    var result: terminal.RenderState.CellSet = .empty;
+    defer result.deinit(alloc);
+    try set.renderCellMap(
+        alloc,
+        &result,
+        &state,
+        null,
+        .{},
+    );
+
+    // The ordinary URL on the first row is still matched.
+    try testing.expect(result.contains(.{ .x = 0, .y = 0 }));
+    try testing.expect(result.contains(.{ .x = 12, .y = 0 }));
 }
 
 test "renderCellMap hover links" {

--- a/src/renderer/link.zig
+++ b/src/renderer/link.zig
@@ -120,15 +120,23 @@ pub const Set = struct {
                     .{},
                     &match_param,
                 ) catch |err| switch (err) {
-                    // A budget overrun is treated the same as no match:
-                    // we stop looking at the rest of the viewport for
-                    // this link.
-                    error.Mismatch,
+                    error.Mismatch => break,
+
+                    // We ran out of budget somewhere in the rest of the
+                    // viewport, and Oniguruma doesn't tell us which start
+                    // position was expensive. Skip a single codepoint and
+                    // keep scanning so one pathological position doesn't
+                    // hide every link after it.
                     error.RetryLimitInMatchOver,
                     error.RetryLimitInSearchOver,
                     error.MatchStackLimitOver,
                     error.SubexpCallLimitInSearchOver,
-                    => break,
+                    => {
+                        offset += std.unicode.utf8ByteSequenceLength(
+                            str[offset],
+                        ) catch 1;
+                        continue;
+                    },
 
                     else => return err,
                 };
@@ -224,18 +232,19 @@ test "renderCellMap bounds regex backtracking" {
     // URL regex has to consider every way of splitting that run between
     // its repeated groups, which is exponential work, so this only
     // finishes because the search has a retry budget.
-    const url = "https://x.com/";
-    const trailing = "." ** 40;
+    const pathological = "https://x.com/" ++ ("." ** 40);
+    const trailing_url = "https://b.com";
+    const row = pathological ++ " " ++ trailing_url;
 
     var t: terminal.Terminal = try .init(testing.io, alloc, .{
-        .cols = url.len + trailing.len,
+        .cols = row.len,
         .rows = 2,
     });
     defer t.deinit(alloc);
 
     var s = t.vtStream();
     defer s.deinit();
-    s.nextSlice("https://a.com\r\n" ++ url ++ trailing);
+    s.nextSlice("https://a.com\r\n" ++ row);
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -258,9 +267,41 @@ test "renderCellMap bounds regex backtracking" {
         .{},
     );
 
-    // The ordinary URL on the first row is still matched.
+    // The ordinary URL before the pathological one is still matched.
     try testing.expect(result.contains(.{ .x = 0, .y = 0 }));
     try testing.expect(result.contains(.{ .x = 12, .y = 0 }));
+
+    // The pathological URL only highlights in part. Every search that
+    // starts on its scheme exhausts the retry budget, so those start
+    // positions are skipped and "https://" stays unhighlighted. The first
+    // position that does match is the host, which the regex's path branch
+    // matches linearly. Highlighting the whole thing would mean letting
+    // the regex run unbounded, so the lost scheme is the price of the
+    // budget.
+    const host = std.mem.indexOf(u8, pathological, "x.com").?;
+    for (0..host) |x| {
+        try testing.expect(!result.contains(.{ .x = @intCast(x), .y = 1 }));
+    }
+    for (host..pathological.len) |x| {
+        try testing.expect(result.contains(.{ .x = @intCast(x), .y = 1 }));
+    }
+
+    // The space between the two links belongs to neither.
+    try testing.expect(!result.contains(.{
+        .x = pathological.len,
+        .y = 1,
+    }));
+
+    // The link after it on the same row is still matched, because a budget
+    // overrun skips one position instead of abandoning the rest of the scan.
+    try testing.expect(result.contains(.{
+        .x = pathological.len + 1,
+        .y = 1,
+    }));
+    try testing.expect(result.contains(.{
+        .x = row.len - 1,
+        .y = 1,
+    }));
 }
 
 test "renderCellMap hover links" {

--- a/src/renderer/link.zig
+++ b/src/renderer/link.zig
@@ -10,6 +10,16 @@ const Terminal = terminal.Terminal;
 
 const log = std.log.scoped(.renderer_link);
 
+/// How many regex retry budget overruns a single link scan tolerates
+/// before it stops scanning.
+///
+/// Oniguruma's retry limit is per search call, so a scan that restarts a
+/// search at every start position also restarts the budget, and the total
+/// work becomes the budget times the viewport size. Counting overruns for
+/// the whole scan puts a ceiling on that total while still letting the
+/// scan step over a few expensive positions.
+const scan_overrun_budget: usize = 3;
+
 /// The link configuration needed for renderers.
 pub const Link = struct {
     /// The regular expression to match the link against.
@@ -109,6 +119,10 @@ pub const Set = struct {
             terminal.StringMap.oni_search_retry_limit,
         );
 
+        // Overruns are counted for the whole scan so that the budget above
+        // bounds the total work, not the work at one start position.
+        var overruns_left: usize = scan_overrun_budget;
+
         // Go through each link and see if we have any matches.
         for (self.links) |*link| {
             if (!link.active(mouse_viewport, mouse_mods)) continue;
@@ -124,17 +138,18 @@ pub const Set = struct {
 
                     // We ran out of budget somewhere in the rest of the
                     // viewport, and Oniguruma doesn't tell us which start
-                    // position was expensive. Skip a single codepoint and
-                    // keep scanning so one pathological position doesn't
-                    // hide every link after it.
+                    // position was expensive. Skip the run of text we are
+                    // sitting on and keep scanning, so one pathological
+                    // position doesn't hide every link after it, but stop
+                    // once the scan has spent its overrun budget.
                     error.RetryLimitInMatchOver,
                     error.RetryLimitInSearchOver,
                     error.MatchStackLimitOver,
                     error.SubexpCallLimitInSearchOver,
                     => {
-                        offset += std.unicode.utf8ByteSequenceLength(
-                            str[offset],
-                        ) catch 1;
+                        if (overruns_left == 0) break;
+                        overruns_left -= 1;
+                        offset = skipRun(str, offset);
                         continue;
                     },
 
@@ -168,6 +183,31 @@ pub const Set = struct {
                 }
             }
         }
+    }
+
+    /// The offset just past the whitespace-delimited run of text at
+    /// `offset`, used to step over a search that blew its retry budget.
+    ///
+    /// A single codepoint would be enough to make progress, but the next
+    /// search then re-reads the same expensive text and spends a fresh
+    /// budget on it, once per byte, which is how a per-search budget
+    /// turns back into unbounded work. A whitespace-delimited run is the
+    /// smallest unit that gets us past the candidate we could not match,
+    /// and a search that overran found no match before it, so nothing
+    /// that would have been highlighted is lost except a match starting
+    /// inside that run. The default path patterns can match a single
+    /// space, so such a match is possible; giving it up on pathological
+    /// input is the price of the budget.
+    ///
+    /// Always advances by at least one byte when `offset < str.len`.
+    fn skipRun(str: []const u8, offset: usize) usize {
+        const whitespace = " \t\r\n";
+        var i: usize = offset;
+        while (i < str.len and
+            std.mem.indexOfScalar(u8, whitespace, str[i]) != null) i += 1;
+        while (i < str.len and
+            std.mem.indexOfScalar(u8, whitespace, str[i]) == null) i += 1;
+        return i;
     }
 };
 
@@ -271,19 +311,12 @@ test "renderCellMap bounds regex backtracking" {
     try testing.expect(result.contains(.{ .x = 0, .y = 0 }));
     try testing.expect(result.contains(.{ .x = 12, .y = 0 }));
 
-    // The pathological URL only highlights in part. Every search that
-    // starts on its scheme exhausts the retry budget, so those start
-    // positions are skipped and "https://" stays unhighlighted. The first
-    // position that does match is the host, which the regex's path branch
-    // matches linearly. Highlighting the whole thing would mean letting
-    // the regex run unbounded, so the lost scheme is the price of the
-    // budget.
-    const host = std.mem.indexOf(u8, pathological, "x.com").?;
-    for (0..host) |x| {
+    // The pathological URL is not highlighted at all. A budget overrun
+    // skips the whole whitespace-delimited run it happened on, because
+    // retrying it one codepoint at a time would spend a fresh budget on
+    // the same expensive text once per byte.
+    for (0..pathological.len) |x| {
         try testing.expect(!result.contains(.{ .x = @intCast(x), .y = 1 }));
-    }
-    for (host..pathological.len) |x| {
-        try testing.expect(result.contains(.{ .x = @intCast(x), .y = 1 }));
     }
 
     // The space between the two links belongs to neither.
@@ -292,8 +325,9 @@ test "renderCellMap bounds regex backtracking" {
         .y = 1,
     }));
 
-    // The link after it on the same row is still matched, because a budget
-    // overrun skips one position instead of abandoning the rest of the scan.
+    // The link after it on the same row is still matched, because an
+    // overrun skips the run it happened on instead of abandoning the rest
+    // of the scan.
     try testing.expect(result.contains(.{
         .x = pathological.len + 1,
         .y = 1,
@@ -301,6 +335,62 @@ test "renderCellMap bounds regex backtracking" {
     try testing.expect(result.contains(.{
         .x = row.len - 1,
         .y = 1,
+    }));
+}
+
+test "renderCellMap gives up after repeated regex budget overruns" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // Each of these rows costs a full retry budget to give up on. The
+    // budget is shared by the whole scan, so once enough rows have burned
+    // it the scan stops and the ordinary link on the last row is never
+    // reached. Without a shared budget the scan would keep paying a fresh
+    // budget for every row, which is how a viewport of this text turns a
+    // bounded search into unbounded work per frame.
+    const pathological = "https://x.com/" ++ ("." ** 40);
+    const rows = scan_overrun_budget + 1;
+
+    var t: terminal.Terminal = try .init(testing.io, alloc, .{
+        .cols = pathological.len,
+        .rows = @intCast(rows + 2),
+    });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    s.nextSlice("https://a.com\r\n");
+    for (0..rows) |_| s.nextSlice(pathological ++ "\r\n");
+    s.nextSlice("https://b.com");
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var set = try Set.fromConfig(alloc, &.{.{
+        .regex = @import("../config/url.zig").regex,
+        .action = .{ .open = {} },
+        .highlight = .{ .always = {} },
+    }});
+    defer set.deinit(alloc);
+
+    var result: terminal.RenderState.CellSet = .empty;
+    defer result.deinit(alloc);
+    try set.renderCellMap(
+        alloc,
+        &result,
+        &state,
+        null,
+        .{},
+    );
+
+    // The link before the pathological rows is matched.
+    try testing.expect(result.contains(.{ .x = 0, .y = 0 }));
+
+    // The link after them is not: the scan ran out of budget first.
+    try testing.expect(!result.contains(.{
+        .x = 0,
+        .y = @intCast(rows + 1),
     }));
 }
 

--- a/src/terminal/StringMap.zig
+++ b/src/terminal/StringMap.zig
@@ -11,11 +11,12 @@ const Selection = @import("Selection.zig");
 const Screen = @import("Screen.zig");
 const Allocator = std.mem.Allocator;
 
-// Retry budget for StringMap regex searches.
-//
-// Units are Oniguruma retry steps (internal backtracking/retry counter),
-// not bytes/characters/time.
-const oni_search_retry_limit = 100_000;
+/// Retry budget for regex searches over terminal contents. Shared with
+/// the renderer's link matcher so both paths bound the same work.
+///
+/// Units are Oniguruma retry steps (internal backtracking/retry counter),
+/// not bytes/characters/time.
+pub const oni_search_retry_limit = 100_000;
 
 string: [:0]const u8,
 

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -2202,6 +2202,20 @@ fn execCommand(
     /// blocks.
     utf8_console: configpkg.Config.Utf8Console,
 ) (Allocator.Error || error{SystemError})![]const [:0]const u8 {
+    // A direct command with no arguments has no program to execute and
+    // every consumer of the result indexes argv[0]. Nothing should hand
+    // us one, but we'd rather start a shell than spawn nothing.
+    if (command == .direct and command.direct.len == 0) {
+        log.warn("command has no arguments, falling back to basic shell", .{});
+
+        // The comptime here is important to ensure the full slice
+        // is put into the binary data and not the stack.
+        return comptime switch (builtin.os.tag) {
+            .windows => &.{"cmd.exe"},
+            else => &.{"/bin/sh"},
+        };
+    }
+
     // If we're on macOS, we have to use `login(1)` to get all of
     // the proper environment variables set, a login shell, and proper
     // hushlogin behavior.
@@ -3271,6 +3285,31 @@ test "execCommand darwin: direct command" {
     try testing.expectEqualStrings(result[2], "testuser");
     try testing.expectEqualStrings(result[3], "foo");
     try testing.expectEqualStrings(result[4], "bar baz");
+}
+
+test "execCommand: empty direct command" {
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const result = try execCommand(
+        alloc,
+        .{ .direct = &.{} },
+        struct {
+            fn get(_: Allocator) !PasswdEntry {
+                return .{ .name = "testuser" };
+            }
+        },
+        .auto,
+    );
+
+    // Never empty: argv[0] is always read by the caller.
+    try testing.expectEqual(1, result.len);
+    try testing.expectEqualStrings(
+        if (comptime builtin.os.tag == .windows) "cmd.exe" else "/bin/sh",
+        result[0],
+    );
 }
 
 test "execCommand: shell command, empty passwd" {


### PR DESCRIPTION
Sixteen small fixes from a read-only security audit of the core, each
re-verified against this branch before it was written. Most are ordinary
hardening: a truncated UTF-8 sequence in the config codepoint iterator, an
over-long config line silently ending the parse, `\r` and NEL treated as
unsafe paste data, `click-repeat-interval` and `window-width`/`window-height`
overflow clamps, a `font-size` clamp at finalize, `xdg-terminal-exec` with no
arguments, and a shared retry budget for the link scanner's regex.

Three things in here deserve a careful read.

## A use-after-free in chained keybinds

`Surface.maybeHandleBinding` walks a chain's action slice and performs each
action in turn. That slice is owned by the surface's derived config.
`reload_config` is a legal chain member and replaces exactly that config, so
`keybind = a=reload_config` followed by `keybind = chain=new_tab` had the loop
read the next action out of freed memory.

On the gtk apprt the whole path is synchronous, with no event loop in
between: `Application.reloadConfig` calls `App.updateConfig`, which calls
`Surface.updateConfig`, which calls `config.deinit()` while the loop is still
iterating.

The fix splits the predicate. `endsChain()` covers every action that can free
the keybind set, `closesSurface()` covers every action that can take the
surface pointer with it, and three consumers key off them: the surface's
chain loop, the app-wide chain loop, and the config parser.

`closesSurface()` now also lists `quit`, `close_all_windows`, `undo` and
`redo`. Note what that list is and is not. It is **not** a measurement that
some runtime frees the core surface inside `performAction` — no runtime in
this tree has been shown to do that. The embedded apprt hands the action to
the embedder and returns; gtk's `quit` destroys windows inline, but the core
surface is freed in GObject `finalize`, at last unref. Membership is a claim
about what an apprt is *allowed* to do, because the caller cannot check
afterwards and being wrong in the other direction is a use-after-free.

That is a visible change for a binding to one of those four: the key event is
reported as closing, so it is no longer encoded to the terminal or handed back
to the window system. `undo` and `redo` still answer the runtime, so a
`performable` binding that had nothing to undo still falls through.

## A closing binding used to leave its leader key queued

`maybeHandleBinding` answers `.closed` and returns before its own tail, and
that tail is where all four of its `endKeySequence` calls live.
`endKeySequence` is the only drain for `keyboard.sequence_queued` outside
`Surface.deinit`. So `keybind = ctrl+a>q=quit` left the leader key's encoded
write sitting in the queue.

That is not harmless bookkeeping for a surface about to die, because the
surface is not about to die. `performBindingAction` reports `true` for `quit`
unconditionally from its `else` arm, over an answer `App.performAction` has
already discarded with `_ =`; and the Windows host has no handler for `quit`
at all (`GHOSTTY_ACTION_QUIT` is ordinal 0, `GhosttyActionTag` starts at 2, so
it lands on `default: return 0`). The surface takes the `.closed` path and
stays alive holding a write that the next unrelated key sequence flushes into
the pty, out of order.

The fix drains the sequence before the chain runs, while `self` is certainly
still ours, in a new `endKeySequenceBeforeClose`.

**What that costs, in full.** The drain fires whenever a chain *contains* a
closing action, and whether a chain performs is not knowable until it has run
— by which time the surface may be gone. A chain that contains a closing
action but does not in fact close therefore goes on to reach a path that would
rather flush, and finds the queue already dropped. Three paths are defeated,
not one:

- `performable` with nothing performed.
- The non-consumed tail. `consumed` defaults true, so this needs the
  `unconsumed:` prefix, which is legal on a sequence — the parser rejects only
  `global`/`all` there. So `keybind = unconsumed:ctrl+a>u=undo` is legal;
  `undo` returns the apprt's own boolean and the Windows host answers false,
  so the chain does not close. Before, the queued `\x01` was flushed and the
  user saw `^A` then `u`. Now the leader keystroke is silently swallowed.
- The `end_key_sequence` binding action itself, whose whole stated purpose is
  to flush. It does not end a chain, so pairing it with a closing action in
  one chain is legal, and it then finds nothing left to flush.

No shipped default is a key sequence at all — every default goes through
`set.put`/`set.putFlags` with a single trigger — so none of this is reachable
without user config. Draining later would not help: the cost is in what the
drain does (`.drop`), not in when it runs. Keeping both behaviours means
detaching the queue before the chain and handing it back only if the surface
survived. That is a design change, it is not in this PR, and it is filed as a
follow-up.

Two smaller deltas from the same change: `.closed` now emits one
`.key_sequence = .end` where it previously emitted none, which makes it
consistent with every other exit; and a closing chain that does not close
emits two, because `endKeySequence` notifies before its own empty-queue early
return. The notification is idempotent everywhere it is handled, and the
Windows host does not handle it at all.

## Coverage, stated plainly

`endKeySequenceBeforeClose`'s body is pinned by two tests, verified by
mutation: neutering the drain fails
`Surface.test.endKeySequenceBeforeClose: a closing action drops the queued
sequence` by name, and the testing allocator reports the leak as well.

The **call site** in `maybeHandleBinding` is not pinned. Deleting that one
line leaves both tests green. `maybeHandleBinding` needs a live apprt, an IO
thread and a renderer, and that harness is not in this PR.

It is worse than untested, and this is the part worth knowing before trusting
a green run: **`zig build test -Dapp-runtime=none` does not semantically
analyse `maybeHandleBinding` at all.** `src/apprt.zig` selects the runtime by
artifact, not by the flag alone — `.lib` goes to `embedded` regardless — and
the unit-test binary is the `.exe` + `none` combination, which reaches nothing
that references that function. A `@compileError` probe guarded behind a
runtime condition stays silent there through a genuine recompile, while the
same probe fires from the exe/lib build. So the type-level evidence for the
changed line is

```
zig build -Dapp-runtime=none -Dtarget=x86_64-linux-gnu --summary all
-> Build Summary: 98/98 steps succeeded, exit 0
```

and not the test run. Both are green on this branch.

The same gap applies to the earlier `ignore` restoration in this PR:
reverting it at its real site leaves the suite green, and its four call-site
substitutions were verified by reading. The accessors they call are tested,
and those tests were checked by removing each fix and confirming the failure.

## `undo` and `redo` as chain parents are now a parse error

Because they end a chain, `keybind = a=undo` followed by
`keybind = chain=new_tab` is rejected. This is config-visible, so:

- One line is rejected, not the file. The continuation line gets a
  diagnostic and the loader keeps going; the parent line still binds and
  still works.
- `undo` and `redo` remain legal as the last member of a chain, which is the
  useful direction.
- Nothing in the tree binds them that way. The three shipped defaults go
  through a path that never builds a chain.

The same rule already applied to `reload_config`, `quit` and
`close_all_windows`.

Related, and not fixed here: `keybind = a=ignore` chained with one of the four
newly-closing actions now answers `.closed` rather than `.ignored`. That shape
already answered `.closed` before this branch's key-sequence commit; undoing
it means reversing the `closesSurface()` widening above.

## What this costs on Windows

Nothing for the chain guards, and that is why the parse error is cheap here.
Every action arm in the Windows host goes through `_dispatcher.TryEnqueue`, so
the work happens on a later UI-thread turn and never re-enters the core from
inside an action callback. `Quit`, `Undo`, `Redo` and `MoveTabToNewWindow`
have no arm at all, so they are simply unhandled.

So on this fork's own runtime the chain-guard family is defence in depth
against something that cannot fire. On gtk it is a real synchronous
use-after-free, and the code is shared, which is why the fix belongs in the
core rather than in an apprt. The key-sequence drain is the exception: it
fires on this fork's own runtime, precisely *because* the Windows host does
not implement `quit`.

## For whoever rebases this

Measured with `git merge-tree --write-tree` (git 2.49.0), against the sibling
audit branches:

| Pair | Result |
| --- | --- |
| 1015 x 1023 (`fix/audit-datastruct`) | tree `dd084b5688`, exit 0, **clean** |
| 1015 x 1026 (`fix/audit-openurl`) | tree `ba9dfc2f24`, exit 0, **clean** |
| 1015 x 1040 (`fix/audit-openurl2`) | exit 1, **CONFLICT in `src/Surface.zig`** |

The conflict is **1040, not 1023**. Both branches append their test blocks
immediately after `pub fn getProcessInfo`, the same anchor line.

It is one block, and git has split it mid-test on both sides. "Ours" ends on

```zig
    try testing.expectEqual(
        @as(u64, 5000 * std.time.ns_per_ms),
        derived.mouse_interval,
```

"theirs" ends on

```zig
    try testing.expectEqualStrings(
        "C:\\Users\\me\\notes.md",
        urlForLinkPath(.{ .resolved = "C:\\Users\\me\\notes.md" }, "notes.md").?,
```

and there is a **single shared trailing `    );` / `}`** below the marker.
So:

- Deleting the markers and concatenating both sides does **not** compile —
  one `expectEqual` is left unterminated. That failure is loud and safe.
- **Picking either side compiles green and silently deletes the other PR's
  tests.** Both sides are self-contained helpers plus `test` blocks, so
  dropping one leaves a building tree with no diagnostic. That is the
  dangerous resolution, and it is the one a hurried rebase takes.

**Correct resolution: keep both sides in full and duplicate the trailing
`    );` and `}`** — once to close `derived.mouse_interval,` and once to close
the `urlForLinkPath(...)` argument list. Then verify by name that all six
survived:

- `endKeySequenceBeforeClose: a closing action drops the queued sequence`
- `endKeySequenceBeforeClose: an ordinary action leaves the sequence alone`
- `DerivedConfig: a long click-repeat-interval does not overflow` (this one is
  on the ours side too, from the earlier `click-repeat-interval` commit — it
  is collateral if the side is dropped)
- 1040's `a link resolution that leaves the working directory's host is
  refused`, `a link resolution with nothing to resolve against`, and
  `a refused link resolution opens nothing`

Two more notes for the rebase: `src/apprt/none.zig` is new in this branch's
footprint and the cross-stack overlap table does not list it; and that table
was computed against `origin/windows = 26104ad291`, which has since moved to
`255f3c0a81`. This branch's merge base with 1040 is `218b8243db`.
