### PR TITLE
renderer, font: guard the alpha divide and cap atlas growth with a reset

### DIFF
--- a/src/font/Atlas.zig
+++ b/src/font/Atlas.zig
@@ -31,6 +31,16 @@ data: []u8,
 /// always square so this is both the width and the height.
 size: u32 = 0,
 
+/// The largest size this atlas may grow to. Growing past the maximum 2D
+/// texture size of the GPU makes every subsequent texture upload fail, so
+/// `grow` refuses instead and leaves it to the caller to make room some
+/// other way (see `reset`).
+///
+/// The default is the size guaranteed by D3D feature level 11_0, OpenGL 4.3
+/// and Metal's apple3 family. A backend that knows its device's real limit
+/// should lower this.
+max_size: u32 = default_max_size,
+
 /// The nodes (rectangles) of available space.
 nodes: std.ArrayList(Node) = .empty,
 
@@ -49,6 +59,14 @@ modified: std.atomic.Value(usize) = .{ .raw = 0 },
 /// for knowing if a GPU texture can be updated in-place or if it requires
 /// a resize operation.
 resized: std.atomic.Value(usize) = .{ .raw = 0 },
+
+/// This will be incremented every time the atlas is emptied by `reset`,
+/// which invalidates every region previously handed out. Anything caching
+/// atlas coordinates must drop that cache when this changes.
+generation: std.atomic.Value(usize) = .{ .raw = 0 },
+
+/// The default value of `max_size`.
+pub const default_max_size: u32 = 16384;
 
 pub const Format = enum(u8) {
     /// 1 byte per pixel grayscale.
@@ -76,6 +94,11 @@ const Node = struct {
 pub const Error = error{
     /// Atlas cannot fit the desired region. You must enlarge the atlas.
     AtlasFull,
+};
+
+pub const GrowError = Allocator.Error || error{
+    /// The requested size is past `max_size`. The atlas is unchanged.
+    AtlasTooLarge,
 };
 
 /// A region within the texture atlas. These can be acquired using the
@@ -311,11 +334,12 @@ pub const grow_tw = tripwire.module(enum {
 }, grow);
 
 // Grow the texture to the new size, preserving all previously written data.
-pub fn grow(self: *Atlas, alloc: Allocator, size_new: u32) Allocator.Error!void {
+pub fn grow(self: *Atlas, alloc: Allocator, size_new: u32) GrowError!void {
     const tw = grow_tw;
 
     assert(size_new >= self.size);
     if (size_new == self.size) return;
+    if (size_new > self.max_size) return error.AtlasTooLarge;
 
     // We reserve space ahead of time for the new node, so that we
     // won't have to handle any errors after allocating our new data.
@@ -373,6 +397,16 @@ pub fn clear(self: *Atlas) void {
     // and is the initial rectangle we fit our regions in. We keep a 1px border
     // to avoid artifacting when sampling the texture.
     self.nodes.appendAssumeCapacity(.{ .x = 1, .y = 1, .width = self.size - 2 });
+}
+
+/// Empty the atlas, invalidating every region previously reserved from it.
+///
+/// This is `clear` plus a generation bump, which is how a caller that has
+/// handed out atlas coordinates learns that they are all stale. Use it when
+/// the atlas is full and cannot grow any further.
+pub fn reset(self: *Atlas) void {
+    self.clear();
+    _ = self.generation.fetchAdd(1, .monotonic);
 }
 
 /// Dump the atlas as a PPM to a writer, for debug purposes.
@@ -886,4 +920,51 @@ test "grow error" {
         try testing.expectEqual(@as(u8, 3), atlas.data[9]);
         try testing.expectEqual(@as(u8, 4), atlas.data[10]);
     }
+}
+
+test "grow past the maximum size" {
+    const alloc = testing.allocator;
+    var atlas = try init(alloc, 4, .grayscale); // +2 for 1px border
+    defer atlas.deinit(alloc);
+    atlas.max_size = 5;
+
+    const reg = try atlas.reserve(alloc, 2, 2);
+    atlas.set(reg, &[_]u8{ 1, 2, 3, 4 });
+
+    // Up to the maximum is allowed.
+    try atlas.grow(alloc, 5);
+    try testing.expectEqual(@as(u32, 5), atlas.size);
+
+    // Past it is refused and leaves the atlas untouched.
+    const old_modified = atlas.modified.load(.monotonic);
+    const old_resized = atlas.resized.load(.monotonic);
+    try testing.expectError(
+        GrowError.AtlasTooLarge,
+        atlas.grow(alloc, 6),
+    );
+    try testing.expectEqual(@as(u32, 5), atlas.size);
+    try testing.expectEqual(old_modified, atlas.modified.load(.monotonic));
+    try testing.expectEqual(old_resized, atlas.resized.load(.monotonic));
+    try testing.expectEqual(@as(u8, 1), atlas.data[atlas.size + 1]);
+    try testing.expectEqual(@as(u8, 2), atlas.data[atlas.size + 2]);
+}
+
+test "reset empties the atlas and bumps the generation" {
+    const alloc = testing.allocator;
+    var atlas = try init(alloc, 4, .grayscale); // +2 for 1px border
+    defer atlas.deinit(alloc);
+
+    const reg = try atlas.reserve(alloc, 2, 2);
+    atlas.set(reg, &[_]u8{ 1, 2, 3, 4 });
+    try testing.expectError(Error.AtlasFull, atlas.reserve(alloc, 1, 1));
+
+    const old_generation = atlas.generation.load(.monotonic);
+    const old_modified = atlas.modified.load(.monotonic);
+    atlas.reset();
+    try testing.expect(atlas.generation.load(.monotonic) > old_generation);
+    try testing.expect(atlas.modified.load(.monotonic) > old_modified);
+
+    // The space is available again and the old data is gone.
+    try testing.expectEqual(@as(u8, 0), atlas.data[5]);
+    _ = try atlas.reserve(alloc, 2, 2);
 }

--- a/src/font/Atlas.zig
+++ b/src/font/Atlas.zig
@@ -36,9 +36,9 @@ size: u32 = 0,
 /// `grow` refuses instead and leaves it to the caller to make room some
 /// other way (see `reset`).
 ///
-/// The default is the size guaranteed by D3D feature level 11_0, OpenGL 4.3
-/// and Metal's apple3 family. A backend that knows its device's real limit
-/// should lower this.
+/// Atlases are created before any renderer exists, so the default has to
+/// hold on the weakest device we support (see `default_max_size`). A backend
+/// raises or lowers it with `setMaxSize` once it has a device to ask.
 max_size: u32 = default_max_size,
 
 /// The nodes (rectangles) of available space.
@@ -65,8 +65,17 @@ resized: std.atomic.Value(usize) = .{ .raw = 0 },
 /// atlas coordinates must drop that cache when this changes.
 generation: std.atomic.Value(usize) = .{ .raw = 0 },
 
-/// The default value of `max_size`.
-pub const default_max_size: u32 = 16384;
+/// The default value of `max_size`: the smallest maximum any backend we
+/// support reports. Metal devices below the apple3 family stop at 8192, and
+/// the OpenGL atlas is a rectangle texture, whose limit is its own
+/// (GL_MAX_RECTANGLE_TEXTURE_SIZE) and can be lower than the ordinary 2D
+/// texture limit. Starting here means no device ever gets an atlas it cannot
+/// hold, even before a renderer has attached.
+///
+/// Metal never calls `setMaxSize`: it cannot be built on the machine this
+/// branch is developed on, and 8192 is already its worst case, so it keeps
+/// the default until someone can compile and test the call.
+pub const default_max_size: u32 = 8192;
 
 pub const Format = enum(u8) {
     /// 1 byte per pixel grayscale.
@@ -326,6 +335,16 @@ pub fn setFromLarger(
     }
 
     _ = self.modified.fetchAdd(1, .monotonic);
+}
+
+/// Set the ceiling `grow` refuses to pass, for a caller that has queried
+/// the real limit of the device the atlas is uploaded to.
+///
+/// A limit below the current size is raised to it: the atlas already exists
+/// at that size, and refusing to grow it is the most we can do about a device
+/// that cannot hold it.
+pub fn setMaxSize(self: *Atlas, size_max: u32) void {
+    self.max_size = @max(size_max, self.size);
 }
 
 pub const grow_tw = tripwire.module(enum {
@@ -947,6 +966,26 @@ test "grow past the maximum size" {
     try testing.expectEqual(old_resized, atlas.resized.load(.monotonic));
     try testing.expectEqual(@as(u8, 1), atlas.data[atlas.size + 1]);
     try testing.expectEqual(@as(u8, 2), atlas.data[atlas.size + 2]);
+}
+
+test "setMaxSize" {
+    const alloc = testing.allocator;
+    var atlas = try init(alloc, 4, .grayscale); // +2 for 1px border
+    defer atlas.deinit(alloc);
+
+    // A device that can hold more than the default raises the ceiling.
+    atlas.setMaxSize(16384);
+    try testing.expectEqual(@as(u32, 16384), atlas.max_size);
+    try atlas.grow(alloc, 8);
+
+    // A device that can hold less lowers it, but never below what we
+    // already have.
+    atlas.setMaxSize(4);
+    try testing.expectEqual(@as(u32, 8), atlas.max_size);
+    try testing.expectError(
+        GrowError.AtlasTooLarge,
+        atlas.grow(alloc, 16),
+    );
 }
 
 test "reset empties the atlas and bumps the generation" {

--- a/src/font/SharedGrid.zig
+++ b/src/font/SharedGrid.zig
@@ -147,6 +147,19 @@ pub fn cellSize(self: *SharedGrid) renderer.CellSize {
     };
 }
 
+/// Set the size both atlases refuse to grow past, for a renderer that has
+/// attached to this grid and knows what its device can hold.
+///
+/// The atlases are built before any renderer exists, so they start at a
+/// ceiling low enough for every device we support. A backend that can ask
+/// its device raises or lowers that here.
+pub fn setMaxAtlasSize(self: *SharedGrid, size_max: u32) void {
+    self.lock.lockUncancelable(global.io());
+    defer self.lock.unlock(global.io());
+    self.atlas_grayscale.setMaxSize(size_max);
+    self.atlas_color.setMaxSize(size_max);
+}
+
 /// Get the font index for a given codepoint. This is cached.
 ///
 /// This always forces loading any deferred fonts since we assume that if

--- a/src/font/SharedGrid.zig
+++ b/src/font/SharedGrid.zig
@@ -403,7 +403,11 @@ pub fn renderGlyph(
 
     const gop = try self.glyphs.getOrPut(alloc, key);
     if (gop.found_existing) return gop.value_ptr.*;
-    errdefer self.glyphs.removeByPtr(gop.key_ptr);
+
+    // Cleared when the atlas reset below drops the whole cache, taking our
+    // reserved slot with it. After that `gop` dangles and must not be used.
+    var slot_valid = true;
+    errdefer if (slot_valid) self.glyphs.removeByPtr(gop.key_ptr);
 
     // Get the presentation to determine what atlas to use
     try tw.check(.get_presentation);
@@ -441,9 +445,28 @@ pub fn renderGlyph(
         glyph_index,
         render_opts,
     ) catch |err| switch (err) {
-        // If the atlas is full, we resize it
+        // If the atlas is full, we make room and try once more.
         error.AtlasFull => blk: {
-            try atlas.grow(alloc, atlas.size * 2);
+            atlas.grow(alloc, atlas.size * 2) catch |grow_err| switch (grow_err) {
+                // The atlas is as large as the GPU can hold, so growing
+                // it any further would only produce a texture that fails
+                // to upload from now on. Start over with an empty atlas
+                // instead. Every cached render points into the old
+                // layout, so the cache goes with it; users of the atlas
+                // watch its generation to drop their own caches.
+                error.AtlasTooLarge => {
+                    log.warn(
+                        "atlas full at its maximum size, resetting size={} max={}",
+                        .{ atlas.size, atlas.max_size },
+                    );
+                    atlas.reset();
+                    slot_valid = false;
+                    self.glyphs.clearRetainingCapacity();
+                },
+
+                else => |e| return e,
+            };
+
             break :blk try self.resolver.renderGlyph(
                 alloc,
                 atlas,
@@ -456,12 +479,19 @@ pub fn renderGlyph(
         else => return err,
     };
 
-    // Cache and return
-    gop.value_ptr.* = .{
+    const render: Render = .{
         .glyph = glyph,
         .presentation = p,
     };
 
+    // Cache and return. A reset above invalidated our reserved slot, so
+    // in that case we insert into the now empty cache from scratch.
+    if (!slot_valid) {
+        try self.glyphs.put(alloc, key, render);
+        return render;
+    }
+
+    gop.value_ptr.* = render;
     return gop.value_ptr.*;
 }
 
@@ -621,6 +651,45 @@ test "renderGlyph error after cache insert rolls back cache entry" {
     // The errdefer should have removed the cache entry, leaving the cache clean.
     // Without the errdefer fix, this would contain garbage/uninitialized data.
     try testing.expect(grid.glyphs.get(key) == null);
+}
+
+test "renderGlyph resets the Atlas when it can no longer grow" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var lib = try Library.init(alloc);
+    defer lib.deinit();
+
+    var grid = try testGrid(.normal, alloc, lib);
+    defer grid.deinit(alloc);
+
+    // Swap in a tiny grayscale atlas that is already at its maximum size, so
+    // it fills up quickly and has nowhere to grow into.
+    grid.atlas_grayscale.deinit(alloc);
+    grid.atlas_grayscale = try Atlas.init(alloc, 64, .grayscale);
+    grid.atlas_grayscale.max_size = 64;
+
+    const render_opts: RenderOptions = .{ .grid_metrics = grid.metrics };
+
+    // Render visible ASCII. Each render must succeed: once the atlas fills up
+    // it is emptied and started over rather than failing from here on.
+    var rendered: usize = 0;
+    for (32..127) |i| {
+        const cp: u21 = @intCast(i);
+        const idx = (try grid.getIndex(alloc, cp, .regular, null)).?;
+        const glyph_index = glyph_index: {
+            grid.lock.lockSharedUncancelable(testing.io);
+            defer grid.lock.unlockShared(testing.io);
+            const face = try grid.resolver.collection.getFace(idx);
+            break :glyph_index face.glyphIndex(cp) orelse continue;
+        };
+        _ = try grid.renderGlyph(alloc, idx, glyph_index, render_opts);
+        rendered += 1;
+    }
+
+    // The atlas was emptied at least once and the stale renders went with it.
+    try testing.expect(grid.atlas_grayscale.generation.load(.monotonic) > 0);
+    try testing.expect(grid.glyphs.count() < rendered);
 }
 
 test "init error" {

--- a/src/font/SharedGrid.zig
+++ b/src/font/SharedGrid.zig
@@ -464,17 +464,26 @@ pub fn renderGlyph(
                 // The atlas is as large as the GPU can hold, so growing
                 // it any further would only produce a texture that fails
                 // to upload from now on. Start over with an empty atlas
-                // instead. Every cached render points into the old
-                // layout, so the cache goes with it; users of the atlas
-                // watch its generation to drop their own caches.
+                // instead. Every render cached in it points into the old
+                // layout, so those go with it; users of the atlas watch
+                // its generation to drop their own caches.
                 error.AtlasTooLarge => {
                     log.warn(
                         "atlas full at its maximum size, resetting size={} max={}",
                         .{ atlas.size, atlas.max_size },
                     );
                     atlas.reset();
+
+                    // Our own slot goes first: its value is still
+                    // undefined, so the sweep below must not read it.
+                    self.glyphs.removeByPtr(gop.key_ptr);
                     slot_valid = false;
-                    self.glyphs.clearRetainingCapacity();
+
+                    // The other atlas was not reset, so its renders stay
+                    // valid. If we cannot afford the list of keys to drop
+                    // we drop everything, which is correct, just wasteful.
+                    self.dropRenders(alloc, p) catch
+                        self.glyphs.clearRetainingCapacity();
                 },
 
                 else => |e| return e,
@@ -506,6 +515,29 @@ pub fn renderGlyph(
 
     gop.value_ptr.* = render;
     return gop.value_ptr.*;
+}
+
+/// Drop every cached render that lives in the atlas for presentation `p`.
+///
+/// Removing an entry can move a later one into a slot the iterator has
+/// already passed, so the keys are collected before any of them is removed.
+///
+/// Caller must hold the write lock.
+fn dropRenders(
+    self: *SharedGrid,
+    alloc: Allocator,
+    p: Presentation,
+) Allocator.Error!void {
+    var stale: std.ArrayList(GlyphKey) = .empty;
+    defer stale.deinit(alloc);
+
+    var it = self.glyphs.iterator();
+    while (it.next()) |entry| {
+        if (entry.value_ptr.presentation != p) continue;
+        try stale.append(alloc, entry.key_ptr.*);
+    }
+
+    for (stale.items) |stale_key| _ = self.glyphs.remove(stale_key);
 }
 
 const CodepointKey = struct {
@@ -684,6 +716,19 @@ test "renderGlyph resets the Atlas when it can no longer grow" {
 
     const render_opts: RenderOptions = .{ .grid_metrics = grid.metrics };
 
+    // A cached render that lives in the color atlas, which the grayscale
+    // reset must not touch. Faked so this doesn't depend on an emoji font
+    // being installed.
+    const color_key: GlyphKey = .{
+        .index = (try grid.getIndex(alloc, 'A', .regular, null)).?,
+        .glyph = std.math.maxInt(u32),
+        .opts = render_opts,
+    };
+    try grid.glyphs.put(alloc, color_key, .{
+        .glyph = std.mem.zeroes(Glyph),
+        .presentation = .emoji,
+    });
+
     // Render visible ASCII. Each render must succeed: once the atlas fills up
     // it is emptied and started over rather than failing from here on.
     var rendered: usize = 0;
@@ -703,6 +748,9 @@ test "renderGlyph resets the Atlas when it can no longer grow" {
     // The atlas was emptied at least once and the stale renders went with it.
     try testing.expect(grid.atlas_grayscale.generation.load(.monotonic) > 0);
     try testing.expect(grid.glyphs.count() < rendered);
+
+    // The color atlas never reset, so its render is still cached.
+    try testing.expect(grid.glyphs.get(color_key) != null);
 }
 
 test "init error" {

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -752,6 +752,16 @@ pub fn waitGpu(self: *DirectX12) void {
     }
 }
 
+/// The largest 2D texture this device can hold, in either dimension.
+///
+/// D3D12 makes this a property of the feature level rather than something
+/// to ask the device, and we create ours at 12_0 (see `device.zig`), which
+/// guarantees 16384.
+pub fn maxTextureSize(self: *const DirectX12) u32 {
+    _ = self;
+    return 16384;
+}
+
 pub fn drawFrameStart(self: *DirectX12) void {
     _ = self;
     // RTV heap slots are per-frame and stable. No reset needed; each frame's

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -292,6 +292,25 @@ pub fn surfaceSize(self: *const OpenGL) !struct { width: u32, height: u32 } {
     };
 }
 
+/// The largest atlas texture this device can hold, in either dimension.
+///
+/// The atlases are rectangle textures (see `initAtlasTexture`), which have
+/// their own limit, separate from and possibly lower than the one for
+/// ordinary 2D textures.
+///
+/// Requires a current GL context, so this is only safe to call from the
+/// draw path.
+pub fn maxTextureSize(self: *const OpenGL) u32 {
+    _ = self;
+    var size: gl.c.GLint = 0;
+    gl.glad.context.GetIntegerv.?(gl.c.GL_MAX_RECTANGLE_TEXTURE_SIZE, &size);
+
+    // A driver that answers with nonsense (or not at all) leaves us with
+    // the size we already know every device we support can hold.
+    if (size <= 0) return font.Atlas.default_max_size;
+    return @intCast(size);
+}
+
 /// Initialize a new render target which can be presented by this API.
 pub fn initTarget(self: *const OpenGL, width: usize, height: usize) !Target {
     return Target.init(.{

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -163,6 +163,12 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         atlas_generation_grayscale: usize = 0,
         atlas_generation_color: usize = 0,
 
+        /// Whether we have told the font grid what this device can hold.
+        /// Done once per grid, from `drawFrame`, because that is where the
+        /// graphics API is guaranteed to be usable (OpenGL needs a current
+        /// context to be asked anything).
+        atlas_max_size_synced: bool = false,
+
         /// Latched copy of `renderer.State.first_content`, captured under
         /// the render state mutex in `updateFrame`. Lets `drawFrame` tell
         /// whether the terminal has produced content without re-taking the
@@ -1586,6 +1592,10 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // Update our grid
             self.font_grid = grid;
 
+            // The new grid's atlases start at the conservative default
+            // ceiling, so it has to be told what this device can hold.
+            self.atlas_max_size_synced = false;
+
             // Update all our textures so that they sync on the next frame.
             // We can modify this without a lock because the GPU does not
             // touch this data. A released swap chain is rebuilt with
@@ -2137,6 +2147,19 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                         error.DeviceRecoveryPending => return,
                         else => return err,
                     };
+                }
+            }
+
+            // Tell the font grid how large a texture this device can hold,
+            // now that we're somewhere the graphics API can be asked. The
+            // atlases are built before any renderer exists so they start at
+            // a ceiling that holds everywhere; this is what lets a device
+            // that can do better actually use it. Backends that can't
+            // report a limit keep the conservative default.
+            if (comptime @hasDecl(GraphicsAPI, "maxTextureSize")) {
+                if (!self.atlas_max_size_synced) {
+                    self.atlas_max_size_synced = true;
+                    self.font_grid.setMaxAtlasSize(self.api.maxTextureSize());
                 }
             }
 

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -2691,6 +2691,21 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 self.images_lost = true;
                 if (self.bg_image) |img| img.deinit(self.alloc);
                 self.bg_image = null;
+                // The atlas ceiling came from the device that has just
+                // gone, so the replacement gets asked for its own. Here
+                // rather than after the rebuild because this is the block
+                // that runs exactly once per loss, however many attempts
+                // the rebuild takes.
+                //
+                // Latent on DirectX12, the only backend that recovers at
+                // all: its limit is a feature-level constant, so the
+                // answer cannot change. It stops being latent the moment
+                // that becomes a real device query.
+                //
+                // Above the loss spend below, which can return early on the
+                // abandon path: this belongs with the other releases of
+                // state the dead device owned.
+                self.atlas_max_size_synced = false;
 
                 // Spend the loss last, so everything above is released
                 // even by a surface that has run out of budget. What that

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -157,6 +157,12 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         /// cells for the draw call.
         cells_rebuilt: bool = false,
 
+        /// The atlas generations we last built cells against. A generation
+        /// change means the atlas was emptied because it could not grow any
+        /// further, so every glyph position we cached is stale.
+        atlas_generation_grayscale: usize = 0,
+        atlas_generation_color: usize = 0,
+
         /// Latched copy of `renderer.State.first_content`, captured under
         /// the render state mutex in `updateFrame`. Lets `drawFrame` tell
         /// whether the terminal has produced content without re-taking the
@@ -1925,6 +1931,20 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             {
                 self.draw_mutex.lockUncancelable(global.io());
                 defer self.draw_mutex.unlock(global.io());
+
+                // If an atlas was emptied because it hit its maximum size,
+                // rows we already built still point into the old layout and
+                // would draw garbage. Rebuild everything, the same way a font
+                // grid change does.
+                atlas: {
+                    const grayscale = self.font_grid.atlas_grayscale.generation.load(.monotonic);
+                    const color = self.font_grid.atlas_color.generation.load(.monotonic);
+                    if (grayscale == self.atlas_generation_grayscale and
+                        color == self.atlas_generation_color) break :atlas;
+                    self.atlas_generation_grayscale = grayscale;
+                    self.atlas_generation_color = color;
+                    self.markDirty();
+                }
 
                 // Build our GPU cells
                 self.rebuildCells(

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1257,6 +1257,22 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             self.terminal_state.dirty = .full;
         }
 
+        /// Whether either atlas was emptied since we last looked, syncing
+        /// our record of both generations while we're here.
+        ///
+        /// An emptied atlas invalidates every coordinate we hold, so a true
+        /// return means everything we have built has to be built again.
+        fn atlasGenerationsChanged(self: *Self) bool {
+            const grayscale = self.font_grid.atlas_grayscale.generation.load(.monotonic);
+            const color = self.font_grid.atlas_color.generation.load(.monotonic);
+            if (grayscale == self.atlas_generation_grayscale and
+                color == self.atlas_generation_color) return false;
+
+            self.atlas_generation_grayscale = grayscale;
+            self.atlas_generation_color = color;
+            return true;
+        }
+
         /// Called when we get an updated display ID for our display link.
         pub fn setMacOSDisplayID(
             self: *Self,
@@ -1932,36 +1948,54 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 self.draw_mutex.lockUncancelable(global.io());
                 defer self.draw_mutex.unlock(global.io());
 
-                // If an atlas was emptied because it hit its maximum size,
-                // rows we already built still point into the old layout and
-                // would draw garbage. Rebuild everything, the same way a font
-                // grid change does.
-                atlas: {
-                    const grayscale = self.font_grid.atlas_grayscale.generation.load(.monotonic);
-                    const color = self.font_grid.atlas_color.generation.load(.monotonic);
-                    if (grayscale == self.atlas_generation_grayscale and
-                        color == self.atlas_generation_color) break :atlas;
-                    self.atlas_generation_grayscale = grayscale;
-                    self.atlas_generation_color = color;
+                // If an atlas was emptied between frames because it hit its
+                // maximum size, the rows we still hold point into the old
+                // layout and would draw garbage. Rebuild everything, the
+                // same way a font grid change does.
+                if (self.atlasGenerationsChanged()) self.markDirty();
+
+                // Build our GPU cells.
+                //
+                // An atlas can also be emptied from inside this call, because
+                // rendering a glyph is what fills it up. Rows built before
+                // that point keep their old coordinates, and this same frame
+                // uploads the emptied atlas over them, so we check again
+                // afterwards and build the whole thing over. Once we start
+                // over into an empty atlas a second reset needs a full atlas
+                // worth of glyphs in one frame, which is why one retry is
+                // enough; if it somehow happens anyway we draw the frame we
+                // have and say so rather than looping.
+                var attempts: usize = 0;
+                while (true) {
+                    self.rebuildCells(
+                        critical.preedit,
+                        renderer.cursorStyle(&self.terminal_state, .{
+                            .preedit = critical.preedit != null,
+                            .focused = self.focused,
+                            .blink_visible = cursor_blink_visible,
+                        }),
+                        &critical.links,
+                    ) catch |err| {
+                        // This means we weren't able to allocate our buffer
+                        // to update the cells. In this case, we continue with
+                        // our old buffer (frozen contents) and log it.
+                        comptime assert(@TypeOf(err) == error{OutOfMemory});
+                        log.warn("error rebuilding GPU cells err={}", .{err});
+                    };
+
+                    if (!self.atlasGenerationsChanged()) break;
+
+                    attempts += 1;
+                    if (attempts > 1) {
+                        log.warn(
+                            "atlas emptied repeatedly while building cells, frame may be incorrect",
+                            .{},
+                        );
+                        break;
+                    }
+
                     self.markDirty();
                 }
-
-                // Build our GPU cells
-                self.rebuildCells(
-                    critical.preedit,
-                    renderer.cursorStyle(&self.terminal_state, .{
-                        .preedit = critical.preedit != null,
-                        .focused = self.focused,
-                        .blink_visible = cursor_blink_visible,
-                    }),
-                    &critical.links,
-                ) catch |err| {
-                    // This means we weren't able to allocate our buffer
-                    // to update the cells. In this case, we continue with
-                    // our old buffer (frozen contents) and log it.
-                    comptime assert(@TypeOf(err) == error{OutOfMemory});
-                    log.warn("error rebuilding GPU cells err={}", .{err});
-                };
 
                 // The scrollbar is only emitted during draws so we also
                 // check the scrollbar cache here and update if needed.

--- a/src/renderer/shaders/glsl/cell_text.f.glsl
+++ b/src/renderer/shaders/glsl/cell_text.f.glsl
@@ -33,8 +33,10 @@ void main() {
             //
             // Since the alpha is premultiplied, we need to divide
             // it out before unlinearizing and re-multiply it after.
+            // A fully transparent texel is all zeroes, so the divisor is
+            // clamped away from zero to keep 0/0 NaNs out of the blender.
             if (!use_linear_blending) {
-                color.rgb /= vec3(color.a);
+                color.rgb /= vec3(max(color.a, 1e-6));
                 color = unlinearize(color);
                 color.rgb *= vec3(color.a);
             }
@@ -89,7 +91,9 @@ void main() {
 
             // Otherwise we need to unlinearize the color. Since the alpha is
             // premultiplied, we need to divide it out before unlinearizing.
-            color.rgb /= vec3(color.a);
+            // A fully transparent texel is all zeroes, so the divisor is
+            // clamped away from zero to keep 0/0 NaNs out of the blender.
+            color.rgb /= vec3(max(color.a, 1e-6));
             color = unlinearize(color);
             color.rgb *= vec3(color.a);
 

--- a/src/renderer/shaders/shaders.metal
+++ b/src/renderer/shaders/shaders.metal
@@ -698,8 +698,10 @@ fragment float4 cell_text_fragment(
       //
       // Since the alpha is premultiplied, we need to divide
       // it out before unlinearizing and re-multiply it after.
+      // A fully transparent texel is all zeroes, so the divisor is
+      // clamped away from zero to keep 0/0 NaNs out of the blender.
       if (!uniforms.use_linear_blending) {
-        color.rgb /= color.a;
+        color.rgb /= max(color.a, 1e-6);
         color = unlinearize(color);
         color.rgb *= color.a;
       }
@@ -751,7 +753,9 @@ fragment float4 cell_text_fragment(
 
       // Otherwise we need to unlinearize the color. Since the alpha is
       // premultiplied, we need to divide it out before unlinearizing.
-      color.rgb /= color.a;
+      // A fully transparent texel is all zeroes, so the divisor is
+      // clamped away from zero to keep 0/0 NaNs out of the blender.
+      color.rgb /= max(color.a, 1e-6);
       color = unlinearize(color);
       color.rgb *= color.a;
 


### PR DESCRIPTION
Two renderer fixes.

- The cell text fragment shaders divided by alpha with no guard in the non-linear-blending path, so fully transparent texels inside a colour glyph produced NaN that reached the blender; output was only correct because hardware happens to clamp NaN to 0 on UNORM targets. The GLSL and Metal shaders now guard the division identically. HLSL never had the divide, so it is unchanged. Metal is not compiled on this host.
- The glyph atlas doubled without a cap; past the device limit texture creation failed and every later frame errored, freezing every surface on that font grid. The atlas now caps at a maximum (default 8192, the worst case for Metal and GL rectangle textures), DirectX12 and OpenGL set their real limit, and when full at the cap the atlas is cleared and its glyph renders dropped (a generation counter) instead of failing forever. `updateFrame` re-checks the generation after rebuilding cells and rebuilds once more if an atlas emptied mid-rebuild, so the emptied atlas is never drawn with stale coordinates. Metal keeps the default because it cannot be built here.

Already handled on this branch: the link-scan early return, custom-shader-animation gating, and the run iterator allocation.

Deliberately not changed: `cells_rebuilt` is still set even when no row was rebuilt. The right fix depends on `DirectX12.presentLastTarget`, which bare-presents a three-buffer flip chain and looks wrong on its own; that wants a separate look.

Test plan:
- [x] `zig build test -Dapp-runtime=none` with the Atlas, SharedGrid and renderer filters (309/309)
- [x] x86_64-linux cross-build (OpenGL backend) 98/98
- [x] `zig fmt --check` on touched files

Follow-ups noted in review: a glyph larger than an empty max-size atlas still cannot be rendered (warned, not looped); the growth step is still doubling so a non-power-of-two device limit leaves capacity unused; there is no test instantiation of GenericRenderer, so the mid-rebuild path has manual verification steps in the branch report only.
