### PR TITLE
termio, datastruct: keep waiting for a queue slot, bound pty writes, grow CircBuf geometrically

### DIFF
--- a/src/App.zig
+++ b/src/App.zig
@@ -592,6 +592,25 @@ pub const Message = union(enum) {
     /// message if it needs to.
     redraw_surface: *apprt.Surface,
 
+    /// Release anything the message owns. `Mailbox.push` calls this when
+    /// a full queue makes it give the message up.
+    ///
+    /// Exhaustive on purpose: a variant that starts owning memory has to
+    /// be decided here rather than compiling into a silent leak on every
+    /// drop.
+    pub fn deinit(self: Message) void {
+        switch (self) {
+            .surface_message => |v| v.message.deinit(),
+
+            .open_config,
+            .new_window,
+            .close,
+            .quit,
+            .redraw_surface,
+            => {},
+        }
+    }
+
     const NewWindow = struct {
         /// The parent surface
         parent: ?*Surface = null,
@@ -613,25 +632,40 @@ pub const Mailbox = struct {
     rt_app: *apprt.App,
     mailbox: *Queue,
 
-    /// Send a message to the surface.
+    /// Send a message to the surface. `.forever` takes ownership of
+    /// `msg`: it is either queued or released.
     ///
     /// `.forever` does not park here. This queue is drained by `App.tick`
     /// alone and the apprt calls that from its wakeup handler -- on the
     /// embedded runtime that handler is the only caller there is -- so a
     /// producer waiting inside the queue is waiting for a drain its own
     /// wake has to start. It waits in windows instead and re-issues the
-    /// wake after each one, with no attempt limit: these messages carry
-    /// clipboard payloads and heap pointers that nothing here can
-    /// release, so giving up would leak them.
+    /// wake after each one.
+    ///
+    /// The budget is the background pair, roughly a minute, because every
+    /// producer that reaches this path is a background thread: the search
+    /// thread, the termio writer and the pty reader. The cost of the wait
+    /// is a stalled search or a stalled child, not a frozen window.
+    ///
+    /// It is a budget and not an unbounded wait because a wedged consumer
+    /// is not the same thing as a dead one. The app thread can be alive
+    /// and itself blocked pushing to another full mailbox, and then a
+    /// producer that never gives up is one half of a deadlock that only a
+    /// kill recovers from. Giving up costs one message; `Message.deinit`
+    /// is what makes that cost bounded rather than a leak.
+    ///
+    /// The re-issued wake has no test of its own. Under
+    /// `-Dapp-runtime=none` -- the only runtime that compiles here --
+    /// `apprt.none.App.wakeup` is an empty body, so a fixed and an
+    /// unfixed push are observationally identical and reverting this
+    /// produces no failure. The loop is tested in
+    /// `BlockingQueue.pushWake`; the give-up path is tested below.
     pub fn push(self: Mailbox, msg: Message, timeout: Queue.Timeout) Queue.Size {
         const result = switch (timeout) {
-            .forever => self.mailbox.pushWake(
-                global.io(),
+            .forever => self.pushBounded(
                 msg,
-                self.rt_app,
-                wakeApp,
                 Queue.wake_retry_timeout_ns,
-                Queue.wake_retry_forever,
+                Queue.wake_retry_attempts,
             ),
 
             .instant, .ns => self.mailbox.push(global.io(), msg, timeout),
@@ -643,10 +677,71 @@ pub const Mailbox = struct {
         return result;
     }
 
+    fn pushBounded(
+        self: Mailbox,
+        msg: Message,
+        timeout_ns: u64,
+        max_attempts: usize,
+    ) Queue.Size {
+        const size = self.mailbox.pushWake(
+            global.io(),
+            msg,
+            self.rt_app,
+            wakeApp,
+            timeout_ns,
+            max_attempts,
+        );
+        if (size == 0) {
+            log.warn("app mailbox full, message dropped", .{});
+            msg.deinit();
+        }
+
+        return size;
+    }
+
     fn wakeApp(rt_app: *apprt.App) void {
         rt_app.wakeup();
     }
 };
+
+test "app mailbox push frees the message it has to give up" {
+    const testing = std.testing;
+    const build_config = @import("build_config.zig");
+
+    // The only runtime whose `wakeup` ignores its receiver, which is what
+    // lets this test hand it an undefined one.
+    if (build_config.app_runtime != .none) return error.SkipZigTest;
+
+    const alloc = testing.allocator;
+    const io = global.io();
+
+    const queue = try Mailbox.Queue.create(alloc);
+    defer queue.destroy(alloc);
+
+    var rt_app: apprt.App = undefined;
+    const mailbox: Mailbox = .{ .rt_app = &rt_app, .mailbox = queue };
+
+    // Fill the queue and never drain it. An app thread that is alive but
+    // blocked on another full mailbox looks exactly like this from a
+    // producer's side, and that is the state an unbounded wait here turns
+    // into a deadlock.
+    while (queue.push(io, .{ .quit = {} }, .{ .instant = {} }) > 0) {}
+
+    // A pwd longer than the inline capacity is heap allocated, so
+    // std.testing.allocator fails this test if the give-up path leaks it.
+    const pwd = "/" ++ ("d" ** 400);
+    const req = try apprt.surface.Message.WriteReq.init(alloc, @as([]const u8, pwd));
+    try testing.expect(req == .alloc);
+
+    // A tiny budget so the test finishes; production uses the queue's
+    // wake_retry_* defaults.
+    const size = mailbox.pushBounded(.{ .surface_message = .{
+        .surface = undefined,
+        .message = .{ .pwd_change = req },
+    } }, 1 * std.time.ns_per_ms, 3);
+
+    try testing.expectEqual(@as(Mailbox.Queue.Size, 0), size);
+}
 
 // Wasm API.
 pub const Wasm = if (!builtin.target.isWasm()) struct {} else struct {

--- a/src/App.zig
+++ b/src/App.zig
@@ -690,6 +690,12 @@ pub const Mailbox = struct {
             wakeApp,
             timeout_ns,
             max_attempts,
+            // The search thread emits match batches per tick and the pty
+            // reader emits per OSC, so this queue's producers do arrive
+            // in streams. Spending the budget once per stall rather than
+            // once per message is what keeps a wedged app thread from
+            // stalling them for as long as it is wedged.
+            .fail_fast,
         );
         if (size == 0) {
             log.warn("app mailbox full, message dropped", .{});

--- a/src/App.zig
+++ b/src/App.zig
@@ -704,12 +704,40 @@ pub const Mailbox = struct {
     /// so the budget is the only thing standing between a wedge and a tab
     /// that never learns its child is gone.
     ///
-    /// The cost, stated plainly: the caller is the termio writer thread
-    /// inside an xev callback, so a wedged app thread can now park it for
-    /// the whole background budget once per child exit, where `push`
-    /// would have returned immediately. That is what this queue did on
-    /// the merge base for every producer, and it is bounded: past the
-    /// budget the message is still given up and freed.
+    /// Where this stands against the merge base: better, not equal. On
+    /// `218b8243db` this function's ancestor waited on the not-full
+    /// condition with no timeout at all, and only a `pop` can signal
+    /// that condition, so a producer facing an app thread that had
+    /// stopped draining parked here forever. `.persist` **bounds** that
+    /// hang at one background budget; it does not restore one.
+    ///
+    /// The cost, stated plainly, and it is worse on Windows than on
+    /// POSIX. On POSIX the caller is `Exec.processExit`, an `xev.Process`
+    /// wait callback on the termio writer thread, so a wedged app thread
+    /// parks that thread for one background budget per child exit.
+    ///
+    /// On Windows -- which is what this fork ships -- the caller is
+    /// `Exec.winProcessWaitThread`, a dedicated `WaitForSingleObject`
+    /// thread, and at teardown the wait reaches the UI thread through two
+    /// joins: `Surface.deinit` joins the io thread, and `Exec.threadExit`
+    /// joins the wait thread. In that path the stall is **guaranteed, not
+    /// conditional**: the app thread is inside `Surface.deinit`, so it is
+    /// by construction not draining this mailbox, and no separate "wedged
+    /// app thread" precondition is needed -- a full mailbox at close time
+    /// is enough. Worse, that is the push `Exec.threadExit` itself calls
+    /// harmless: `App.surfaceMessage` gates on `hasSurface` and the
+    /// surface is being destroyed, so the budget is spent delivering a
+    /// message guaranteed to be discarded.
+    ///
+    /// That path is worth closing and is filed as a follow-up
+    /// (suppressing the teardown push in `Exec`), not fixed here: the
+    /// flag would be written on the io thread and read on the wait
+    /// thread, so it needs an ordering argument rather than an
+    /// assignment, and it can only narrow the window -- the wait thread
+    /// can already be inside `processExitCommon` when the flag is set.
+    ///
+    /// It is bounded either way: past the budget the message is still
+    /// given up and freed.
     pub fn pushRequired(self: Mailbox, msg: Message) Queue.Size {
         return self.pushRequiredBounded(
             msg,

--- a/src/App.zig
+++ b/src/App.zig
@@ -660,16 +660,74 @@ pub const Mailbox = struct {
     /// unfixed push are observationally identical and reverting this
     /// produces no failure. The loop is tested in
     /// `BlockingQueue.pushWake`; the give-up path is tested below.
+    ///
+    /// `push` is the streaming policy: it fails fast while the queue is
+    /// latched wedged. Use `pushRequired` for the rare message whose
+    /// loss nothing re-derives.
     pub fn push(self: Mailbox, msg: Message, timeout: Queue.Timeout) Queue.Size {
         const result = switch (timeout) {
             .forever => self.pushBounded(
                 msg,
                 Queue.wake_retry_timeout_ns,
                 Queue.wake_retry_attempts,
+                // The search thread emits match batches per tick and the
+                // pty reader emits per OSC, so this queue's producers do
+                // arrive in streams. Spending the budget once per stall
+                // rather than once per message is what keeps a wedged app
+                // thread from stalling them for as long as it is wedged.
+                .fail_fast,
             ),
 
             .instant, .ns => self.mailbox.push(global.io(), msg, timeout),
         };
+
+        // Wake up our app loop
+        self.rt_app.wakeup();
+
+        return result;
+    }
+
+    /// Push a one-shot message that nothing re-derives if it is lost.
+    ///
+    /// The latch that `push` respects turns a *delayed* delivery into a
+    /// *permanent* loss for this class of message: an app thread wedged
+    /// past one budget and then recovering would still have delivered it
+    /// on the next attempt, and `.fail_fast` throws that attempt away.
+    /// `.persist` spends the full budget instead, which is what the queue
+    /// did for every message before the latch existed.
+    ///
+    /// This is deliberately NOT the policy for `password_input`, the
+    /// other one-shot on this queue: that one is re-derived by the
+    /// termios poll every 200ms until the surface agrees, so a give-up
+    /// there costs one poll rather than the state. `.child_exited` has no
+    /// such poll -- `processExitCommon` runs once per surface lifetime --
+    /// so the budget is the only thing standing between a wedge and a tab
+    /// that never learns its child is gone.
+    ///
+    /// The cost, stated plainly: the caller is the termio writer thread
+    /// inside an xev callback, so a wedged app thread can now park it for
+    /// the whole background budget once per child exit, where `push`
+    /// would have returned immediately. That is what this queue did on
+    /// the merge base for every producer, and it is bounded: past the
+    /// budget the message is still given up and freed.
+    pub fn pushRequired(self: Mailbox, msg: Message) Queue.Size {
+        return self.pushRequiredBounded(
+            msg,
+            Queue.wake_retry_timeout_ns,
+            Queue.wake_retry_attempts,
+        );
+    }
+
+    /// `pushRequired` with the budget as a parameter, so a test can make
+    /// the wait short enough to observe. The wedge token is the whole
+    /// point of the function and is what a mutation should revert.
+    fn pushRequiredBounded(
+        self: Mailbox,
+        msg: Message,
+        timeout_ns: u64,
+        max_attempts: usize,
+    ) Queue.Size {
+        const result = self.pushBounded(msg, timeout_ns, max_attempts, .persist);
 
         // Wake up our app loop
         self.rt_app.wakeup();
@@ -682,6 +740,7 @@ pub const Mailbox = struct {
         msg: Message,
         timeout_ns: u64,
         max_attempts: usize,
+        wedge: Queue.Wedge,
     ) Queue.Size {
         const size = self.mailbox.pushWake(
             global.io(),
@@ -690,12 +749,7 @@ pub const Mailbox = struct {
             wakeApp,
             timeout_ns,
             max_attempts,
-            // The search thread emits match batches per tick and the pty
-            // reader emits per OSC, so this queue's producers do arrive
-            // in streams. Spending the budget once per stall rather than
-            // once per message is what keeps a wedged app thread from
-            // stalling them for as long as it is wedged.
-            .fail_fast,
+            wedge,
         );
         if (size == 0) {
             log.warn("app mailbox full, message dropped", .{});
@@ -744,9 +798,61 @@ test "app mailbox push frees the message it has to give up" {
     const size = mailbox.pushBounded(.{ .surface_message = .{
         .surface = undefined,
         .message = .{ .pwd_change = req },
-    } }, 1 * std.time.ns_per_ms, 3);
+    } }, 1 * std.time.ns_per_ms, 3, .fail_fast);
 
     try testing.expectEqual(@as(Mailbox.Queue.Size, 0), size);
+}
+
+test "app mailbox pushRequired ignores a latch that push respects" {
+    const testing = std.testing;
+    const build_config = @import("build_config.zig");
+
+    // The only runtime whose `wakeup` ignores its receiver, which is what
+    // lets this test hand it an undefined one.
+    if (build_config.app_runtime != .none) return error.SkipZigTest;
+
+    const alloc = testing.allocator;
+    const io = global.io();
+
+    const queue = try Mailbox.Queue.create(alloc);
+    defer queue.destroy(alloc);
+
+    var rt_app: apprt.App = undefined;
+    const mailbox: Mailbox = .{ .rt_app = &rt_app, .mailbox = queue };
+
+    // A wedged app thread: full, and nothing drains it.
+    while (queue.push(io, .{ .quit = {} }, .{ .instant = {} }) > 0) {}
+
+    // Latch the queue the way a stream of search results would.
+    const window_ns = 20 * std.time.ns_per_ms;
+    try testing.expectEqual(@as(Mailbox.Queue.Size, 0), mailbox.pushBounded(
+        .{ .quit = {} },
+        window_ns,
+        3,
+        .fail_fast,
+    ));
+    try testing.expect(queue.wedged.load(.acquire));
+
+    // `.child_exited` is the message this exists for: one shot, nothing
+    // re-derives it. It must still spend its budget against the latch,
+    // because an app thread that recovers inside that budget delivers it.
+    // Measured rather than asserted on the token, so swapping `.persist`
+    // for `.fail_fast` in `pushRequiredBounded` fails here: three 20ms
+    // windows cannot complete in under 30ms, and a fail-fast give-up is
+    // a single non-blocking attempt.
+    const start = std.Io.Timestamp.now(io, .awake);
+    try testing.expectEqual(@as(Mailbox.Queue.Size, 0), mailbox.pushRequiredBounded(
+        .{ .surface_message = .{
+            .surface = undefined,
+            .message = .{ .child_exited = .{ .exit_code = 0, .runtime_ms = 0 } },
+        } },
+        window_ns,
+        3,
+    ));
+
+    // One-directional: load on the build machine can only lengthen this,
+    // never shorten it, so a busy host cannot make this flaky.
+    try testing.expect(start.untilNow(io, .awake).toMilliseconds() >= 30);
 }
 
 // Wasm API.

--- a/src/App.zig
+++ b/src/App.zig
@@ -614,13 +614,37 @@ pub const Mailbox = struct {
     mailbox: *Queue,
 
     /// Send a message to the surface.
+    ///
+    /// `.forever` does not park here. This queue is drained by `App.tick`
+    /// alone and the apprt calls that from its wakeup handler -- on the
+    /// embedded runtime that handler is the only caller there is -- so a
+    /// producer waiting inside the queue is waiting for a drain its own
+    /// wake has to start. It waits in windows instead and re-issues the
+    /// wake after each one, with no attempt limit: these messages carry
+    /// clipboard payloads and heap pointers that nothing here can
+    /// release, so giving up would leak them.
     pub fn push(self: Mailbox, msg: Message, timeout: Queue.Timeout) Queue.Size {
-        const result = self.mailbox.push(global.io(), msg, timeout);
+        const result = switch (timeout) {
+            .forever => self.mailbox.pushWake(
+                global.io(),
+                msg,
+                self.rt_app,
+                wakeApp,
+                Queue.wake_retry_timeout_ns,
+                Queue.wake_retry_forever,
+            ),
+
+            .instant, .ns => self.mailbox.push(global.io(), msg, timeout),
+        };
 
         // Wake up our app loop
         self.rt_app.wakeup();
 
         return result;
+    }
+
+    fn wakeApp(rt_app: *apprt.App) void {
+        rt_app.wakeup();
     }
 };
 

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -5183,26 +5183,29 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
                 break :search;
             }
 
-            _ = s.state.mailbox.push(
-                global.io(),
+            // This runs on the UI thread and the search thread drains
+            // only when it is woken, so the push must not be able to
+            // park; it takes ownership of the needle either way.
+            _ = terminal.search.Thread.pushMailbox(
+                s.state.mailbox,
+                &s.state.wakeup,
                 .{ .change_needle = try .init(
                     self.alloc,
                     text,
                 ) },
-                .forever,
             );
             s.state.wakeup.notify() catch {};
         },
 
         .navigate_search => |nav| {
             const s: *Search = if (self.search) |*s| s else return false;
-            _ = s.state.mailbox.push(
-                global.io(),
+            _ = terminal.search.Thread.pushMailbox(
+                s.state.mailbox,
+                &s.state.wakeup,
                 .{ .select = switch (nav) {
                     .next => .next,
                     .previous => .prev,
                 } },
-                .forever,
             );
             s.state.wakeup.notify() catch {};
         },

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -909,41 +909,14 @@ inline fn surfaceMailbox(self: *Surface) Mailbox {
 ///
 /// Every historical push here used `.forever`, which trusts that the
 /// renderer thread always drains its mailbox. On the IOCP backend that
-/// trust has a hole (#1036): the Async wake can be lost in the window
-/// between a completion firing and its re-arm, and once the renderer is
-/// asleep with a full mailbox (64 messages, reached in practice by a
-/// hidden surface whose termio-driven wakes are gated) the pushing
-/// thread parks forever in the queue's not-full condition -- observed
-/// as the UI thread hanging inside `ghostty_surface_set_occlusion`.
-///
-/// The bounded retry closes the hole from the producer side: a timed-out
-/// push re-issues the wake (`queueRender`) before trying again, so a
-/// single lost notify costs one `renderer_push_timeout` stall and a
-/// retry, never a hang. `error.Timeout` callers keep the old
-/// fail-and-drop behavior for the one genuinely fatal case (the
-/// renderer thread is gone), which a `.forever` push would have turned
-/// into a deadlock anyway.
-const renderer_push_timeout_ns: u64 = 250 * std.time.ns_per_ms;
-
+/// trust has a hole (#1036), so every producer of that mailbox goes
+/// through the bounded retry instead; see `renderer.Thread.pushMailbox`.
 fn pushRendererMailbox(self: *Surface, msg: rendererpkg.Message) rendererpkg.Thread.Mailbox.Size {
-    var attempts: usize = 0;
-    while (true) {
-        const size = self.renderer_thread.mailbox.push(
-            global.io(),
-            msg,
-            .{ .ns = renderer_push_timeout_ns },
-        );
-        if (size > 0) return size;
-
-        // The push timed out: the mailbox is full and the renderer has
-        // not drained it within the window, so assume the wake was lost
-        // and issue a fresh one before retrying. The notify below is
-        // also the recovery when the renderer is merely busy.
-        self.queueRender() catch {};
-
-        attempts += 1;
-        if (attempts >= 240) return 0; // ~1 minute: treat as dead consumer
-    }
+    return rendererpkg.Thread.pushMailbox(
+        self.renderer_thread.mailbox,
+        &self.renderer_thread.wakeup,
+        msg,
+    );
 }
 
 /// Queue a message for the IO thread, taking ownership of `msg`.

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -3480,10 +3480,12 @@ pub const CAPI = struct {
     const Darwin = struct {
         export fn ghostty_surface_set_display_id(ptr: *Surface, display_id: u32) void {
             const surface = &ptr.core_surface;
-            _ = surface.renderer_thread.mailbox.push(
-                global.io(),
+            // Bounded: the notify below is what makes the renderer
+            // drain, so parking in the queue here would withhold it.
+            _ = renderer.Thread.pushMailbox(
+                surface.renderer_thread.mailbox,
+                &surface.renderer_thread.wakeup,
                 .{ .macos_display_id = display_id },
-                .{ .forever = {} },
             );
             surface.renderer_thread.wakeup.notify() catch {};
         }

--- a/src/apprt/surface.zig
+++ b/src/apprt/surface.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
+const assert = std.debug.assert;
 
 const apprt = @import("../apprt.zig");
 const build_config = @import("../build_config.zig");
@@ -221,6 +222,68 @@ pub const Message = union(enum) {
         }
     }
 
+    /// Whether a full mailbox may give this message up.
+    ///
+    /// This is the delivery policy `Mailbox.push` and
+    /// `Mailbox.pushRequired` assert on, kept as data rather than as a
+    /// convention two call sites have to remember. `false` means nothing
+    /// re-derives the message, so dropping it is permanent and
+    /// user-visible; those must go through `pushRequired`.
+    ///
+    /// `.child_exited` is the only one today. `Exec.processExitCommon`
+    /// runs once per surface lifetime and `Surface.childExited` is what
+    /// sets `self.child_exited`, so without it `close-on-exit` never
+    /// fires, the exit overlay never appears, and the close confirmation
+    /// keeps asking about a process that is already gone.
+    ///
+    /// Exhaustive on purpose, matching `deinit`. Two things follow, and
+    /// both are the point of writing it this way:
+    ///
+    ///   * A rebase that collapses `Exec.processExitCommon`'s
+    ///     `pushRequired` back into `push` -- which type-checks, because
+    ///     both functions still exist with matching signatures -- now
+    ///     panics on the first child exit in any Debug build instead of
+    ///     silently losing the notice. Nothing else in the tree catches
+    ///     that collapse: `termio/Exec.zig` is in no test graph, and both
+    ///     spellings pass the exe build.
+    ///   * A new `Message` variant is a compile error here until someone
+    ///     picks its delivery policy, rather than inheriting `push`'s by
+    ///     default. That default-inheritance is the trap this whole
+    ///     change exists to close.
+    pub fn dropAllowed(self: Message) bool {
+        return switch (self) {
+            .child_exited => false,
+
+            .set_title,
+            .report_title,
+            .set_mouse_shape,
+            .clipboard_read,
+            .kitty_clipboard_read,
+            .kitty_clipboard_write,
+            .clipboard_write,
+            .change_config,
+            .close,
+            .desktop_notification,
+            .renderer_health,
+            .present_surface,
+            .password_input,
+            .color_change,
+            .selection_scroll_tick,
+            .pwd_change,
+            .ring_bell,
+            .progress_report,
+            .start_command,
+            .stop_command,
+            .prompt_input,
+            .first_render,
+            .custom_shader_failed,
+            .scrollbar,
+            .search_total,
+            .search_selected,
+            => true,
+        };
+    }
+
     pub const ReportTitleStyle = enum {
         csi_21_t,
 
@@ -250,11 +313,17 @@ pub const Mailbox = struct {
     app: App.Mailbox,
 
     /// Send a message to the surface.
+    ///
+    /// This is the droppable policy: it fails fast while the app mailbox
+    /// is latched wedged. Use `pushRequired` for a message nothing
+    /// re-derives, and see `Message.dropAllowed` for which those are.
     pub fn push(
         self: Mailbox,
         msg: Message,
         timeout: App.Mailbox.Queue.Timeout,
     ) App.Mailbox.Queue.Size {
+        assert(msg.dropAllowed());
+
         // Surface message sending is actually implemented on the app
         // thread, so we have to rewrap the message with our surface
         // pointer and send it to the app thread.
@@ -270,8 +339,12 @@ pub const Mailbox = struct {
     ///
     /// See `App.Mailbox.pushRequired`. Only for a one-shot whose loss is
     /// permanent and user-visible; everything the stream handler sends
-    /// is an event and belongs on `push`.
+    /// is an event and belongs on `push`. `Message.dropAllowed` is the
+    /// list, and this assert is the other half of `push`'s: neither
+    /// function will carry a message the other one owns.
     pub fn pushRequired(self: Mailbox, msg: Message) App.Mailbox.Queue.Size {
+        assert(!msg.dropAllowed());
+
         return self.app.pushRequired(.{
             .surface_message = .{
                 .surface = self.surface,
@@ -420,4 +493,26 @@ test "surface message variants are all accounted for by the push give-up path" {
     // owning variant compiles and leaks silently on every drop.
     const fields = @typeInfo(Message).@"union".fields;
     try std.testing.expectEqual(@as(usize, 27), fields.len);
+}
+
+test "the child-exit notice is the one message push may not carry" {
+    // This is the decision `Mailbox.push` and `Mailbox.pushRequired`
+    // assert on, and it is the only part of the guard a test in this
+    // config can reach: `Mailbox.push` itself is not semantically
+    // analysed by `zig build test -Dapp-runtime=none` (only the Linux
+    // exe build analyses it), and a Debug panic is not catchable by the
+    // test runner in any case. Moving `.child_exited` into the droppable
+    // arm neuters the guard silently, so grip it here.
+    try std.testing.expect(!(Message{ .child_exited = .{
+        .exit_code = 0,
+        .runtime_ms = 0,
+    } }).dropAllowed());
+
+    // And the assert in `push` must not fire on anything the stream
+    // handler, the renderer or the search thread actually send, one per
+    // producer so a wrong `false` cannot hide behind a passing sibling.
+    try std.testing.expect((Message{ .ring_bell = {} }).dropAllowed());
+    try std.testing.expect((Message{ .password_input = true }).dropAllowed());
+    try std.testing.expect((Message{ .renderer_health = .healthy }).dropAllowed());
+    try std.testing.expect((Message{ .search_total = null }).dropAllowed());
 }

--- a/src/apprt/surface.zig
+++ b/src/apprt/surface.zig
@@ -177,16 +177,46 @@ pub const Message = union(enum) {
     /// including the struct itself -- with nothing registered anywhere
     /// else that a destroy could dangle.
     ///
-    /// `change_config` is deliberately not listed: nothing pushes it onto
-    /// a mailbox. `App.updateConfig` hands it straight to
+    /// `change_config` frees nothing here on purpose: nothing pushes it
+    /// onto a mailbox. `App.updateConfig` hands it straight to
     /// `Surface.handleMessage`, so this layer never owns one.
+    ///
+    /// Exhaustive on purpose, matching `App.Message.deinit`: a variant
+    /// that starts owning memory is then a compile error here rather
+    /// than a silent leak on every drop. The field-count test below is
+    /// the weaker guard this replaces -- it fires only if this file is
+    /// in the running build graph, and only at test time.
     pub fn deinit(self: Message) void {
         switch (self) {
             .clipboard_write => |v| v.req.deinit(),
             .pwd_change => |v| v.deinit(),
             .kitty_clipboard_read => |v| v.destroy(),
             .kitty_clipboard_write => |v| v.destroy(),
-            else => {},
+
+            .set_title,
+            .report_title,
+            .set_mouse_shape,
+            .clipboard_read,
+            .change_config,
+            .close,
+            .child_exited,
+            .desktop_notification,
+            .renderer_health,
+            .present_surface,
+            .password_input,
+            .color_change,
+            .selection_scroll_tick,
+            .ring_bell,
+            .progress_report,
+            .start_command,
+            .stop_command,
+            .prompt_input,
+            .first_render,
+            .custom_shader_failed,
+            .scrollbar,
+            .search_total,
+            .search_selected,
+            => {},
         }
     }
 

--- a/src/apprt/surface.zig
+++ b/src/apprt/surface.zig
@@ -166,6 +166,30 @@ pub const Message = union(enum) {
     /// Selected search index change
     search_selected: ?usize,
 
+    /// Release anything the message owns. A mailbox push calls this when
+    /// it has to give the message up, so a variant that starts owning
+    /// memory has to free it here or it leaks on that path.
+    ///
+    /// Every owning variant already carries its own destructor, so this
+    /// needs no allocator and settles no ownership rule that was not
+    /// already settled: `MessageData` holds the allocator it was built
+    /// with, and the two Kitty requests own the arena they live in --
+    /// including the struct itself -- with nothing registered anywhere
+    /// else that a destroy could dangle.
+    ///
+    /// `change_config` is deliberately not listed: nothing pushes it onto
+    /// a mailbox. `App.updateConfig` hands it straight to
+    /// `Surface.handleMessage`, so this layer never owns one.
+    pub fn deinit(self: Message) void {
+        switch (self) {
+            .clipboard_write => |v| v.req.deinit(),
+            .pwd_change => |v| v.deinit(),
+            .kitty_clipboard_read => |v| v.destroy(),
+            .kitty_clipboard_write => |v| v.destroy(),
+            else => {},
+        }
+    }
+
     pub const ReportTitleStyle = enum {
         csi_21_t,
 
@@ -327,4 +351,28 @@ test "copyUtf8Z preserves UTF-8 that fits" {
     Message.DesktopNotification.copyUtf8Z(dst.len, &dst, "abcЯ");
 
     try std.testing.expectEqualStrings("abcЯ", std.mem.sliceTo(&dst, 0));
+}
+
+test "surface message deinit frees a push the mailbox gave up" {
+    const alloc = std.testing.allocator;
+
+    // A pwd longer than the inline capacity is heap allocated, so
+    // std.testing.allocator fails this test if `deinit` misses it. This
+    // is the whole reason the app mailbox can take an attempt budget
+    // instead of waiting forever for a slot.
+    const pwd = "/" ++ ("d" ** 400);
+    const req = try Message.WriteReq.init(alloc, @as([]const u8, pwd));
+    try std.testing.expect(req == .alloc);
+
+    const msg: Message = .{ .pwd_change = req };
+    msg.deinit();
+}
+
+test "surface message variants are all accounted for by the push give-up path" {
+    // Adding a variant to Message is a decision: does it own memory that
+    // `deinit` has to release when a full mailbox gives the message up?
+    // Make that decision, then bump this count. Without the guard a new
+    // owning variant compiles and leaks silently on every drop.
+    const fields = @typeInfo(Message).@"union".fields;
+    try std.testing.expectEqual(@as(usize, 27), fields.len);
 }

--- a/src/apprt/surface.zig
+++ b/src/apprt/surface.zig
@@ -183,8 +183,9 @@ pub const Message = union(enum) {
     ///
     /// Exhaustive on purpose, matching `App.Message.deinit`: a variant
     /// that starts owning memory is then a compile error here rather
-    /// than a silent leak on every drop. The field-count test below is
-    /// the weaker guard this replaces -- it fires only if this file is
+    /// than a silent leak on every drop. The field-count test below
+    /// backs this up rather than being replaced by it; it is kept, and
+    /// it is the weaker of the two because it fires only if this file is
     /// in the running build graph, and only at test time.
     pub fn deinit(self: Message) void {
         switch (self) {
@@ -263,6 +264,20 @@ pub const Mailbox = struct {
                 .message = msg,
             },
         }, timeout);
+    }
+
+    /// Send a message the surface cannot re-derive if it is lost.
+    ///
+    /// See `App.Mailbox.pushRequired`. Only for a one-shot whose loss is
+    /// permanent and user-visible; everything the stream handler sends
+    /// is an event and belongs on `push`.
+    pub fn pushRequired(self: Mailbox, msg: Message) App.Mailbox.Queue.Size {
+        return self.app.pushRequired(.{
+            .surface_message = .{
+                .surface = self.surface,
+                .message = msg,
+            },
+        });
     }
 };
 

--- a/src/datastruct/blocking_queue.zig
+++ b/src/datastruct/blocking_queue.zig
@@ -112,29 +112,40 @@ pub fn BlockingQueue(
                     .forever => {
                         self.not_full_waiters += 1;
                         defer self.not_full_waiters -= 1;
-                        self.cond_not_full.waitUncancelable(io, &self.mutex);
+
+                        // Being woken doesn't mean there is a slot for
+                        // us: we have multiple producers, so another one
+                        // can take the freed slot before we reacquire
+                        // the mutex. Wait again instead of dropping the
+                        // value, which callers have no way to notice.
+                        while (self.full()) {
+                            self.cond_not_full.waitUncancelable(io, &self.mutex);
+                        }
                     },
 
                     .ns => |ns| {
                         self.not_full_waiters += 1;
                         defer self.not_full_waiters -= 1;
-                        compat_thread.waitTimeout(
-                            &self.cond_not_full,
-                            io,
-                            &self.mutex,
-                            .{
-                                .duration = .{
-                                    .raw = .fromNanoseconds(ns),
-                                    .clock = .awake,
-                                },
-                            },
-                        ) catch return 0;
+
+                        // Same as above, except we resolve the timeout to
+                        // an absolute deadline first so that waiting
+                        // again can't extend the caller's timeout.
+                        const relative: std.Io.Timeout = .{ .duration = .{
+                            .raw = .fromNanoseconds(ns),
+                            .clock = .awake,
+                        } };
+                        const deadline = relative.toDeadline(io);
+
+                        while (self.full()) {
+                            compat_thread.waitTimeout(
+                                &self.cond_not_full,
+                                io,
+                                &self.mutex,
+                                deadline,
+                            ) catch return 0;
+                        }
                     },
                 }
-
-                // If we're still full, then we failed to write. This can
-                // happen in situations where we are interrupted.
-                if (self.full()) return 0;
             }
 
             // Add our data and update our accounting
@@ -258,4 +269,60 @@ test "timed push" {
 
     // Timed push should fail
     try testing.expectEqual(@as(Q.Size, 0), q.push(io, 2, .{ .ns = 1000 }));
+}
+
+test "BlockingQueue push forever retries when woken with no free slot" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    const Q = BlockingQueue(u64, 1);
+    const q = try Q.create(alloc);
+    defer q.destroy(alloc);
+
+    // Fill the queue so the pusher below has to wait for a slot.
+    try testing.expectEqual(@as(Q.Size, 1), q.push(io, 1, .{ .instant = {} }));
+
+    const Pusher = struct {
+        q: *Q,
+        result: Q.Size = 0,
+
+        fn run(self: *@This(), thread_io: std.Io) void {
+            self.result = self.q.push(thread_io, 2, .{ .forever = {} });
+        }
+    };
+
+    var pusher: Pusher = .{ .q = q };
+    const thread = try std.Thread.spawn(.{}, Pusher.run, .{ &pusher, io });
+
+    // Wait until the pusher is parked on the condition.
+    while (true) {
+        q.mutex.lockUncancelable(io);
+        const parked = q.not_full_waiters > 0;
+        q.mutex.unlock(io);
+        if (parked) break;
+        std.Thread.yield() catch {};
+    }
+
+    // Wake the pusher while the queue is still full. This is what a
+    // second producer taking the slot first looks like from the woken
+    // pusher's side: there is nothing for it, so it has to keep waiting
+    // instead of dropping the value.
+    for (0..1000) |_| {
+        q.cond_not_full.broadcast(io);
+        std.Thread.yield() catch {};
+    }
+
+    q.mutex.lockUncancelable(io);
+    const still_parked = q.not_full_waiters > 0;
+    q.mutex.unlock(io);
+
+    // Free a slot so the pusher can finish either way, then join before
+    // asserting so a failure doesn't leave the thread behind.
+    try testing.expect(q.pop(io).? == 1);
+    thread.join();
+
+    try testing.expect(still_parked);
+    try testing.expectEqual(@as(Q.Size, 1), pusher.result);
+    try testing.expect(q.pop(io).? == 2);
 }

--- a/src/datastruct/blocking_queue.zig
+++ b/src/datastruct/blocking_queue.zig
@@ -96,9 +96,30 @@ pub fn BlockingQueue(
             alloc.destroy(self);
         }
 
+        /// How long one `pushWake` attempt waits for a slot before the
+        /// consumer's wake is re-issued.
+        pub const wake_retry_timeout_ns: u64 = 250 * std.time.ns_per_ms;
+
+        /// How many of those windows a producer spends before it treats
+        /// the consumer as gone. Roughly a minute.
+        pub const wake_retry_attempts: usize = 240;
+
+        /// A `pushWake` budget that never gives up, for queues carrying
+        /// values the push has no way to release.
+        pub const wake_retry_forever: usize = std.math.maxInt(usize);
+
         /// Push a value to the queue. This returns the total size of the
-        /// queue (unread items) after the push. A return value of zero
-        /// means that the push failed.
+        /// queue (unread items) after the push, so a queued value always
+        /// returns at least one.
+        ///
+        /// A return of zero means the value was NOT queued and the caller
+        /// still owns it: a value that owns memory must be released on
+        /// that path. Only `.instant` and `.ns` can return zero.
+        /// `.forever` waits until a slot is genuinely free, so it never
+        /// returns zero -- and never returns at all while the consumer is
+        /// not draining. Producers of a queue that is drained only when
+        /// its consumer is woken should use `pushWake` instead, because a
+        /// `.forever` wait there withholds the wake it waits on.
         pub fn push(self: *Self, io: std.Io, value: T, timeout: Timeout) Size {
             self.mutex.lockUncancelable(io);
             defer self.mutex.unlock(io);
@@ -155,6 +176,42 @@ pub fn BlockingQueue(
             self.len += 1;
 
             return self.len;
+        }
+
+        /// Push a value, re-issuing the consumer's wake between bounded
+        /// attempts instead of parking on the not-full condition.
+        ///
+        /// Our mailboxes are drained by a thread that only runs when it
+        /// is woken, so a producer that waits inside the queue is waiting
+        /// for a drain its own wake has to start, and on the IOCP backend
+        /// that wake can be lost outright (#1036). `wakeFn` is therefore
+        /// called after every window that did not land the value, which
+        /// is what makes the wait recoverable.
+        ///
+        /// A zero return means the value was not queued and THE CALLER
+        /// STILL OWNS IT: anything holding memory must be released on
+        /// that path. Pass `wake_retry_forever` as `max_attempts` when
+        /// there is nothing sensible to do with a refused value; that
+        /// budget never returns zero.
+        pub fn pushWake(
+            self: *Self,
+            io: std.Io,
+            value: T,
+            ctx: anytype,
+            comptime wakeFn: fn (@TypeOf(ctx)) void,
+            timeout_ns: u64,
+            max_attempts: usize,
+        ) Size {
+            var attempts: usize = 0;
+            while (true) {
+                const result = self.push(io, value, .{ .ns = timeout_ns });
+                if (result > 0) return result;
+
+                wakeFn(ctx);
+
+                attempts += 1;
+                if (attempts >= max_attempts) return 0;
+            }
         }
 
         /// Pop a value from the queue without blocking.
@@ -325,4 +382,79 @@ test "BlockingQueue push forever retries when woken with no free slot" {
     try testing.expect(still_parked);
     try testing.expectEqual(@as(Q.Size, 1), pusher.result);
     try testing.expect(q.pop(io).? == 2);
+}
+
+test "BlockingQueue pushWake wakes the consumer on every window it loses" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    const Q = BlockingQueue(u64, 1);
+    const q = try Q.create(alloc);
+    defer q.destroy(alloc);
+
+    // Fill the queue and never drain it. That is what a consumer asleep
+    // on a lost wake looks like from a producer's side.
+    try testing.expectEqual(@as(Q.Size, 1), q.push(io, 1, .{ .instant = {} }));
+
+    var woken: usize = 0;
+    const result = q.pushWake(
+        io,
+        2,
+        &woken,
+        countWake,
+        1 * std.time.ns_per_ms,
+        3,
+    );
+
+    // The invariant: a producer that cannot land its value must have
+    // woken the consumer anyway, once per window, because that wake is
+    // the only thing that frees the slot it is waiting for.
+    try testing.expectEqual(@as(usize, 3), woken);
+
+    // It gave up rather than parking, and took nothing with it.
+    try testing.expectEqual(@as(Q.Size, 0), result);
+    try testing.expect(q.pop(io).? == 1);
+}
+
+test "BlockingQueue pushWake lands once a wake frees a slot" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    const Q = BlockingQueue(u64, 1);
+    const q = try Q.create(alloc);
+    defer q.destroy(alloc);
+
+    try testing.expectEqual(@as(Q.Size, 1), q.push(io, 1, .{ .instant = {} }));
+
+    // A consumer that drains only when it is woken.
+    const Consumer = struct {
+        q: *Q,
+        io: std.Io,
+        woken: usize = 0,
+
+        fn wake(self: *@This()) void {
+            self.woken += 1;
+            _ = self.q.pop(self.io);
+        }
+    };
+
+    var consumer: Consumer = .{ .q = q, .io = io };
+    const result = q.pushWake(
+        io,
+        2,
+        &consumer,
+        Consumer.wake,
+        1 * std.time.ns_per_ms,
+        3,
+    );
+
+    try testing.expectEqual(@as(Q.Size, 1), result);
+    try testing.expectEqual(@as(usize, 1), consumer.woken);
+    try testing.expect(q.pop(io).? == 2);
+}
+
+fn countWake(woken: *usize) void {
+    woken.* += 1;
 }

--- a/src/datastruct/blocking_queue.zig
+++ b/src/datastruct/blocking_queue.zig
@@ -663,6 +663,66 @@ test "BlockingQueue pushWake spends the budget again once the consumer drains" {
     try testing.expect(q.pop(io).? == 3);
 }
 
+test "BlockingQueue pushWake clears the latch when a persist push lands the slow way" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    const Q = BlockingQueue(u64, 1);
+    const q = try Q.create(alloc);
+    defer q.destroy(alloc);
+
+    try testing.expectEqual(@as(Q.Size, 1), q.push(io, 1, .{ .instant = {} }));
+
+    // Latch it, the way a stream of UI events against a wedged consumer
+    // does.
+    var woken: usize = 0;
+    try testing.expectEqual(@as(Q.Size, 0), q.pushWake(
+        io,
+        2,
+        &woken,
+        countWake,
+        1 * std.time.ns_per_ms,
+        3,
+        .fail_fast,
+    ));
+    try testing.expect(q.wedged.load(.acquire));
+
+    // A `.persist` push now skips the fast path by construction, so if it
+    // lands it lands inside the budget loop -- and that is the only place
+    // left that can clear the latch. Without the clear there, a queue
+    // carrying both kinds (the termio mailbox; the app mailbox as of
+    // `pushRequired`) stays latched after a genuine recovery and keeps
+    // failing its droppable pushes fast for no reason.
+    const Consumer = struct {
+        q: *Q,
+        io: std.Io,
+        woken: usize = 0,
+
+        fn wake(self: *@This()) void {
+            self.woken += 1;
+            _ = self.q.pop(self.io);
+        }
+    };
+
+    var consumer: Consumer = .{ .q = q, .io = io };
+    try testing.expectEqual(@as(Q.Size, 1), q.pushWake(
+        io,
+        3,
+        &consumer,
+        Consumer.wake,
+        1 * std.time.ns_per_ms,
+        3,
+        .persist,
+    ));
+
+    // It went the slow way: the first window had to expire before the
+    // wake freed a slot. If this is 0 the push took the fast path and the
+    // test is no longer covering the branch it names.
+    try testing.expectEqual(@as(usize, 1), consumer.woken);
+    try testing.expect(!q.wedged.load(.acquire));
+}
+
 fn countWake(woken: *usize) void {
     woken.* += 1;
 }

--- a/src/datastruct/blocking_queue.zig
+++ b/src/datastruct/blocking_queue.zig
@@ -97,16 +97,24 @@ pub fn BlockingQueue(
         }
 
         /// How long one `pushWake` attempt waits for a slot before the
-        /// consumer's wake is re-issued.
+        /// consumer's wake is re-issued, and how many of those windows a
+        /// producer spends before it treats the consumer as gone. Roughly
+        /// a minute. This is the budget for a producer that is never the
+        /// UI thread, where the cost of the wait is a stalled background
+        /// job.
         pub const wake_retry_timeout_ns: u64 = 250 * std.time.ns_per_ms;
-
-        /// How many of those windows a producer spends before it treats
-        /// the consumer as gone. Roughly a minute.
         pub const wake_retry_attempts: usize = 240;
 
-        /// A `pushWake` budget that never gives up, for queues carrying
-        /// values the push has no way to release.
-        pub const wake_retry_forever: usize = std.math.maxInt(usize);
+        /// The same pair for a queue whose producer can be the UI thread,
+        /// where the cost of the wait is a frozen window. Windows paints
+        /// a window "Not Responding" after about five seconds without a
+        /// message pump and offers to kill it, so the total has to stay
+        /// well under that: a minute-long "bound" is not one a user can
+        /// tell apart from a hang. The shorter window also re-issues the
+        /// consumer's wake five times as often, and that re-issue is what
+        /// recovers a lost notify.
+        pub const wake_retry_timeout_ns_ui: u64 = 50 * std.time.ns_per_ms;
+        pub const wake_retry_attempts_ui: usize = 40;
 
         /// Push a value to the queue. This returns the total size of the
         /// queue (unread items) after the push, so a queued value always
@@ -190,9 +198,17 @@ pub fn BlockingQueue(
         ///
         /// A zero return means the value was not queued and THE CALLER
         /// STILL OWNS IT: anything holding memory must be released on
-        /// that path. Pass `wake_retry_forever` as `max_attempts` when
-        /// there is nothing sensible to do with a refused value; that
-        /// budget never returns zero.
+        /// that path. There is deliberately no budget that never gives
+        /// up. Every mailbox in this tree can release a refused message,
+        /// and a producer that waits without a limit takes its own thread
+        /// out of service for as long as the consumer is wedged -- which
+        /// is how two mailboxes deadlock each other rather than one of
+        /// them losing a message.
+        ///
+        /// Mutation-testing note: `wakeFn` is a comptime function
+        /// parameter, so `_ = wakeFn;` does not compile ("pointless
+        /// discard of function parameter"). Neutralise the call instead,
+        /// e.g. `if (attempts > 1_000_000) wakeFn(ctx);`.
         pub fn pushWake(
             self: *Self,
             io: std.Io,

--- a/src/datastruct/blocking_queue.zig
+++ b/src/datastruct/blocking_queue.zig
@@ -71,6 +71,12 @@ pub fn BlockingQueue(
         cond_not_full: std.Io.Condition = .init,
         not_full_waiters: usize = 0,
 
+        /// Latched by a `pushWake` that spends its whole budget without
+        /// landing, cleared by the next push that lands. It is advisory:
+        /// a stale read costs one budget or one message, never
+        /// correctness, so it is deliberately not under the mutex.
+        wedged: std.atomic.Value(bool) = .init(false),
+
         /// Allocate the blocking queue on the heap.
         pub fn create(alloc: Allocator) Allocator.Error!*Self {
             const ptr = try alloc.create(Self);
@@ -84,6 +90,7 @@ pub fn BlockingQueue(
                 .mutex = .init,
                 .cond_not_full = .init,
                 .not_full_waiters = 0,
+                .wedged = .init(false),
             };
 
             return ptr;
@@ -106,15 +113,38 @@ pub fn BlockingQueue(
         pub const wake_retry_attempts: usize = 240;
 
         /// The same pair for a queue whose producer can be the UI thread,
-        /// where the cost of the wait is a frozen window. Windows paints
-        /// a window "Not Responding" after about five seconds without a
-        /// message pump and offers to kill it, so the total has to stay
-        /// well under that: a minute-long "bound" is not one a user can
-        /// tell apart from a hang. The shorter window also re-issues the
-        /// consumer's wake five times as often, and that re-issue is what
-        /// recovers a lost notify.
+        /// where the cost of the wait is a frozen window. The shorter
+        /// window also re-issues the consumer's wake five times as often,
+        /// and that re-issue is what recovers a lost notify.
+        ///
+        /// This bounds ONE push, not the stall. A UI thread feeding a
+        /// wedged consumer -- mouse reporting, autorepeat, typing in the
+        /// search box -- makes one of these calls per event, so on its
+        /// own the pair buys a window that freezes two seconds per event
+        /// indefinitely while pumping often enough that Windows never
+        /// paints it "Not Responding" and never offers the kill. That is
+        /// worse than the minute it replaced, not better. The `wedged`
+        /// latch in `pushWake` is what turns it into a bound on the
+        /// stall: the budget is spent once per wedge, and every push
+        /// after it fails fast until the consumer drains again.
         pub const wake_retry_timeout_ns_ui: u64 = 50 * std.time.ns_per_ms;
         pub const wake_retry_attempts_ui: usize = 40;
+
+        /// What a `pushWake` does when the queue is already latched
+        /// `wedged`, i.e. an earlier push already spent a whole budget
+        /// against this consumer and lost it.
+        pub const Wedge = enum {
+            /// Try once, without waiting, and give up. For a producer
+            /// that will be back with another message immediately: the
+            /// budget is then spent once for the whole stall rather than
+            /// once per event, and the thread stays responsive.
+            fail_fast,
+
+            /// Spend the full budget anyway. For the rare message whose
+            /// loss costs more than the wait, and only from a producer
+            /// that is never the UI thread.
+            persist,
+        };
 
         /// Push a value to the queue. This returns the total size of the
         /// queue (unread items) after the push, so a queued value always
@@ -205,6 +235,23 @@ pub fn BlockingQueue(
         /// is how two mailboxes deadlock each other rather than one of
         /// them losing a message.
         ///
+        /// The budget bounds one call. It does not bound the stall the
+        /// producer sees, because nothing stops that producer arriving
+        /// with the next message the moment this one gives up. So a lost
+        /// budget latches `wedged`, and a `.fail_fast` caller then skips
+        /// the wait until a push lands and clears the latch. The wake is
+        /// still re-issued on that path, so the consumer can still
+        /// recover; what is given up is only the waiting, which the
+        /// previous full budget already proved was not being repaid.
+        ///
+        /// The cost, stated plainly: after one lost budget, a message
+        /// that would have landed in the next budget's second window is
+        /// dropped instead. A consumer that frees a slot within a budget
+        /// never latches, so the trade only applies to one that has
+        /// already failed to free a single slot across the whole of one
+        /// -- for the UI pair, 40 windows of 50ms with a wake re-issued
+        /// after each.
+        ///
         /// Mutation-testing note: `wakeFn` is a comptime function
         /// parameter, so `_ = wakeFn;` does not compile ("pointless
         /// discard of function parameter"). Neutralise the call instead,
@@ -217,16 +264,41 @@ pub fn BlockingQueue(
             comptime wakeFn: fn (@TypeOf(ctx)) void,
             timeout_ns: u64,
             max_attempts: usize,
+            wedge: Wedge,
         ) Size {
+            if (wedge == .fail_fast and self.wedged.load(.acquire)) {
+                const result = self.push(io, value, .{ .instant = {} });
+                if (result > 0) {
+                    self.wedged.store(false, .release);
+                    return result;
+                }
+
+                // Still wake. A lost notify is exactly the failure this
+                // function exists for, and withholding the wake here
+                // would make the latch self-sustaining.
+                wakeFn(ctx);
+                return 0;
+            }
+
             var attempts: usize = 0;
             while (true) {
                 const result = self.push(io, value, .{ .ns = timeout_ns });
-                if (result > 0) return result;
+                if (result > 0) {
+                    // Load before storing: this is every push's path and
+                    // the latch is clear on all but the recovering one.
+                    if (self.wedged.load(.monotonic)) {
+                        self.wedged.store(false, .release);
+                    }
+                    return result;
+                }
 
                 wakeFn(ctx);
 
                 attempts += 1;
-                if (attempts >= max_attempts) return 0;
+                if (attempts >= max_attempts) {
+                    self.wedged.store(true, .release);
+                    return 0;
+                }
             }
         }
 
@@ -421,6 +493,7 @@ test "BlockingQueue pushWake wakes the consumer on every window it loses" {
         countWake,
         1 * std.time.ns_per_ms,
         3,
+        .fail_fast,
     );
 
     // The invariant: a producer that cannot land its value must have
@@ -464,11 +537,130 @@ test "BlockingQueue pushWake lands once a wake frees a slot" {
         Consumer.wake,
         1 * std.time.ns_per_ms,
         3,
+        .fail_fast,
     );
 
     try testing.expectEqual(@as(Q.Size, 1), result);
     try testing.expectEqual(@as(usize, 1), consumer.woken);
     try testing.expect(q.pop(io).? == 2);
+}
+
+test "BlockingQueue pushWake stops spending the budget once it has lost one" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    const Q = BlockingQueue(u64, 1);
+    const q = try Q.create(alloc);
+    defer q.destroy(alloc);
+
+    // Fill the queue and never drain it. This is a wedged consumer.
+    try testing.expectEqual(@as(Q.Size, 1), q.push(io, 1, .{ .instant = {} }));
+
+    // The first push pays the full budget: three windows, three wakes.
+    var woken: usize = 0;
+    try testing.expectEqual(@as(Q.Size, 0), q.pushWake(
+        io,
+        2,
+        &woken,
+        countWake,
+        1 * std.time.ns_per_ms,
+        3,
+        .fail_fast,
+    ));
+    try testing.expectEqual(@as(usize, 3), woken);
+
+    // The second does not. This is what bounds the stall rather than one
+    // message: without it a UI thread with an event stream pays the whole
+    // budget again for every event, indefinitely.
+    woken = 0;
+    try testing.expectEqual(@as(Q.Size, 0), q.pushWake(
+        io,
+        3,
+        &woken,
+        countWake,
+        1 * std.time.ns_per_ms,
+        3,
+        .fail_fast,
+    ));
+
+    // One wake, not three: it tried once and gave up, but it still woke
+    // the consumer, because a lost notify is what it may be recovering.
+    try testing.expectEqual(@as(usize, 1), woken);
+
+    // A `.persist` caller ignores the latch and pays in full. This is
+    // the message whose loss costs more than the wait, and it must not
+    // be shortened by some other producer's give-up.
+    woken = 0;
+    try testing.expectEqual(@as(Q.Size, 0), q.pushWake(
+        io,
+        4,
+        &woken,
+        countWake,
+        1 * std.time.ns_per_ms,
+        3,
+        .persist,
+    ));
+    try testing.expectEqual(@as(usize, 3), woken);
+
+    try testing.expect(q.pop(io).? == 1);
+}
+
+test "BlockingQueue pushWake spends the budget again once the consumer drains" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    const Q = BlockingQueue(u64, 1);
+    const q = try Q.create(alloc);
+    defer q.destroy(alloc);
+
+    try testing.expectEqual(@as(Q.Size, 1), q.push(io, 1, .{ .instant = {} }));
+
+    // Latch it.
+    var woken: usize = 0;
+    try testing.expectEqual(@as(Q.Size, 0), q.pushWake(
+        io,
+        2,
+        &woken,
+        countWake,
+        1 * std.time.ns_per_ms,
+        3,
+        .fail_fast,
+    ));
+    try testing.expect(q.wedged.load(.acquire));
+
+    // The consumer comes back. The next push lands on the fast path and
+    // clears the latch, so recovery costs nothing and drops nothing.
+    try testing.expect(q.pop(io).? == 1);
+    woken = 0;
+    try testing.expectEqual(@as(Q.Size, 1), q.pushWake(
+        io,
+        3,
+        &woken,
+        countWake,
+        1 * std.time.ns_per_ms,
+        3,
+        .fail_fast,
+    ));
+    try testing.expectEqual(@as(usize, 0), woken);
+    try testing.expect(!q.wedged.load(.acquire));
+
+    // And a later wedge is paid for in full again, so the fast path is a
+    // response to one stall and not a permanent downgrade.
+    woken = 0;
+    try testing.expectEqual(@as(Q.Size, 0), q.pushWake(
+        io,
+        4,
+        &woken,
+        countWake,
+        1 * std.time.ns_per_ms,
+        3,
+        .fail_fast,
+    ));
+    try testing.expectEqual(@as(usize, 3), woken);
+
+    try testing.expect(q.pop(io).? == 3);
 }
 
 fn countWake(woken: *usize) void {

--- a/src/datastruct/circ_buf.zig
+++ b/src/datastruct/circ_buf.zig
@@ -158,7 +158,7 @@ pub fn CircBuf(comptime T: type, comptime default: T) type {
             // Grow geometrically. Our callers append in small increments
             // (the search sliding window adds a row at a time), and
             // resizing to exactly what was asked for makes that quadratic.
-            try self.resize(alloc, @max(new_cap, self.capacity() * 2));
+            try self.resize(alloc, @max(new_cap, self.capacity() *| 2));
         }
 
         /// Resize the buffer to the given size (larger or smaller).

--- a/src/datastruct/circ_buf.zig
+++ b/src/datastruct/circ_buf.zig
@@ -154,7 +154,11 @@ pub fn CircBuf(comptime T: type, comptime default: T) type {
         ) Allocator.Error!void {
             const new_cap = self.len() + amount;
             if (new_cap <= self.capacity()) return;
-            try self.resize(alloc, new_cap);
+
+            // Grow geometrically. Our callers append in small increments
+            // (the search sliding window adds a row at a time), and
+            // resizing to exactly what was asked for makes that quadratic.
+            try self.resize(alloc, @max(new_cap, self.capacity() * 2));
         }
 
         /// Resize the buffer to the given size (larger or smaller).
@@ -918,4 +922,23 @@ test "CircBuf deleteOldest zero" {
     // Verify data is unchanged
     var it = buf.iterator(.forward);
     try testing.expectEqual(@as(u8, 'h'), it.next().?.*);
+}
+
+test "CircBuf ensureUnusedCapacity grows geometrically" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const Buf = CircBuf(u8, 0);
+
+    var buf = try Buf.init(alloc, 4);
+    defer buf.deinit(alloc);
+    for (0..4) |_| try buf.append(1);
+
+    // Growing by one has to leave room for more than one, otherwise
+    // appending n items in a row costs n reallocations and n copies.
+    try buf.ensureUnusedCapacity(alloc, 1);
+    try testing.expectEqual(@as(usize, 8), buf.capacity());
+
+    // ...and the next append is then free.
+    try buf.ensureUnusedCapacity(alloc, 1);
+    try testing.expectEqual(@as(usize, 8), buf.capacity());
 }

--- a/src/font/shaper/coretext.zig
+++ b/src/font/shaper/coretext.zig
@@ -24,6 +24,16 @@ const global = @import("../../global.zig");
 
 const log = std.log.scoped(.font_shaper);
 
+/// How long `endFrame` waits for room in the release thread's mailbox
+/// before releasing the frame's references itself.
+///
+/// It cannot wait indefinitely: the wake that makes the release thread
+/// drain is only issued once the push has landed, so a shaping thread
+/// that parks on a full mailbox has no way to produce one, and the
+/// thread it is waiting for is stopped outright on shutdown and font
+/// reload. Releasing here costs a slow frame; waiting costs the process.
+const release_push_timeout_ns: u64 = 100 * std.time.ns_per_ms;
+
 /// Shaper that uses CoreText.
 ///
 /// CoreText shaping differs in subtle ways from HarfBuzz so it may result
@@ -281,12 +291,12 @@ pub const Shaper = struct {
         };
 
         // Send the items. If the send succeeds then we wake up the
-        // thread to process the items. If the send fails then do a manual
-        // cleanup.
+        // thread to process the items. If the send times out then do a
+        // manual cleanup rather than parking this thread.
         if (self.cf_release_thread.mailbox.push(global.io(), .{ .release = .{
             .refs = items,
             .alloc = self.alloc,
-        } }, .{ .forever = {} }) != 0) {
+        } }, .{ .ns = release_push_timeout_ns }) != 0) {
             self.cf_release_thread.wakeup.notify() catch |err| {
                 log.warn(
                     "error notifying cf release thread to wake up, may stall err={}",

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -1027,3 +1027,143 @@ const Compression = struct {
         };
     }
 };
+
+/// How long a bounded mailbox push waits for a slot before it re-issues
+/// this thread's wake and tries again.
+pub const mailbox_push_timeout_ns: u64 = 250 * std.time.ns_per_ms;
+
+/// How many of those windows a producer spends before it treats the
+/// consumer as gone and drops the message. Roughly a minute.
+pub const mailbox_push_attempts: usize = 240;
+
+/// Push a message to a renderer thread's mailbox, re-issuing the
+/// thread's wake between attempts, and give up rather than parking.
+///
+/// This thread drains its mailbox in exactly two places: the `wakeup`
+/// callback, and the safety-net timer that only runs while the surface
+/// is hidden. On a visible surface the wake is therefore the only thing
+/// that can free a slot, so a producer that blocks in the queue instead
+/// of issuing it has removed the wake source it is waiting on. That is
+/// what #1036 was: on the IOCP backend the Async wake can be lost in the
+/// window between a completion firing and its re-arm, and a producer
+/// that then parks in the not-full condition never wakes anyone --
+/// observed as the UI thread hanging inside
+/// `ghostty_surface_set_occlusion`.
+///
+/// A timed-out push re-issues the wake before trying again, so a single
+/// lost notify costs one window rather than the process. Returns the
+/// queue length after the push, or zero when the consumer never drained
+/// at all -- the one genuinely fatal case (the renderer thread is gone),
+/// which an unbounded push would have turned into a deadlock anyway.
+pub fn pushMailbox(
+    mailbox: *Mailbox,
+    wakeup: *xev.Async,
+    msg: rendererpkg.Message,
+) Mailbox.Size {
+    return pushMailboxBounded(
+        mailbox,
+        wakeup,
+        msg,
+        mailbox_push_timeout_ns,
+        mailbox_push_attempts,
+    );
+}
+
+fn pushMailboxBounded(
+    mailbox: *Mailbox,
+    wakeup: *xev.Async,
+    msg: rendererpkg.Message,
+    timeout_ns: u64,
+    max_attempts: usize,
+) Mailbox.Size {
+    var attempts: usize = 0;
+    while (true) {
+        const size = mailbox.push(global.io(), msg, .{ .ns = timeout_ns });
+        if (size > 0) return size;
+
+        // The mailbox is full and the thread has not drained it within
+        // the window, so assume the wake was lost and issue a fresh one.
+        // This is also the recovery when the thread is merely busy.
+        wakeup.notify() catch {};
+
+        attempts += 1;
+        if (attempts >= max_attempts) return 0;
+    }
+}
+
+test "renderer mailbox push wakes the thread when it cannot land" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = global.io();
+
+    const mailbox = try Mailbox.create(alloc);
+    defer mailbox.destroy(alloc);
+
+    var wakeup: xev.Async = try .init();
+    defer wakeup.deinit();
+
+    var loop: xev.Loop = try .init(.{});
+    defer loop.deinit();
+
+    // Fill the mailbox and never drain it. That is what a renderer
+    // asleep on a lost wake looks like from a producer's side.
+    while (mailbox.push(io, .{ .reset_cursor_blink = {} }, .{ .instant = {} }) > 0) {}
+
+    var woken: usize = 0;
+    var c: xev.Completion = .{};
+    wakeup.wait(&loop, &c, usize, &woken, (struct {
+        fn callback(
+            ud: ?*usize,
+            _: *xev.Loop,
+            _: *xev.Completion,
+            r: xev.Async.WaitError!void,
+        ) xev.CallbackAction {
+            _ = r catch return .disarm;
+            ud.?.* += 1;
+            return .disarm;
+        }
+    }).callback);
+
+    const Producer = struct {
+        mailbox: *Mailbox,
+        wakeup: *xev.Async,
+        result: Mailbox.Size = 0,
+
+        fn run(self: *@This()) void {
+            // A tiny budget so the test finishes; production uses
+            // mailbox_push_timeout_ns and mailbox_push_attempts.
+            self.result = pushMailboxBounded(
+                self.mailbox,
+                self.wakeup,
+                .{ .reset_cursor_blink = {} },
+                1 * std.time.ns_per_ms,
+                3,
+            );
+        }
+    };
+
+    var producer: Producer = .{ .mailbox = mailbox, .wakeup = &wakeup };
+    const thread = try std.Thread.spawn(.{}, Producer.run, .{&producer});
+    thread.join();
+
+    // The message could not land, because nothing drained.
+    try testing.expectEqual(@as(Mailbox.Size, 0), producer.result);
+
+    // The invariant: a producer that cannot land its message must still
+    // have woken the consumer, because that wake is the only thing that
+    // makes the consumer drain and free the slot the producer wants. A
+    // producer that parks in the queue instead withholds it, and the
+    // hang is permanent while the surface is visible: the safety-net
+    // drain only runs while it is hidden.
+    const start: std.Io.Timestamp = .now(io, .awake);
+    while (woken == 0) {
+        try loop.run(.no_wait);
+        const now: std.Io.Timestamp = .now(io, .awake);
+        if (start.durationTo(now).toMilliseconds() > 2000) break;
+        std.Thread.yield() catch {};
+    }
+    try testing.expect(woken > 0);
+
+    // Nothing was dropped from the queue on the way.
+    try testing.expect(mailbox.pop(io) != null);
+}

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -1057,24 +1057,25 @@ const Compression = struct {
 /// The list to cover before moving it, which is larger than round 3
 /// claimed:
 ///
-///   - `.change_config` (`Surface.zig:1903`), the largest: a
+///   - `.change_config` (`Surface.updateConfig`), the largest: a
 ///     `renderer.Thread.DerivedConfig` and a renderer `DerivedConfig`
 ///     that itself owns allocations. `rendererpkg.Message.deinit`
 ///     ALREADY handles this variant, so one call would cover it -- but
 ///     read the ownership note below before adding that call.
-///   - `.font_grid` (`Surface.zig:2540`), a refcount pair rather than
+///   - `.font_grid` (`Surface.setFontSize`), a refcount pair rather than
 ///     memory: a give-up leaks the new grid's ref and strands the old
 ///     key's. No `deinit` arm covers it.
 ///   - `.search_viewport_matches` and `.search_selected_match`
-///     (`Surface.zig:1560-1585`), each carrying an arena moved into the
-///     message. No `deinit` arm covers these either.
+///     (`Surface.searchCallback_`), each carrying an arena moved into
+///     the message. No `deinit` arm covers these either.
 ///
 /// Ownership note, and why this is not a drive-by fix: adding
 /// `msg.deinit()` below is a use-after-free until `Surface.updateConfig`
-/// is restructured. Its three `errdefer`s (`Surface.zig:1897`, `:1899`,
-/// `:1901`) are still live at the `try performAction` calls on `:1918`
-/// and `:1925`, after `:1903` has already handed the message to this
-/// thread. Fix `updateConfig`'s ownership first.
+/// is restructured. Its three `errdefer`s -- `renderer_message.deinit`,
+/// the `destroy` of `termio_config_ptr`, and that pointer's `deinit` --
+/// are still live at the `try performAction` calls further down that
+/// function, after its `pushRendererMailbox` has already handed the
+/// message to this thread. Fix `updateConfig`'s ownership first.
 ///
 /// All of this is pre-existing on merge base `218b8243db`, which had the
 /// same constants and the same absent ownership handling hand-rolled in

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -1047,6 +1047,13 @@ const Compression = struct {
 /// queue length after the push, or zero when the consumer never drained
 /// at all -- the one genuinely fatal case (the renderer thread is gone),
 /// which an unbounded push would have turned into a deadlock anyway.
+///
+/// This keeps the background budget even though most producers are
+/// UI-thread input handlers, where a minute-long wait is a window the
+/// user is told to kill. Moving it to the UI budget has to wait for
+/// `rendererpkg.Message.deinit` to cover `search_viewport_matches` and
+/// `search_selected_match`: both carry an arena, this give-up path frees
+/// nothing, and a shorter budget would trade a freeze for a leak.
 pub fn pushMailbox(
     mailbox: *Mailbox,
     wakeup: *xev.Async,

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -1028,14 +1028,6 @@ const Compression = struct {
     }
 };
 
-/// How long a bounded mailbox push waits for a slot before it re-issues
-/// this thread's wake and tries again.
-pub const mailbox_push_timeout_ns: u64 = 250 * std.time.ns_per_ms;
-
-/// How many of those windows a producer spends before it treats the
-/// consumer as gone and drops the message. Roughly a minute.
-pub const mailbox_push_attempts: usize = 240;
-
 /// Push a message to a renderer thread's mailbox, re-issuing the
 /// thread's wake between attempts, and give up rather than parking.
 ///
@@ -1064,8 +1056,8 @@ pub fn pushMailbox(
         mailbox,
         wakeup,
         msg,
-        mailbox_push_timeout_ns,
-        mailbox_push_attempts,
+        Mailbox.wake_retry_timeout_ns,
+        Mailbox.wake_retry_attempts,
     );
 }
 
@@ -1076,19 +1068,20 @@ fn pushMailboxBounded(
     timeout_ns: u64,
     max_attempts: usize,
 ) Mailbox.Size {
-    var attempts: usize = 0;
-    while (true) {
-        const size = mailbox.push(global.io(), msg, .{ .ns = timeout_ns });
-        if (size > 0) return size;
+    return mailbox.pushWake(
+        global.io(),
+        msg,
+        wakeup,
+        notifyWake,
+        timeout_ns,
+        max_attempts,
+    );
+}
 
-        // The mailbox is full and the thread has not drained it within
-        // the window, so assume the wake was lost and issue a fresh one.
-        // This is also the recovery when the thread is merely busy.
-        wakeup.notify() catch {};
-
-        attempts += 1;
-        if (attempts >= max_attempts) return 0;
-    }
+/// The `pushWake` wake for an `xev.Async`. A notify that fails means the
+/// loop is gone, which the retry budget already gives up on.
+fn notifyWake(wakeup: *xev.Async) void {
+    wakeup.notify() catch {};
 }
 
 test "renderer mailbox push wakes the thread when it cannot land" {
@@ -1131,7 +1124,7 @@ test "renderer mailbox push wakes the thread when it cannot land" {
 
         fn run(self: *@This()) void {
             // A tiny budget so the test finishes; production uses
-            // mailbox_push_timeout_ns and mailbox_push_attempts.
+            // the mailbox's wake_retry_* defaults.
             self.result = pushMailboxBounded(
                 self.mailbox,
                 self.wakeup,

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -1048,12 +1048,37 @@ const Compression = struct {
 /// at all -- the one genuinely fatal case (the renderer thread is gone),
 /// which an unbounded push would have turned into a deadlock anyway.
 ///
-/// This keeps the background budget even though most producers are
-/// UI-thread input handlers, where a minute-long wait is a window the
-/// user is told to kill. Moving it to the UI budget has to wait for
-/// `rendererpkg.Message.deinit` to cover `search_viewport_matches` and
-/// `search_selected_match`: both carry an arena, this give-up path frees
-/// nothing, and a shorter budget would trade a freeze for a leak.
+/// This keeps the background budget, and `.persist` with it, even though
+/// seven of its `Surface.zig` producers are on the UI thread, where a
+/// minute-long wait is a window the user is told to kill. Both stay until
+/// this give-up path frees what it gives up, because it frees nothing
+/// today and a cheaper give-up would trade a freeze for a leak.
+///
+/// The list to cover before moving it, which is larger than round 3
+/// claimed:
+///
+///   - `.change_config` (`Surface.zig:1903`), the largest: a
+///     `renderer.Thread.DerivedConfig` and a renderer `DerivedConfig`
+///     that itself owns allocations. `rendererpkg.Message.deinit`
+///     ALREADY handles this variant, so one call would cover it -- but
+///     read the ownership note below before adding that call.
+///   - `.font_grid` (`Surface.zig:2540`), a refcount pair rather than
+///     memory: a give-up leaks the new grid's ref and strands the old
+///     key's. No `deinit` arm covers it.
+///   - `.search_viewport_matches` and `.search_selected_match`
+///     (`Surface.zig:1560-1585`), each carrying an arena moved into the
+///     message. No `deinit` arm covers these either.
+///
+/// Ownership note, and why this is not a drive-by fix: adding
+/// `msg.deinit()` below is a use-after-free until `Surface.updateConfig`
+/// is restructured. Its three `errdefer`s (`Surface.zig:1897`, `:1899`,
+/// `:1901`) are still live at the `try performAction` calls on `:1918`
+/// and `:1925`, after `:1903` has already handed the message to this
+/// thread. Fix `updateConfig`'s ownership first.
+///
+/// All of this is pre-existing on merge base `218b8243db`, which had the
+/// same constants and the same absent ownership handling hand-rolled in
+/// `Surface.zig`. Moving the loop here did not introduce it.
 pub fn pushMailbox(
     mailbox: *Mailbox,
     wakeup: *xev.Async,
@@ -1082,6 +1107,11 @@ fn pushMailboxBounded(
         notifyWake,
         timeout_ns,
         max_attempts,
+        // Deliberately NOT `.fail_fast`: this give-up path frees
+        // nothing, so making give-ups cheaper here would make the
+        // pre-existing leak above cheaper to reach. It stays `.persist`
+        // until that path frees what it gives up.
+        .persist,
     );
 }
 

--- a/src/terminal/search/Thread.zig
+++ b/src/terminal/search/Thread.zig
@@ -568,6 +568,10 @@ fn pushMailboxBounded(
         notifyWake,
         timeout_ns,
         max_attempts,
+        // One `change_needle` per keystroke against a wedged search
+        // thread is the textbook stream: without this the search box
+        // costs the whole budget on every character typed into it.
+        .fail_fast,
     );
     if (size == 0) {
         log.warn("search mailbox full, message dropped", .{});

--- a/src/terminal/search/Thread.zig
+++ b/src/terminal/search/Thread.zig
@@ -535,6 +535,11 @@ pub const Mailbox = BlockingQueue(Message, 64);
 ///
 /// Takes ownership of `msg`. It is either queued or released, so giving
 /// up cannot leak the needle's payload.
+///
+/// The budget is the UI pair. The wait here is a window that has stopped
+/// pumping messages, and a window that stops pumping for a minute is one
+/// Windows offers to kill long before the budget runs out -- from the
+/// user's chair that is the hang, not a bound on it.
 pub fn pushMailbox(
     mailbox: *Mailbox,
     wakeup: *xev.Async,
@@ -544,8 +549,8 @@ pub fn pushMailbox(
         mailbox,
         wakeup,
         msg,
-        Mailbox.wake_retry_timeout_ns,
-        Mailbox.wake_retry_attempts,
+        Mailbox.wake_retry_timeout_ns_ui,
+        Mailbox.wake_retry_attempts_ui,
     );
 }
 

--- a/src/terminal/search/Thread.zig
+++ b/src/terminal/search/Thread.zig
@@ -523,6 +523,61 @@ pub const EventCallback = *const fn (event: Event, userdata: ?*anyopaque) void;
 /// The type used for sending messages to the thread.
 pub const Mailbox = BlockingQueue(Message, 64);
 
+/// Push a message to a search thread's mailbox, re-issuing the thread's
+/// wake between attempts, and give up rather than parking.
+///
+/// This thread drains its mailbox in exactly one place, the `wakeup`
+/// callback; the refresh timer does not drain. The wake is therefore the
+/// only thing that can free a slot, so a producer that waits inside the
+/// queue withholds it. That matters most because the producer is the UI
+/// thread: a push that parks here is a frozen window, the same failure
+/// #1036 was.
+///
+/// Takes ownership of `msg`. It is either queued or released, so giving
+/// up cannot leak the needle's payload.
+pub fn pushMailbox(
+    mailbox: *Mailbox,
+    wakeup: *xev.Async,
+    msg: Message,
+) Mailbox.Size {
+    return pushMailboxBounded(
+        mailbox,
+        wakeup,
+        msg,
+        Mailbox.wake_retry_timeout_ns,
+        Mailbox.wake_retry_attempts,
+    );
+}
+
+fn pushMailboxBounded(
+    mailbox: *Mailbox,
+    wakeup: *xev.Async,
+    msg: Message,
+    timeout_ns: u64,
+    max_attempts: usize,
+) Mailbox.Size {
+    const size = mailbox.pushWake(
+        global.io(),
+        msg,
+        wakeup,
+        notifyWake,
+        timeout_ns,
+        max_attempts,
+    );
+    if (size == 0) {
+        log.warn("search mailbox full, message dropped", .{});
+        msg.deinit();
+    }
+
+    return size;
+}
+
+/// The `pushWake` wake for an `xev.Async`. A notify that fails means the
+/// loop is gone, which the retry budget already gives up on.
+fn notifyWake(wakeup: *xev.Async) void {
+    wakeup.notify() catch {};
+}
+
 /// The messages that can be sent to the thread.
 pub const Message = union(enum) {
     /// Represents a write request. Magic number comes from the max size
@@ -536,6 +591,16 @@ pub const Message = union(enum) {
 
     /// Select a search result.
     select: ScreenSearch.Select,
+
+    /// Release anything the message owns. The mailbox push calls this
+    /// when it has to give the message up, so a variant that starts
+    /// owning memory has to free it here or it leaks on that path.
+    pub fn deinit(self: Message) void {
+        switch (self) {
+            .change_needle => |v| v.deinit(),
+            .select => {},
+        }
+    }
 };
 
 /// Events that can be emitted from the search thread. The caller
@@ -678,4 +743,40 @@ test {
             .y = 0,
         } }, t.screens.active.pages.pointFromPin(.screen, sel.end).?);
     }
+}
+
+test "search mailbox push frees the needle it has to give up" {
+    const alloc = testing.allocator;
+    const io = global.io();
+
+    const mailbox = try Mailbox.create(alloc);
+    defer mailbox.destroy(alloc);
+
+    var wakeup: xev.Async = try .init();
+    defer wakeup.deinit();
+
+    // Fill the mailbox and never drain it. That is what a search thread
+    // asleep on a lost wake looks like from the UI thread's side. These
+    // fillers own nothing, so only the needle below can leak.
+    while (mailbox.push(io, .{ .select = .next }, .{ .instant = {} }) > 0) {}
+
+    // Long enough that MessageData has to allocate rather than inline it.
+    const needle: [300]u8 = @splat('a');
+
+    // A tiny budget so the test finishes; production uses the mailbox's
+    // wake_retry_* defaults.
+    const result = pushMailboxBounded(
+        mailbox,
+        &wakeup,
+        .{ .change_needle = try .init(alloc, @as([]const u8, &needle)) },
+        1 * std.time.ns_per_ms,
+        3,
+    );
+
+    // It gave up rather than parking the UI thread, and the testing
+    // allocator fails the test if the refused needle was not freed.
+    try testing.expectEqual(@as(Mailbox.Size, 0), result);
+
+    // Nothing was taken from the queue on the way.
+    try testing.expect(mailbox.pop(io) != null);
 }

--- a/src/termio.zig
+++ b/src/termio.zig
@@ -26,6 +26,7 @@ pub const Exec = @import("termio/Exec.zig");
 pub const Options = @import("termio/Options.zig");
 pub const Termio = @import("termio/Termio.zig");
 pub const Thread = @import("termio/Thread.zig");
+pub const WriteLimit = @import("termio/write_limit.zig").WriteLimit;
 pub const Backend = backend.Backend;
 pub const DerivedConfig = Termio.DerivedConfig;
 pub const Mailbox = mailbox.Mailbox;
@@ -36,4 +37,5 @@ test {
     @import("std").testing.refAllDecls(@This());
 
     _ = @import("termio/shell_integration.zig");
+    _ = @import("termio/write_limit.zig");
 }

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -446,7 +446,6 @@ fn termiosTimer(
     // If the mode changed, then we process it.
     if (!std.meta.eql(mode, exec.termios_mode)) mode_change: {
         log.debug("termios change mode={}", .{mode});
-        exec.termios_mode = mode;
 
         // We assume we're in some sort of password input if we're
         // in canonical mode and not echoing. This is a heuristic.
@@ -466,16 +465,39 @@ fn termiosTimer(
             }
             const t = td.renderer_state.terminal;
             if (t.flags.password_input == password_input) {
+                exec.termios_mode = mode;
                 break :mode_change;
             }
         }
 
-        // We have to notify the surface that we're in password input.
-        // We must block on this because the balanced true/false state
-        // of this is critical to apprt behavior.
-        _ = td.surface_mailbox.push(.{
+        // Notify the surface that we're in password input. The balanced
+        // true/false state of this is critical to apprt behavior: on
+        // macOS the `false` turns `EnableSecureEventInput` back off, a
+        // mode with effects outside this process, and `passwordInput`'s
+        // own `if (old == v) return` means a later duplicate re-arms
+        // nothing. A dropped `false` therefore sticks the surface in
+        // secure input for as long as it lives.
+        //
+        // We do not block to prevent that, because a producer that waits
+        // without a limit on a wedged app thread does not deliver the
+        // message either. We commit the observed mode only once the
+        // message is actually queued: a give-up leaves `termios_mode`
+        // where it was, so the next poll sees the same change again and
+        // re-sends. The guard above reads the terminal flag the consumer
+        // itself sets, so the retry stops exactly when the surface has
+        // caught up -- and if the mode has flipped back by then, the
+        // guard commits without a send. The state is balanced by
+        // re-deriving it every poll rather than by never dropping it.
+        if (td.surface_mailbox.push(.{
             .password_input = password_input,
-        }, .{ .forever = {} });
+        }, .{ .forever = {} }) > 0) {
+            exec.termios_mode = mode;
+        } else {
+            log.warn(
+                "password input notification dropped, retrying next poll",
+                .{},
+            );
+        }
     }
 
     // Repeat the timer

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -371,12 +371,22 @@ fn processExitCommon(td: *termio.Termio.ThreadData, exit_code: u32) void {
 
     // We always notify the surface immediately that the child has
     // exited and some metadata about the exit.
-    _ = td.surface_mailbox.push(.{
+    //
+    // `pushRequired`, not `push`: this runs once per surface lifetime and
+    // nothing re-derives it, so a drop is permanent and user-visible.
+    // `Surface.childExited` is what sets `self.child_exited`, and without
+    // it `close-on-exit` never fires, the exit overlay never appears, and
+    // the close confirmation keeps asking about a process that is already
+    // gone -- for the life of the surface. The streaming producers on this
+    // queue (search results, the stream handler's OSC replies) fail fast
+    // against a wedged app thread precisely so that this one can afford to
+    // spend its budget.
+    _ = td.surface_mailbox.pushRequired(.{
         .child_exited = .{
             .exit_code = exit_code,
             .runtime_ms = runtime_ms,
         },
-    }, .{ .forever = {} });
+    });
 }
 
 fn processExit(
@@ -487,9 +497,22 @@ fn termiosTimer(
         // flag the consumer itself sets, so the retry stops exactly when
         // the surface has caught up -- and if the mode has flipped back
         // by then, the guard commits without a send. The state is
-        // balanced by re-deriving it every poll rather than by never
-        // dropping it, which also recovers from a wedge that outlasts
-        // any budget we could have picked.
+        // balanced by re-deriving the *undelivered change* rather than by
+        // never dropping it, which also recovers from a wedge that
+        // outlasts any budget we could have picked.
+        //
+        // Be precise about the scope of that, because it is narrower than
+        // "re-derived every poll": the re-derivation only runs while
+        // `mode != exec.termios_mode`. Nothing polls the terminal flag
+        // itself, so a path that clears `t.flags.password_input` behind
+        // our back leaves the apprt armed with no send to correct it.
+        // `Terminal.fullReset` is exactly such a path -- it assigns
+        // `self.flags = .{ .visible = visible }` -- so RIS after a
+        // delivered `true` desyncs the apprt for the surface's life. That
+        // hole is pre-existing (the merge base committed `termios_mode`
+        // unconditionally and had the same gap) and is not fixed here;
+        // closing it means the reset path telling the surface, which is
+        // not this function's to do.
         if (td.surface_mailbox.push(.{
             .password_input = password_input,
         }, .{ .forever = {} }) > 0) {

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -381,6 +381,22 @@ fn processExitCommon(td: *termio.Termio.ThreadData, exit_code: u32) void {
     // queue (search results, the stream handler's OSC replies) fail fast
     // against a wedged app thread precisely so that this one can afford to
     // spend its budget.
+    //
+    // Collapsing this back to `push` type-checks and fails no test --
+    // this file is in no test graph, and both spellings pass the exe
+    // build -- so `apprt.surface.Message.dropAllowed` classifies
+    // `.child_exited` as undroppable and `push` asserts on it. After a
+    // rebase that collapses this line, the first child exit panics in a
+    // Debug build rather than losing the notice quietly.
+    //
+    // What that budget costs at teardown, on Windows: the caller here is
+    // `winProcessWaitThread`, `threadExit` joins that thread, and
+    // `Surface.deinit` joins the io thread on the UI thread, so a full
+    // app mailbox at close spends the whole background budget on the UI
+    // thread -- delivering the push `threadExit` above calls harmless,
+    // which `App.surfaceMessage`'s `hasSurface` gate then discards. See
+    // `App.Mailbox.pushRequired`; suppressing that teardown push is
+    // filed separately.
     _ = td.surface_mailbox.pushRequired(.{
         .child_exited = .{
             .exit_code = exit_code,

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -185,6 +185,12 @@ pub fn threadEnter(
     );
     read_thread.setName(global.io(), "io-reader") catch {};
 
+    // The write accounting outlives a backend run: it lives on the
+    // Termio, not on this thread data, and a run that ends with writes
+    // still queued never sees their completions. Start every run from
+    // zero so leftovers can't hold us at the cap forever.
+    io.write_limit.reset();
+
     // Setup our threadata backend state to be our own
     td.backend = .{ .exec = .{
         .start = process_start,

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -482,12 +482,14 @@ fn termiosTimer(
         // without a limit on a wedged app thread does not deliver the
         // message either. We commit the observed mode only once the
         // message is actually queued: a give-up leaves `termios_mode`
-        // where it was, so the next poll sees the same change again and
-        // re-sends. The guard above reads the terminal flag the consumer
-        // itself sets, so the retry stops exactly when the surface has
-        // caught up -- and if the mode has flipped back by then, the
-        // guard commits without a send. The state is balanced by
-        // re-deriving it every poll rather than by never dropping it.
+        // where it was, so the next poll (TERMIOS_POLL_MS) sees the same
+        // change again and re-sends. The guard above reads the terminal
+        // flag the consumer itself sets, so the retry stops exactly when
+        // the surface has caught up -- and if the mode has flipped back
+        // by then, the guard commits without a send. The state is
+        // balanced by re-deriving it every poll rather than by never
+        // dropping it, which also recovers from a wedge that outlasts
+        // any budget we could have picked.
         if (td.surface_mailbox.push(.{
             .password_input = password_input,
         }, .{ .forever = {} }) > 0) {

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -177,6 +177,15 @@ pub fn threadEnter(
     var termios_timer = try xev.Timer.init();
     errdefer termios_timer.deinit();
 
+    // The write accounting outlives a backend run: it lives on the
+    // Termio, not on this thread data, and a run that ends with writes
+    // still queued never sees their completions. Start every run from
+    // zero so leftovers can't hold us at the cap forever. This has to
+    // happen before the read thread exists, because the reader is what
+    // observes the cap and would otherwise refuse replies against a
+    // previous run's backlog.
+    io.write_limit.reset();
+
     // Start our read thread
     const read_thread = try std.Thread.spawn(
         .{},
@@ -184,12 +193,6 @@ pub fn threadEnter(
         .{ pty_fds.read, io, pipe[0] },
     );
     read_thread.setName(global.io(), "io-reader") catch {};
-
-    // The write accounting outlives a backend run: it lives on the
-    // Termio, not on this thread data, and a run that ends with writes
-    // still queued never sees their completions. Start every run from
-    // zero so leftovers can't hold us at the cap forever.
-    io.write_limit.reset();
 
     // Setup our threadata backend state to be our own
     td.backend = .{ .exec = .{

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -189,6 +189,7 @@ pub fn threadEnter(
     td.backend = .{ .exec = .{
         .start = process_start,
         .write_stream = stream,
+        .write_limit = &io.write_limit,
         .process = process,
         .read_thread = read_thread,
         .read_thread_pipe = pipe[1],
@@ -539,6 +540,12 @@ pub fn queueWrite(
 
         //for (slice) |b| log.warn("write: {x}", .{b});
 
+        // Account for the backlog before queueing so that a pty which
+        // has stopped draining is visible to the read thread, which
+        // decides whether terminal replies are still worth queueing.
+        w.len = slice.len;
+        exec.write_limit.queued(slice.len);
+
         exec.write_stream.queueWrite(
             td.loop,
             &exec.write_queue,
@@ -560,6 +567,7 @@ fn ttyWrite(
     r: xev.WriteError!usize,
 ) xev.CallbackAction {
     const w = w_.?;
+    w.td.write_limit.completed(w.len);
     w.td.write_pool.destroy(w);
 
     const d = r catch |err| {
@@ -588,6 +596,10 @@ pub const ThreadData = struct {
 
         /// The buffer for the data being written.
         buf: [64]u8,
+
+        /// How much of `buf` this write covers, so the completion can
+        /// take it back off the outstanding-bytes count.
+        len: usize = 0,
     };
 
     /// Process start time and boolean of whether its already exited.
@@ -596,6 +608,10 @@ pub const ThreadData = struct {
 
     /// The data stream is the main IO for the pty.
     write_stream: xev.Stream,
+
+    /// Bounds the data we have queued to the pty. Owned by the Termio
+    /// so that the read thread can see it too.
+    write_limit: *termio.WriteLimit,
 
     /// The process watcher
     process: ?xev.Process,

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -92,6 +92,11 @@ size: renderer.Size,
 /// The mailbox implementation to use.
 mailbox: termio.Mailbox,
 
+/// Bounds the data queued to the pty. The backend accounts for its
+/// writes here and the stream handler consults it before queueing a
+/// terminal reply.
+write_limit: termio.WriteLimit = .{},
+
 /// The stream parser. This parses the stream of escape codes and so on
 /// from the child process and calls callbacks in the stream handler.
 terminal_stream: StreamHandler.Stream,
@@ -356,6 +361,7 @@ pub fn init(self: *Termio, alloc: Allocator, opts: termio.Options) !void {
         .alloc = alloc,
         .osc7 = osc7,
         .termio_mailbox = &self.mailbox,
+        .write_limit = &self.write_limit,
         .surface_mailbox = opts.surface_mailbox,
         .renderer_state = opts.renderer_state,
         .renderer_wakeup = opts.renderer_wakeup,

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -366,7 +366,6 @@ pub fn init(self: *Termio, alloc: Allocator, opts: termio.Options) !void {
         .renderer_state = opts.renderer_state,
         .renderer_wakeup = opts.renderer_wakeup,
         .renderer_visible = opts.renderer_visible,
-        .renderer_mailbox = opts.renderer_mailbox,
         .size = &self.size,
         .terminal = &self.terminal,
         .osc_color_report_format = opts.config.osc_color_report_format,

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -498,6 +498,14 @@ pub fn threadExit(self: *Termio, data: *ThreadData) void {
 /// This will also notify the mailbox thread to process the message. If
 /// you're sending a lot of messages, it may be more efficient to use
 /// the mailbox directly and then call notify separately.
+///
+/// Every message through here takes `termio.Mailbox.Budget.droppable`,
+/// because this is `Surface.queueIo`'s tail and that is a UI-thread
+/// producer. This function is a shared tail and hands its policy to its
+/// callers without their asking: read `Budget.droppable`'s comment before
+/// adding a call site, because three of the ones already here are state
+/// or user data rather than events, and a fourth would be missed the same
+/// way.
 pub fn queueMessage(
     self: *Termio,
     msg: termio.Message,

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -611,8 +611,15 @@ pub fn resize(
         }
     }
 
-    // Mail the renderer so that it can update the GPU and re-render
-    _ = self.renderer_mailbox.push(global.io(), .{ .resize = size }, .{ .forever = {} });
+    // Mail the renderer so that it can update the GPU and re-render.
+    // The wake on the next line is what makes the renderer drain, so
+    // this push must not be able to park: waiting in the queue would
+    // withhold the very notify the renderer needs to free a slot.
+    if (renderer.Thread.pushMailbox(
+        self.renderer_mailbox,
+        self.renderer_wakeup,
+        .{ .resize = size },
+    ) == 0) log.warn("renderer mailbox full, resize not delivered", .{});
     self.renderer_wakeup.notify() catch {};
 }
 

--- a/src/termio/mailbox.zig
+++ b/src/termio/mailbox.zig
@@ -135,7 +135,7 @@ pub const Mailbox = union(enum) {
         ///
         /// Do not read this as "one advisory event". `send` is the tail
         /// of `Termio.queueMessage`, which is the tail of
-        /// `Surface.queueIo`, so this budget is what 45 UI-thread call
+        /// `Surface.queueIo`, so this budget is what 47 UI-thread call
         /// sites in `Surface.zig` get without naming it. Most of them
         /// really are events -- keystrokes, mouse reports, scroll
         /// sequences, selection-scroll ticks, focus and visibility
@@ -177,6 +177,27 @@ pub const Mailbox = union(enum) {
         /// -- is the fix those three want, and it is a change to
         /// `Surface`'s size and config invariants, not to a budget
         /// constant. Filed separately; `.resize` first.
+        ///
+        /// The two newest call sites are the footprint ones, and both
+        /// are events rather than state, so this budget is right for
+        /// them and they are named here only so the next reader does not
+        /// have to re-derive it:
+        ///
+        ///   * `.deep_idle` (`Surface.idleCallback`) asks the io thread
+        ///     to trim what a live surface does not need. Dropping it
+        ///     defers the reclaim to the next idle transition; nothing
+        ///     is lost but memory, and briefly.
+        ///   * `.go_dormant` (`Surface.goDormantCallback`) asks for the
+        ///     terminal to be torn down into its snapshot. Its own
+        ///     handler already re-checks eligibility and the caller
+        ///     learns the outcome by reading `Surface.isDormant` rather
+        ///     than by the send succeeding, so a drop is a request that
+        ///     did not happen -- the surface stays live, which is the
+        ///     conservative direction.
+        ///
+        /// Neither is one-shot: losing them costs footprint, not
+        /// correctness, which is exactly the line `.child_exited` is on
+        /// the other side of.
         pub const droppable: Budget = .{
             .timeout_ns = Queue.wake_retry_timeout_ns_ui,
             .attempts = Queue.wake_retry_attempts_ui,

--- a/src/termio/mailbox.zig
+++ b/src/termio/mailbox.zig
@@ -71,14 +71,40 @@ pub const Mailbox = union(enum) {
 
     /// Sends the given message without notifying there are messages.
     ///
+    /// Takes ownership of `msg`: it is either queued or released, so a
+    /// message that owns a write buffer cannot leak here.
+    ///
     /// If the optional mutex is given, it must already be LOCKED. If the
     /// send would block, we'll unlock this mutex, resend the message, and
     /// lock it again. This handles an edge case where queues are full.
     /// This may not apply to all writer types.
+    ///
+    /// The budget is the UI one because most of this queue's producers
+    /// are UI-thread input handlers reaching us through
+    /// `Surface.queueIo`. A push that parks here parks the thread that
+    /// drains the app mailbox, and the writer thread this waits on can
+    /// itself be parked on that same app mailbox -- two unbounded hops
+    /// that hold each other up forever, which is what this bound exists
+    /// to break.
     pub fn send(
         self: *Mailbox,
         msg: termio.Message,
         mutex: ?*std.Io.Mutex,
+    ) void {
+        self.sendBounded(
+            msg,
+            mutex,
+            Queue.wake_retry_timeout_ns_ui,
+            Queue.wake_retry_attempts_ui,
+        );
+    }
+
+    fn sendBounded(
+        self: *Mailbox,
+        msg: termio.Message,
+        mutex: ?*std.Io.Mutex,
+        timeout_ns: u64,
+        max_attempts: usize,
     ) void {
         switch (self.*) {
             .spsc => |*mb| send: {
@@ -110,27 +136,33 @@ pub const Mailbox = union(enum) {
                 // and a single notify can be lost outright on the IOCP
                 // backend, so keep re-issuing it while we wait rather
                 // than sleeping on the queue with no wake source left.
-                // There is no attempt limit: a message here can own a
-                // write buffer and this path has nowhere to hand it back
-                // to, so waiting for the slot is the only thing that does
-                // not lose it.
+                //
+                // The wait is bounded. A message here can own a write
+                // buffer, but `termio.Message.deinit` releases exactly
+                // those variants -- the failed-notify path above already
+                // calls it -- so giving up costs one message rather than
+                // the thread.
                 if (mutex) |m| m.unlock(global.io());
                 defer if (mutex) |m| m.lockUncancelable(global.io());
-                _ = mb.queue.pushWake(
+                const size = mb.queue.pushWake(
                     global.io(),
                     msg,
                     mb.wakeup,
                     notifyWake,
-                    Queue.wake_retry_timeout_ns,
-                    Queue.wake_retry_forever,
+                    timeout_ns,
+                    max_attempts,
                 );
+                if (size == 0) {
+                    log.warn("io mailbox full, message dropped", .{});
+                    msg.deinit();
+                }
             },
         }
     }
 
     /// The `pushWake` wake for our writer thread. A notify that fails
-    /// means the loop is gone; the send has nothing better to do than
-    /// keep trying, and the queue drains at teardown.
+    /// means the loop is gone, which the retry budget already gives up
+    /// on.
     fn notifyWake(wakeup: *xev.Async) void {
         wakeup.notify() catch {};
     }
@@ -186,4 +218,54 @@ test "Mailbox: spsc wakeup survives copying the union" {
     producer.notify();
     try loop.run(.until_done);
     try testing.expect(fired);
+}
+
+test "Mailbox: a push it has to give up frees the message" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = global.io();
+
+    var mailbox = try Mailbox.initSPSC(alloc);
+    defer mailbox.deinit(alloc);
+
+    var loop = try xev.Loop.init(.{});
+    defer loop.deinit();
+
+    // Register the wait so the notify inside `send` succeeds. Without it
+    // the send can take the failed-notify branch instead, which frees the
+    // message for a different reason and would make this test pass
+    // whatever the retry path does.
+    var fired: bool = false;
+    var c: xev.Completion = .{};
+    mailbox.spsc.wakeup.wait(&loop, &c, bool, &fired, (struct {
+        fn callback(
+            ud: ?*bool,
+            _: *xev.Loop,
+            _: *xev.Completion,
+            r: xev.Async.WaitError!void,
+        ) xev.CallbackAction {
+            _ = r catch return .disarm;
+            ud.?.* = true;
+            return .disarm;
+        }
+    }).callback);
+
+    // Fill the queue and never drain it. A writer thread that is alive
+    // but parked pushing to the full app mailbox looks exactly like this
+    // from a producer's side, and the producer here is usually the UI
+    // thread coming through `Surface.queueIo`.
+    while (mailbox.spsc.queue.push(io, .{ .focused = true }, .{ .instant = {} }) > 0) {}
+
+    // A write too large for the union is heap allocated, so
+    // std.testing.allocator fails this test if the give-up path leaks it.
+    const data = "e" ** 128;
+    const msg = try termio.Message.writeReq(alloc, @as([]const u8, data));
+    try testing.expect(msg == .write_alloc);
+
+    // A tiny budget so the test finishes; production uses the queue's
+    // wake_retry_*_ui defaults.
+    mailbox.sendBounded(msg, null, 1 * std.time.ns_per_ms, 3);
+
+    // Nothing landed, so nothing was dropped from the queue either.
+    try testing.expect(mailbox.spsc.queue.len == 64);
 }

--- a/src/termio/mailbox.zig
+++ b/src/termio/mailbox.zig
@@ -79,23 +79,86 @@ pub const Mailbox = union(enum) {
     /// lock it again. This handles an edge case where queues are full.
     /// This may not apply to all writer types.
     ///
-    /// The budget is the UI one because most of this queue's producers
-    /// are UI-thread input handlers reaching us through
+    /// The budget is the droppable one because most of this queue's
+    /// producers are UI-thread input handlers reaching us through
     /// `Surface.queueIo`. A push that parks here parks the thread that
     /// drains the app mailbox, and the writer thread this waits on can
     /// itself be parked on that same app mailbox -- two unbounded hops
     /// that hold each other up forever, which is what this bound exists
     /// to break.
+    ///
+    /// Use `sendRequired` for a message the consumer is blocked on
+    /// rather than merely informed by.
     pub fn send(
         self: *Mailbox,
         msg: termio.Message,
         mutex: ?*std.Io.Mutex,
     ) void {
+        self.sendBudgeted(msg, mutex, .droppable);
+    }
+
+    /// Send a message the consumer is blocked on, from a producer that
+    /// is never the UI thread.
+    ///
+    /// This does NOT promise the message is never dropped, and nothing
+    /// here could: a producer that waits without a limit on a wedged
+    /// consumer does not deliver the message either, it just stops being
+    /// a producer. For the one caller this has -- tmux control-mode
+    /// commands on the pty read thread -- that trade is strictly worse,
+    /// because a read thread that stops reading stops draining the
+    /// child's output and wedges the session harder than losing one
+    /// command would. What `required` buys is a budget two orders of
+    /// magnitude longer than a droppable send's, and immunity to the
+    /// wedge latch, so the command survives anything short of a consumer
+    /// that has genuinely stopped.
+    pub fn sendRequired(
+        self: *Mailbox,
+        msg: termio.Message,
+        mutex: ?*std.Io.Mutex,
+    ) void {
+        self.sendBudgeted(msg, mutex, .required);
+    }
+
+    /// What a send spends before it gives the message up, chosen by what
+    /// the caller can tolerate losing rather than by which mailbox it
+    /// happens to be pushing to. One number for the whole queue cannot
+    /// be right for both a mouse-motion report and a tmux command.
+    pub const Budget = struct {
+        timeout_ns: u64,
+        attempts: usize,
+        wedge: Queue.Wedge,
+
+        /// One event, whose producer can be the UI thread. Short budget,
+        /// and it fails fast while the consumer is latched wedged so a
+        /// stream of events costs one budget rather than one apiece.
+        pub const droppable: Budget = .{
+            .timeout_ns = Queue.wake_retry_timeout_ns_ui,
+            .attempts = Queue.wake_retry_attempts_ui,
+            .wedge = .fail_fast,
+        };
+
+        /// State the consumer has to observe, from a background
+        /// producer. Long budget, and it ignores the latch: a droppable
+        /// send losing its budget must not decide this one's fate.
+        pub const required: Budget = .{
+            .timeout_ns = Queue.wake_retry_timeout_ns,
+            .attempts = Queue.wake_retry_attempts,
+            .wedge = .persist,
+        };
+    };
+
+    fn sendBudgeted(
+        self: *Mailbox,
+        msg: termio.Message,
+        mutex: ?*std.Io.Mutex,
+        budget: Budget,
+    ) void {
         self.sendBounded(
             msg,
             mutex,
-            Queue.wake_retry_timeout_ns_ui,
-            Queue.wake_retry_attempts_ui,
+            budget.timeout_ns,
+            budget.attempts,
+            budget.wedge,
         );
     }
 
@@ -105,6 +168,7 @@ pub const Mailbox = union(enum) {
         mutex: ?*std.Io.Mutex,
         timeout_ns: u64,
         max_attempts: usize,
+        wedge: Queue.Wedge,
     ) void {
         switch (self.*) {
             .spsc => |*mb| send: {
@@ -137,11 +201,17 @@ pub const Mailbox = union(enum) {
                 // backend, so keep re-issuing it while we wait rather
                 // than sleeping on the queue with no wake source left.
                 //
-                // The wait is bounded. A message here can own a write
-                // buffer, but `termio.Message.deinit` releases exactly
-                // those variants -- the failed-notify path above already
-                // calls it -- so giving up costs one message rather than
-                // the thread.
+                // The queue wait is bounded. A message here can own a
+                // write buffer, but `termio.Message.deinit` releases
+                // exactly those variants -- the failed-notify path above
+                // already calls it -- so giving up costs one message
+                // rather than the thread.
+                //
+                // The function as a whole is NOT bounded: the deferred
+                // re-acquire below is `lockUncancelable`, which has no
+                // timed form, so a renderer-state mutex held elsewhere
+                // still stalls us after the budget expires. Pre-existing
+                // shape; the budget bounds the queue wait, not this.
                 if (mutex) |m| m.unlock(global.io());
                 defer if (mutex) |m| m.lockUncancelable(global.io());
                 const size = mb.queue.pushWake(
@@ -151,6 +221,7 @@ pub const Mailbox = union(enum) {
                     notifyWake,
                     timeout_ns,
                     max_attempts,
+                    wedge,
                 );
                 if (size == 0) {
                     log.warn("io mailbox full, message dropped", .{});
@@ -262,10 +333,26 @@ test "Mailbox: a push it has to give up frees the message" {
     const msg = try termio.Message.writeReq(alloc, @as([]const u8, data));
     try testing.expect(msg == .write_alloc);
 
-    // A tiny budget so the test finishes; production uses the queue's
-    // wake_retry_*_ui defaults.
-    mailbox.sendBounded(msg, null, 1 * std.time.ns_per_ms, 3);
+    // A tiny budget so the test finishes; production uses `Budget`.
+    mailbox.sendBounded(msg, null, 1 * std.time.ns_per_ms, 3, .fail_fast);
 
     // Nothing landed, so nothing was dropped from the queue either.
     try testing.expect(mailbox.spsc.queue.len == 64);
+}
+
+test "Mailbox: a required send outlasts a droppable one and ignores the wedge" {
+    const testing = std.testing;
+
+    // The policy, not the numbers: a message the consumer is blocked on
+    // gets more budget than one that is merely an event, and a droppable
+    // send that has already lost its budget cannot shorten it.
+    const droppable = Mailbox.Budget.droppable;
+    const required = Mailbox.Budget.required;
+
+    try testing.expect(
+        required.timeout_ns * required.attempts >
+            droppable.timeout_ns * droppable.attempts,
+    );
+    try testing.expectEqual(Queue.Wedge.fail_fast, droppable.wedge);
+    try testing.expectEqual(Queue.Wedge.persist, required.wedge);
 }

--- a/src/termio/mailbox.zig
+++ b/src/termio/mailbox.zig
@@ -128,9 +128,42 @@ pub const Mailbox = union(enum) {
         attempts: usize,
         wedge: Queue.Wedge,
 
-        /// One event, whose producer can be the UI thread. Short budget,
-        /// and it fails fast while the consumer is latched wedged so a
-        /// stream of events costs one budget rather than one apiece.
+        /// The default, for a producer that can be the UI thread. Short
+        /// budget, and it fails fast while the consumer is latched wedged
+        /// so a stream of messages costs one budget rather than one
+        /// apiece.
+        ///
+        /// Do not read this as "one advisory event". `send` is the tail
+        /// of `Termio.queueMessage`, which is the tail of
+        /// `Surface.queueIo`, so this budget is what 45 UI-thread call
+        /// sites in `Surface.zig` get without naming it. Most of them
+        /// really are events -- keystrokes, mouse reports, scroll
+        /// sequences, selection-scroll ticks, focus and visibility
+        /// reports -- but three are not, and a reader deciding a new call
+        /// site's policy needs to know that:
+        ///
+        ///   * `.resize` (`Surface.zig:2499`, `:2602`) is state, and its
+        ///     loss is silent AND permanent. `Surface.sizeCallback`
+        ///     early-returns when `self.size.screen` already equals the
+        ///     new size, and `resize` assigns that field before it
+        ///     queues, so a dropped resize leaves the renderer on the new
+        ///     size and the child on the old one until the user resizes
+        ///     again. Nothing re-derives it.
+        ///   * `.change_config` (`Surface.zig:1904`) is state. It is
+        ///     freed on the give-up path -- `termio.Message.deinit`
+        ///     covers it -- so it does not leak, but the io thread keeps
+        ///     the old config until the next config change.
+        ///   * `.paste` / `write_alloc` (`Surface.zig:5944`, `:6311`,
+        ///     `:6368`, `:6414`) is user data. It vanishes with a
+        ///     `log.warn` the user never sees.
+        ///
+        /// They stay droppable deliberately: their producer *is* the UI
+        /// thread, and `required` would hand it a 60s `.persist` wait,
+        /// which is the frozen window this whole budget split exists to
+        /// remove. Making the loss self-correcting -- the move
+        /// `password_input` makes in `termio/Exec.zig` -- is the fix
+        /// those three want, and it is a change to `Surface`, not to a
+        /// budget constant.
         pub const droppable: Budget = .{
             .timeout_ns = Queue.wake_retry_timeout_ns_ui,
             .attempts = Queue.wake_retry_attempts_ui,
@@ -140,6 +173,16 @@ pub const Mailbox = union(enum) {
         /// State the consumer has to observe, from a background
         /// producer. Long budget, and it ignores the latch: a droppable
         /// send losing its budget must not decide this one's fate.
+        ///
+        /// The reverse of that is true too and is the price of it: a
+        /// `required` send that spends its whole budget without landing
+        /// latches the queue like any other, so it fails the *next*
+        /// droppable send fast. On this mailbox -- the only one with both
+        /// kinds -- a tmux command's give-up therefore costs the
+        /// following keystroke, paste or resize its wait. That is the
+        /// intended direction (the consumer really is wedged), but it is
+        /// not symmetric with the sentence above, so do not read that
+        /// sentence as saying the latch is invisible to `droppable`.
         pub const required: Budget = .{
             .timeout_ns = Queue.wake_retry_timeout_ns,
             .attempts = Queue.wake_retry_attempts,

--- a/src/termio/mailbox.zig
+++ b/src/termio/mailbox.zig
@@ -142,28 +142,41 @@ pub const Mailbox = union(enum) {
         /// reports -- but three are not, and a reader deciding a new call
         /// site's policy needs to know that:
         ///
-        ///   * `.resize` (`Surface.zig:2499`, `:2602`) is state, and its
-        ///     loss is silent AND permanent. `Surface.sizeCallback`
-        ///     early-returns when `self.size.screen` already equals the
-        ///     new size, and `resize` assigns that field before it
-        ///     queues, so a dropped resize leaves the renderer on the new
-        ///     size and the child on the old one until the user resizes
-        ///     again. Nothing re-derives it.
-        ///   * `.change_config` (`Surface.zig:1904`) is state. It is
+        ///   * `.resize` (`Surface.setCellSize`, `Surface.resize`) is
+        ///     state, and its loss is silent AND permanent.
+        ///     `Surface.sizeCallback` early-returns when
+        ///     `self.size.screen` already equals the new size, and
+        ///     `Surface.resize` assigns that field before it queues, so a
+        ///     dropped resize leaves the renderer on the new size and the
+        ///     child on the old one until the user resizes again.
+        ///     Nothing re-derives it.
+        ///   * `.change_config` (`Surface.updateConfig`) is state. It is
         ///     freed on the give-up path -- `termio.Message.deinit`
         ///     covers it -- so it does not leak, but the io thread keeps
         ///     the old config until the next config change.
-        ///   * `.paste` / `write_alloc` (`Surface.zig:5944`, `:6311`,
-        ///     `:6368`, `:6414`) is user data. It vanishes with a
-        ///     `log.warn` the user never sees.
+        ///   * `.paste` / `write_alloc` (`Surface.writeScreenFile`,
+        ///     `Surface.completeClipboardPaste`,
+        ///     `Surface.completeClipboardPasteEvent`,
+        ///     `Surface.completeClipboardReadOSC52`) is user data. It
+        ///     vanishes with a `log.warn` the user never sees.
+        ///
+        /// **Those three losses are new.** On merge base `218b8243db`
+        /// this tail ended in a `.forever` push with no timeout, so a
+        /// `.resize` was never dropped -- the UI thread blocked instead,
+        /// indefinitely. Bounding the wait converts that hang into a
+        /// silent, permanent mis-size. That is the right trade, and
+        /// unbounding the hang was the entire point, but do not read the
+        /// list above as documenting a property that was already there:
+        /// it is a user-visible failure mode this change introduces.
         ///
         /// They stay droppable deliberately: their producer *is* the UI
         /// thread, and `required` would hand it a 60s `.persist` wait,
         /// which is the frozen window this whole budget split exists to
         /// remove. Making the loss self-correcting -- the move
-        /// `password_input` makes in `termio/Exec.zig` -- is the fix
-        /// those three want, and it is a change to `Surface`, not to a
-        /// budget constant.
+        /// `password_input` makes in `termio/Exec.zig`'s `termiosTimer`
+        /// -- is the fix those three want, and it is a change to
+        /// `Surface`'s size and config invariants, not to a budget
+        /// constant. Filed separately; `.resize` first.
         pub const droppable: Budget = .{
             .timeout_ns = Queue.wake_retry_timeout_ns_ui,
             .attempts = Queue.wake_retry_attempts_ui,

--- a/src/termio/mailbox.zig
+++ b/src/termio/mailbox.zig
@@ -105,9 +105,15 @@ pub const Mailbox = union(enum) {
                 // are other messages in the writer queue (resize, focus) that
                 // could acquire the lock. This is why we have to release our lock
                 // here.
+                //
+                // A `.forever` push cannot fail, so there is no drop path
+                // here: the message is either queued or this thread is
+                // still waiting for a slot. The wake above is what makes
+                // the writer thread drain, and it has already been issued
+                // by the time we get here.
                 if (mutex) |m| m.unlock(global.io());
                 defer if (mutex) |m| m.lockUncancelable(global.io());
-                if (mb.queue.push(global.io(), msg, .{ .forever = {} }) == 0) msg.deinit();
+                _ = mb.queue.push(global.io(), msg, .{ .forever = {} });
             },
         }
     }

--- a/src/termio/mailbox.zig
+++ b/src/termio/mailbox.zig
@@ -106,16 +106,33 @@ pub const Mailbox = union(enum) {
                 // could acquire the lock. This is why we have to release our lock
                 // here.
                 //
-                // A `.forever` push cannot fail, so there is no drop path
-                // here: the message is either queued or this thread is
-                // still waiting for a slot. The wake above is what makes
-                // the writer thread drain, and it has already been issued
-                // by the time we get here.
+                // The wake above is what makes the writer thread drain,
+                // and a single notify can be lost outright on the IOCP
+                // backend, so keep re-issuing it while we wait rather
+                // than sleeping on the queue with no wake source left.
+                // There is no attempt limit: a message here can own a
+                // write buffer and this path has nowhere to hand it back
+                // to, so waiting for the slot is the only thing that does
+                // not lose it.
                 if (mutex) |m| m.unlock(global.io());
                 defer if (mutex) |m| m.lockUncancelable(global.io());
-                _ = mb.queue.push(global.io(), msg, .{ .forever = {} });
+                _ = mb.queue.pushWake(
+                    global.io(),
+                    msg,
+                    mb.wakeup,
+                    notifyWake,
+                    Queue.wake_retry_timeout_ns,
+                    Queue.wake_retry_forever,
+                );
             },
         }
+    }
+
+    /// The `pushWake` wake for our writer thread. A notify that fails
+    /// means the loop is gone; the send has nothing better to do than
+    /// keep trying, and the queue drains at teardown.
+    fn notifyWake(wakeup: *xev.Async) void {
+        wakeup.notify() catch {};
     }
 
     /// Notify that there are new messages. This may be a noop depending

--- a/src/termio/message.zig
+++ b/src/termio/message.zig
@@ -180,6 +180,16 @@ test "io message variants are all accounted for by the push give-up path" {
     // failed-notify branch, its give-up branch, and the teardown drain.
     // Adding a variant is a decision: does it own memory? Make it, then
     // bump this count.
+    //
+    // `deep_idle` and `go_dormant` are the two most recent, and both
+    // answer no: they are `void`, so `deinit`'s `else` and
+    // `writesToPty`'s `else` are both right for them. Their delivery
+    // policy is the other half of the decision and is settled in
+    // `Mailbox.Budget.droppable`, which is what they inherit through
+    // `Surface.queueIo`: losing either defers a memory reclaim to the
+    // next idle transition or leaves the surface live, which is the
+    // conservative direction and re-derivable from the state that asked
+    // for it. Neither is a one-shot the way `.child_exited` is.
     const fields = @typeInfo(Message).@"union".fields;
-    try std.testing.expectEqual(@as(usize, 19), fields.len);
+    try std.testing.expectEqual(@as(usize, 21), fields.len);
 }

--- a/src/termio/message.zig
+++ b/src/termio/message.zig
@@ -129,6 +129,21 @@ pub const Message = union(enum) {
         };
     }
 
+    /// Whether handling this message results in a write to the pty.
+    pub fn writesToPty(self: Message) bool {
+        return switch (self) {
+            .color_scheme_report,
+            .visibility_report,
+            .size_report,
+            .write_small,
+            .write_stable,
+            .write_alloc,
+            => true,
+
+            else => false,
+        };
+    }
+
     /// Free resources owned by a message that will not be processed.
     /// The message is invalid after this call.
     pub fn deinit(self: *const Message) void {

--- a/src/termio/message.zig
+++ b/src/termio/message.zig
@@ -173,3 +173,13 @@ test {
     const testing = std.testing;
     try testing.expectEqual(@as(usize, 40), @sizeOf(Message));
 }
+
+test "io message variants are all accounted for by the push give-up path" {
+    // `deinit` ends in `else => {}`, so a new variant that owns memory
+    // compiles and then leaks on every drop path -- the mailbox's
+    // failed-notify branch, its give-up branch, and the teardown drain.
+    // Adding a variant is a decision: does it own memory? Make it, then
+    // bump this count.
+    const fields = @typeInfo(Message).@"union".fields;
+    try std.testing.expectEqual(@as(usize, 19), fields.len);
+}

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -197,11 +197,15 @@ pub const StreamHandler = struct {
         }
     }
 
+    /// Send a message to the termio thread. Almost everything this handler
+    /// sends is a reply to output the child produced, so once the pty write
+    /// backlog is at its cap we drop it: a child that isn't draining its
+    /// input isn't reading the replies either. User input doesn't come
+    /// through here.
+    ///
+    /// Use `messageWriterRequired` for a write something is blocked on
+    /// rather than merely informed by.
     inline fn messageWriter(self: *StreamHandler, msg: termio.Message) void {
-        // Everything this handler sends is a reply to output the child
-        // produced, so once the pty write backlog is at its cap we can
-        // drop it: a child that isn't draining its input isn't reading
-        // the replies either. User input doesn't come through here.
         if (msg.writesToPty() and self.write_limit.atCapacity()) {
             const now = std.Io.Timestamp.now(global.io(), .awake);
             if (self.write_limit.recordDrop(now.toMilliseconds())) |n| {
@@ -215,6 +219,14 @@ pub const StreamHandler = struct {
             return;
         }
 
+        self.messageWriterRequired(msg);
+    }
+
+    /// Send a message the backlog cap must not drop.
+    inline fn messageWriterRequired(
+        self: *StreamHandler,
+        msg: termio.Message,
+    ) void {
         self.termio_mailbox.send(msg, self.renderer_state.mutex);
         self.termio_messaged = true;
     }
@@ -554,7 +566,12 @@ pub const StreamHandler = struct {
                                 self.alloc,
                                 command,
                             );
-                            self.messageWriter(msg);
+
+                            // Not a reply: this drives the control mode
+                            // session the user asked for, and tmux answers
+                            // every command with a %begin/%end block the
+                            // viewer waits for. Dropping one wedges it.
+                            self.messageWriterRequired(msg);
                         },
 
                         .windows => {
@@ -2347,6 +2364,73 @@ test "kitty clipboard write: oversized text replies EFBIG" {
     // Teardown leaves no transaction that could be committed and
     // forwarded to the macOS clipboard path.
     try testing.expect(mailbox.spsc.queue.pop(global.io()) == null);
+}
+
+test "tmux control mode commands survive a full pty write backlog" {
+    if (comptime !StreamHandler.tmux_enabled) return error.SkipZigTest;
+
+    const testing = std.testing;
+
+    var mailbox = try termio.Mailbox.initSPSC(testing.allocator);
+    defer mailbox.deinit(testing.allocator);
+
+    var mutex: std.Io.Mutex = .init;
+    mutex.lockUncancelable(global.io());
+    defer mutex.unlock(global.io());
+
+    var renderer_state: renderer.State = .{
+        .mutex = &mutex,
+        .terminal = undefined,
+    };
+
+    // A backlog that is already at its cap.
+    var write_limit: termio.WriteLimit = .{ .max = 1 };
+    write_limit.queued(1);
+
+    var handler: StreamHandler = undefined;
+    handler.alloc = testing.allocator;
+    handler.termio_mailbox = &mailbox;
+    handler.write_limit = &write_limit;
+    handler.renderer_state = &renderer_state;
+    handler.termio_messaged = false;
+    handler.tmux_viewer = null;
+    defer if (handler.tmux_viewer) |viewer| {
+        viewer.deinit();
+        testing.allocator.destroy(viewer);
+    };
+
+    // A terminal reply is refused at the cap...
+    handler.messageWriter(.{ .write_stable = "\x1B[0n" });
+    try testing.expect(mailbox.spsc.queue.pop(global.io()) == null);
+
+    // ...but a control mode command is not a reply: tmux answers each
+    // one with a %begin/%end block the viewer waits for, so dropping it
+    // wedges a session the user asked for.
+    var enter: terminal.dcs.Command = .{ .tmux = .enter };
+    try handler.dcsCommand(&enter);
+    var block_end: terminal.dcs.Command = .{ .tmux = .{ .block_end = "" } };
+    try handler.dcsCommand(&block_end);
+    var session_changed: terminal.dcs.Command = .{ .tmux = .{ .session_changed = .{
+        .id = 1,
+        .name = "first",
+    } } };
+    try handler.dcsCommand(&session_changed);
+
+    const queued = mailbox.spsc.queue.pop(global.io());
+    try testing.expect(queued != null);
+    const msg = queued.?;
+    defer msg.deinit();
+    const command: termio.Message.WriteReq = switch (msg) {
+        .write_small => |v| .{ .small = v },
+        .write_stable => |v| .{ .stable = v },
+        .write_alloc => |v| .{ .alloc = v },
+        else => return error.TestUnexpectedResult,
+    };
+    try testing.expect(std.mem.startsWith(
+        u8,
+        command.slice(),
+        "display-message",
+    ));
 }
 
 /// Everything a pwd report needs from a `StreamHandler`, and nothing else.

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -181,6 +181,25 @@ pub const StreamHandler = struct {
         self.messageWriter(.{ .color_scheme_report = .{ .force = false } });
     }
 
+    /// Send a surface message on behalf of the child's output.
+    ///
+    /// This is a shared tail, so name what it hands its callers: all 22
+    /// call sites in this file get `App.Mailbox.push`'s `.fail_fast`, on
+    /// the pty read thread. That is right for them -- they are produced
+    /// per OSC by whatever the child emits, so they arrive in exactly the
+    /// stream the latch exists to stop paying for, and every one of them
+    /// is either advisory or re-derivable by the next escape sequence.
+    ///
+    /// It is right for them *by that argument*, not because a wrapper
+    /// happened to pass it. Two are worth knowing about before adding a
+    /// third: a lost `.stop_command` leaves a shell-integration mark
+    /// showing a command still running until the next prompt, and a lost
+    /// `.clipboard_read` / `.kitty_clipboard_read` drops an OSC 52 reply
+    /// the child may be waiting on. Both need a wedged app thread first,
+    /// and both are recoverable by the user. A message that is neither --
+    /// one shot, and nothing re-derives it -- must use
+    /// `apprt.surface.Mailbox.pushRequired` instead; `.child_exited` in
+    /// `termio/Exec.zig` is the one message in the tree that qualifies.
     inline fn surfaceMessageWriter(
         self: *StreamHandler,
         msg: apprt.surface.Message,

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -31,6 +31,10 @@ pub const StreamHandler = struct {
     /// Mailbox for data to the termio thread.
     termio_mailbox: *termio.Mailbox,
 
+    /// Bounds the data queued to the pty. Terminal replies are dropped
+    /// while this is at capacity; see termio.WriteLimit.
+    write_limit: *termio.WriteLimit,
+
     /// Mailbox for the surface.
     surface_mailbox: apprt.surface.Mailbox,
 
@@ -194,6 +198,23 @@ pub const StreamHandler = struct {
     }
 
     inline fn messageWriter(self: *StreamHandler, msg: termio.Message) void {
+        // Everything this handler sends is a reply to output the child
+        // produced, so once the pty write backlog is at its cap we can
+        // drop it: a child that isn't draining its input isn't reading
+        // the replies either. User input doesn't come through here.
+        if (msg.writesToPty() and self.write_limit.atCapacity()) {
+            const now = std.Io.Timestamp.now(global.io(), .awake);
+            if (self.write_limit.recordDrop(now.toMilliseconds())) |n| {
+                log.warn(
+                    "pty write backlog full, dropped {} terminal responses",
+                    .{n},
+                );
+            }
+
+            msg.deinit();
+            return;
+        }
+
         self.termio_mailbox.send(msg, self.renderer_state.mutex);
         self.termio_messaged = true;
     }
@@ -2281,9 +2302,11 @@ test "kitty clipboard write: oversized text replies EFBIG" {
         .mutex = &mutex,
         .terminal = undefined,
     };
+    var write_limit: termio.WriteLimit = .{};
     var handler: StreamHandler = undefined;
     handler.alloc = testing.allocator;
     handler.termio_mailbox = &mailbox;
+    handler.write_limit = &write_limit;
     handler.renderer_state = &renderer_state;
     handler.clipboard_write = .allow;
     handler.clipboard_write_limit = 4;

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -198,8 +198,12 @@ pub const StreamHandler = struct {
     /// the child may be waiting on. Both need a wedged app thread first,
     /// and both are recoverable by the user. A message that is neither --
     /// one shot, and nothing re-derives it -- must use
-    /// `apprt.surface.Mailbox.pushRequired` instead; `.child_exited` in
-    /// `termio/Exec.zig` is the one message in the tree that qualifies.
+    /// `apprt.surface.Mailbox.pushRequired` instead. `.child_exited`,
+    /// pushed by `Exec.processExitCommon`, is the one message in the tree
+    /// that qualifies, and `apprt.surface.Message.dropAllowed` is where
+    /// that classification lives now: `push` asserts on it, so a variant
+    /// added here that should not be dropped is a compile error there
+    /// before it is a bug.
     inline fn surfaceMessageWriter(
         self: *StreamHandler,
         msg: apprt.surface.Message,

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -220,11 +220,15 @@ pub const StreamHandler = struct {
     }
 
     /// Send a message the backlog cap must not drop.
+    ///
+    /// This runs on the pty read thread, never the UI thread, so it takes
+    /// the required budget rather than the droppable one: the cost of
+    /// waiting here is a stalled child, not a frozen window.
     inline fn messageWriterRequired(
         self: *StreamHandler,
         msg: termio.Message,
     ) void {
-        self.termio_mailbox.send(msg, self.renderer_state.mutex);
+        self.termio_mailbox.sendRequired(msg, self.renderer_state.mutex);
         self.termio_messaged = true;
     }
 
@@ -535,7 +539,19 @@ pub const StreamHandler = struct {
                             // Not a reply: this drives the control mode
                             // session the user asked for, and tmux answers
                             // every command with a %begin/%end block the
-                            // viewer waits for. Dropping one wedges it.
+                            // viewer waits for, so dropping one wedges the
+                            // viewer.
+                            //
+                            // That is why this bypasses the pty write
+                            // backlog cap, which drops replies freely. It
+                            // is not an absolute guarantee and cannot be:
+                            // waiting on the writer thread without a limit
+                            // would stop this thread reading the pty, and a
+                            // tmux session whose output is no longer read
+                            // is wedged either way. So the command gets the
+                            // required budget -- roughly a minute, and
+                            // unaffected by another producer's give-up --
+                            // and past that it is dropped and logged.
                             self.messageWriterRequired(msg);
                         },
 

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -216,14 +216,22 @@ pub const StreamHandler = struct {
             return;
         }
 
-        self.messageWriterRequired(msg);
+        // Deliberately NOT routed through `messageWriterRequired`. A
+        // child that spams cursor-position queries produces a stream of
+        // these, and the required budget would spend up to a minute on
+        // each one while ignoring the wedge latch -- stalling the pty
+        // read thread per reply, which is the per-message-not-per-stall
+        // trap one level down. These are advisory; they are droppable.
+        self.termio_mailbox.send(msg, self.renderer_state.mutex);
+        self.termio_messaged = true;
     }
 
     /// Send a message the backlog cap must not drop.
     ///
     /// This runs on the pty read thread, never the UI thread, so it takes
     /// the required budget rather than the droppable one: the cost of
-    /// waiting here is a stalled child, not a frozen window.
+    /// waiting here is a stalled child, not a frozen window. It has one
+    /// caller, the tmux control-mode command path.
     inline fn messageWriterRequired(
         self: *StreamHandler,
         msg: termio.Message,

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -47,9 +47,6 @@ pub const StreamHandler = struct {
     /// The shared render state
     renderer_state: *renderer.State,
 
-    /// The mailbox for notifying the renderer of things.
-    renderer_mailbox: *renderer.Thread.Mailbox,
-
     /// A handle to wake up the renderer. This hints to the renderer that
     /// a repaint should happen. See termio.Options for why this is a pointer.
     renderer_wakeup: *xev.Async,
@@ -229,38 +226,6 @@ pub const StreamHandler = struct {
     ) void {
         self.termio_mailbox.send(msg, self.renderer_state.mutex);
         self.termio_messaged = true;
-    }
-
-    /// Send a renderer message and unlock the renderer state mutex
-    /// if necessary to ensure we don't deadlock.
-    ///
-    /// This assumes the renderer state mutex is locked.
-    inline fn rendererMessageWriter(
-        self: *StreamHandler,
-        msg: renderer.Message,
-    ) void {
-        // See termio.Mailbox.send for more details on how this works.
-
-        // Try instant first. If it works then we can return.
-        if (self.renderer_mailbox.push(msg, .{ .instant = {} }) > 0) {
-            return;
-        }
-
-        // Instant would have blocked. Release the renderer mutex,
-        // wake up the renderer to allow it to process the message,
-        // and then try again.
-        self.renderer_state.mutex.unlock(global.io());
-        defer self.renderer_state.mutex.lockUncancelable(global.io());
-        self.renderer_wakeup.notify() catch |err| {
-            // This is an EXTREMELY unlikely case. We still don't return
-            // and attempt to send the message because its most likely
-            // that everything is fine, but log in case a freeze happens.
-            log.warn(
-                "failed to notify renderer, may deadlock err={}",
-                .{err},
-            );
-        };
-        _ = self.renderer_mailbox.push(msg, .{ .forever = {} });
     }
 
     pub fn vt(

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -2644,3 +2644,41 @@ test "pwd: the first report of a session is not swallowed by the spawn cwd" {
     try testing.expectEqual(@as(usize, 1), counts.pwd);
     try testing.expectEqual(@as(usize, 1), counts.title);
 }
+
+test "stream handler refuses and frees an owned write at the backlog cap" {
+    const testing = std.testing;
+
+    var mailbox = try termio.Mailbox.initSPSC(testing.allocator);
+    defer mailbox.deinit(testing.allocator);
+
+    var mutex: std.Io.Mutex = .init;
+    mutex.lockUncancelable(global.io());
+    defer mutex.unlock(global.io());
+
+    var renderer_state: renderer.State = .{
+        .mutex = &mutex,
+        .terminal = undefined,
+    };
+
+    // A backlog that is already at its cap, so every advisory write is
+    // refused rather than queued.
+    var write_limit: termio.WriteLimit = .{ .max = 1 };
+    write_limit.queued(1);
+
+    var handler: StreamHandler = undefined;
+    handler.alloc = testing.allocator;
+    handler.termio_mailbox = &mailbox;
+    handler.write_limit = &write_limit;
+    handler.renderer_state = &renderer_state;
+    handler.termio_messaged = false;
+
+    // Longer than WriteReq's inline capacity, so this is a .write_alloc
+    // that owns its bytes. Refusing it has to free them: the testing
+    // allocator fails the test if the drop path forgets.
+    const data: []const u8 = "\x1B]11;rgb:1111/2222/3333\x1B\\" ** 4;
+    const msg = try termio.Message.writeReq(testing.allocator, data);
+    try testing.expect(msg == .write_alloc);
+
+    handler.messageWriter(msg);
+    try testing.expect(mailbox.spsc.queue.pop(global.io()) == null);
+}

--- a/src/termio/write_limit.zig
+++ b/src/termio/write_limit.zig
@@ -16,9 +16,14 @@ const std = @import("std");
 /// paste larger than the cap still goes through in full; it just makes us
 /// refuse replies until it drains.
 ///
-/// The counter is written from the termio thread (queueing writes and
-/// their completions) and read from the read thread (deciding whether to
-/// refuse a reply), so it is atomic.
+/// Every field is touched from more than one thread. The outstanding
+/// count is written by the termio thread (queueing writes and their
+/// completions) and read by the read thread (deciding whether to refuse a
+/// reply); the drop counter and the warning timestamp are written by both,
+/// because a config change hands `changeConfig` a colour report to write
+/// from the termio thread while every other reply comes from the read
+/// thread. So all of them are atomic, and the warning claims its interval
+/// with a compare-exchange rather than a load and a store.
 pub const WriteLimit = struct {
     /// Bytes queued to the write stream whose writes have not completed.
     outstanding: std.atomic.Value(usize) = .init(0),
@@ -59,14 +64,27 @@ pub const WriteLimit = struct {
     /// refused since the last warning if it is time to warn again, and
     /// null if the last warning was too recent.
     pub fn recordDrop(self: *WriteLimit, now_ms: i64) ?usize {
-        const count = self.dropped.fetchAdd(1, .monotonic) + 1;
+        _ = self.dropped.fetchAdd(1, .monotonic);
 
-        const last = self.last_warn_ms.load(.monotonic);
-        if (last != 0 and now_ms -| last < warn_interval_ms) return null;
+        // Claim the interval before reporting anything: only the caller
+        // that moves the timestamp gets to warn, so two threads dropping
+        // at once produce one warning rather than two, and only one of
+        // them takes the counter.
+        var last = self.last_warn_ms.load(.monotonic);
+        while (true) {
+            if (last != 0 and now_ms -| last < warn_interval_ms) return null;
+            last = self.last_warn_ms.cmpxchgWeak(
+                last,
+                now_ms,
+                .monotonic,
+                .monotonic,
+            ) orelse break;
+        }
 
-        self.last_warn_ms.store(now_ms, .monotonic);
-        _ = self.dropped.fetchSub(count, .monotonic);
-        return count;
+        // Taking the whole counter rather than subtracting what we
+        // counted keeps the drops another thread added meanwhile, and
+        // can't underflow.
+        return self.dropped.swap(0, .monotonic);
     }
 };
 
@@ -102,5 +120,45 @@ test "termio WriteLimit rate limits its warning" {
     try testing.expectEqual(
         @as(?usize, 3),
         limit.recordDrop(1_000 + WriteLimit.warn_interval_ms),
+    );
+}
+
+test "termio WriteLimit accounts for every drop with two threads warning" {
+    const testing = std.testing;
+
+    const thread_count = 4;
+    const drops_per_thread = 500;
+
+    // A config change writes a colour report from the termio thread while
+    // the read thread is refusing replies, so two threads can be in
+    // recordDrop at once. Whatever the interleaving, every drop has to be
+    // reported exactly once or still be waiting in the counter: reporting
+    // one twice, or losing one, means the subtraction underflowed.
+    const Dropper = struct {
+        limit: *WriteLimit,
+        reported: usize = 0,
+
+        fn run(self: *@This()) void {
+            for (0..drops_per_thread) |i| {
+                const now: i64 = 1 + @as(i64, @intCast(i)) * WriteLimit.warn_interval_ms;
+                if (self.limit.recordDrop(now)) |n| self.reported += n;
+            }
+        }
+    };
+
+    var limit: WriteLimit = .{};
+    var droppers: [thread_count]Dropper = undefined;
+    var threads: [thread_count]std.Thread = undefined;
+    for (&droppers, &threads) |*d, *t| {
+        d.* = .{ .limit = &limit };
+        t.* = try std.Thread.spawn(.{}, Dropper.run, .{d});
+    }
+    for (&threads) |t| t.join();
+
+    var total: usize = limit.dropped.load(.monotonic);
+    for (&droppers) |*d| total += d.reported;
+    try testing.expectEqual(
+        @as(usize, thread_count * drops_per_thread),
+        total,
     );
 }

--- a/src/termio/write_limit.zig
+++ b/src/termio/write_limit.zig
@@ -1,0 +1,106 @@
+//! Accounting for data handed to the pty whose writes have not finished.
+
+const std = @import("std");
+
+/// Bounds the amount of data queued to a single pty write stream.
+///
+/// A child that keeps asking the terminal questions (an `ESC [ 6 n` loop,
+/// say) without ever reading its own stdin makes us queue a reply per
+/// query. Each queued reply holds a pooled write request until the write
+/// completes, so with no bound the pool grows for as long as the child
+/// misbehaves.
+///
+/// Terminal replies are advisory: a child that is not reading its input
+/// gains nothing from them, so refusing them is better than growing
+/// without bound. User input is not advisory and is never refused, so a
+/// paste larger than the cap still goes through in full; it just makes us
+/// refuse replies until it drains.
+///
+/// The counter is written from the termio thread (queueing writes and
+/// their completions) and read from the read thread (deciding whether to
+/// refuse a reply), so it is atomic.
+pub const WriteLimit = struct {
+    /// Bytes queued to the write stream whose writes have not completed.
+    outstanding: std.atomic.Value(usize) = .init(0),
+
+    /// Advisory writes refused since the last warning.
+    dropped: std.atomic.Value(usize) = .init(0),
+
+    /// Timestamp in milliseconds of the last warning, zero for never.
+    last_warn_ms: std.atomic.Value(i64) = .init(0),
+
+    /// The backlog at which advisory writes start being refused.
+    max: usize = default_max,
+
+    /// Enough headroom that no interactive workload reaches it: a pty
+    /// that is being read at all drains far faster than this.
+    pub const default_max: usize = 1024 * 1024;
+
+    /// The minimum gap between warnings. A child in a query loop would
+    /// otherwise turn our own log into the flood.
+    pub const warn_interval_ms: i64 = 5 * std.time.ms_per_s;
+
+    /// Account for bytes handed to the write stream.
+    pub fn queued(self: *WriteLimit, n: usize) void {
+        _ = self.outstanding.fetchAdd(n, .monotonic);
+    }
+
+    /// Account for bytes whose write has completed.
+    pub fn completed(self: *WriteLimit, n: usize) void {
+        _ = self.outstanding.fetchSub(n, .monotonic);
+    }
+
+    /// Whether advisory writes should be refused right now.
+    pub fn atCapacity(self: *const WriteLimit) bool {
+        return self.outstanding.load(.monotonic) >= self.max;
+    }
+
+    /// Record an advisory write we refused. Returns how many have been
+    /// refused since the last warning if it is time to warn again, and
+    /// null if the last warning was too recent.
+    pub fn recordDrop(self: *WriteLimit, now_ms: i64) ?usize {
+        const count = self.dropped.fetchAdd(1, .monotonic) + 1;
+
+        const last = self.last_warn_ms.load(.monotonic);
+        if (last != 0 and now_ms -| last < warn_interval_ms) return null;
+
+        self.last_warn_ms.store(now_ms, .monotonic);
+        _ = self.dropped.fetchSub(count, .monotonic);
+        return count;
+    }
+};
+
+test "termio WriteLimit refuses advisory writes past the cap" {
+    const testing = std.testing;
+
+    var limit: WriteLimit = .{ .max = 100 };
+    try testing.expect(!limit.atCapacity());
+
+    limit.queued(99);
+    try testing.expect(!limit.atCapacity());
+
+    limit.queued(1);
+    try testing.expect(limit.atCapacity());
+
+    limit.completed(1);
+    try testing.expect(!limit.atCapacity());
+}
+
+test "termio WriteLimit rate limits its warning" {
+    const testing = std.testing;
+
+    var limit: WriteLimit = .{ .max = 1 };
+
+    // The first refusal warns immediately.
+    try testing.expectEqual(@as(?usize, 1), limit.recordDrop(1_000));
+
+    // Refusals inside the interval are counted but not warned about.
+    try testing.expectEqual(@as(?usize, null), limit.recordDrop(1_001));
+    try testing.expectEqual(@as(?usize, null), limit.recordDrop(2_000));
+
+    // The next warning reports everything since the last one.
+    try testing.expectEqual(
+        @as(?usize, 3),
+        limit.recordDrop(1_000 + WriteLimit.warn_interval_ms),
+    );
+}

--- a/src/termio/write_limit.zig
+++ b/src/termio/write_limit.zig
@@ -55,6 +55,20 @@ pub const WriteLimit = struct {
         _ = self.outstanding.fetchSub(n, .monotonic);
     }
 
+    /// Start a fresh accounting run.
+    ///
+    /// Outstanding bytes are only given back by write completions, so a
+    /// backend run that ends with writes still queued never accounts for
+    /// them. This limit lives on the Termio rather than on the per-run
+    /// thread data, so without this a later run inherits the leftover and
+    /// can sit above the cap for the life of the surface, refusing every
+    /// terminal reply.
+    pub fn reset(self: *WriteLimit) void {
+        self.outstanding.store(0, .monotonic);
+        self.dropped.store(0, .monotonic);
+        self.last_warn_ms.store(0, .monotonic);
+    }
+
     /// Whether advisory writes should be refused right now.
     pub fn atCapacity(self: *const WriteLimit) bool {
         return self.outstanding.load(.monotonic) >= self.max;
@@ -161,4 +175,24 @@ test "termio WriteLimit accounts for every drop with two threads warning" {
         @as(usize, thread_count * drops_per_thread),
         total,
     );
+}
+
+test "termio WriteLimit clears a backlog a teardown left behind" {
+    const testing = std.testing;
+
+    var limit: WriteLimit = .{ .max = 100 };
+
+    // A backend run queues writes and then goes away without its
+    // completions running, so the bytes are never accounted back.
+    limit.queued(100);
+    _ = limit.recordDrop(1_000);
+    try testing.expect(limit.atCapacity());
+
+    // The next run starts from a clean sheet. Without this the counter
+    // is above the cap forever and every terminal reply is refused for
+    // the life of the surface.
+    limit.reset();
+    try testing.expect(!limit.atCapacity());
+    try testing.expectEqual(@as(usize, 0), limit.dropped.load(.monotonic));
+    try testing.expectEqual(@as(i64, 0), limit.last_warn_ms.load(.monotonic));
 }


### PR DESCRIPTION
Fixes a set of data-structure and pty-write defects found by a read-only
audit, plus the queue regression the first version of this PR introduced.

## What `.forever` used to do, and what it does now

`BlockingQueue.push` with `.forever` used to wait exactly once on the
not-full condition and then, if the queue was still full, return zero and
drop the value. Every caller discarded the return, so a dropped message
was invisible. That is a bug: a woken producer can lose the freed slot to
another producer, and the value disappears.

It is worth being precise about what that escape was, because an earlier
draft of this description overstated it. The single wait had **no
timeout**, and the only thing that can signal the not-full condition is a
`pop`. So a producer facing a consumer that is not draining parked on
that first wait and never returned: unbounded parking was already the
behaviour, not something this PR introduced. The drop-and-continue only
fired in the narrow case where the consumer *did* drain and a competing
producer then stole the freed slot. This PR removed a probabilistic
escape, not a reliable one.

This PR loops the wait, so `.forever` now waits until a slot is genuinely
free, which fixes the silent drop. But that makes the parking
deterministic, and our mailboxes are drained by a thread that only runs
when it is woken. A producer that pushes first and wakes second, and then
parks in the queue, has withheld the very wake that would free the slot
it is waiting for. That is the shape of the hidden surface hang (#1036).

So this PR also adds `BlockingQueue.pushWake`. It waits in windows and
calls the consumer's wake after every window that did not land the value,
so the wait can never withhold the wake and a single lost wake costs one
window rather than the process. Every use of it takes an attempt budget.

`pushWake` returning zero means the value was not queued and the caller
still owns it. That is written into the doc comment, because the caller
is the only place that knows whether the value owns memory.

## A budget chosen by what the caller can lose, and a bound on the stall

Two budgets (READ-FROM-SOURCE, `datastruct/blocking_queue.zig:106-131`):

- **Background / `required`**: 250 ms windows, 240 of them, about a
  minute. The cost of this wait is a stalled search or a stalled child.
- **UI / `droppable`**: 50 ms windows, 40 of them, about two seconds. The
  cost of this wait is a window that has stopped pumping messages. The
  shorter window also re-issues the consumer's wake five times as often,
  and that re-issue is what recovers a lost notify.

**Which one a send takes is a property of the message, not of the queue.**
An earlier round of this PR made it a per-mailbox constant, and that was
wrong in both directions at once: it gave a tmux control-mode command the
shortest budget in the tree, and it gave a mouse-motion report the same
budget as a tmux command. `termio.Mailbox` now exposes `Budget.droppable`
and `Budget.required`, and `send` / `sendRequired` name which applies.

**A budget bounds one push, not the stall.** Nothing stops a producer
arriving with the next message the moment this one gives up, so on its own
the UI pair buys a window that freezes for two seconds *per event*,
indefinitely, while pumping often enough that Windows never paints it "Not
Responding" and never offers the kill. That is worse than the minute it
replaced. So `BlockingQueue` latches `wedged` when a push spends a whole
budget without landing, and a `.fail_fast` caller then tries once and
gives up until a push lands and clears the latch. The budget is spent once
per wedge, not once per event, and the thread stays responsive.

The cost, stated plainly: after one lost budget, a message that would have
landed in the next budget's second window is dropped instead. A consumer
that frees one slot within a budget never latches, so this only applies to
one that failed to free a single slot across 40 windows with a wake
re-issued after each. `.persist` callers ignore the latch entirely, so one
producer's give-up cannot shorten another's budget. The symmetric fact is
true too and is the price of it: a `.persist` push that spends its whole
budget latches the queue like any other, so on the termio mailbox a tmux
command's give-up costs the *following* keystroke, paste or resize its
wait.

**"Budget by message" exists on one of the four queues.** The termio
mailbox has both budgets. The app mailbox is `.fail_fast` with one named
exception (`.child_exited`, below); the search mailbox is blanket
`.fail_fast`; the renderer mailbox is blanket `.persist`, and its latch is
therefore write-only — nothing on that queue ever reads it. That is not an
oversight to be inferred from the diff; it is the current state, and the
renderer queue's seven UI-thread producers still pay the full background
budget apiece.

**What the shared tails hand their callers, enumerated rather than
implied.** `Budget.droppable` is the tail of `Termio.queueMessage`, which
is the tail of `Surface.queueIo`, so it is what **47** UI-thread call
sites in `Surface.zig` get without naming it (measured by listing every
`.queueIo(` call expression and mapping each to its enclosing function; a
48th is inside a test). Most are events. Three are not, and the doc
comment now says so:

- `.resize` (`Surface.setCellSize`, `Surface.resize`) is state, and its loss is silent
  **and permanent**: `sizeCallback` early-returns when `self.size.screen`
  already equals the new size, and `resize` assigns that field before it
  queues, so the renderer ends up on the new size and the child on the old
  one until the user resizes again.
- `.change_config` (`Surface.updateConfig`) is state. It is freed on the
  give-up path (`termio.Message.deinit` covers it) so nothing leaks, but
  the io thread keeps the old config until the next config change.
- `.paste` / `write_alloc` (`Surface.writeScreenFile`,
  `Surface.completeClipboardPaste`, `Surface.completeClipboardPasteEvent`,
  `Surface.completeClipboardReadOSC52`)
  is user data, lost with a `log.warn` the user never sees.

**Those three losses are NEW, and the description should not read as
though they were already there.** On merge base `218b8243db` that shared
tail ended in a `.forever` push with no timeout, so a `.resize` was
**never dropped** — the UI thread blocked instead, indefinitely. This PR
converts that hang into a silent, permanent mis-size. That is the right
trade, and unbounding the hang is the entire point of the change, but it
is a user-visible failure mode this PR introduces, not a property it
merely documents.

> **On the base named throughout this description.** Every
> "merge base `218b8243db`" claim below was derived against that commit,
> and the branch has since been rebased onto `255f3c0a81`. They all still
> hold, and not by assumption: `src/datastruct/blocking_queue.zig` and
> `src/termio/mailbox.zig` are **byte-identical** between the two bases
> (`git rev-parse <base>:<file>` matches for both), and nothing on the
> target touched `Termio.queueMessage`. The one shared function the
> target did edit is `Termio.resize`, where #1060 added a dormancy wake
> guard ahead of everything this PR changes there.

They stay droppable **on purpose**: their producer *is* the UI thread, and
`Budget.required` is `.persist` plus a minute, which is exactly the frozen
window this split exists to remove. The fix those three want is
self-correcting delivery — the move `password_input` makes below — which
is a change to `Surface`'s size and config invariants, not to a budget
constant, and is deliberately not in this PR. It is **filed** as a
follow-up (`.resize` first), not merely flagged here.

Two of the 47 arrived while this PR was in review, from the footprint
work on `origin/windows`: `.deep_idle` (`Surface.idleCallback`, #1057)
and `.go_dormant` (`Surface.goDormantCallback`, #1060). Both reached
`Budget.droppable` through the wrapper without anyone choosing it —
exactly the delegation this section exists to make visible — so both were
classified rather than inherited. Both are events: a lost `.deep_idle`
defers a memory reclaim to the next idle transition, and a lost
`.go_dormant` leaves the surface live, which its caller already has to
tolerate because it reads `Surface.isDormant` for the outcome instead of
trusting the send. Droppable is right for both, and the doc comment now
names them so the next reader does not re-derive it.

One queue over, `stream_handler.surfaceMessageWriter` is the same shape:
**22** call sites inherit `App.Mailbox.push`'s `.fail_fast`
(`color_change` x6, `pwd_change` x2, `set_title` x2, `ring_bell`,
`set_mouse_shape`, `clipboard_read`, `clipboard_write`,
`kitty_clipboard_read`, `kitty_clipboard_write`, `start_command`,
`stop_command`, `prompt_input`, `desktop_notification`, `report_title`,
`progress_report`). That is right for them — they are produced per OSC on
the pty read thread, so they arrive in exactly the stream the latch exists
for, and each is advisory or re-derived by the next escape sequence — but
it is right *by that argument*, not because a wrapper passed it. A lost
`.stop_command` leaves a shell-integration mark showing a command still
running until the next prompt; a lost `.clipboard_read` drops an OSC 52
reply. Both need a wedged app thread first and both are user-recoverable.

There is no budget that never gives up. Every mailbox in the tree can
release a refused message, and a producer that waits without a limit takes
its own thread out of service for as long as the consumer is wedged, which
is how two mailboxes deadlock each other.

## The deadlock this closes

The app mailbox and the io mailbox both waited without a limit, and one
interleaving reaches both:

1. The app mailbox fills while the UI thread is busy.
2. The termio **writer** thread pushes to it from its own xev callbacks
   (`termiosTimer`, `processExit`) and parks. Its event loop stops, so
   `termio.Thread.drainMailbox` never runs again and the io mailbox stops
   draining.
3. The UI thread writes to the pty through `Surface.queueIo` (a
   keystroke, a paste, a resize), finds the io mailbox full, and parks.
4. The UI thread no longer pumps, so `App.tick` never runs and the app
   mailbox never drains. Both parked threads re-issue their wakes four
   times a second at consumers that cannot act. Only a kill recovers.

A previous round of this PR left both hops unbounded and published a
justification for it that was wrong on two counts, so both are corrected
here rather than left in the tree:

- The comment at `termio/mailbox.zig` said a message there "can own a
  write buffer and this path has nowhere to hand it back to".
  `termio.Message.deinit` covers every owning variant, and the
  failed-notify path eleven lines above already calls it.
- The comment at `App.Mailbox.push` said the only way to stay parked is a
  thread that never drains despite repeated wakes, "the app thread being
  dead". Step 4 above is a live app thread, parked, with everything to
  recover to.

Both sites now take a budget and free what they give up. The app mailbox
needed `apprt.surface.Message.deinit`, which turned out to be four owning
arms: `MessageData` carries the allocator it was built with, and the two
Kitty clipboard requests own the arena they live in. `change_config` is
never pushed onto that mailbox at all.

That switch is now **exhaustive**, matching `App.Message.deinit`. An
earlier round used `else => {}` here and an exhaustive switch there, in
the same commit, with no stated reason; the field-count test that stood in
for it only fires if this file is in the running build graph and only at
test time. Exhaustive costs 23 listed no-op variants and buys a compile
error instead of a silent leak the next time a variant starts owning
memory.

## Queues audited

Every queue in the tree, with where it is drained and who pushes to it:

- **Renderer mailbox** - drained in the wakeup callback and in a
  safety-net timer that runs only while the surface is hidden. All
  producers go through `renderer.Thread.pushMailbox`, background budget.
  See the residual below.
- **App mailbox** - drained by `App.tick` alone, which the app runtime
  calls from its wakeup handler; on the embedded runtime that handler is
  the only caller there is. `App.Mailbox.push` routes `.forever` through
  `pushWake` on the background budget, `.fail_fast`, which covers the
  streaming producers at once: the stream handler's 22 surface messages,
  the password-input message from the pty layer, and the search result
  messages. Background because every producer *that reaches this path* is
  a background thread. It frees what it gives up.

  **One message on this queue takes `.persist` instead: `.child_exited`.**
  `App.Mailbox.pushRequired` is the mirror of `termio.Mailbox.sendRequired`
  and `termio/Exec.zig`'s `processExitCommon` is its only caller. The
  latch is right for streams and wrong for that message: it runs once per
  surface lifetime, nothing re-derives it, and an app thread wedged past
  one budget and then recovering would still have delivered it on the next
  attempt. Losing it means `close-on-exit` never fires, the exit overlay
  never appears, and the close confirmation keeps asking about a process
  that already exited — for the life of the surface.
  `App.Mailbox.pushBounded` now takes its wedge as a parameter rather than
  hard-coding one, so the choice is testable.

  **Where that stands against the merge base: better, not equal.** On
  `218b8243db` this push waited on the not-full condition with **no
  timeout at all**, and only a `pop` can signal that condition, so a
  producer facing an app thread that had stopped draining parked here
  forever. `.persist` **bounds** that hang at one background budget; it
  does not restore one.

  **What it costs, and it is worse on Windows than on POSIX.** On POSIX
  the caller is `Exec.processExit`, an `xev.Process` wait callback on the
  termio writer thread, so a wedged app thread parks that thread for one
  budget per child exit. On Windows — what this fork ships — the caller is
  `Exec.winProcessWaitThread`, and at teardown the wait reaches the **UI
  thread** through two joins: `Surface.deinit` joins the io thread, and
  `Exec.threadExit` joins the wait thread. In that path the stall is
  **guaranteed, not conditional**: the app thread is inside
  `Surface.deinit`, so it is by construction not draining this mailbox,
  and no separate "wedged app thread" precondition is needed — a full
  mailbox at close time is enough. Worse, it is the push `Exec.threadExit`
  itself calls harmless: `App.surfaceMessage` gates on `hasSurface` and
  the surface is being destroyed, so the budget is spent delivering a
  message guaranteed to be discarded. Bounded either way — past the budget
  the message is given up and freed — but that teardown path is worth
  closing, and suppressing the push is **filed as a follow-up** rather
  than fixed here: the flag would be written on the io thread and read on
  the wait thread, so it needs an ordering argument rather than an
  assignment, and it can only narrow the window, since the wait thread can
  already be inside `processExitCommon` when the flag is set.

  **A guard now backs that choice up.** Collapsing `processExitCommon`'s
  `pushRequired` back into `push` type-checks and fails no test — that
  file is in no test graph and both spellings pass the exe build — so
  `apprt.surface.Message.dropAllowed` classifies which messages a full
  mailbox may give up, and `push` / `pushRequired` assert on it. After a
  rebase that collapses the call, the first child exit panics in a Debug
  build instead of losing the notice quietly, and a new `Message` variant
  is a compile error there until someone picks its delivery policy.

  `password_input` deliberately keeps `.fail_fast`: it is re-derived by
  the termios poll until the surface agrees, so a give-up there costs one
  poll rather than the state.

  Precisely (MEASURED, by enumerating callers rather than by grep): no
  UI-thread producer reaches `App.Mailbox.push`. The *queue* does have
  three UI-thread producers, at `apprt/gtk/class/application.zig:1543`,
  `:2100` and `:2125`, which bypass `App.Mailbox` and use the raw
  `Queue.push(.forever)`. A previous round of this description said "no
  UI-thread producer of that queue exists", which was false as written.
  None of the three owns memory, so nothing leaks; see the GTK residual.
- **Search thread mailbox** - drained in its wakeup callback only; the
  refresh timer does not drain. Its producer is the UI thread, so it
  takes the UI budget, `.fail_fast` -- one `change_needle` per keystroke
  against a wedged search thread is exactly the stream the latch exists
  for. Its push takes ownership and frees the needle when it has to give
  up, and `search.Thread.Message.deinit` is an exhaustive switch so a new
  variant that owns memory has to say so.
- **Termio mailbox** - drained in the writer thread's wakeup callback. It
  already woke before pushing, so it never withheld the wake, but one
  notify can be lost outright on the IOCP backend and the wait had no
  recovery. It now re-issues the notify each window. `send` takes
  `Budget.droppable` because most of its producers are UI-thread input
  handlers reaching it through `Surface.queueIo`; `sendRequired` takes
  `Budget.required` and has exactly one caller,
  `stream_handler.messageWriterRequired`, on the pty read thread. It
  frees what it gives up.

  The *queue wait* is bounded; `send` as a whole is not. After the budget
  expires it still has to re-take the renderer-state mutex with
  `lockUncancelable`, which has no timed form. Pre-existing shape, now
  said out loud in the comment rather than implied away.
- **CoreText release mailbox** - converted to a 100 ms timeout, which
  restores the inline release below it as the timeout path. macOS only,
  not compiled here.

## Residuals

**The renderer mailbox keeps the background budget and `.persist`**, so a
full renderer mailbox can still freeze the window for about a minute. Its
give-up path frees nothing, so a cheaper give-up there would only make a
pre-existing leak easier to reach. Seven of its `Surface.zig` producers
are on the UI thread (`:997`, `:1014`, `:1903`, `:2540`, `:3414`,
`:3435`, `:5734`), plus one in `apprt/embedded.zig` and one on the IO
thread in `termio/Termio.zig`; five more `Surface.zig` sites are on the
**search** thread. A previous round of this description said "twelve
UI-thread call sites", counting all twelve `Surface.zig` sites as UI.

The list that has to be covered before the budget can move is larger than
a previous round claimed (all READ-FROM-SOURCE):

- `.change_config` (`Surface.updateConfig`), the largest: a
  `renderer.Thread.DerivedConfig` plus a renderer `DerivedConfig` that
  itself owns allocations. `rendererpkg.Message.deinit` **already**
  handles this variant, so one call would cover it.
- `.font_grid` (`Surface.setFontSize`), a refcount pair rather than memory.
  No `deinit` arm covers it.
- `.search_viewport_matches` and `.search_selected_match`, each carrying
  an arena moved into the message. No `deinit` arm covers these either.

**Do not add that `deinit` call without restructuring
`Surface.updateConfig` first.** Its three `errdefer`s -- on
`renderer_message`, on the `destroy` of `termio_config_ptr`, and on that
pointer's own `deinit` -- are still live at the `try performAction` calls
further down that function, *after* its `pushRendererMailbox` has handed
the message to the renderer thread. That is a pre-existing use-after-free on a failed action
-- identical on merge base `218b8243db`, so not this PR's to fix -- but a
give-up that also freed the message would turn it into a double-free from
a far more reachable path. The whole ordering constraint is recorded in a
comment at `renderer/Thread.zig:pushMailbox`.

All of this is pre-existing on the merge base, which had the same
constants and the same absent ownership handling hand-rolled in
`Surface.zig`. Moving the loop into `renderer.Thread` did not introduce it.

**Three pushes in the GTK application class** are left alone and are not
covered by anything above: they push straight to the raw app queue rather
than through `App.Mailbox`, from the GTK main thread, which is also the
thread that drains it. A full queue there is a self-deadlock, and it was
one before this PR too, since the single unbounded wait had no other
consumer to signal it. GTK does not compile on the machine this was
developed on, so the fix belongs in a change that can be built and
tested.

## The rest of the PR

- `CircBuf.ensureUnusedCapacity` grew to exactly the requested size,
  making the search sliding window's growth quadratic. It now doubles,
  saturating rather than wrapping. The search window's resident footprint
  can therefore be up to twice what it was at the same content size.
- The pty write path had no bound on outstanding writes, so a child that
  emits cursor-position queries in a loop without reading its input grew
  memory without limit. There is now a per-surface cap on outstanding
  write bytes: terminal replies are refused above it, with a rate-limited
  warning and a count of what was dropped, while user input is never
  refused. The accounting is reset when a backend run starts, before the
  read thread exists, so a run that ended with writes still queued cannot
  leave the next one at the cap.
- The backlog cap refuses only advisory replies. A tmux control-mode
  command bypasses the cap via `messageWriterRequired`, and a refused
  message that owns memory is freed rather than leaked.

  An earlier round of this description said the command "is never dropped
  by it" without qualification, and then a later commit in the same
  branch gave that send the shortest budget in the tree. Both halves are
  corrected here. The command is not dropped *by the backlog cap*, which
  is what `cb9f6bf460` was about, and it now takes `Budget.required` --
  roughly a minute, and immune to another producer's give-up. It is not
  an absolute guarantee and cannot be: waiting without a limit would stop
  the pty read thread reading, and a tmux session whose output is no
  longer drained is wedged either way. Past the budget it is dropped and
  logged. The comment at the call site now says this instead of the
  opposite.
- **`password_input` no longer relies on never being dropped.** The
  comment at `termio/Exec.zig` said "we must block on this because the
  balanced true/false state is critical", and after the budget landed
  that was false: a dropped `false` leaves `terminal.flags.password_input`
  set and the apprt's `.secure_input` action never turned off, which on
  macOS is a process-external `EnableSecureEventInput`. Rather than
  restore a block that cannot deliver anyway, the termios timer now
  commits the observed mode **only once the message is actually queued**.
  A give-up leaves `termios_mode` where it was, so the next poll
  (`TERMIOS_POLL_MS`, 200 ms) re-derives the same change and re-sends;
  the guard reads the
  terminal flag the consumer itself sets, so the retry stops exactly when
  the surface has caught up, and if the mode flipped back in the meantime
  the guard commits without a send. The state is balanced by re-deriving
  the *undelivered change* rather than by never dropping it.

  Be precise about the scope of that, because an earlier draft said
  "re-derived every poll" and it is narrower: the re-derivation runs only
  while `mode != exec.termios_mode`. Nothing polls the terminal flag
  itself, so a path that clears `t.flags.password_input` behind the timer
  leaves the apprt armed with no send to correct it.
  `Terminal.fullReset` is such a path -- it assigns
  `self.flags = .{ .visible = visible }` -- so RIS after a delivered
  `true` desyncs the apprt for the surface's life. That hole is
  **pre-existing** (the merge base committed `termios_mode`
  unconditionally and had the same gap) and is not closed here; closing it
  means the reset path telling the surface. The comment at the call site
  now says this rather than claiming the stronger property.
- The unreferenced renderer message writer in the stream handler is
  removed; it had no callers and could not have compiled if it had any.

## Testing

**Two configurations are required, and this PR's merge gate is both.**

```
zig build test -Dapp-runtime=none   (filtered)
  -> 87/87 steps succeeded; 106/106 tests passed; no failures, no leaks
zig build -Dapp-runtime=none -Dtarget=x86_64-linux-gnu
  -> 98/98 steps succeeded
```

**Those two lines are from before the rebase onto `255f3c0a81`.** After
the rebase the test config was re-run **unfiltered** and passed:

```
Build Summary: 87/87 steps succeeded; 4325/4406 tests passed (81 skipped)
```

Zero failures, and a strict superset of the filtered `106/106` above —
same `87/87` steps; the earlier run had a `-Dtest-filter` applied, which
cuts the test count but not the step count.

The Linux exe build and the `.child_exited` mutation were **not** re-run,
because the volume fell below its floor mid-session. Until those two are
re-run, treat the `98/98` line as the old base's, not this one's — and
note that the exe build is the only config that semantically analyses
`Mailbox.push`. See `fix-B-1023-rebase-report.md` section 7.

A green `zig build test` does **not** prove a touched file compiles. An
earlier draft of this description claimed a Windows test run was what
proved the `messageWriter` fix compiled; that was false, and it was found
by putting a runtime-conditional `@compileError` at the production site
and watching the build come back green with the marker still in the tree.
Three of this PR's five wedge decisions are not in that build's graph at
all. So every production site this PR touches has been probed, and the
config that analyses it is named:

| Site | Analysed by |
| --- | --- |
| `datastruct/blocking_queue.zig` `pushWake` | `zig build test` (probe fired) |
| `App.zig` `Mailbox.pushRequiredBounded` (the `.persist` token) | `zig build test` (probe fired) |
| `apprt/surface.zig` `Mailbox.pushRequired` | Linux exe build only (probe fired there, silent in `zig build test`) |
| `termio/Exec.zig` `processExitCommon`, `termiosTimer` | Linux exe build only |
| `renderer.Thread.pushMailboxBounded`, `search.Thread.pushMailboxBounded`, `termio/stream_handler.zig`'s writers | Linux exe build only |

**Consequence for the branches that rebase onto this one:** gating on
`zig build test -Dapp-runtime=none` alone lets a rebase touch
`stream_handler.zig`, `renderer/Thread.zig`, `search/Thread.zig`,
`termio/Exec.zig` and `apprt/surface.zig` — the files whose policy this PR
*sets* — and go green without those files being compiled. Run the exe
build too.

Every assertion below was
mutation-tested by reverting its fix at the **production** site, never in
a test, keeping the tree compiling, and confirming the test **fails by its
qualified name** -- not by counter arithmetic. Note leaks are reported as
`0 fail` and counted in `pass`, so leak-based assertions are read from the
`leaked N allocations` lines rather than the pass count.

What grips, and under which mutation (all MEASURED):

- Swapping `.persist` for `.fail_fast` in `App.Mailbox.pushRequiredBounded`
  -- the token that decides `.child_exited`'s fate:
  `App.test.app mailbox pushRequired ignores a latch that push respects`.
  The test latches a full app mailbox, then measures that the required
  push still spends its budget; the assertion is one-directional
  (`elapsed >= 30ms` for three 20 ms windows), so load can only lengthen
  it, never make it flaky.
- Making `.child_exited` droppable in `apprt.surface.Message.dropAllowed`
  -- the classifier both mailbox asserts read, and therefore the whole
  content of the guard against a rebase collapsing `processExitCommon`'s
  `pushRequired` back into `push`:
  `apprt.surface.test.the child-exit notice is the one message push may
  not carry`, alone (105/106). What a test in this config *cannot* reach
  is the assert firing: `Mailbox.push` is not semantically analysed by
  `zig build test`, and a Debug panic is not catchable by the test runner
  either way. That the assert is compiled into the production path is
  instead proven by a `@compileError` probe inside `push`, which fires in
  the Linux exe build (`PROBE_APS_PUSH_ASSERT_ANALYSED`,
  `apprt/surface.zig:325`) and is removed again.
- Deleting the slow-path latch clear in `BlockingQueue.pushWake`:
  `datastruct.blocking_queue.test.BlockingQueue pushWake clears the latch
  when a persist push lands the slow way`. That branch was uncovered until
  this round -- the four pre-existing `pushWake` tests all clear the latch
  on the fast path or never land -- and it is the only thing that lifts a
  latch on a queue carrying both budgets, which the termio mailbox and now
  the app mailbox both do.

- Never latching `wedged` on a lost budget:
  `datastruct.blocking_queue.test.BlockingQueue pushWake stops spending
  the budget once it has lost one` (expected 1, found 3) and
  `... pushWake spends the budget again once the consumer drains`.
- Neutralising only the fail-fast branch, latch intact: the first of
  those two, alone (expected 1, found 3). The second correctly still
  passes -- with no fast path the recovering push lands through the
  normal budget loop and clears the latch on the way, which is the same
  observable outcome.
- Swapping `Budget.required` to the UI pair and `.fail_fast`:
  `termio.mailbox.test.Mailbox: a required send outlasts a droppable one
  and ignores the wedge`.
- Moving `.pwd_change` to the no-op arm of `apprt.surface.Message.deinit`:
  `App.test.app mailbox push frees the message it has to give up` and
  `apprt.surface.test.surface message deinit frees a push the mailbox gave
  up`, both as leaks.

Earlier rounds' mutations (the three give-up `deinit` calls, and the wake
inside `pushWake`) were reproduced by the round-3 re-review and are not
re-run here.

### What is NOT covered by a test, stated rather than implied

- **Which budget a given call site asks for.** The tests above grip the
  `Budget.droppable` / `Budget.required` *mapping* and the app mailbox's
  wedge token. That `messageWriterRequired` calls `sendRequired`, and that
  `termio/Exec.zig`'s `processExitCommon` calls `pushRequired` rather than `push`, is
  READ-FROM-SOURCE and compile-probed, not test-gripped: distinguishing
  them at runtime means waiting out a 2 s or 60 s production budget, and
  the budget is hard-coded inside `processExitCommon`'s callee, so the
  only sound construction takes a full minute. This is the gap that hid a
  real bug earlier in this branch.

  For `.child_exited` the gap is now **narrowed rather than open**:
  `Message.dropAllowed` plus the asserts in `push` / `pushRequired` turn
  the collapse from silence into a Debug panic on the first child exit,
  the classifier itself is mutation-gripped by a named test, and the
  assert is probe-proven compiled. What is still not gripped is the panic
  itself. For `messageWriterRequired` -> `sendRequired` there is no such
  guard, and a rebase that collapses it still compiles and fails nothing;
  treat that one as the highest-risk line in the change. Making
  `processExitCommon` testable at all needs a
  `processExitCommonBounded` taking the budget as a parameter across
  three platform call paths — **filed**, and deliberately not on this hub.
- **The `password_input` retry.** `termio/Exec.zig`'s termios timer is
  POSIX-only, so it cannot be exercised on the machine this was built on.

  It is worse than "no test", and the PR should say so: **the Windows
  test build does not even compile that function.** On Windows its
  `@panic` sits under a comptime-true condition, so Sema never enters the
  rest of the body. Verified by putting `@compileError` at the production
  site and watching `zig build test -Dapp-runtime=none` come back
  `87/87 steps succeeded; 83/83 tests passed` with the marker still in
  place. The Linux *test* build does not cover it either (test binaries
  only pull in what test roots reach). `zig build -Dapp-runtime=none
  -Dtarget=x86_64-linux-gnu` **does** — proven by the same probe firing
  there — and with the probe removed that build is `98/98 steps
  succeeded`. So the change is compile-verified on a configuration
  demonstrated to analyse it, and not test-verified at all.

  Consequence for reviewers: no Windows `zig build test` result is
  evidence about anything in `termiosTimer`, including the parts earlier
  rounds discussed.
- **The wake at `App.Mailbox.push`.** Under `-Dapp-runtime=none`, the only
  runtime that compiles on Windows, `apprt.none.App.wakeup` is an empty
  body, so a fixed and an unfixed push are observationally identical for
  the *wake* and reverting it produces no failure. The retry loop is
  tested in `BlockingQueue.pushWake` and the give-up path has its own
  test; a comment at the call site records this so nobody assumes
  coverage.

**Two drop-path side effects are known and not fixed here.** A Kitty
clipboard read consumes a one-time session grant at
`stream_handler.zig:1256`, before the message is built and pushed at
`:1283`; if that push gives up, the grant is spent and no request
completed, so the next legitimate read re-prompts. That is fail-closed --
the user sees an extra prompt, nothing is granted that should not be --
and un-consuming it means a non-consuming variant of
`kitty_clipboard.Grants.use`, which is a change to security-relevant grant
accounting and belongs in its own PR. The search thread's shutdown drain
(`terminal/search/Thread.zig:187-189`) also still discards messages
without freeing them; that is fixed on the separate branch
`fix/search-shutdown-leak`, which covers both the drain and
`Thread.deinit` and adds two tests, so it is deliberately **not**
duplicated here.

## Not built here

GTK does not compile on the machine this was developed on, and neither
does macOS. No GTK file is touched. Two macOS-only files are: the
CoreText release mailbox timeout, and one call in the embedded runtime
that now uses the same renderer helper as the other producers of that
queue. Both should go through a macOS cross-build before this merges.
