### PR TITLE
terminal: bound OSC 66 capture, fix colour reply overflow, gate tmux control mode

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2542,6 +2542,27 @@ keybind: Keybinds = .{},
 /// Available since: 1.0.1
 @"title-report": bool = false,
 
+/// Allow a program running in the terminal to put it into tmux control mode
+/// (DCS 1000 p). In control mode Ghostty drives the tmux session directly:
+/// it renders the panes tmux describes rather than the raw output, and it
+/// writes tmux commands (`list-windows`, `display-message`) back into the
+/// pty on its own initiative.
+///
+/// This is disabled by default because nothing about the escape sequence
+/// identifies the sender as tmux. Any program that writes it, including one
+/// that is only echoing untrusted text, gets the terminal to start issuing
+/// commands to whatever is actually on the other end of the pty.
+///
+/// When disabled the sequence is ignored and the program sees a terminal
+/// that never entered control mode.
+///
+/// This can be changed at runtime and applies to sequences received after
+/// the change. A session already in control mode stays there until it
+/// leaves on its own.
+///
+/// Available since: 1.4.0
+@"tmux-control-mode": bool = false,
+
 /// The total amount of bytes that can be used for image data (e.g. the Kitty
 /// image protocol) per terminal screen. The maximum value is 4,294,967,295
 /// (4GiB). The default is 320MB. If this is set to zero, then all image

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2553,8 +2553,13 @@ keybind: Keybinds = .{},
 /// that is only echoing untrusted text, gets the terminal to start issuing
 /// commands to whatever is actually on the other end of the pty.
 ///
-/// When disabled the sequence is ignored and the program sees a terminal
-/// that never entered control mode.
+/// When disabled, no viewer is ever created and no tmux command is ever
+/// written into the pty, so the program sees a terminal that never entered
+/// control mode. This option only gates that outcome, though: the DCS
+/// sequence is still hooked, and its body is still parsed line by line into
+/// an internal buffer (capped at 1MB) as it arrives, regardless of the
+/// setting. With the option off, those parsed notifications are simply
+/// dropped instead of acted on.
 ///
 /// This can be changed at runtime and applies to sequences received after
 /// the change. A session already in control mode stays there until it

