### PR TITLE
agents: require a signoff against the windows a PR lands on

### DIFF
--- a/.agents/scripts/README.md
+++ b/.agents/scripts/README.md
@@ -43,31 +43,31 @@ human) working in this repo uses the same contract:
   merging: countable size limit, body present, no unchecked task items,
   no spaced issue references, signoff present. The hook form also denies a
   raw `gh pr merge` whose signoff window has moved (commits landed on
-  `origin/windows` after the record's base) and names the guard recipe,
-  because per #969 such a merge is allowed but its resignoff issue is not
-  optional; a same-window merge stays allowed raw, and any window answer
-  is only as fresh as the checkout's last fetch. Its honest limits: a hook
+  `origin/windows` after the record's base) and names the fix: rebase,
+  `just signoff` again (unmoved legs carry their green in seconds), then
+  `just merge-checked`; a same-window merge stays allowed raw, and any
+  window answer is only as fresh as the checkout's last fetch. Its honest limits: a hook
   only sees commands typed through tools it is wired into, so the GitHub
   web UI or mobile, a plain `git push` to `windows` (which has no branch
   protection), and hosts without the hook wiring are all uncovered, and
   `gh pr merge --auto` is judged at submit time.
 - `just merge-checked <n>` - the merge guard (`merge_guard.py`) and the
   normal way to merge: it re-validates the record (missing, red,
-  scope-mismatched and ledger-blocked records still refuse; the policy
-  forgives head movement, never a bad run), fetches and measures the delta
-  from the record's base to `origin/windows` first-parent, squash-merges,
-  reads back the squash sha, verifies it against a second fetch, and files
-  a `resignoff-required` issue on the #970 template, with a structured
+  scope-mismatched and ledger-blocked records refuse), fetches and
+  measures the delta from the record's base to `origin/windows`
+  first-parent, and refuses a moved window with the fix named (rebase,
+  `just signoff` again, merge); on an unmoved one it squash-merges, reads
+  back the squash sha and verifies it against a second fetch. The owner's
+  override `--carry-risk` merges on a moved window anyway and files a
+  `resignoff-required` issue on the #970 template, with a structured
   delta: per-commit attribution, the risks in words (same files, same
   top-level directories, same signoff legs as the record's scope, plus the
   never-signed-off squash itself), and the resignoff status. `--dry-run`
-  prints all of it and mutates nothing (it also accepts a MERGED pr);
-  `--file-only <n>` files the owed issue without merging, for a merge that
-  landed outside the guard. A bypass does not just skip the rule: the
-  resignoff issue only exists if the guard ran, since the record and the
-  delta it files both come from it.
+  prints all of it and the would-be verdict, mutating nothing (it also
+  accepts a MERGED pr); `--file-only <n>` files the owed issue without
+  merging, for a merge that landed outside the guard.
 - `just resignoff-bot [--max N] [--dry-run]` - work the pile the guard
