### PR TITLE
terminal: widen page ref counts so wide pages cannot overflow them

### DIFF
--- a/src/terminal/hyperlink.zig
+++ b/src/terminal/hyperlink.zig
@@ -211,7 +211,7 @@ pub const PageEntry = struct {
 pub const Set = RefCountedSet(
     PageEntry,
     Id,
-    size.CellCountInt,
+    size.RefCountInt,
     struct {
         /// The page which holds the strings for items in this set.
         page: ?*Page = null,

--- a/src/terminal/page.zig
+++ b/src/terminal/page.zig
@@ -3051,6 +3051,41 @@ test "Page clone graphemes" {
     }
 }
 
+test "Page style ref count can cover every cell of an oversized page" {
+    // A page that is wider than our standard capacity keeps the standard
+    // row count instead of shrinking it, so its cell count is far more than
+    // a CellCountInt can hold. Every one of those cells may reference the
+    // same style, so the ref count has to be wider than a cell count.
+    //
+    // We only compute the capacity here; actually allocating a page that
+    // wide would cost tens of megabytes for no extra coverage.
+    var wide = std_capacity;
+    wide.cols = std_capacity.maxCols().? + 1;
+    const cells: usize = @as(usize, wide.cols) * @as(usize, wide.rows);
+    try testing.expect(cells > std.math.maxInt(size.CellCountInt));
+
+    var page = try Page.init(.{
+        .cols = 10,
+        .rows = 10,
+        .styles = 8,
+    });
+    defer page.deinit();
+
+    const id = try page.styles.add(page.memory, .{ .flags = .{
+        .bold = true,
+    } });
+    page.styles.useMultiple(page.memory, id, @intCast(cells - 1));
+    try testing.expectEqual(cells, @as(usize, page.styles.refCount(page.memory, id)));
+
+    // Releasing a single cell must not drop the style.
+    page.styles.release(page.memory, id);
+    try testing.expectEqual(cells - 1, @as(usize, page.styles.refCount(page.memory, id)));
+    try testing.expectEqual(@as(usize, 1), page.styles.count());
+
+    page.styles.releaseMultiple(page.memory, id, @intCast(cells - 1));
+    try testing.expectEqual(@as(usize, 0), page.styles.count());
+}
+
 test "Page clone styles" {
     var page = try Page.init(.{
         .cols = 10,

--- a/src/terminal/ref_counted_set.zig
+++ b/src/terminal/ref_counted_set.zig
@@ -430,7 +430,7 @@ pub fn RefCountedSet(
         /// Release a specified number of references to an item by its ID.
         ///
         /// Asserts that the item's reference count is at least `n`.
-        pub fn releaseMultiple(self: *Self, base: anytype, id: Id, n: Id) void {
+        pub fn releaseMultiple(self: *Self, base: anytype, id: Id, n: RefCountInt) void {
             assert(id > 0);
             assert(id < self.layout.cap);
 

--- a/src/terminal/size.zig
+++ b/src/terminal/size.zig
@@ -31,6 +31,14 @@ pub const CellCountInt = u16;
 pub const StyleCountInt = CellCountInt;
 pub const HyperlinkCountInt = CellCountInt;
 
+// The int type used for the reference counts in a page's ref-counted sets
+// (styles and hyperlinks). This is deliberately wider than CellCountInt: a
+// page wider than our standard capacity keeps the standard row count rather
+// than shrinking it, so a single page can hold far more than
+// maxInt(CellCountInt) cells and every one of them can reference the same
+// style or hyperlink.
+pub const RefCountInt = u32;
+
 // Total number of bytes that can be taken up by grapheme data and string
 // data. Both of these technically unlimited with malicious input, but
 // we choose a reasonable limit of 2^32 (4GB) per.

--- a/src/terminal/size.zig
+++ b/src/terminal/size.zig
@@ -39,6 +39,17 @@ pub const HyperlinkCountInt = CellCountInt;
 // style or hyperlink.
 pub const RefCountInt = u32;
 
+// The bound above holds by coincidence of two independently chosen widths:
+// a page's cell count is at most maxCols * maxRows, both CellCountInt, and
+// 65535 * 65535 is 4294836225 against a u32 ceiling of 4294967295, leaving
+// 131070 to spare. Widening CellCountInt to support very wide terminals is
+// exactly the change that would reintroduce the overflow, and it would do
+// so in a build that stays green, so bind the two types here.
+comptime {
+    assert(@as(u64, std.math.maxInt(CellCountInt)) *
+        std.math.maxInt(CellCountInt) <= std.math.maxInt(RefCountInt));
+}
+
 // Total number of bytes that can be taken up by grapheme data and string
 // data. Both of these technically unlimited with malicious input, but
 // we choose a reasonable limit of 2^32 (4GB) per.

--- a/src/terminal/style.zig
+++ b/src/terminal/style.zig
@@ -681,7 +681,7 @@ pub const Style = struct {
 pub const Set = RefCountedSet(
     Style,
     Id,
-    size.CellCountInt,
+    size.RefCountInt,
     struct {
         pub fn hash(self: *const @This(), style: Style) u64 {
             _ = self;


### PR DESCRIPTION
A page's style and hyperlink reference counts were `u16`, but a page can hold far more than 65535 cells and every one of them can reference the same style.

A page wider than the standard capacity keeps the standard row count rather than shrinking it, so a 300x300 page is 90000 cells. Fill it with one style and `item.meta.ref += 1` wraps: in ReleaseFast that frees a style that is still referenced, and in ReleaseSafe it panics.

What changed:

- New `size.RefCountInt = u32`, used for the `ref` field of `RefCountedSet.Item.Metadata` and for the counts in `useMultiple` and `releaseMultiple`.
- `releaseMultiple` previously took its count as `Id`, so even with a wide counter a caller could not express a release run longer than 65535. That is fixed by the same change.
- A `comptime` assertion binds `RefCountInt` to `CellCountInt` squared. Every call site of `useMultiple`, `releaseMultiple` and `refCount` now widens rather than narrows, so no production site assumes the old width.

## Footprint

This makes every pooled page slightly bigger, which is worth stating rather than leaving to be measured.

`Item.Metadata` is a plain auto-layout struct, so widening `ref` from `u16` to `u32` lifts the item's alignment from 2 to 4 and its size from 20 to 24 bytes, **+4 bytes and +20% per style-set item**. Measured on the lane toolchain with a layout probe, using a 14-byte 2-aligned stand-in for `Style`:

```
sizeOf(StyleLike)=14 align=2
Item(u16 ref) size=20 align=2
Item(u32 ref) size=24 align=4
styles cap=128 table_cap=128 items_cap=104
style set total: old=2336 new=2752 delta=416
```

With `std_capacity.styles = 128`, `Layout.init` gives `table_cap = 128` and `items_cap = floor(0.8125 * 128) = 104`, so the style set costs **+416 bytes per page**. The hyperlink set is the same `RefCountedSet` and pays the same +4 bytes per item; its capacity is derived from a byte budget rather than a fixed count, so its total moves with `hyperlink_bytes`.

All of that flows into `std_size = Page.layout(std_capacity).total_size`, the memory-pool item size, so every pooled page in every surface pays it, and the pool-versus-heap threshold moves with it.

For scale, a standard page's cell array alone is `215 * 215 * 8`, about 360 KB, so the delta is well under 1%. Not a blocker, but this project tracks page footprint deliberately and the number belongs here.

## Why the assertion, given the bound already holds

It holds by 0.003%. The largest layout-able cell count is `maxCols * maxRows`, both `CellCountInt`, and `Capacity.maxCols()` clamps to `maxInt(CellCountInt)`:

```
65535 * 65535 = 4294836225
maxInt(u32)   = 4294967295
headroom      =     131070
```

References are not exclusively per-cell (`Screen` holds one extra style and one extra hyperlink reference for the cursor), so the true worst case is cells plus a small constant, comfortably inside 131070. But that is an arithmetic coincidence between two independently chosen widths, and widening `CellCountInt` to support very wide terminals is exactly the change someone would make next. Without the assertion it would silently reintroduce the overflow in a build that stays green. The file already applies this discipline to the Id types.

Test plan:

- [x] `zig build test -Dapp-runtime=none -Dtest-filter=oversized`, no leak lines.
- [x] `RefCountInt = u32` back to `u16` fails `terminal.page.test.Page style ref count can cover every cell of an oversized page` with `integer does not fit in destination type`.
- [x] With the assertion in place, the same narrowing now fails at compile time instead: `error: reached unreachable code`, `size.zig:49:11: note: called at comptime here`. A container-level `comptime` block is always analysed, so the assertion cannot be skipped.
- [x] `zig fmt --check` on every touched file.

Note on the new test: it computes a cell count from `std_capacity` arithmetic and calls `useMultiple` with it on a small page, so it asserts the width of `RefCountInt` rather than exercising an overflow at a production site. That is what it claims to do, and allocating a page that wide would cost tens of megabytes, but it would not catch a regression that kept the counter wide and reintroduced a narrowing cast elsewhere. The comptime assertion is the cheaper and stronger guard.