--- a/src/terminal/osc.zig
+++ b/src/terminal/osc.zig
@@ -875,6 +875,9 @@ pub const Parser = struct {
     ) void {
         assert(self.capture == null);
         switch (mode) {
+            // max_bytes doesn't apply here: the fixed buffer is already the
+            // bound (self.buffer's own size), and there is no allocator to
+            // enforce a smaller one against.
             .fixed => Capture.fixed(
                 &self.capture,
                 &self.buffer,

--- a/src/terminal/osc.zig
+++ b/src/terminal/osc.zig
@@ -861,6 +861,18 @@ pub const Parser = struct {
         self: *Parser,
         comptime mode: Capture.Mode,
     ) void {
+        self.captureTrailingMax(mode, self.max_allocating_bytes);
+    }
+
+    /// `captureTrailing` for a key whose own payload limit is below the
+    /// parser's general ceiling. The capture is bounded by whichever of
+    /// the two budgets is smaller, so a payload the key is going to
+    /// reject for its length is never buffered in full first.
+    inline fn captureTrailingMax(
+        self: *Parser,
+        comptime mode: Capture.Mode,
+        max_bytes: usize,
+    ) void {
         assert(self.capture == null);
         switch (mode) {
             .fixed => Capture.fixed(
@@ -872,7 +884,7 @@ pub const Parser = struct {
                 const alloc = self.alloc orelse {
                     // We don't have an allocator - fall back to a fixed buffer and hope
                     // that it's big enough.
-                    self.captureTrailing(.fixed);
+                    self.captureTrailingMax(.fixed, max_bytes);
                     return;
                 };
 
@@ -880,7 +892,7 @@ pub const Parser = struct {
                     &self.capture,
                     alloc,
                     &self.buffer,
-                    self.max_allocating_bytes,
+                    @min(self.max_allocating_bytes, max_bytes),
                 );
             },
         }
@@ -1069,10 +1081,20 @@ pub const Parser = struct {
                 else => self.state = .invalid,
             },
 
-            .@"52",
-            .@"66",
-            => switch (c) {
+            .@"52" => switch (c) {
                 ';' => self.captureTrailing(.allocating),
+                else => self.state = .invalid,
+            },
+
+            // OSC 66 has a payload limit of its own that is well under the
+            // general ceiling, so cap the capture there. Checking it only
+            // once the sequence ended meant a payload that was always
+            // going to be rejected still got buffered in full.
+            .@"66" => switch (c) {
+                ';' => self.captureTrailingMax(
+                    .allocating,
+                    parsers.kitty_text_sizing.max_capture_length,
+                ),
                 else => self.state = .invalid,
             },
 

--- a/src/terminal/osc/parsers/kitty_text_sizing.zig
+++ b/src/terminal/osc/parsers/kitty_text_sizing.zig
@@ -17,9 +17,11 @@ pub const max_payload_length = 4096;
 /// Upper bound on what an OSC 66 capture is allowed to retain: the payload
 /// limit, the parameter section that precedes it, and the NUL `parse`
 /// appends. The parameters are six single-character keys with small numeric
-/// values, so the allowance for them is generous. Bounding the capture is
-/// what keeps a payload that will be rejected for its length from being
-/// buffered in full first.
+/// values, so the ~512-byte allowance for them is generous by design: it is
+/// a deliberate tradeoff of a round, roomy constant over the much tighter
+/// bound the six keys could actually require. Bounding the capture is what
+/// keeps a payload that will be rejected for its length from being buffered
+/// in full first.
 pub const max_capture_length = max_payload_length + 512;
 
 pub const VAlign = lib.Enum(lib.target, &.{

--- a/src/terminal/osc/parsers/kitty_text_sizing.zig
+++ b/src/terminal/osc/parsers/kitty_text_sizing.zig
@@ -14,6 +14,14 @@ const log = std.log.scoped(.kitty_text_sizing);
 
 pub const max_payload_length = 4096;
 
+/// Upper bound on what an OSC 66 capture is allowed to retain: the payload
+/// limit, the parameter section that precedes it, and the NUL `parse`
+/// appends. The parameters are six single-character keys with small numeric
+/// values, so the allowance for them is generous. Bounding the capture is
+/// what keeps a payload that will be rejected for its length from being
+/// buffered in full first.
+pub const max_capture_length = max_payload_length + 512;
+
 pub const VAlign = lib.Enum(lib.target, &.{
     "top",
     "bottom",
@@ -252,4 +260,37 @@ test "OSC 66: overlong UTF-8" {
     for (input) |ch| p.next(ch);
 
     try testing.expect(p.end('\x1b') == null);
+}
+
+test "OSC 66: an overlong payload is bounded while it is captured" {
+    const testing = std.testing;
+
+    var p: Parser = .init(testing.allocator);
+    defer p.deinit();
+
+    // Far past the payload limit, so a capture that only checks the limit
+    // once the sequence has ended holds all of it in the meantime.
+    for ("66;;") |ch| p.next(ch);
+    for (0..1024 * 1024) |_| p.next('a');
+
+    try testing.expect(p.end('\x1b') == null);
+
+    const cap = &p.capture.?;
+    try testing.expect(cap.trailing().len <= max_capture_length);
+    try testing.expect(cap.writer.buffer.len <= max_capture_length);
+}
+
+test "OSC 66: a payload at the limit still parses" {
+    const testing = std.testing;
+
+    var p: Parser = .init(testing.allocator);
+    defer p.deinit();
+
+    for ("66;s=2;") |ch| p.next(ch);
+    for (0..max_payload_length) |_| p.next('a');
+
+    const cmd = p.end('\x1b').?.*;
+    try testing.expect(cmd == .kitty_text_sizing);
+    try testing.expectEqual(2, cmd.kitty_text_sizing.scale);
+    try testing.expectEqual(max_payload_length, cmd.kitty_text_sizing.text.len);
 }

--- a/src/terminal/tmux/layout.zig
+++ b/src/terminal/tmux/layout.zig
@@ -2,6 +2,14 @@ const std = @import("std");
 const testing = std.testing;
 const Allocator = std.mem.Allocator;
 const ArenaAllocator = std.heap.ArenaAllocator;
+const size = @import("../size.zig");
+
+/// The largest width or height a node may claim. Every pane becomes a
+/// terminal of the node's size, and a terminal addresses its cells with
+/// `size.CellCountInt`, so anything outside this range has no terminal
+/// that could represent it. Real tmux never sends one, but the layout
+/// string arrives over the pty like any other untrusted input.
+const max_dimension = std.math.maxInt(size.CellCountInt);
 
 /// A tmux layout.
 ///
@@ -116,6 +124,11 @@ pub const Layout = struct {
                 10,
             ) catch return error.SyntaxError;
         } else return error.SyntaxError;
+
+        // Reject dimensions no terminal could be built for before we go
+        // any further, so the pane setup that follows can cast them.
+        if (width < 1 or width > max_dimension) return error.SyntaxError;
+        if (height < 1 or height > max_dimension) return error.SyntaxError;
 
         // Find X
         const x: usize = if (std.mem.indexOfScalar(
@@ -635,4 +648,36 @@ test "checksum known tmux layout bb62" {
     // The checksum "bb62" corresponds to the layout "159x48,0,0{79x48,0,0,79x48,80,0}"
     const checksum = Checksum.calculate("159x48,0,0{79x48,0,0,79x48,80,0}");
     try testing.expectEqualStrings("bb62", &checksum.asString());
+}
+
+test "syntax error zero dimensions" {
+    var arena: ArenaAllocator = .init(testing.allocator);
+    defer arena.deinit();
+
+    try testing.expectError(error.SyntaxError, Layout.parse(arena.allocator(), "0x0,0,0,1"));
+    try testing.expectError(error.SyntaxError, Layout.parse(arena.allocator(), "80x0,0,0,1"));
+    try testing.expectError(error.SyntaxError, Layout.parse(arena.allocator(), "0x24,0,0,1"));
+}
+
+test "syntax error dimensions beyond a terminal" {
+    var arena: ArenaAllocator = .init(testing.allocator);
+    defer arena.deinit();
+
+    try testing.expectError(error.SyntaxError, Layout.parse(arena.allocator(), "65536x24,0,0,1"));
+    try testing.expectError(error.SyntaxError, Layout.parse(arena.allocator(), "80x65536,0,0,1"));
+
+    // The largest a terminal can represent is still accepted.
+    const layout: Layout = try .parse(arena.allocator(), "65535x65535,0,0,1");
+    try testing.expectEqual(@as(usize, 65535), layout.width);
+    try testing.expectEqual(@as(usize, 65535), layout.height);
+}
+
+test "syntax error child with zero dimensions" {
+    var arena: ArenaAllocator = .init(testing.allocator);
+    defer arena.deinit();
+
+    try testing.expectError(error.SyntaxError, Layout.parse(
+        arena.allocator(),
+        "80x24,0,0{0x24,0,0,1,40x24,40,0,2}",
+    ));
 }

--- a/src/terminal/tmux/viewer.zig
+++ b/src/terminal/tmux/viewer.zig
@@ -1153,9 +1153,9 @@ pub const Viewer = struct {
                     break :pane;
                 }
 
-                // TODO: We need to gracefully handle overflow of our
-                // max cols/width here. In practice we shouldn't hit this
-                // so we cast but its not safe.
+                // Layout parsing rejects any node whose width or height
+                // a terminal could not represent, so this cast can't
+                // overflow on anything that got this far.
                 var t: Terminal = try .init(io, gpa_alloc, .{
                     .cols = @intCast(layout.width),
                     .rows = @intCast(layout.height),

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -220,6 +220,7 @@ pub const DerivedConfig = struct {
     osc_color_report_format: configpkg.Config.OSCColorReportFormat,
     clipboard_write: configpkg.ClipboardAccess,
     clipboard_write_limit: usize,
+    tmux_control_mode: bool,
     enquiry_response: []const u8,
     conditional_state: configpkg.ConditionalState,
 
@@ -257,6 +258,7 @@ pub const DerivedConfig = struct {
             .osc_color_report_format = config.@"osc-color-report-format",
             .clipboard_write = config.@"clipboard-write",
             .clipboard_write_limit = config.@"clipboard-write-limit-bytes".value,
+            .tmux_control_mode = config.@"tmux-control-mode",
             .enquiry_response = try alloc.dupe(u8, config.@"enquiry-response"),
             .conditional_state = config._conditional_state,
 
@@ -371,6 +373,7 @@ pub fn init(self: *Termio, alloc: Allocator, opts: termio.Options) !void {
         .osc_color_report_format = opts.config.osc_color_report_format,
         .clipboard_write = opts.config.clipboard_write,
         .clipboard_write_limit = opts.config.clipboard_write_limit,
+        .tmux_control_mode = opts.config.tmux_control_mode,
         .enquiry_response = opts.config.enquiry_response,
     };
 

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -556,8 +556,11 @@ pub const StreamHandler = struct {
                 assert(tmux != .exit);
 
                 const viewer = self.tmux_viewer orelse {
-                    // This can only really happen if we failed to
-                    // initialize the viewer on enter.
+                    // Normal when tmux-control-mode is configured off: dcs.zig
+                    // hooks and parses the tmux DCS stream unconditionally, so
+                    // notifications keep arriving even though .enter above
+                    // never created a viewer for them to land on. Can also
+                    // happen if viewer creation itself failed.
                     log.info(
                         "received tmux control mode command without viewer: {f}",
                         .{tmux},

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -19,6 +19,65 @@ const posix = std.posix;
 const log = std.log.scoped(.io_handler);
 const log_validate = std.log.scoped(.validate_transport);
 
+/// How much of a reply a single OSC color sequence may produce.
+///
+/// The reply used to be formatted into a 1 KiB fixed buffer, and the first
+/// answer that did not fit returned an error out of `colorOperation`, so the
+/// program got no reply at all -- after any sets in the same sequence had
+/// already been applied, leaving its idea of the palette wrong with nothing
+/// to tell it so. Asking for the whole 256 entry palette is an ordinary thing
+/// to do and produces a little over 7 KiB in the widest report format, so
+/// that was reached by accident rather than by attack.
+///
+/// The reply is grown on demand now, and this is the ceiling on it. It is not
+/// what fixes the above, and it is not a fix for anything the pty can do: the
+/// parser caps an OSC 4 payload at `terminal.osc.Parser.MAX_BUF` bytes in a
+/// capture that cannot move to the heap, and the cheapest repeating query is
+/// four bytes for 26 of answer, so the largest reply the pty can provoke is
+/// about 13 KiB and this sits nearly five times above it. It is cheap defense
+/// in depth against a future caller that is not the parser.
+const color_report_limit = 64 * 1024;
+
+/// The formats one answer to a color query is built with. Named so that the
+/// stack buffer they are formatted into can be sized against them by the
+/// compiler rather than by an argument in a comment.
+const color_report_fmt = struct {
+    const palette_16 = "\x1b]4;{d};rgb:{x:0>4}/{x:0>4}/{x:0>4}";
+    const dynamic_16 = "\x1b]{d};rgb:{x:0>4}/{x:0>4}/{x:0>4}";
+    const palette_8 = "\x1b]4;{d};rgb:{x:0>2}/{x:0>2}/{x:0>2}";
+    const dynamic_8 = "\x1b]{d};rgb:{x:0>2}/{x:0>2}/{x:0>2}";
+
+    /// The longest answer any of them can produce, terminator included. A
+    /// palette index is a `u8`; a `Dynamic` tag only reaches 19, but it is
+    /// measured as a `u8` as well so that the widest arguments are one pair
+    /// rather than four, which can only over-estimate. ST is the longer of
+    /// the two terminators.
+    const max_len = max: {
+        const wide_16 = .{ @as(u8, 255), @as(u16, 0xffff), @as(u16, 0xffff), @as(u16, 0xffff) };
+        const wide_8 = .{ @as(u8, 255), @as(u16, 0xff), @as(u16, 0xff), @as(u16, 0xff) };
+        break :max @max(
+            std.fmt.comptimePrint(palette_16, wide_16).len,
+            std.fmt.comptimePrint(dynamic_16, wide_16).len,
+            std.fmt.comptimePrint(palette_8, wide_8).len,
+            std.fmt.comptimePrint(dynamic_8, wide_8).len,
+        ) + terminal.osc.Terminator.st.string().len;
+    };
+};
+
+/// Size of the stack buffer one answer to a color query is formatted into.
+const color_answer_buf_len = 64;
+
+// An answer that did not fit its buffer would return `error.WriteFailed` out
+// of `colorOperation` and drop the whole reply after the sequence's sets had
+// already landed -- the exact defect the reply bound exists to prevent, but
+// reached through a buffer size instead of an allocator. So widening a report
+// format past the buffer is a build failure rather than a silent regression.
+comptime {
+    if (color_report_fmt.max_len > color_answer_buf_len) @compileError(
+        "a color report format outgrew color_answer_buf_len",
+    );
+}
+
 /// This is used as the handler for the terminal.Stream type. This is
 /// stateful and is expected to live for the entire lifetime of the terminal.
 /// It is NOT VALID to stop a stream handler, create a new one, and use that
@@ -1938,13 +1997,16 @@ pub const StreamHandler = struct {
         // return early if there is nothing to do
         if (requests.count() == 0) return;
 
-        // One OSC can carry an unbounded number of queries, and each one
-        // adds around thirty bytes of reply. A fixed reply buffer meant a
-        // long enough burst of queries failed the whole sequence partway
-        // through: no reply at all, after any sets in the same OSC had
-        // already been applied.
+        // One OSC can carry a few hundred queries, and each one adds around
+        // thirty bytes of reply. A fixed reply buffer meant an ordinary
+        // full palette query failed the whole sequence partway through: no
+        // reply at all, after any sets in the same OSC had already been
+        // applied. The reply grows on demand instead, up to
+        // `color_report_limit`; past that we stop answering rather than
+        // keep buffering whatever the caller asks us to.
         var response: std.Io.Writer.Allocating = .init(self.alloc);
         defer response.deinit();
+        var refused_queries: usize = 0;
 
         var it = requests.constIterator(0);
         while (it.next()) |req| {
@@ -2067,6 +2129,15 @@ pub const StreamHandler = struct {
 
                     if (self.osc_color_report_format == .none) break :report;
 
+                    // Once the reply is full we stop for the rest of the
+                    // sequence rather than squeezing in a later, shorter
+                    // answer, so what a program gets back is always a prefix
+                    // of what it asked for and never has a hole in it.
+                    if (refused_queries > 0) {
+                        refused_queries += 1;
+                        break :report;
+                    }
+
                     const color = switch (kind) {
                         .palette => |i| self.terminal.colors.palette.current[i],
                         .dynamic => |dynamic| switch (dynamic) {
@@ -2095,10 +2166,17 @@ pub const StreamHandler = struct {
                         },
                     };
 
+                    // Each answer is built on its own so the shared reply
+                    // only ever grows by a whole one. The buffer is sized
+                    // against the formats below at compile time, so these
+                    // prints cannot fail.
+                    var answer_buf: [color_answer_buf_len]u8 = undefined;
+                    var answer: std.Io.Writer = .fixed(&answer_buf);
+
                     switch (self.osc_color_report_format) {
                         .@"16-bit" => switch (kind) {
-                            .palette => |i| try response.writer.print(
-                                "\x1b]4;{d};rgb:{x:0>4}/{x:0>4}/{x:0>4}",
+                            .palette => |i| try answer.print(
+                                color_report_fmt.palette_16,
                                 .{
                                     i,
                                     @as(u16, color.r) * 257,
@@ -2106,8 +2184,8 @@ pub const StreamHandler = struct {
                                     @as(u16, color.b) * 257,
                                 },
                             ),
-                            .dynamic => |dynamic| try response.writer.print(
-                                "\x1b]{d};rgb:{x:0>4}/{x:0>4}/{x:0>4}",
+                            .dynamic => |dynamic| try answer.print(
+                                color_report_fmt.dynamic_16,
                                 .{
                                     @intFromEnum(dynamic),
                                     @as(u16, color.r) * 257,
@@ -2119,8 +2197,8 @@ pub const StreamHandler = struct {
                         },
 
                         .@"8-bit" => switch (kind) {
-                            .palette => |i| try response.writer.print(
-                                "\x1b]4;{d};rgb:{x:0>2}/{x:0>2}/{x:0>2}",
+                            .palette => |i| try answer.print(
+                                color_report_fmt.palette_8,
                                 .{
                                     i,
                                     @as(u16, color.r),
@@ -2128,8 +2206,8 @@ pub const StreamHandler = struct {
                                     @as(u16, color.b),
                                 },
                             ),
-                            .dynamic => |dynamic| try response.writer.print(
-                                "\x1b]{d};rgb:{x:0>2}/{x:0>2}/{x:0>2}",
+                            .dynamic => |dynamic| try answer.print(
+                                color_report_fmt.dynamic_8,
                                 .{
                                     @intFromEnum(dynamic),
                                     @as(u16, color.r),
@@ -2143,10 +2221,28 @@ pub const StreamHandler = struct {
                         .none => unreachable,
                     }
 
-                    try response.writer.writeAll(terminator.string());
+                    try answer.writeAll(terminator.string());
+
+                    // Checked before the write, so the reply is never
+                    // allocated past the limit in the first place, and cut
+                    // between answers rather than inside one: a half written
+                    // OSC is worse for the program than a missing one. Sets
+                    // and resets later in the same sequence still apply.
+                    const reply = answer.buffered();
+                    if (response.writer.end + reply.len > color_report_limit) {
+                        refused_queries += 1;
+                        break :report;
+                    }
+
+                    try response.writer.writeAll(reply);
                 },
             }
         }
+
+        if (refused_queries > 0) log.warn(
+            "color report hit the {d} byte limit, {d} queries unanswered",
+            .{ color_report_limit, refused_queries },
+        );
 
         if (response.writer.end > 0) {
             // If any of the operations were reports, finalize the report
@@ -2812,6 +2908,134 @@ test "color operation: every query in one OSC is answered" {
             @as(usize, count),
             std.mem.count(u8, v.data, "\x1b]4;"),
         ),
+        else => try testing.expect(false),
+    }
+}
+
+test "color operation: a full palette query is answered in full" {
+    const testing = std.testing;
+
+    var mailbox = try termio.Mailbox.initSPSC(testing.allocator);
+    defer mailbox.deinit(testing.allocator);
+
+    var mutex: std.Io.Mutex = .init;
+    mutex.lockUncancelable(global.io());
+    defer mutex.unlock(global.io());
+
+    var term = try terminal.Terminal.init(global.io(), testing.allocator, .{
+        .cols = 80,
+        .rows = 24,
+    });
+    defer term.deinit(testing.allocator);
+
+    var renderer_state: renderer.State = .{
+        .mutex = &mutex,
+        .terminal = &term,
+    };
+
+    // Empty, so nothing is refused for a reason this test is not about.
+    var write_limit: termio.WriteLimit = .{};
+
+    var handler: StreamHandler = undefined;
+    handler.alloc = testing.allocator;
+    handler.terminal = &term;
+    handler.termio_mailbox = &mailbox;
+    handler.write_limit = &write_limit;
+    handler.renderer_state = &renderer_state;
+    handler.osc_color_report_format = .@"16-bit";
+
+    // The whole palette in one sequence, in the widest report format, is the
+    // largest reply a program has any reason to ask for.
+    var requests: terminal.osc.color.List = .{};
+    defer requests.deinit(testing.allocator);
+    for (0..256) |i| try requests.append(testing.allocator, .{
+        .query = .{ .palette = @intCast(i) },
+    });
+
+    try handler.colorOperation(.osc_4, &requests, .st);
+
+    const response = mailbox.spsc.queue.pop(global.io());
+    try testing.expect(response != null);
+    const msg = response.?;
+    defer msg.deinit();
+    switch (msg) {
+        .write_alloc => |v| {
+            try testing.expectEqual(
+                @as(usize, 256),
+                std.mem.count(u8, v.data, "\x1b]4;"),
+            );
+            try testing.expect(std.mem.startsWith(u8, v.data, "\x1b]4;0;rgb:"));
+            try testing.expect(std.mem.indexOf(u8, v.data, "\x1b]4;255;rgb:") != null);
+
+            // The bound has to sit well clear of this, not just above it.
+            try testing.expect(v.data.len * 4 < color_report_limit);
+        },
+        else => try testing.expect(false),
+    }
+}
+
+test "color operation: the reply to one OSC is bounded" {
+    const testing = std.testing;
+
+    var mailbox = try termio.Mailbox.initSPSC(testing.allocator);
+    defer mailbox.deinit(testing.allocator);
+
+    var mutex: std.Io.Mutex = .init;
+    mutex.lockUncancelable(global.io());
+    defer mutex.unlock(global.io());
+
+    var term = try terminal.Terminal.init(global.io(), testing.allocator, .{
+        .cols = 80,
+        .rows = 24,
+    });
+    defer term.deinit(testing.allocator);
+
+    var renderer_state: renderer.State = .{
+        .mutex = &mutex,
+        .terminal = &term,
+    };
+
+    // Empty, so the reply is cut by `color_report_limit` and not by the pty
+    // write backlog. The two bounds are independent and this test is the
+    // first one's.
+    var write_limit: termio.WriteLimit = .{};
+
+    var handler: StreamHandler = undefined;
+    handler.alloc = testing.allocator;
+    handler.terminal = &term;
+    handler.termio_mailbox = &mailbox;
+    handler.write_limit = &write_limit;
+    handler.renderer_state = &renderer_state;
+    handler.osc_color_report_format = .@"16-bit";
+
+    // Far more queries than there are colours to ask about, which is what a
+    // sequence built to make us allocate looks like: without a bound the
+    // reply is proportional to the query count.
+    const count = 20000;
+    var requests: terminal.osc.color.List = .{};
+    defer requests.deinit(testing.allocator);
+    for (0..count) |i| try requests.append(testing.allocator, .{
+        .query = .{ .palette = @intCast(i % 256) },
+    });
+
+    try handler.colorOperation(.osc_4, &requests, .st);
+
+    const response = mailbox.spsc.queue.pop(global.io());
+    try testing.expect(response != null);
+    const msg = response.?;
+    defer msg.deinit();
+    switch (msg) {
+        .write_alloc => |v| {
+            try testing.expect(v.data.len <= color_report_limit);
+
+            // Cutting the reply between answers rather than inside one means
+            // every answer the program does get is still parseable.
+            try testing.expect(std.mem.endsWith(u8, v.data, "\x1b\\"));
+            try testing.expectEqual(
+                std.mem.count(u8, v.data, "\x1b]4;"),
+                std.mem.count(u8, v.data, "\x1b\\"),
+            );
+        },
         else => try testing.expect(false),
     }
 }

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -74,6 +74,10 @@ pub const StreamHandler = struct {
     /// (OSC 5522) write transaction; exceeding it aborts with EFBIG.
     clipboard_write_limit: usize,
 
+    /// Whether a program running in the terminal is allowed to put it
+    /// into tmux control mode.
+    tmux_control_mode: bool,
+
     //---------------------------------------------------------------
     // Internal state
 
@@ -173,6 +177,7 @@ pub const StreamHandler = struct {
         self.osc_color_report_format = config.osc_color_report_format;
         self.clipboard_write = config.clipboard_write;
         self.clipboard_write_limit = config.clipboard_write_limit;
+        self.tmux_control_mode = config.tmux_control_mode;
         self.enquiry_response = config.enquiry_response;
         self.terminal.setDefaultCursorStyle(config.cursor_style);
         self.terminal.setDefaultCursorBlink(config.cursor_blink);
@@ -509,6 +514,18 @@ pub const StreamHandler = struct {
 
                 switch (tmux) {
                     .enter => {
+                        // Control mode hands the session over to us: we
+                        // start writing tmux commands into the pty on our
+                        // own initiative. Nothing in the sequence proves
+                        // tmux sent it, so it stays off until asked for.
+                        if (!self.tmux_control_mode) {
+                            log.info(
+                                "tmux control mode is disabled by configuration, ignoring",
+                                .{},
+                            );
+                            break :tmux;
+                        }
+
                         // Setup our viewer state
                         assert(self.tmux_viewer == null);
                         const viewer = try self.alloc.create(terminal.tmux.Viewer);
@@ -2408,6 +2425,10 @@ test "tmux control mode commands survive a full pty write backlog" {
     handler.renderer_state = &renderer_state;
     handler.termio_messaged = false;
     handler.tmux_viewer = null;
+    // Control mode is opt-in now, and this test's subject is the write
+    // backlog, not the gate: it asks what happens to a command inside a
+    // session the user did ask for. The gate has its own test below.
+    handler.tmux_control_mode = true;
     defer if (handler.tmux_viewer) |viewer| {
         viewer.deinit();
         testing.allocator.destroy(viewer);
@@ -2790,4 +2811,28 @@ test "color operation: every query in one OSC is answered" {
         ),
         else => try testing.expect(false),
     }
+}
+
+test "tmux control mode: a program cannot enter it unless configured" {
+    if (comptime !StreamHandler.tmux_enabled) return error.SkipZigTest;
+
+    const testing = std.testing;
+
+    var handler: StreamHandler = undefined;
+    handler.alloc = testing.allocator;
+    handler.tmux_viewer = null;
+    handler.tmux_control_mode = false;
+
+    var enter: terminal.dcs.Command = .{ .tmux = .enter };
+    try handler.dcsCommand(&enter);
+    try testing.expect(handler.tmux_viewer == null);
+
+    // With the option on, the existing behaviour is unchanged.
+    handler.tmux_control_mode = true;
+    try handler.dcsCommand(&enter);
+    try testing.expect(handler.tmux_viewer != null);
+
+    var exit: terminal.dcs.Command = .{ .tmux = .exit };
+    try handler.dcsCommand(&exit);
+    try testing.expect(handler.tmux_viewer == null);
 }

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -1918,11 +1918,13 @@ pub const StreamHandler = struct {
         // return early if there is nothing to do
         if (requests.count() == 0) return;
 
-        var buffer: [1024]u8 = undefined;
-        var fba: std.heap.FixedBufferAllocator = .init(&buffer);
-        const alloc = fba.allocator();
-
-        var response: std.Io.Writer.Allocating = .init(alloc);
+        // One OSC can carry an unbounded number of queries, and each one
+        // adds around thirty bytes of reply. A fixed reply buffer meant a
+        // long enough burst of queries failed the whole sequence partway
+        // through: no reply at all, after any sets in the same OSC had
+        // already been applied.
+        var response: std.Io.Writer.Allocating = .init(self.alloc);
+        defer response.deinit();
 
         var it = requests.constIterator(0);
         while (it.next()) |req| {
@@ -2728,4 +2730,64 @@ test "stream handler refuses and frees an owned write at the backlog cap" {
 
     handler.messageWriter(msg);
     try testing.expect(mailbox.spsc.queue.pop(global.io()) == null);
+}
+
+test "color operation: every query in one OSC is answered" {
+    const testing = std.testing;
+
+    var mailbox = try termio.Mailbox.initSPSC(testing.allocator);
+    defer mailbox.deinit(testing.allocator);
+
+    var mutex: std.Io.Mutex = .init;
+    mutex.lockUncancelable(global.io());
+    defer mutex.unlock(global.io());
+
+    var term = try terminal.Terminal.init(global.io(), testing.allocator, .{
+        .cols = 80,
+        .rows = 24,
+    });
+    defer term.deinit(testing.allocator);
+
+    var renderer_state: renderer.State = .{
+        .mutex = &mutex,
+        .terminal = &term,
+    };
+
+    // A colour reply is advisory, so it goes out on the droppable path and
+    // `messageWriter` weighs it against the pty write backlog. An empty
+    // limit is the state this test is about: nothing outstanding, so the
+    // question is whether every query is answered, not whether a full
+    // backlog refuses them.
+    var write_limit: termio.WriteLimit = .{};
+
+    var handler: StreamHandler = undefined;
+    handler.alloc = testing.allocator;
+    handler.terminal = &term;
+    handler.termio_mailbox = &mailbox;
+    handler.write_limit = &write_limit;
+    handler.renderer_state = &renderer_state;
+    handler.osc_color_report_format = .@"16-bit";
+
+    // Enough replies to overflow any fixed reply buffer. A program can
+    // legitimately query the whole palette in one sequence.
+    const count = 100;
+    var requests: terminal.osc.color.List = .{};
+    defer requests.deinit(testing.allocator);
+    for (0..count) |i| try requests.append(testing.allocator, .{
+        .query = .{ .palette = @intCast(i) },
+    });
+
+    try handler.colorOperation(.osc_4, &requests, .st);
+
+    const response = mailbox.spsc.queue.pop(global.io());
+    try testing.expect(response != null);
+    const msg = response.?;
+    defer msg.deinit();
+    switch (msg) {
+        .write_alloc => |v| try testing.expectEqual(
+            @as(usize, count),
+            std.mem.count(u8, v.data, "\x1b]4;"),
+        ),
+        else => try testing.expect(false),
+    }
 }


### PR DESCRIPTION
## What this fixes

`colorOperation` formatted the reply to an OSC colour sequence into a 1 KiB
fixed buffer. The first answer that did not fit returned `error.WriteFailed`
out of the function, so the program got **no reply at all** rather than a short
one — and it got that silence *after* any sets in the same sequence had already
been applied to `terminal.colors`. A program that set some colours and then
asked one question too many was left with a wrong idea of the palette and
nothing to tell it so.

This was reached by accident, not by attack. Querying the whole 256 entry
palette is an ordinary thing for a program to do, and it produces a little over
7 KiB in the widest report format (`osc-color-report-format = 16-bit`) — about
seven times what the old buffer held. Roughly 35 palette queries were enough to
fill it.

The reply is now grown on demand, so the full-palette case works. That is the
fix.

## The 64 KiB ceiling

The reply is capped at `color_report_limit = 64 * 1024`.

**This is defence in depth, not a DoS fix, and it should not be read as one.**
Nothing the pty can send comes near it:

- Every OSC state that reaches `colorOperation` (4, 5, 10-19, 104, 110-119)
  routes to `captureTrailing(.fixed)`, which pins the payload to
  `Parser.MAX_BUF` = 2048 bytes in a capture with `alloc = null` — it cannot
  promote to the heap. Byte 2049 fails the capture and the parser discards the
  whole sequence rather than truncating it.
- The cheapest repeating query costs 4 payload bytes and yields 26 bytes of
  answer, so a surviving OSC 4 carries at most **512 queries** and produces at
  most **13,312 bytes** of reply. The limit sits 4.9x above that.

So the cap exists for a future caller that is not the parser. It is cheap, and
it is worth having, but the branch that enforces it is not reachable from pty
input today.

## Behaviour at the limit

Stop answering for the rest of the sequence, send everything answered so far,
log once. Specifically: the query that would cross the limit is not written, no
later query in the same sequence is answered, **sets and resets later in the
sequence still apply**, and a single `log.warn` names the limit and the count.

The alternatives were considered and rejected:

- **Truncate mid-answer** — a half-written `\x1b]4;7;rgb:ffff/f` has no
  terminator, so the receiving parser either waits for one that never comes or
  swallows the next real output as OSC payload. A missing answer is
  recoverable; a malformed one corrupts the stream.
- **Drop the whole reply** — that is the bug this PR exists to fix.
- **Skip the over-long answer and keep answering shorter ones** — puts a hole
  in the middle, and a program matching replies to queries positionally would
  silently mis-assign every colour after it. Stopping means what a program
  receives is always a *prefix* of what it asked.

The cut is always between whole answers, never inside one: the limit is tested
against `response.writer.end + reply.len` *before* the append, and the append is
the single write site.

## Compile-time guard on the answer buffer

Each answer is formatted into a fixed stack buffer before being appended. That
buffer relied on an unenforced fact — that the widest answer is 28 bytes and the
buffer is 64. If a future report format were wider, `answer.print` would return
`error.WriteFailed` out of `colorOperation` and drop the whole reply after the
sets had landed, which is exactly the defect above, reintroduced through a
buffer size instead of an allocator.

The four report formats are now named constants used at their call sites, and
the buffer is sized against them with `std.fmt.comptimePrint` at compile time.
Widening a format past the buffer is a build failure:

```
src\termio\stream_handler.zig:76:58: error: a color report format outgrew color_answer_buf_len
```

No behaviour changes: same formats, same buffer size, same bytes on the wire.

## Tests

Both in `src/termio/stream_handler.zig`, alongside the existing "every query in
one OSC is answered" test, whose assertions are unchanged — the rebase onto
#1023 only gives it the `write_limit` every `StreamHandler` test now needs.

- **`color operation: a full palette query is answered in full`** — 256 palette
  queries in one OSC, 16-bit format. Asserts 256 replies, that the first is
  index 0 and index 255 is present, and that the reply is under a quarter of
  the limit, so the headroom claim is enforced rather than asserted in prose.
- **`color operation: the reply to one OSC is bounded`** — 20,000 palette
  queries in one direct call. Asserts the message is `<= color_report_limit`,
  still ends with `ST`, and has equal introducer and terminator counts, so a
  future change cannot satisfy the bound by truncating mid-answer. (A direct
  call: no pty can produce 20,000 queries. The test guards the bound for the
  future caller the bound is for.)

Removing the limit check makes
`termio.stream_handler.test.color operation: the reply to one OSC is bounded`
fail by qualified name.

## Relation to the pty write backlog (#1023)

Two independent bounds now sit on the same path and neither replaces the other.
`color_report_limit` bounds how much reply *one sequence* may build;
`termio.WriteLimit` bounds how much unwritten data may be *queued to the pty*
across all of them.

The finished reply still goes out through `messageWriter`, which is the
droppable budget — deliberately, not by inheritance. A colour reply is
advisory and the program can ask again, and #1023's own reasoning applies
unchanged: a child whose backlog is at the cap is not draining its input, so it
is not reading the reply either. `messageWriterRequired` would be wrong here for
the reason that function's doc comment gives — it would spend a required budget
on the pty read thread per reply, stalling the reader for a message nothing is
blocked on.

## Not changed, deliberately

- **`kittyColorReport`** needs no bound. OSC 21 is in the same 2048-byte fixed
  capture group, and its parser caps the request count at `Kind.max * 2`
  independently, so its reply is about 4.5 KB. It should not inherit
  `color_report_limit`.
- **`src/terminal/stream_terminal.zig`'s parallel `colorOperation`** (the
  libghostty-vt one) uses `stackFallback(1024, gpa)`, so it grows past 1 KiB
  instead of failing. It never had this defect and needs no bound.