-  files (#969 phase 2): an operator loop, never a merge step, so agents
+  filed under #969 and files under `--carry-risk`: an operator loop, never a merge step, so agents
   merging a PR do not run it. Each invocation spends at most `--max`
   signoff runs (default 1; a full ladder is over an hour of lane time),
   newest window first: a window whose recorded squash already has a green

--- a/.agents/scripts/merge_guard.py
+++ b/.agents/scripts/merge_guard.py
@@ -1,12 +1,20 @@
 #!/usr/bin/env python3
-"""The merge guard: squash-merge a PR and file the resignoff ceremony.
+"""The merge guard: squash-merge a PR on a signoff taken against the
+`windows` it lands on.
 
-Policy (issue #969, decided 2026-09-03): a green signoff does not block on
-head movement. When `windows` moved after the record was taken, merge
-anyway and carry the risk explicitly in a `resignoff-required` issue
-instead of re-gating inline. The guard is that ceremony: it refuses on a
-missing or bad record, measures what the branch gained since the record's
-base, merges, and files the issue with the delta and the risks in words.
+Policy (decided 2026-09-05, superseding #969's default): a green signoff
+vouches for a head against the `windows` it was taken on. When `windows`
+moved after the record was taken, the guard refuses and names the fix:
+rebase onto the current `windows`, run `just signoff` again, merge. That
+second signoff is cheap now - a leg whose inputs the rebase did not move
+carries its earlier green in seconds (leg_cache.py) - which is what made
+the #969 trade obsolete: when re-gating cost an hour, merging on the old
+green and carrying the risk in a `resignoff-required` issue was the
+lesser evil; when it costs a minute, the issue is debt for nothing. That
+ceremony survives only as an explicit override, `--carry-risk`, for an
+owner who has decided the debt is worth it this once; the guard then
+measures what the branch gained since the record's base, merges, and
+files the issue with the delta and the risks in words, exactly as before.
 
 Why a script and not a rule: enforcement has to work the way the
 signoff-per-head rule works. Agents read AGENTS.md and follow it because a
@@ -32,16 +40,18 @@ possibly-stale, which is printed loudly and carried into the filed issue.
 Refusals (nothing is mutated when one fires): no local record for the PR
 head, a red record, a deferred record the ledger no longer permits, a
 record whose file set or legs no longer match the PR (the same
-revalidation the hook does: window movement is forgiven, a record that no
-longer describes this PR is not), a checkout that is not this fork, a PR
-that is not open and mergeable or that does not target `windows`, and a
-window that cannot be measured. The policy forgives head movement only;
-it never forgives a bad or absent run.
+revalidation the hook does), a moved window without `--carry-risk`, a
+checkout that is not this fork, a PR that is not open and mergeable or
+that does not target `windows`, and a window that cannot be measured.
+Nothing forgives a bad or absent run.
 
 Modes:
-  <pr>             validate, squash-merge, read back the squash sha, verify
-                   it against a second fetch, file the resignoff-required
-                   issue when the window moved.
+  <pr>             validate, refuse a moved window, squash-merge, read
+                   back the squash sha, verify it against a second fetch.
+  --carry-risk <pr> the same, but a moved window merges anyway and files
+                   the resignoff-required issue with the delta (the #969
+                   ceremony); the owner's override, never an agent's
+                   default.
   --dry-run <pr>   print the resolved inputs, the delta, the risks and the
                    would-be issue body; mutate nothing. Also the recovery
                    preview for a PR that already merged (it accepts MERGED
@@ -459,10 +469,10 @@ def refusals(pr, rec, ledger, mode="merge"):
     (code, message) pairs. All of them are reported together, so one run
     tells the agent everything to fix rather than only the first thing.
     The scope revalidation is the hook's own two checks: a record whose
-    file set or legs no longer match the PR must be re-taken even though
-    the window policy forgives movement. The recovery modes forgive the
-    closed-state checks instead, because their whole point is a PR that
-    already merged."""
+    file set or legs no longer match the PR must be re-taken. The window
+    itself is judged by the caller once the delta is measured. The
+    recovery modes forgive the closed-state checks instead, because their
+    whole point is a PR that already merged."""
     out = []
     head = pr.get("headRefOid", "?")
     n = pr.get("number", "?")
@@ -477,8 +487,8 @@ def refusals(pr, rec, ledger, mode="merge"):
             failed = [k for k, v in (rec.get("steps") or {}).items() if v.get("rc") != 0]
             out.append(("signoff-red",
                         f"the signoff for {head[:10]} is red (failed: "
-                        f"{', '.join(failed) or 'unknown'}). The window policy forgives head "
-                        "movement, never a bad run; fix and rerun 'just signoff'."))
+                        f"{', '.join(failed) or 'unknown'}). Nothing forgives a bad run; "
+                        "fix and rerun 'just signoff'."))
         if rec.get("deferred"):
             blockers = gate_scope.ledger_blockers(ledger)
             if blockers:
@@ -495,8 +505,8 @@ def refusals(pr, rec, ledger, mode="merge"):
                 out.append(("signoff-stale",
                             f"the signoff for {head[:10]} was computed over a different file "
                             f"set than this PR reports ({len(rec_paths)} vs {len(pr_paths)} "
-                            "paths). Re-run 'just signoff'; the guard files the delta for "
-                            "branch movement, never for a PR that changed under its record."))
+                            "paths). Re-run 'just signoff'; a record must describe the PR "
+                            "it vouches for."))
             else:
                 required = set(gate_scope.required_legs(
                     pr_paths, justfile_legs=scope.get("justfile_legs")))
