### PR TITLE
stb, unicode, inspector: drop the unused PNG decoder and two small fixes

### DIFF
--- a/src/font/embedded.zig
+++ b/src/font/embedded.zig
@@ -12,7 +12,8 @@ pub const variable_italic = @embedFile("jetbrains_mono_variable_italic");
 /// Symbols-only nerd font.
 pub const symbols_nerd_font = @embedFile("nerd_fonts_symbols_only");
 
-/// Static jetbrains mono faces, currently unused.
+/// Static jetbrains mono faces. `regular` is used by tests; `bold`,
+/// `italic`, and `bold_italic` are currently unused.
 pub const regular = @embedFile("jetbrains_mono_regular");
 pub const bold = @embedFile("jetbrains_mono_bold");
 pub const italic = @embedFile("jetbrains_mono_italic");

--- a/src/font/embedded.zig
+++ b/src/font/embedded.zig
@@ -54,3 +54,38 @@ pub const terminus_ttf = @embedFile("res/TerminusTTF-Regular.ttf");
 pub const spleen_bdf = @embedFile("res/spleen-8x16.bdf");
 pub const spleen_pcf = @embedFile("res/spleen-8x16.pcf");
 pub const spleen_otb = @embedFile("res/spleen-8x16.otb");
+
+test "variable face defaults to the Regular instance" {
+    // lib-vt source archives intentionally exclude full Ghostty font fixtures.
+    if (comptime @import("terminal_options").artifact == .lib) return error.SkipZigTest;
+
+    const std = @import("std");
+    const sfnt = @import("opentype/sfnt.zig");
+    const alloc = std.testing.allocator;
+
+    // The inspector hands this face to imgui without pinning a variation
+    // axis, so FreeType renders whatever the fvar default instance is. If
+    // that stops being Regular the entire inspector UI changes weight, and
+    // nothing else in the tree would notice: the terminal faces pin `wght`
+    // explicitly in SharedGridSet.
+    const face = try sfnt.SFNT.init(variable, alloc);
+    defer face.deinit(alloc);
+
+    const fvar = face.getTable("fvar").?;
+    const axes_offset = std.mem.readInt(u16, fvar[4..6], .big);
+    const axis_count = std.mem.readInt(u16, fvar[8..10], .big);
+    const axis_size = std.mem.readInt(u16, fvar[10..12], .big);
+
+    var weight_axes: usize = 0;
+    for (0..axis_count) |i| {
+        const axis = fvar[axes_offset + i * axis_size ..][0..axis_size];
+        if (!std.mem.eql(u8, axis[0..4], "wght")) continue;
+        weight_axes += 1;
+
+        const default: sfnt.Fixed = @bitCast(
+            std.mem.readInt(i32, axis[8..12], .big),
+        );
+        try std.testing.expectEqual(400, default.int);
+    }
+    try std.testing.expectEqual(1, weight_axes);
+}

