### PR TITLE
lanes: split the incoda key into build, desktop and publish lanes

### DIFF
--- a/.agents/scripts/README.md
+++ b/.agents/scripts/README.md
@@ -73,7 +73,7 @@ human) working in this repo uses the same contract:
   newest window first: a window whose recorded squash already has a green
   record closes on that evidence, an unproven window takes one claim
   marker, one detached worktree at the recorded squash sha and one
-  `incoda run --queue wintty -- just signoff`, and a red window bisects
+  `incoda run --queue wintty-build -- just signoff`, and a red window bisects
   the recorded squash SHAs down to a single culprit issue, which gets the
   `signoff-bisect-culprit` label, the failing legs and the trail, and
   stays open. One instance at a time: a lock beside the worktree refuses a

--- a/.agents/scripts/merge_guard.py
+++ b/.agents/scripts/merge_guard.py
@@ -434,7 +434,7 @@ def issue_body(pr, rec, rec_path, base, base_estimated, win, squash, delta, risk
         "## Status",
         "",
         f"Resignoff for `{short(squash)}`: not started at filing time. Check "
-        "`incoda status --queue wintty` first; the #969 bot owns this (`just "
+        "`incoda status --queue wintty-build` first; the #969 bot owns this (`just "
         "resignoff-bot`, owner-run): agents do not queue runs for it.",
         f"Squash commit: `{squash}`" + (" (full sha)" if len(squash) == 40 else ""),
     ]
@@ -1099,7 +1099,7 @@ def self_test():
             "## Status\n"
             "\n"
             "Resignoff for `eeeeeeeee`: not started at filing time. Check "
-            "`incoda status --queue wintty` first; the #969 bot owns this (`just "
+            "`incoda status --queue wintty-build` first; the #969 bot owns this (`just "
             "resignoff-bot`, owner-run): agents do not queue runs for it.\n"
             f"Squash commit: `{'e' * 40}` (full sha)\n"
         )

--- a/.agents/scripts/resignoff_bot.py
+++ b/.agents/scripts/resignoff_bot.py
@@ -25,7 +25,7 @@ The loop, per invocation:
      (nightly_fuzz.ps1's recipe: worktree add --detach, reset --hard,
      clean -fdx with the .zig-cache and zig-out exclusions, because
      signoff refuses a dirty tree), then takes the incoda lane exactly
-     once: incoda run --queue wintty --reason "resignoff <sha7>" -- just
+     once: incoda run --queue wintty-build --reason "resignoff <sha7>" -- just
      signoff. The worktree hangs off this clone, so the record the run
      writes lands in the same git common dir the gate and this bot read.
      Nothing but the run holds the lane.
@@ -153,7 +153,7 @@ def incoda_run(path, args, cwd=None):
 
 
 def incoda_status_run(path, args, cwd=None):
-    """The real lane status reader (`incoda status --queue wintty`). Short
+    """The real lane status reader (`incoda status --queue wintty-build`). Short
     timeout: a status read that hangs is worse than no status at all, and
     lane_busy_with treats a failed read as silent."""
     return subprocess.run([path] + args, cwd=cwd or REPO_ROOT,
@@ -545,13 +545,13 @@ def lane_busy_with(env, incoda_path, sha):
     behind it, which is what the lane is for). The match can be stale: a
     finished-but-unreleased holder or an old line in the status pane reads
     the same as a live one, so the skip note surfaces the raw status and
-    names the escalation (check `incoda status --queue wintty`, clear the
+    names the escalation (check `incoda status --queue wintty-build`, clear the
     stale holder or wait) instead of trusting the match silently. A failed
     status read stays silent: the lane serializes regardless."""
     if env.incoda_status is None:
         return None
     try:
-        out = env.incoda_status(incoda_path, ["status", "--queue", "wintty"])
+        out = env.incoda_status(incoda_path, ["status", "--queue", "wintty-build"])
     except (OSError, subprocess.TimeoutExpired):
         return None
     if out.returncode != 0:
@@ -618,7 +618,7 @@ def run_ladder(env, incoda_path, issue_number, sha, budget_line):
         return False
     print(f"resignoff-bot: #{issue_number}: {budget_line}")
     out = env.incoda(incoda_path,
-                     ["run", "--queue", "wintty", "--reason", f"resignoff {sha[:SHA7]}",
+                     ["run", "--queue", "wintty-build", "--reason", f"resignoff {sha[:SHA7]}",
                       "--", "just", "signoff"],
                      cwd=env.worktree_dir)
     if out.returncode not in (0, 1):
@@ -790,7 +790,7 @@ def work_one(env, windows, idx, runs_used, max_runs, incoda_path):
               f"{merge_guard.short(w['squash'])} appears to be already in flight on the "
               "lane; leaving the issue alone rather than double-queuing it.")
         print(f"  holder status: {busy}")
-        print("  this match can be stale: check `incoda status --queue wintty`, clear the "
+        print("  this match can be stale: check `incoda status --queue wintty-build`, clear the "
               "stale holder or wait, then re-run.")
         return 0, "skipped"
     ok, note = prepare_worktree(env.git, env.worktree_dir, w["squash"])
@@ -978,7 +978,7 @@ def bot_flow(max_runs=1, dry_run=False, env=None):
     if not ok:
         print(f"resignoff-bot: refusing (exit 2): another resignoff bot instance appears "
               f"to hold the worktree lock: {holder}. Check that pid and "
-              "`incoda status --queue wintty` before touching anything; a dead pid's "
+              "`incoda status --queue wintty-build` before touching anything; a dead pid's "
               "lock is taken over automatically, so a live one is being named here.")
         return 2
     try:
@@ -1028,7 +1028,7 @@ def describe_run_commands(w, prefix):
         f"{prefix}would: git worktree add --detach <worktree> {w['squash']}",
         f"{prefix}would: git -C <worktree> reset --hard {w['squash']} && "
         f"git -C <worktree> clean -fdx -e .zig-cache -e zig-out",
-        f"{prefix}would: incoda run --queue wintty --reason "
+        f"{prefix}would: incoda run --queue wintty-build --reason "
         f"\"resignoff {w['squash'][:SHA7]}\" -- just signoff   (cwd <worktree>)",
     ]
 