@@ -578,9 +588,18 @@ def file_issue(pr, rec, head, base, base_estimated, win, squash, delta, risks, n
     return 0
 
 
-def merge_flow(number, mode="merge", gh=None, git=None, sleep=time.sleep):
+def rebase_advice(number):
+    return (f"rebase onto {BASE_REF}, run 'just signoff' (a leg whose inputs the rebase "
+            f"did not move carries its green in seconds), then `just merge-checked {number}` "
+            f"again. To merge on the old green anyway and file the risk as debt, the "
+            f"owner's override is `just merge-checked {number} --carry-risk`.")
+
+
+def merge_flow(number, mode="merge", gh=None, git=None, sleep=time.sleep,
+               carry_risk=False):
     """The whole sequence: fetch, validate, measure, merge, read back,
-    verify, file. mode is "merge", "dry-run" or "file-only". Returns the
+    verify, file. mode is "merge", "dry-run" or "file-only"; carry_risk
+    lets a moved window merge and file instead of refusing. Returns the
     process exit code (see the module docstring). gh, git and sleep are
     injectable so the self-test can replay whole sessions without touching
     GitHub or the clock."""
@@ -683,6 +702,11 @@ def merge_flow(number, mode="merge", gh=None, git=None, sleep=time.sleep):
         if pr.get("state") == "MERGED":
             print("merge-guard: this PR is already MERGED; the body below is the recovery "
                   "body (file it with `--file-only`).")
+        elif not carry_risk:
+            print(f"merge-guard: the window has moved, so `just merge-checked {number}` would "
+                  f"REFUSE: {rebase_advice(number)}")
+            print("merge-guard: with --carry-risk it would merge with: gh pr merge "
+                  f"{number} --repo {REPO} --squash")
         else:
             print("merge-guard: would merge with: gh pr merge "
                   f"{number} --repo {REPO} --squash")
@@ -709,8 +733,19 @@ def merge_flow(number, mode="merge", gh=None, git=None, sleep=time.sleep):
         return file_issue(pr, rec, head, base, estimated, win, squash, delta, risks,
                           notes, gh)
 
-    # mode == "merge": the real thing. From here on a failure is a 1, not
-    # a 2, because the merge may already have landed.
+    # mode == "merge": the real thing. A moved window is refused here,
+    # after the delta is measured, so the refusal can say what moved.
+    if moved and not carry_risk:
+        print("merge-guard: refusing (nothing was mutated):")
+        print(f"merge-guard:   [window-moved] {len(delta['commits'])} commit(s) landed on "
+              f"{BASE_REF} since the record's base{est}, touching {len(delta['files'])} "
+              f"file(s); the green for {head[:10]} was taken against an older `windows`. "
+              + rebase_advice(number))
+        for c in delta["commits"]:
+            print(f"merge-guard:   {short(c['sha'])} {c['subject']} [{len(c['files'])} file(s)]")
+        return 2
+    # From here on a failure is a 1, not a 2, because the merge may
+    # already have landed.
     out = gh(["pr", "merge", str(number), "--repo", REPO, "--squash"])
     if out.returncode != 0:
         print(f"merge-guard: the merge command failed (rc={out.returncode}): "
@@ -968,7 +1003,7 @@ def self_test():
             fgh = FakeGh(pr)
             fgit = FakeGit(td, win, remote="https://github.com/deblasis/wintty.git",
                            merge_base=base, commits=commits, all_files=all_files)
-            rc, out = run_capture(merge_flow, 700, gh=fgh, git=fgit)
+            rc, out = run_capture(merge_flow, 700, gh=fgh, git=fgit, carry_risk=True)
             report(rc == 2 and not merged_calls(fgh) and f"[{label}]" in out,
                    "refuse-" + label, f"rc={rc}, merged={merged_calls(fgh)}")
 
@@ -979,7 +1014,7 @@ def self_test():
         fgh = FakeGh(make_pr(700, head))
         fgit = FakeGit(td, win, remote="https://github.com/other/fork.git",
                        merge_base=base, commits=commits, all_files=all_files)
-        rc, out = run_capture(merge_flow, 700, gh=fgh, git=fgit)
+        rc, out = run_capture(merge_flow, 700, gh=fgh, git=fgit, carry_risk=True)
         report(rc == 2 and not fgh.calls and "wrong-repo" in out
                and "clone deblasis/wintty" in out.lower(),
                "refuse-wrong-repo", f"rc={rc}, gh calls={len(fgh.calls)}")
@@ -990,7 +1025,7 @@ def self_test():
         fgh = FakeGh(make_pr(700, head, files=files_ok))
         fgit = FakeGit(td, win, remote="https://github.com/deblasis/wintty.git",
                        merge_base=None, commits=commits, all_files=all_files)
-        rc, out = run_capture(merge_flow, 700, gh=fgh, git=fgit)
+        rc, out = run_capture(merge_flow, 700, gh=fgh, git=fgit, carry_risk=True)
         report(rc == 2 and not merged_calls(fgh) and not filed_calls(fgh)
                and "window-unknown" in out,
                "refuse-window-unknown", f"rc={rc}")
@@ -1000,7 +1035,7 @@ def self_test():
         td = tempfile.mkdtemp(dir=tmp)
         write_record(td, head, green)
         fgh = FakeGh(make_pr(700, head), merge_rc=0, fail_view=True)
-        rc, out = run_capture(merge_flow, 700, gh=fgh, git=FakeGit(
+        rc, out = run_capture(merge_flow, 700, carry_risk=True, gh=fgh, git=FakeGit(
             td, win, remote="https://github.com/deblasis/wintty.git",
             merge_base=base, commits=commits, all_files=all_files))
         report(rc == 2 and not merged_calls(fgh) and not filed_calls(fgh),
@@ -1012,7 +1047,7 @@ def self_test():
         fgh = FakeGh(make_pr(700, head, files=files_ok))
         fgit = FakeGit(td, win, remote="https://github.com/deblasis/wintty.git",
                        merge_base=win, commits=[], all_files=[])
-        rc, out = run_capture(merge_flow, 700, gh=fgh, git=fgit)
+        rc, out = run_capture(merge_flow, 700, gh=fgh, git=fgit, carry_risk=True)
         report(rc == 0 and merged_calls(fgh) and not filed_calls(fgh)
                and "nothing to file" in out,
                "same-window", f"rc={rc}, merged={merged_calls(fgh)}, "
@@ -1024,7 +1059,7 @@ def self_test():
         fgh = FakeGh(make_pr(700, head, files=files_ok))
         fgit = FakeGit(td, win, remote="https://github.com/deblasis/wintty.git",
                        merge_base=base, commits=commits, all_files=all_files)
-        rc, out = run_capture(merge_flow, 700, gh=fgh, git=fgit)
+        rc, out = run_capture(merge_flow, 700, gh=fgh, git=fgit, carry_risk=True)
         bodies = bodies_of(fgh)
         golden = (
             "Filed by the merge guard (issue #969): this PR merged on a green signoff whose "
@@ -1078,6 +1113,25 @@ def self_test():
         report(bool(filed) and "--label" in filed[0] and LABEL in filed[0],
                "issue-labelled", f"filed={len(filed)}")
 
+        # --- the same moved window WITHOUT --carry-risk: refused, nothing
+        #     merged, nothing filed, and the refusal names the rebase path
+        #     and the override.
+        td = tempfile.mkdtemp(dir=tmp)
+        write_record(td, head, green)
+        fgh = FakeGh(make_pr(700, head, files=files_ok))
+        fgit = FakeGit(td, win, remote="https://github.com/deblasis/wintty.git",
+                       merge_base=base, commits=commits, all_files=all_files)
+        rc, out = run_capture(merge_flow, 700, gh=fgh, git=fgit)
+        report(rc == 2 and not merged_calls(fgh) and not filed_calls(fgh)
+               and "[window-moved]" in out and "rebase onto" in out
+               and "--carry-risk" in out and "2 commit(s)" in out,
+               "moved-window-refused-by-default",
+               f"rc={rc}, merged={bool(merged_calls(fgh))}, filed={bool(filed_calls(fgh))}")
+        rc, out = run_capture(merge_flow, 700, mode="dry-run", gh=fgh, git=fgit)
+        report(rc == 0 and not merged_calls(fgh) and not filed_calls(fgh)
+               and "would REFUSE" in out and "with --carry-risk it would merge" in out,
+               "dry-run-moved-says-it-would-refuse", f"rc={rc}")
+
         # The backlog line is one list call before the create, and names
         # the oldest issue the filer saw (this one is not yet among them).
         fgh2 = FakeGh(make_pr(700, head, files=files_ok), backlog=[
@@ -1085,7 +1139,7 @@ def self_test():
             {"number": 965, "createdAt": "2026-09-01T10:00:00Z"}])
         fgit2 = FakeGit(td, win, remote="https://github.com/deblasis/wintty.git",
                         merge_base=base, commits=commits, all_files=all_files)
-        rc, _ = run_capture(merge_flow, 701, gh=fgh2, git=fgit2)
+        rc, _ = run_capture(merge_flow, 701, gh=fgh2, git=fgit2, carry_risk=True)
         bodies2 = bodies_of(fgh2)
         lists = [c for c in fgh2.calls if c[:2] == ["issue", "list"]]
         report(rc == 0 and len(lists) == 1 and bodies2
@@ -1154,7 +1208,7 @@ def self_test():
         fgh = FakeGh(make_pr(700, head, files=files_ok))
         fgit = FakeGit(td, win, remote="https://github.com/deblasis/wintty.git",
                        merge_base=base, commits=commits, all_files=all_files)
-        rc, _ = run_capture(merge_flow, 700, gh=fgh, git=fgit)
+        rc, _ = run_capture(merge_flow, 700, gh=fgh, git=fgit, carry_risk=True)
         bodies = bodies_of(fgh)
         report(rc == 0 and bodies and "estimated at merge time" in bodies[0],
                "legacy-base-estimated", f"rc={rc}, filed={bool(bodies)}")
@@ -1174,7 +1228,7 @@ def self_test():
         fgit = FakeGit(td, win, remote="https://github.com/deblasis/wintty.git",
                        merge_base=base, commits=commits, all_files=all_files,
                        fetch_ok=False)
-        rc, out = run_capture(merge_flow, 700, gh=fgh, git=fgit)
+        rc, out = run_capture(merge_flow, 700, gh=fgh, git=fgit, carry_risk=True)
         bodies = bodies_of(fgh)
         report(rc == 0 and "possibly stale" in out and bodies
                and "## Notes" in bodies[0] and "possibly stale" in bodies[0],
@@ -1188,7 +1242,7 @@ def self_test():
         fgit = FakeGit(td, win, remote="https://github.com/deblasis/wintty.git",
                        merge_base=base, commits=commits, all_files=all_files,
                        squash_parent="f" * 40)
-        rc, out = run_capture(merge_flow, 700, gh=fgh, git=fgit)
+        rc, out = run_capture(merge_flow, 700, gh=fgh, git=fgit, carry_risk=True)
         bodies = bodies_of(fgh)
         report(rc == 0 and "moved in flight" in out and bodies
                and "moved in flight" in bodies[0],
@@ -1201,7 +1255,7 @@ def self_test():
         fgit = FakeGit(td, win, remote="https://github.com/deblasis/wintty.git",
                        merge_base=base, commits=commits, all_files=all_files,
                        ancestor_ok=False)
-        rc, out = run_capture(merge_flow, 700, gh=fgh, git=fgit)
+        rc, out = run_capture(merge_flow, 700, gh=fgh, git=fgit, carry_risk=True)
         bodies = bodies_of(fgh)
         report(rc == 0 and "not an ancestor" in out and bodies
                and "not an ancestor" in bodies[0],
@@ -1218,7 +1272,7 @@ def self_test():
         fgit = FakeGit(td, win, remote="https://github.com/deblasis/wintty.git",
                        merge_base=base, commits=many,
                        all_files=[f for c in many for f in c["files"]])
-        rc, _ = run_capture(merge_flow, 700, gh=fgh, git=fgit)
+        rc, _ = run_capture(merge_flow, 700, gh=fgh, git=fgit, carry_risk=True)
         bodies = bodies_of(fgh)
         bullets = [ln for ln in (bodies[0].splitlines() if bodies else [])
                    if ln.startswith("- `") and " change " in ln]
@@ -1294,7 +1348,7 @@ def self_test():
         fgh = FakeGh(make_pr(700, head, files=files_ok), merge_rc=1)
         fgit = FakeGit(td, win, remote="https://github.com/deblasis/wintty.git",
                        merge_base=base, commits=commits, all_files=all_files)
-        rc, out = run_capture(merge_flow, 700, gh=fgh, git=fgit)
+        rc, out = run_capture(merge_flow, 700, gh=fgh, git=fgit, carry_risk=True)
         report(rc == 1 and not filed_calls(fgh) and "failed" in out,
                "merge-fails-loud", f"rc={rc}")
 
@@ -1335,7 +1389,7 @@ def main(argv):
     if len(positional) != 1 or not positional[0].isdigit():
         print(__doc__)
         return 2
-    return merge_flow(int(positional[0]), mode=mode)
+    return merge_flow(int(positional[0]), mode=mode, carry_risk="--carry-risk" in argv)
 
 
 if __name__ == "__main__":

--- a/.agents/scripts/pr_gate.py
+++ b/.agents/scripts/pr_gate.py
@@ -29,13 +29,12 @@ endpoint) unless the PR passes:
                   expensive one.
   window          a raw merge of a PR whose signoff window has moved (commits
                   landed on origin/windows after the record's base) is denied
-                  and pointed at `just merge-checked <pr>`: per #969 the
-                  merge itself is allowed, but the resignoff issue the guard
-                  files is not optional, and a raw merge skips it. A
-                  same-window merge (delta empty) stays allowed raw, but
-                  note the hook is fast and local on purpose: it judges the
-                  window against the local origin/windows, which is only as
-                  fresh as the last fetch.
+                  and pointed at the fix: rebase, `just signoff` again (a
+                  minute, since unmoved legs carry their green), then
+                  `just merge-checked <pr>`. A same-window merge (delta
+                  empty) stays allowed raw, but note the hook is fast and
+                  local on purpose: it judges the window against the local
+                  origin/windows, which is only as fresh as the last fetch.
 
 The size thresholds fit this repository's merge history: focused
 single-concern PRs stay comfortably under the block line, and the warn line
@@ -422,7 +421,8 @@ def policy_deny(pr, lookup, cwd, run=None):
     if rec is None:
         return None
     number = pr.get("number", "?")
-    guard = f"Merge through the guard instead: `just merge-checked {number}`."
+    guard = (f"Rebase onto {BASE_REF}, run 'just signoff' (unmoved legs carry their green "
+             f"in seconds), then merge through the guard: `just merge-checked {number}`.")
     win = windows_head(cwd, run)
     if not win:
         return (f"pr-gate: the signoff window cannot be measured - {BASE_REF} does not "
@@ -438,8 +438,8 @@ def policy_deny(pr, lookup, cwd, run=None):
     est = " (re-estimated at merge time from a legacy record)" if estimated else ""
     return (
         f"pr-gate: this PR's signoff window has moved{est} - {n} commit(s) landed on "
-        f"{BASE_REF} since the record's base, and a raw merge would skip the resignoff "
-        f"ceremony. {guard}"
+        f"{BASE_REF} since the record's base, so the green vouches for an older "
+        f"`windows`. {guard}"
     )
 
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,20 +54,25 @@ exists on GitHub. If the order ever inverts anyway, `just signoff-post
 <sha>` re-advertises the recorded run without re-running anything. A raw
 `gh pr merge` is tolerated only for a provably same-window merge, and your
 view of `windows` is only as fresh as your last fetch. The `pr_gate` hook refuses
-a merge without that signoff, and it also refuses a raw merge whose
-signoff window has moved (commits landed on `windows` after the record's
-base): per #969 the merge itself is then still allowed, but it goes
-through the guard, which files the `resignoff-required` issue carrying
-the delta and the risks instead of re-gating inline. The one deliberate
-exception is `just sync-publish`, which lands the upstream snapshot merge
-without a PR; in exchange it runs its own assertions at publish time:
-nothing windows merged may be missing from the replay, and work no PR
-reviewed may ride along unnamed or unacknowledged.
+a merge without that signoff, and both the hook and the guard refuse a
+merge whose signoff window has moved (commits landed on `windows` after
+the record's base): the green vouches for an older `windows`, so rebase
+onto the current one, run `just signoff` again, and merge. That second
+run is cheap by design: a leg whose inputs the rebase did not move
+carries its earlier green in seconds (`just leg-cache plan` shows which),
+so a rebase costs a signoff of about a minute, never the ladder. Merging
+on the old green and filing the risk as a `resignoff-required` issue is
+no longer the default; it is the owner's override, `just merge-checked
+<pr> --carry-risk`, and an agent does not reach for it. The one
+deliberate exception is `just sync-publish`, which lands the upstream
+snapshot merge without a PR; in exchange it runs its own assertions at
+publish time: nothing windows merged may be missing from the replay, and
+work no PR reviewed may ride along unnamed or unacknowledged.
 
-The `resignoff-required` issues the guard files are debt, not blockers:
-they are designed to sit until worked, and working them is the owner's
-loop (`just resignoff-bot`), not an agent's merge step. Never run the bot
-as part of merging; each run is an hour of lane time and the pile is meant
+The `resignoff-required` issues that exist are debt, not blockers: they
+are designed to sit until worked, and working them is the owner's loop
+(`just resignoff-bot`), not an agent's merge step. Never run the bot as
+part of merging; each run is an hour of lane time and the pile is meant
 to wait for it.
 
 Always pass `--repo deblasis/wintty`. Never open anything against

--- a/justfile
+++ b/justfile
@@ -1620,14 +1620,17 @@ signoff-post sha:
 pr-gate pr:
     python .agents/scripts/pr_gate.py --check-pr {{pr}}
 
-# Squash-merge a PR through the merge guard (#969): the record is validated,
-# the delta between its base and origin/windows is measured, and a
-# resignoff-required issue is filed when the window moved. Raw `gh pr merge`
-# of a moved-window PR is denied by the pr_gate hook, which names this
-# recipe. `--dry-run` shows the inputs, delta, risks and issue body without
-# touching anything: python .agents/scripts/merge_guard.py --dry-run <pr>.
-merge-checked pr:
-    python .agents/scripts/merge_guard.py {{pr}}
+# Squash-merge a PR through the merge guard: the record is validated, the
+# delta between its base and origin/windows is measured, and a moved
+# window is REFUSED with the fix named (rebase, `just signoff` again, which
+# carries every leg the rebase did not touch, merge). Raw `gh pr merge` of a
+# moved-window PR is denied by the pr_gate hook the same way. The owner's
+# override `--carry-risk` merges on the old green anyway and files the
+# resignoff-required issue with the delta (#969's ceremony). `--dry-run`
+# shows the inputs, delta, risks and the would-be verdict without touching
+# anything: python .agents/scripts/merge_guard.py --dry-run <pr>.
+merge-checked pr *args:
+    python .agents/scripts/merge_guard.py {{pr}} {{args}}
 
 # Work the resignoff-required pile the merge guard files (#969 phase 2): an
 # operator loop, not a merge step. Each invocation spends at most --max


### PR DESCRIPTION
## Summary

The merge guard refuses a PR whose signoff window has moved and names the fix: rebase onto `windows`, `just signoff` again, merge. Merging on the old green and filing the risk as a `resignoff-required` issue (#969) is no longer the default; it survives as the owner's override, `just merge-checked <pr> --carry-risk`. The `pr_gate` hook's denial of a raw merge on a moved window says the same, `--dry-run` reports the verdict a plain merge would get, and AGENTS.md and the scripts' README state the protocol.

## Why

#969 traded re-gating for debt because re-gating cost an hour. With the leg cache (#1008) a signoff after a rebase carries every leg the rebase did not touch and costs about a minute, so the debt buys nothing.

## Verified

- `merge_guard.py --self-test`: the moved window is refused by default with nothing merged or filed, merges and files under `--carry-risk` with the unchanged golden body, and `--dry-run` says which verdict applies. `pr_gate.py --self-test` and `resignoff_bot.py --self-test` green; `just gates-selftest` green.
- `just signoff` on the first head: PASS in 211 s, only the gates leg required and run. `windows` then moved under the PR (#1013's squash), so it was rebased and signed off again, which is the protocol this PR installs: the gates leg carried its green and the record for the new head took 10 seconds. `just pr-gate 1018` passes.