--- a/src/inspector/Inspector.zig
+++ b/src/inspector/Inspector.zig
@@ -46,8 +46,8 @@ pub fn setup() void {
         font_config.FontDataOwnedByAtlas = false;
         _ = cimgui.c.ImFontAtlas_AddFontFromMemoryTTF(
             io.Fonts,
-            @ptrCast(@constCast(font.embedded.regular.ptr)),
-            @intCast(font.embedded.regular.len),
+            @ptrCast(@constCast(font.embedded.variable.ptr)),
+            @intCast(font.embedded.variable.len),
             font_size,
             &font_config,
             null,

--- a/src/inspector/Inspector.zig
+++ b/src/inspector/Inspector.zig
@@ -49,7 +49,11 @@ pub fn setup() void {
         // FreeType loader renders the default instance. JetBrains Mono
         // defaults to wght 400, the same weight as the static Regular
         // face this used to load, which is why the inspector looks the
-        // same. `font/embedded.zig` has a test that keeps it that way.
+        // same. `font/embedded.zig` has a test that fails if a font bump
+        // moves that default; it does not check this call site. Nothing
+        // does: `zig build test -Dapp-runtime=none` never analyzes
+        // `setup()`, since its only callers are the embedded (lib) and
+        // gtk runtimes, so only those builds compile these lines.
         _ = cimgui.c.ImFontAtlas_AddFontFromMemoryTTF(
             io.Fonts,
             @ptrCast(@constCast(font.embedded.variable.ptr)),

--- a/src/inspector/Inspector.zig
+++ b/src/inspector/Inspector.zig
@@ -44,6 +44,12 @@ pub fn setup() void {
         var font_config: cimgui.c.ImFontConfig = undefined;
         cimgui.ext.ImFontConfig_ImFontConfig(&font_config);
         font_config.FontDataOwnedByAtlas = false;
+
+        // We hand imgui a variable font and never pin an axis, so its
+        // FreeType loader renders the default instance. JetBrains Mono
+        // defaults to wght 400, the same weight as the static Regular
+        // face this used to load, which is why the inspector looks the
+        // same. `font/embedded.zig` has a test that keeps it that way.
         _ = cimgui.c.ImFontAtlas_AddFontFromMemoryTTF(
             io.Fonts,
             @ptrCast(@constCast(font.embedded.variable.ptr)),

--- a/src/stb/main.zig
+++ b/src/stb/main.zig
@@ -1,10 +1,7 @@
 const c = @cImport({
-    @cInclude("stb_image.h");
     @cInclude("stb_image_resize.h");
 });
 
 // We'll just add the exports of the functions or types we actually use
 // here, no need to export everything from the C lib if we don't use it.
-pub const stbi_load_from_memory = c.stbi_load_from_memory;
-pub const stbi_image_free = c.stbi_image_free;
 pub const stbir_resize_uint8 = c.stbir_resize_uint8;

--- a/src/stb/stb.c
+++ b/src/stb/stb.c
@@ -1,13 +1,2 @@
-// For STBI we only need PNG because the only use case we have right now
-// is the Kitty Graphics protocol which only supports PNG as a format
-// besides raw RGB/RGBA buffers.
-#define STBI_ONLY_PNG
-
-// We don't want to support super large images.
-#define STBI_MAX_DIMENSIONS 131072
-
-#define STB_IMAGE_IMPLEMENTATION
-#include <stb_image.h>
-
 #define STB_IMAGE_RESIZE_IMPLEMENTATION
 #include <stb_image_resize.h>

--- a/src/unicode/grapheme.zig
+++ b/src/unicode/grapheme.zig
@@ -225,7 +225,7 @@ pub fn main() !void {
 
         for (min..max) |cp2| {
             if (cp2 == '\r' or cp2 == '\n' or
-                uucode.get(.grapheme_break, @intCast(cp1)) == .control) continue;
+                uucode.get(.grapheme_break, @intCast(cp2)) == .control) continue;
 
             const gb = graphemeBreak(@intCast(cp1), @intCast(cp2), &state);
             const uu_gb = uucode.grapheme.isBreak(@intCast(cp1), @intCast(cp2), &uu_state);


### PR DESCRIPTION
Three small footprint and correctness leftovers.

- `src/stb/stb.c` compiled the whole stb_image PNG decoder, but nothing calls `stbi_load_from_memory` any more (kitty PNG decoding moved to wuffs); only the resizer is used by the FreeType face. The decoder implementation and its exports are dropped, the resizer stays. The vendored `stb_image.h` file is left in place for now.
- The grapheme break verifier tested `cp1` where it meant `cp2` in its inner control-character skip. It is a debug binary that is not wired into the build, so no automated test covers it.
- The inspector loaded the static JetBrains Mono Regular face for imgui while the app uses the variable face everywhere else. It now uses the variable face; the "currently unused" comment on the static faces was wrong and now says they are used by tests.

This is where the artifact actually shrinks. `src/stb/stb.c` is added unconditionally by `src/build/SharedDeps.zig:542`, so the PNG decoder was compiled into every build; the surviving `stbir_resize_uint8` call in `src/font/face/freetype.zig` is on the bitmap-glyph path and is compiled by the test build too. Any later change that measures a size delta on this stack should attribute it to this commit, not to the follow-up, whose deletions are source-tree only.

What the inspector change is and is not covered by, stated up front so it is not mistaken for more:

- `zig build test -Dapp-runtime=none` does **not** analyze `Inspector.setup()`. Its only callers are `src/apprt/embedded.zig` and `src/apprt/gtk/class/inspector_widget.zig`, and under the `.exe` artifact with `app_runtime = .none` `apprt.runtime` resolves to `apprt.none` (`src/apprt.zig:43-50`), so the body is never compiled. A green suite is not evidence for this hunk. The `.lib` artifact build is the one that reaches it, via `main_c.zig` → `CAPI` → `ghostty_surface_inspector` → `setup()`, so the Windows leg (`just build-dll`) is what compiles these lines.
- The `test "variable face defaults to the Regular instance"` added to `src/font/embedded.zig` is a font-data oracle, not coverage of the call site: it reads the `fvar` table and fails if a JetBrains Mono bump moves the `wght` default off 400. Reverting the inspector to `font.embedded.regular` leaves it passing. It is worth keeping for what it does check; the comment at the call site now says exactly that rather than implying the test pins the inspector.
- The grapheme fix has no coverage at all and cannot get any here: `grapheme.zig`'s `main()` has no caller, `src/unicode/main.zig` imports the file into a private const, and the file has no `refAllDecls`. The change is right by the function's own contract — `graphemeBreak`'s doc comment says control characters must be filtered out before the call, the outer loop already filters `cp1`, so the inner test on `cp1` was dead and control `cp2` values were reaching a function documented not to accept them.

Test plan:
- [x] `zig build -Dapp-runtime=none` (105/105) proves the decoder removal links
- [x] `zig build test -Dapp-runtime=none`, full suite
- [x] `zig fmt --check` on touched files

Follow-ups, not done here:
- The static bold, italic and bold-italic embedded faces are unreferenced by production code and are removed with the orphaned `stb_image.h` in the follow-up PR.
- `src/inspector/Inspector.zig` maps to zig-fmt + zig-tests under `gate_scope.py`'s `("src/", ZIG_LEGS)` prefix rule, and neither leg compiles `setup()`. Giving that file an `EXACT_RULES` entry with the Windows leg would close the gap; it is a gate change, not a code change, so it belongs on its own.
- `grapheme.zig:246` declares `pub const std_options = struct { ... }` — a type where zig 0.16's `std.Options` value is required. That only bites when the file is the root, which is why it compiles as a module today, but it has to be fixed before the `-Demit-unicode-test` TODO can be actioned.