@@ -1277,7 +1277,7 @@ GUARD_BODY = """Filed by the merge guard (issue #969): this PR merged on a green
 ## Status
 
 Resignoff for `eeeeeeeee`: not started at filing time. Check
-`incoda status --queue wintty` first; the #969 bot owns this (`just resignoff-bot`, owner-run): agents do not queue runs for it.
+`incoda status --queue wintty-build` first; the #969 bot owns this (`just resignoff-bot`, owner-run): agents do not queue runs for it.
 Squash commit: `{squash}` (full sha)
 Outstanding `resignoff-required` issues at filing time: 1 (oldest #690).
 """

--- a/.agents/scripts/resignoff_bot.py
+++ b/.agents/scripts/resignoff_bot.py
@@ -28,7 +28,7 @@ The loop, per invocation:
      once: incoda run --queue wintty-build --reason "resignoff <sha7>" -- just
      signoff. The worktree hangs off this clone, so the record the run
      writes lands in the same git common dir the gate and this bot read.
-     Nothing but the run holds the lane.
+     Nothing but the run holds the slot.
   5. Green: close the issue, quoting the record path and the per-leg rcs,
      then move to the next older window; when every window is green, all
      close. Red: bisect over the RECORDED squash SHAs between the last
@@ -541,13 +541,14 @@ def lane_busy_with(env, incoda_path, sha):
     """The lane's holder text when a resignoff for THIS sha appears to be in
     flight, else None. A textual match on the --reason this bot uses, on
     purpose: the point is not to double-queue a run that is already running.
-    Any other holder is the lane's normal business (the run then queues
-    behind it, which is what the lane is for). The match can be stale: a
+    Any other holder is the lane's normal business (wintty-build has three
+    slots; the run takes a free one or queues). The match can be stale: a
     finished-but-unreleased holder or an old line in the status pane reads
     the same as a live one, so the skip note surfaces the raw status and
     names the escalation (check `incoda status --queue wintty-build`, clear the
     stale holder or wait) instead of trusting the match silently. A failed
-    status read stays silent: the lane serializes regardless."""
+    status read stays silent: the worktree lock still keeps this bot to one
+    run at a time, so the worst case is one duplicate signoff, not two bots."""
     if env.incoda_status is None:
         return None
     try:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,43 +85,53 @@ memory-heavy builds have taken one down with no warning, and two GUI harness
 runs corrupt each other by fighting over focus, the foreground window and
 the desktop. Every session, in every worktree, routes heavy jobs through
 named lanes with [incoda](https://github.com/deblasis/incoda), one lane per
-resource class, shared with `wintty-release`, which builds the same thing:
+resource class. The keys are shared with `wintty-release`, which builds the
+same thing under the same three names:
 
 | key | slots | guards | what goes there |
 | --- | --- | --- | --- |
-| `wintty-build` | 3 | CPU and RAM | `zig build` in any form (`just build-dll`, `build-dll-release`, `test`, `test-full`, `test-win`), `dotnet build` and `dotnet test` of the solutions, `just signoff` and its whole ladder |
-| `wintty-desktop` | 1 | the interactive desktop: focus, the foreground window, pixel capture, the env guard's theme flips, the shared Wintty state | every GUI harness under `windows/scripts/`, `just splash-race`, the window `run-win` opens |
+| `wintty-build` | 3 | CPU and RAM | `zig build` in any form (`just build-dll`, `build-dll-release`, every `test-*` recipe), `just test-win` and any `dotnet build` or `dotnet test` of the solutions, `just signoff` and its whole ladder |
+| `wintty-desktop` | 1 | the interactive desktop: focus, the foreground window, pixel capture, the env guard's theme flips, the shared Wintty state | every GUI harness under `windows/scripts/`, `just splash-race` |
 | `wintty-publish` | 1 | release channels, signing, the installed app | nothing in this repo; `wintty-release` cuts and uploads under it |
 
 There is no quiet key. A job whose finding is a duration takes the build and
 desktop lanes together and alone, `incoda run --queue
 wintty-build,wintty-desktop --exclusive -- <cmd...>`: it waits for every
 holder to leave and keeps the machine to itself while it runs. The old
-`wintty` key is closed and refuses every run with a message naming these.
+`wintty` key is retired: closed on the box, it refuses every run with a
+message naming these.
 
 ```
 incoda run --queue wintty-build --reason "what this is" -- <cmd...>
 incoda queues                       # every lane: held, waiting, oldest wait
 incoda status --queue wintty-build  # who holds it, from which folder, who waits
-incoda watch                        # live overview; enter opens a lane, k kills a job with a reason
+incoda watch                        # live overview; enter opens a lane, k kills
 ```
 
 Who takes which lane:
 
 - You wrap the single-class recipes yourself: `incoda run --queue
-  wintty-build --reason "..." -- just test`, and the same for `test-win`,
-  `build-dll`, `build-dll-release` and `signoff`. They stay lane-free inside
-  because they are cross-platform, and the same recipe has to run unwrapped
-  on a Linux or macOS host.
+  wintty-build --reason "..." -- just test`, and the same for every
+  `test-*` recipe, `test-win`, `build-dll`, `build-dll-release` and
+  `signoff`. They stay lane-free inside because they are cross-platform,
+  and the same recipe has to run unwrapped on a Linux or macOS host.
 - The harness recipes take their lanes themselves, one per phase: `just
   fuzz`, `search-fuzz`, `frame-style-fuzz`, `shader-notice-fuzz`,
   `splash-race` and `theme-matrix` build under `wintty-build`, release it,
-  then hold `wintty-desktop` for the harness. `just run-win` builds under
-  `wintty-build` and launches outside any lane, because the window outlives
-  the recipe. Call these bare. Wrapping one in `run` on the key it is about
-  to take is harmless (a nested run on a held key passes through), but
-  wrapping it in the other key makes the inner phase queue while the outer
-  key is held, which `run` warns about.
+  then hold `wintty-desktop` for the harness. Call these bare. Wrapping one
+  in `run` on a single key is wrong either way: the two phases take
+  different keys, so whichever phase is on the other key nests where the
+  outer run holds nothing, and an outer `wintty-desktop` waiting on
+  `wintty-build` inverts the order the exclusive pair takes, which is a
+  deadlock until both `--wait` budgets elapse. The one safe wrapper is the
+  exclusive pair, which holds both keys before either phase starts.
+- `just run-win` builds under `wintty-build` and launches outside any lane,
+  because the window outlives the recipe: pwsh returns as soon as the
+  process is up. That window is a hazard no lane covers; each harness's own
+  `Assert-NoWintty` is the guard, so close it before queueing a harness.
+- The harness recipes and `run-win` refuse to run without incoda on PATH or
+  in its installer's location (`%LOCALAPPDATA%\Programs\incoda`), naming
+  the install. On this machine that is not optional.
 - Anything else under `windows/scripts/` that launches a window goes under
   `wintty-desktop`; anything timing-sensitive enough to fail on a loaded
   machine goes under the exclusive pair above.
@@ -136,11 +146,12 @@ The rules that matter:
   in the lane's log carries the job's peak memory and CPU time, and `status`
   shows the recent ones. If the machine swaps with three builds up, the
   answer is to say so, not to add a fourth slot or to go around the lane.
-- Set `INCODA_OWNER` once per session, to something that names the worktree
-  (`$env:INCODA_OWNER = 'wt-<name>'`), and pass `--reason` every time; the
-  lanes refuse a run without one. With several sessions sharing a lane,
-  "which worktree is that and why" is the first question anyone asks, and
-  `status` can only answer if you said.
+- Pass `--reason` every time: the lanes are configured to refuse a run
+  without one. Set `INCODA_OWNER` once per session too, to something that
+  names the worktree (`$env:INCODA_OWNER = 'wt-<name>'`); that one is a
+  convention, not enforced, and it is what `status` shows as the owner.
+  With several sessions sharing a lane, "which worktree is that and why" is
+  the first question anyone asks, and `status` can only answer if you said.
 - Kill only your own tickets. `incoda kill --queue KEY --pid N --reason
   "..."`, or `k` in `watch`, asks a job to stop through the lane and its
   owner reads the reason on their stderr. A ticket with another owner

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,58 +78,89 @@ to wait for it.
 Always pass `--repo deblasis/wintty`. Never open anything against
 `ghostty-org/ghostty`.
 
-## Heavy job lane (mandatory on the development machine)
+## Heavy job lanes (mandatory on the development machine)
 
-A development machine cannot run two heavy jobs at once: concurrent
+A development machine cannot run every heavy job at once: concurrent
 memory-heavy builds have taken one down with no warning, and two GUI harness
 runs corrupt each other by fighting over focus, the foreground window and
-the desktop. Every session, in every worktree, routes heavy jobs
-through one named lane with [incoda](https://github.com/deblasis/incoda),
-queue key `wintty` (shared with `wintty-release`, which builds the same
-thing):
+the desktop. Every session, in every worktree, routes heavy jobs through
+named lanes with [incoda](https://github.com/deblasis/incoda), one lane per
+resource class, shared with `wintty-release`, which builds the same thing:
+
+| key | slots | guards | what goes there |
+| --- | --- | --- | --- |
+| `wintty-build` | 3 | CPU and RAM | `zig build` in any form (`just build-dll`, `build-dll-release`, `test`, `test-full`, `test-win`), `dotnet build` and `dotnet test` of the solutions, `just signoff` and its whole ladder |
+| `wintty-desktop` | 1 | the interactive desktop: focus, the foreground window, pixel capture, the env guard's theme flips, the shared Wintty state | every GUI harness under `windows/scripts/`, `just splash-race`, the window `run-win` opens |
+| `wintty-publish` | 1 | release channels, signing, the installed app | nothing in this repo; `wintty-release` cuts and uploads under it |
+
+There is no quiet key. A job whose finding is a duration takes the build and
+desktop lanes together and alone, `incoda run --queue
+wintty-build,wintty-desktop --exclusive -- <cmd...>`: it waits for every
+holder to leave and keeps the machine to itself while it runs. The old
+`wintty` key is closed and refuses every run with a message naming these.
 
 ```
-incoda run --queue wintty --reason "what this is" -- <cmd...>
-incoda status --queue wintty     # who holds it, from which folder, who waits
-incoda watch  --queue wintty     # live view
+incoda run --queue wintty-build --reason "what this is" -- <cmd...>
+incoda queues                       # every lane: held, waiting, oldest wait
+incoda status --queue wintty-build  # who holds it, from which folder, who waits
+incoda watch                        # live overview; enter opens a lane, k kills a job with a reason
 ```
 
-Run under the lane, always:
+Who takes which lane:
 
-- `zig build` in any form that links libghostty: `just build-dll`,
-  `just build-dll-release`, `just test` and `just test-full`, `just test-win`,
-  and `just run-win`, whose build half is one of those whatever it is run for
-- every GUI harness: `just fuzz`, `just search-fuzz`, `just frame-style-fuzz`,
-  `just shader-notice-fuzz`, `just splash-race`, and anything under
-  `windows/scripts/` that launches a window. The theme matrix recipe (#941)
-  takes the lane itself.
-- any test that is timing-sensitive enough to fail on a loaded machine
+- You wrap the single-class recipes yourself: `incoda run --queue
+  wintty-build --reason "..." -- just test`, and the same for `test-win`,
+  `build-dll`, `build-dll-release` and `signoff`. They stay lane-free inside
+  because they are cross-platform, and the same recipe has to run unwrapped
+  on a Linux or macOS host.
+- The harness recipes take their lanes themselves, one per phase: `just
+  fuzz`, `search-fuzz`, `frame-style-fuzz`, `shader-notice-fuzz`,
+  `splash-race` and `theme-matrix` build under `wintty-build`, release it,
+  then hold `wintty-desktop` for the harness. `just run-win` builds under
+  `wintty-build` and launches outside any lane, because the window outlives
+  the recipe. Call these bare. Wrapping one in `run` on the key it is about
+  to take is harmless (a nested run on a held key passes through), but
+  wrapping it in the other key makes the inner phase queue while the outer
+  key is held, which `run` warns about.
+- Anything else under `windows/scripts/` that launches a window goes under
+  `wintty-desktop`; anything timing-sensitive enough to fail on a loaded
+  machine goes under the exclusive pair above.
 
 The rules that matter:
 
-- Never bypass the lane: no "just this once" outside it, no detached
+- Never bypass a lane: no "just this once" outside it, no detached
   background job, no second heavy job in another terminal while one is
-  queued, and never two heavy jobs at once even if both would probably fit.
-  The lane binds only what is routed through it, so a single bypass
+  queued. A lane binds only what is routed through it, so a single bypass
   reintroduces exactly the collision it exists to stop.
-- `run` passes the child's exit status through unchanged, which is why the
-  justfile's `; exit ($LASTEXITCODE ?? 1)` idiom still means what it says
-  under the lane. `--wait` defaults to 30 minutes; when it elapses `run`
-  exits 121 and the command never ran, so a 121 is a queue timeout, not a
-  build failure. `--wait 0` fails immediately instead of queueing.
-- If the lane makes you wait longer than about ten minutes, say so to the
-  user: `incoda status` names the pid, the command and the directory holding
-  it. Do not wait half an hour in silence and do not go around it.
+- Three build slots is a measured number, not a promise. Every release line
+  in the lane's log carries the job's peak memory and CPU time, and `status`
+  shows the recent ones. If the machine swaps with three builds up, the
+  answer is to say so, not to add a fourth slot or to go around the lane.
+- Set `INCODA_OWNER` once per session, to something that names the worktree
+  (`$env:INCODA_OWNER = 'wt-<name>'`), and pass `--reason` every time; the
+  lanes refuse a run without one. With several sessions sharing a lane,
+  "which worktree is that and why" is the first question anyone asks, and
+  `status` can only answer if you said.
+- Kill only your own tickets. `incoda kill --queue KEY --pid N --reason
+  "..."`, or `k` in `watch`, asks a job to stop through the lane and its
+  owner reads the reason on their stderr. A ticket with another owner
+  belongs to another session: tell the user, do not kill it.
 - `incoda force-release` is a human decision, never an agent's. It refuses
   while a live holder exists for a reason; thinking you need it is something
   to tell the user, not something to do.
-- `--reason` every time. With several sessions sharing a lane, "which
-  worktree is that and why" is the first question anyone asks, and `status`
-  can only answer if you said.
+- `run` passes the child's exit status through unchanged, which is why the
+  justfile's `; exit ($LASTEXITCODE ?? 1)` idiom still means what it says
+  under a lane. `--wait` defaults to 30 minutes; when it elapses `run`
+  exits 121 and the command never ran, so a 121 is a queue timeout, not a
+  build failure. 124 means someone killed the job through the lane, and the
+  reason is on stderr. `--wait 0` fails immediately instead of queueing.
+- If a lane makes you wait longer than about ten minutes, say so to the
+  user: `status` names the pid, the command, the owner and the directory
+  holding it. Do not wait half an hour in silence and do not go around it.
 - `run` releases on exit, including a crash: the lock is an OS file lock, so
-  a killed holder frees the lane on its own.
+  a killed holder frees its slot on its own.
 - The working directory does not matter and neither does the worktree; every
-  session using key `wintty` shares one lane. Never set `INCODA_DIR` per
-  checkout: it is machine-level, and setting it in one place splits the lane
-  in two while both halves look healthy.
+  session using a key shares that lane. Never set `INCODA_DIR` per
+  checkout: it is machine-level, and setting it in one place splits every
+  lane in two while both halves look healthy.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ same thing under the same three names:
 
 | key | slots | guards | what goes there |
 | --- | --- | --- | --- |
-| `wintty-build` | 3 | CPU and RAM | `zig build` in any form (`just build-dll`, `build-dll-release`, every `test-*` recipe), `just test-win` and any `dotnet build` or `dotnet test` of the solutions, `just signoff` and its whole ladder |
+| `wintty-build` | 3 | CPU and RAM | `zig build` in any form (`just build-dll`, `build-dll-release`, `just test` and the `test-*` recipes it runs), `just test-win` and any `dotnet build` or `dotnet test` of the solutions, `just signoff` and its whole ladder |
 | `wintty-desktop` | 1 | the interactive desktop: focus, the foreground window, pixel capture, the env guard's theme flips, the shared Wintty state | every GUI harness under `windows/scripts/`, `just splash-race` |
 | `wintty-publish` | 1 | release channels, signing, the installed app | nothing in this repo; `wintty-release` cuts and uploads under it |
 
@@ -122,13 +122,15 @@ Who takes which lane:
   in `run` on a single key is wrong either way: the two phases take
   different keys, so whichever phase is on the other key nests where the
   outer run holds nothing, and an outer `wintty-desktop` waiting on
-  `wintty-build` inverts the order the exclusive pair takes, which is a
-  deadlock until both `--wait` budgets elapse. The one safe wrapper is the
-  exclusive pair, which holds both keys before either phase starts.
+  `wintty-build` inverts the order the exclusive pair takes: against a
+  live exclusive run the two wait on each other until both `--wait`
+  budgets elapse. The one safe wrapper is the exclusive pair, which holds
+  both keys before either phase starts.
 - `just run-win` builds under `wintty-build` and launches outside any lane,
   because the window outlives the recipe: pwsh returns as soon as the
-  process is up. That window is a hazard no lane covers; each harness's own
-  `Assert-NoWintty` is the guard, so close it before queueing a harness.
+  process is up. That window is a hazard no lane covers: the justfile
+  harnesses check for it before building, and most harnesses refuse to
+  start beside it, so close it before queueing one.
 - The harness recipes and `run-win` refuse to run without incoda on PATH or
   in its installer's location (`%LOCALAPPDATA%\Programs\incoda`), naming
   the install. On this machine that is not optional.

--- a/justfile
+++ b/justfile
@@ -265,8 +265,9 @@ inc := '(Get-Command incoda -ErrorAction SilentlyContinue)?.Source ?? (Join-Path
 # Do not wrap one of these recipes in `incoda run` on a single key: the two
 # phases take different keys, so whichever phase is on the other key nests
 # where the outer run holds nothing, and an outer wintty-desktop waiting on
-# wintty-build inverts the order the exclusive pair takes, which is a
-# deadlock until both --wait budgets elapse. Call them bare; the one safe
+# wintty-build inverts the order the exclusive pair takes: against a live
+# exclusive run the two wait on each other until both --wait budgets
+# elapse. Call them bare; the one safe
 # wrapper is the exclusive pair, which holds both keys before either phase
 # starts and lets both nested runs pass through.
 #

--- a/justfile
+++ b/justfile
@@ -197,9 +197,13 @@ build-win:
 build-win-release:
     dotnet build windows/Ghostty.sln /p:Platform=x64 /p:Configuration=Release
 
-# Build the DLL and the shell, then launch it.
+# Build the DLL and the shell under the build lane, then launch it. The
+# launch itself is outside any lane on purpose: pwsh returns as soon as a
+# GUI process is up, so a lane held here would be released while the
+# window is still open. The harnesses' own Assert-NoWintty is what guards
+# the desktop against that window.
 [windows]
-run-win: build-dll build-win
+run-win: (_build-in-lane "run-win" "build-dll" "build-win")
     ./windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Wintty.exe
 
 # Same, optimized on both sides. Startup timings taken from `run-win` are
@@ -207,7 +211,7 @@ run-win: build-dll build-win
 # optimization and libghostty is a Debug build. Use this before concluding
 # anything about how long startup, the launch splash, or a frame takes.
 [windows]
-run-win-release: build-dll-release build-win-release
+run-win-release: (_build-in-lane "run-win-release" "build-dll-release" "build-win-release")
     ./windows/Ghostty/bin/x64/Release/net10.0-windows10.0.19041.0/Wintty.exe
 
 # Run the C# test suites. Ghostty.Tests is pure logic and cross-platform;
@@ -241,12 +245,39 @@ test-win:
     dotnet test dist/windows/IconGen.Tests/IconGen.Tests.csproj --blame-hang --blame-hang-timeout 5m
     dotnet test dist/windows/SplashGen.Tests/SplashGen.Tests.csproj --blame-hang --blame-hang-timeout 5m
 
+# === Heavy job lanes (AGENTS.md) ===
+#
+# incoda is looked up on PATH and then in its installer's location, because
+# the agent shell this was written under had the latter and not the former.
+# This is the expression, not the path: it is evaluated inside each recipe
+# body's pwsh, so a `just test` on a Linux host never runs it.
+inc := '(Get-Command incoda -ErrorAction SilentlyContinue)?.Source ?? (Join-Path $env:LOCALAPPDATA "Programs\incoda\incoda.exe")'
+
+# The build phase of a harness recipe, under the build lane. Every harness
+# recipe depends on this instead of on `build-dll build-win` directly: the
+# lane a build needs (CPU and RAM, three at a time) is not the lane a
+# harness needs (the desktop, alone), and a recipe that held one key across
+# both phases would either serialise every build behind a two-hour fuzz run
+# or run the harness while a build churns next door. So the build takes
+# wintty-build and releases it, and the caller takes wintty-desktop for the
+# harness. RECIPES is what to build, in order. An agent that wraps the whole
+# recipe in `incoda run` on one of these keys is fine: a nested run on a
+# held key passes through.
+[windows]
+_build-in-lane reason +recipes:
+    $inc = {{inc}}; if (-not (Test-Path $inc)) { Write-Host "incoda not found on PATH or in Programs\incoda: the heavy job lanes need it (AGENTS.md; https://github.com/deblasis/incoda)" -ForegroundColor Red; exit 1 }; & $inc run --queue wintty-build --reason "{{reason}}: build" -- just {{recipes}}; exit ($LASTEXITCODE ?? 1)
+
 # Launch two instances a few hundred ms apart and watch for a launch splash
 # owned by the one that should be forwarding itself to the other. Opens real
 # windows, so it needs an interactive desktop and no Wintty already running.
 # Pass extra args through, e.g. `just splash-race "-SecondaryFeatureOff"`.
 [windows]
-splash-race args="": _no-wintty-running build-win
+splash-race args="": _no-wintty-running (_build-in-lane "splash-race" "build-win")
+    $inc = {{inc}}; & $inc run --queue wintty-desktop --reason "splash-race {{args}}" -- just _splash-race-in-lane "{{args}}"; exit ($LASTEXITCODE ?? 1)
+
+# The desktop phase of `just splash-race`, inside the lane it took.
+[windows]
+_splash-race-in-lane args="":
     pwsh -NoProfile -File windows/scripts/splash-single-instance-race.ps1 {{args}}; exit ($LASTEXITCODE ?? 1)
 
 # Checked before the builds, not after: the harnesses refuse to run while a
@@ -281,7 +312,12 @@ _no-wintty-running:
 #
 # Pass extra args through, e.g. `just search-fuzz "-Seed 99 -Iterations 40"`.
 [windows]
-search-fuzz args="": _no-wintty-running build-dll build-win
+search-fuzz args="": _no-wintty-running (_build-in-lane "search-fuzz" "build-dll" "build-win")
+    $inc = {{inc}}; & $inc run --queue wintty-desktop --reason "search-fuzz {{args}}" -- just _search-fuzz-in-lane "{{args}}"; exit ($LASTEXITCODE ?? 1)
+
+# The desktop phase of `just search-fuzz`, inside the lane it took.
+[windows]
+_search-fuzz-in-lane args="":
     pwsh -NoProfile -File windows/scripts/search-fuzz.ps1 \
         -ExePath windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Wintty.exe \
         -OutDir windows/scripts/search-fuzz {{args}}; exit ($LASTEXITCODE ?? 1)
@@ -300,7 +336,12 @@ search-fuzz args="": _no-wintty-running build-dll build-win
 #
 # Pass extra args through, e.g. `just shader-notice-fuzz "-Seed 99"`.
 [windows]
-shader-notice-fuzz args="": _no-wintty-running build-dll build-win
+shader-notice-fuzz args="": _no-wintty-running (_build-in-lane "shader-notice-fuzz" "build-dll" "build-win")
+    $inc = {{inc}}; & $inc run --queue wintty-desktop --reason "shader-notice-fuzz {{args}}" -- just _shader-notice-fuzz-in-lane "{{args}}"; exit ($LASTEXITCODE ?? 1)
+
+# The desktop phase of `just shader-notice-fuzz`, inside the lane it took.
+[windows]
+_shader-notice-fuzz-in-lane args="":
     pwsh -NoProfile -File windows/scripts/shader-notice-fuzz.ps1 \
         -ExePath windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Wintty.exe \
         -OutDir windows/scripts/shader-notice-fuzz {{args}}; exit ($LASTEXITCODE ?? 1)
@@ -323,7 +364,12 @@ shader-notice-fuzz args="": _no-wintty-running build-dll build-win
 #
 # Pass extra args through, e.g. `just frame-style-fuzz "-Seed 99 -Random 3"`.
 [windows]
-frame-style-fuzz args="": _no-wintty-running build-dll build-win
+frame-style-fuzz args="": _no-wintty-running (_build-in-lane "frame-style-fuzz" "build-dll" "build-win")
+    $inc = {{inc}}; & $inc run --queue wintty-desktop --reason "frame-style-fuzz {{args}}" -- just _frame-style-fuzz-in-lane "{{args}}"; exit ($LASTEXITCODE ?? 1)
+
+# The desktop phase of `just frame-style-fuzz`, inside the lane it took.
+[windows]
+_frame-style-fuzz-in-lane args="":
     pwsh -NoProfile -File windows/scripts/frame-style-fuzz.ps1 \
         -ExePath windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Wintty.exe \
         -OutDir windows/scripts/frame-style-fuzz {{args}}; exit ($LASTEXITCODE ?? 1)
@@ -334,15 +380,12 @@ frame-style-fuzz args="": _no-wintty-running build-dll build-win
 # curated set, a day and more for `-Theme all`; a red run is the expected
 # outcome and windows/scripts/theme-matrix/matrix.md is the deliverable.
 #
-# It goes through the incoda lane, and the lane is taken BEFORE the builds:
-# this harness flips the desktop theme and the wallpaper and puts a topmost
-# stage on screen, so nothing else may own the desktop while it runs, and a
-# build started outside the lane while another lane holder ran would be the
-# collision the lane exists to stop. Hence two recipes: this one only takes
-# the lane, the private one below it does the work inside.
-#
-# incoda is looked up on PATH and then in its installer's location, because
-# the agent shell this was written under had the latter and not the former.
+# It takes the lanes itself, one per phase (see _build-in-lane): the DLL
+# and the shell build under wintty-build, then the harness holds
+# wintty-desktop for the whole run, because it flips the desktop theme and
+# the wallpaper and puts a topmost stage on screen, so nothing else may own
+# the desktop while it runs. Hence two recipes: this one takes the lanes,
+# the private one below it does the work inside the desktop lane.
 #
 # Every axis takes one value, a comma list, or all. Pass args through, e.g.
 #   just theme-matrix "-Theme wintty-dark -Polarity dark -Layout vertical"
@@ -358,13 +401,14 @@ frame-style-fuzz args="": _no-wintty-running build-dll build-win
 #
 # Exit codes: 0 clean, 2 findings, 1 could not run or a surface went unmeasured.
 #
-# Run the theme matrix (#937) under the incoda lane against the Debug build.
+# Run the theme matrix (#937) under the incoda lanes against the Debug build.
 [windows]
-theme-matrix args="":
-    $inc = (Get-Command incoda -ErrorAction SilentlyContinue)?.Source ?? (Join-Path $env:LOCALAPPDATA 'Programs\incoda\incoda.exe'); & $inc run --queue wintty --reason "theme matrix (#937)" -- just _theme-matrix-in-lane "{{args}}"; exit ($LASTEXITCODE ?? 1)
+theme-matrix args="": _no-wintty-running (_build-in-lane "theme matrix (#937)" "build-dll" "build-win")
+    $inc = {{inc}}; & $inc run --queue wintty-desktop --reason "theme matrix (#937) {{args}}" -- just _theme-matrix-in-lane "{{args}}"; exit ($LASTEXITCODE ?? 1)
 
+# The desktop phase of `just theme-matrix`, inside the lane it took.
 [windows]
-_theme-matrix-in-lane args="": _no-wintty-running build-dll build-win
+_theme-matrix-in-lane args="":
     pwsh -NoProfile -File windows/scripts/theme-matrix.ps1 \
         -ExePath windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Wintty.exe \
         -OutDir windows/scripts/theme-matrix {{args}}; exit ($LASTEXITCODE ?? 1)
@@ -406,7 +450,12 @@ theme-matrix-report run="windows/scripts/theme-matrix":
 #
 # Run every GUI fuzz harness against the Debug build.
 [windows]
-fuzz args="": _no-wintty-running build-dll build-win
+fuzz args="": _no-wintty-running (_build-in-lane "fuzz" "build-dll" "build-win")
+    $inc = {{inc}}; & $inc run --queue wintty-desktop --reason "fuzz {{args}}" -- just _fuzz-in-lane "{{args}}"; exit ($LASTEXITCODE ?? 1)
+
+# The desktop phase of `just fuzz`, inside the lane it took.
+[windows]
+_fuzz-in-lane args="":
     pwsh -NoProfile -File windows/scripts/fuzz-suite.ps1 \
         -ExePath windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Wintty.exe {{args}}; exit ($LASTEXITCODE ?? 1)
 

--- a/justfile
+++ b/justfile
@@ -260,9 +260,19 @@ inc := '(Get-Command incoda -ErrorAction SilentlyContinue)?.Source ?? (Join-Path
 # both phases would either serialise every build behind a two-hour fuzz run
 # or run the harness while a build churns next door. So the build takes
 # wintty-build and releases it, and the caller takes wintty-desktop for the
-# harness. RECIPES is what to build, in order. An agent that wraps the whole
-# recipe in `incoda run` on one of these keys is fine: a nested run on a
-# held key passes through.
+# harness. RECIPES is what to build, in order.
+#
+# Do not wrap one of these recipes in `incoda run` on a single key: the two
+# phases take different keys, so whichever phase is on the other key nests
+# where the outer run holds nothing, and an outer wintty-desktop waiting on
+# wintty-build inverts the order the exclusive pair takes, which is a
+# deadlock until both --wait budgets elapse. Call them bare; the one safe
+# wrapper is the exclusive pair, which holds both keys before either phase
+# starts and lets both nested runs pass through.
+#
+# The args reach the desktop phase inside double quotes with every double
+# quote doubled (pwsh's own escape), so a `$` or a backtick is what cannot
+# be passed; a single quote and a double quote both survive.
 [windows]
 _build-in-lane reason +recipes:
     $inc = {{inc}}; if (-not (Test-Path $inc)) { Write-Host "incoda not found on PATH or in Programs\incoda: the heavy job lanes need it (AGENTS.md; https://github.com/deblasis/incoda)" -ForegroundColor Red; exit 1 }; & $inc run --queue wintty-build --reason "{{reason}}: build" -- just {{recipes}}; exit ($LASTEXITCODE ?? 1)
@@ -273,7 +283,7 @@ _build-in-lane reason +recipes:
 # Pass extra args through, e.g. `just splash-race "-SecondaryFeatureOff"`.
 [windows]
 splash-race args="": _no-wintty-running (_build-in-lane "splash-race" "build-win")
-    $inc = {{inc}}; & $inc run --queue wintty-desktop --reason "splash-race {{args}}" -- just _splash-race-in-lane "{{args}}"; exit ($LASTEXITCODE ?? 1)
+    $inc = {{inc}}; & $inc run --queue wintty-desktop --reason ("splash-race {{replace(args, '"', '""')}}".Trim()) -- just _splash-race-in-lane "{{replace(args, '"', '""')}}"; exit ($LASTEXITCODE ?? 1)
 
 # The desktop phase of `just splash-race`, inside the lane it took.
 [windows]
@@ -313,7 +323,7 @@ _no-wintty-running:
 # Pass extra args through, e.g. `just search-fuzz "-Seed 99 -Iterations 40"`.
 [windows]
 search-fuzz args="": _no-wintty-running (_build-in-lane "search-fuzz" "build-dll" "build-win")
-    $inc = {{inc}}; & $inc run --queue wintty-desktop --reason "search-fuzz {{args}}" -- just _search-fuzz-in-lane "{{args}}"; exit ($LASTEXITCODE ?? 1)
+    $inc = {{inc}}; & $inc run --queue wintty-desktop --reason ("search-fuzz {{replace(args, '"', '""')}}".Trim()) -- just _search-fuzz-in-lane "{{replace(args, '"', '""')}}"; exit ($LASTEXITCODE ?? 1)
 
 # The desktop phase of `just search-fuzz`, inside the lane it took.
 [windows]
@@ -337,7 +347,7 @@ _search-fuzz-in-lane args="":
 # Pass extra args through, e.g. `just shader-notice-fuzz "-Seed 99"`.
 [windows]
 shader-notice-fuzz args="": _no-wintty-running (_build-in-lane "shader-notice-fuzz" "build-dll" "build-win")
-    $inc = {{inc}}; & $inc run --queue wintty-desktop --reason "shader-notice-fuzz {{args}}" -- just _shader-notice-fuzz-in-lane "{{args}}"; exit ($LASTEXITCODE ?? 1)
+    $inc = {{inc}}; & $inc run --queue wintty-desktop --reason ("shader-notice-fuzz {{replace(args, '"', '""')}}".Trim()) -- just _shader-notice-fuzz-in-lane "{{replace(args, '"', '""')}}"; exit ($LASTEXITCODE ?? 1)
 
 # The desktop phase of `just shader-notice-fuzz`, inside the lane it took.
 [windows]
@@ -365,7 +375,7 @@ _shader-notice-fuzz-in-lane args="":
 # Pass extra args through, e.g. `just frame-style-fuzz "-Seed 99 -Random 3"`.
 [windows]
 frame-style-fuzz args="": _no-wintty-running (_build-in-lane "frame-style-fuzz" "build-dll" "build-win")
-    $inc = {{inc}}; & $inc run --queue wintty-desktop --reason "frame-style-fuzz {{args}}" -- just _frame-style-fuzz-in-lane "{{args}}"; exit ($LASTEXITCODE ?? 1)
+    $inc = {{inc}}; & $inc run --queue wintty-desktop --reason ("frame-style-fuzz {{replace(args, '"', '""')}}".Trim()) -- just _frame-style-fuzz-in-lane "{{replace(args, '"', '""')}}"; exit ($LASTEXITCODE ?? 1)
 
 # The desktop phase of `just frame-style-fuzz`, inside the lane it took.
 [windows]
@@ -396,15 +406,18 @@ _frame-style-fuzz-in-lane args="":
 # commas inside, as in the third line. The recipe body is PowerShell:
 # `"Catppuccin Mocha",Nord` there would be an array that reaches the harness
 # as two arguments, the second of which lands on -Polarity, and a `\"` is
-# not an escape at all. The args cross the lane inside double quotes, so a
-# double quote or a `$` is what cannot be passed.
+# not an escape at all. The args cross the lane inside double quotes with
+# any double quote doubled, so a `$` or a backtick is what cannot be passed.
+# The no-Wintty check runs before the build lane rather than inside the
+# desktop lane, like every other harness: the window check that matters is
+# the harness's own Assert-NoWintty once it holds the desktop.
 #
 # Exit codes: 0 clean, 2 findings, 1 could not run or a surface went unmeasured.
 #
 # Run the theme matrix (#937) under the incoda lanes against the Debug build.
 [windows]
 theme-matrix args="": _no-wintty-running (_build-in-lane "theme matrix (#937)" "build-dll" "build-win")
-    $inc = {{inc}}; & $inc run --queue wintty-desktop --reason "theme matrix (#937) {{args}}" -- just _theme-matrix-in-lane "{{args}}"; exit ($LASTEXITCODE ?? 1)
+    $inc = {{inc}}; & $inc run --queue wintty-desktop --reason ("theme matrix (#937) {{replace(args, '"', '""')}}".Trim()) -- just _theme-matrix-in-lane "{{replace(args, '"', '""')}}"; exit ($LASTEXITCODE ?? 1)
 
 # The desktop phase of `just theme-matrix`, inside the lane it took.
 [windows]
@@ -451,7 +464,7 @@ theme-matrix-report run="windows/scripts/theme-matrix":
 # Run every GUI fuzz harness against the Debug build.
 [windows]
 fuzz args="": _no-wintty-running (_build-in-lane "fuzz" "build-dll" "build-win")
-    $inc = {{inc}}; & $inc run --queue wintty-desktop --reason "fuzz {{args}}" -- just _fuzz-in-lane "{{args}}"; exit ($LASTEXITCODE ?? 1)
+    $inc = {{inc}}; & $inc run --queue wintty-desktop --reason ("fuzz {{replace(args, '"', '""')}}".Trim()) -- just _fuzz-in-lane "{{replace(args, '"', '""')}}"; exit ($LASTEXITCODE ?? 1)
 
 # The desktop phase of `just fuzz`, inside the lane it took.
 [windows]

--- a/windows/scripts/README.md
+++ b/windows/scripts/README.md
@@ -234,8 +234,9 @@ puts everything back in its `finally`: the wallpaper through the API that
 applies one, the polarity through the broadcast, then the env guard's
 restore and read-back. A restore that fails is the run's exit code (1),
 whatever it measured. That is why it is not in the suite and why
-`just theme-matrix` takes the incoda lane before it builds. `-NoFlip` keeps
-the read-only policy every other harness has.
+`just theme-matrix` holds the desktop lane (`wintty-desktop`) for the whole
+run, after building under `wintty-build`. `-NoFlip` keeps the read-only
+policy every other harness has.
 
 After a hard kill (a `taskkill`, the lane's own timeout) the `finally`
 never ran, and the manual recovery is: end `BackdropStage.exe` if it is

--- a/windows/scripts/fuzz-suite.ps1
+++ b/windows/scripts/fuzz-suite.ps1
@@ -282,7 +282,7 @@ $NotInSuite = [ordered]@{
     # wallpaper while it runs, which no other harness here does. Its red run
     # is the expected outcome and the matrix.md it leaves is the deliverable
     # (#937), so aggregating its exit into a suite verdict would say nothing.
-    'theme-matrix.ps1'              = 'hours long by design and it sets the desktop theme and wallpaper; run it on its own through `just theme-matrix`, under the incoda lane, and read its matrix.md (#937)'
+    'theme-matrix.ps1'              = 'hours long by design and it sets the desktop theme and wallpaper; run it on its own through `just theme-matrix`, which takes the build and desktop lanes itself, and read its matrix.md (#937)'
     'theme-matrix-report.ps1'       = 'an analysis tool: it reads a theme-matrix run that has already happened (-RunDir, no -ExePath) and writes matrix.md. Launches nothing and returns no verdict'
 }
 


### PR DESCRIPTION
Splits the single `wintty` incoda key into `wintty-build` (3 slots), `wintty-desktop` and `wintty-publish`, one per resource class, so builds no longer queue behind fuzz runs and harnesses no longer run next to builds. Follows #1002 and incoda v0.3.0.

The harness recipes now take their lanes themselves, one per phase, through a shared `_build-in-lane` recipe; `signoff`, `test`, `test-win` and `build-dll` stay lane-free inside and the caller wraps them. The resignoff bot and the merge guard's issue text move to `wintty-build`.

Test plan
- [x] `just -n fuzz "-Tag smoke"`, `splash-race`, `theme-matrix "-NoFlip"`, `run-win` expand to build lane then desktop lane
- [x] `merge_guard.py --self-test` and `resignoff_bot.py --self-test` pass
- [ ] `just fuzz-selftest` fails on `origin/windows` already: `idle-badge-check.ps1` from #989 is not in the manifest (separate fix)
- [x] the three queues are configured on the box; `wintty` is closed once this and the release-side PR merge
