### PR TITLE
surface: enforce a url scheme allow-list before the fallback opener

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -4730,25 +4730,6 @@ fn openUrl(
     self: *Surface,
     action: apprt.action.OpenUrl,
 ) !void {
-    // Enforce a scheme allow-list before any apprt sees this so every
-    // apprt benefits, not just our own fallback opener. OSC 8 hyperlink
-    // targets are terminal-controlled and can differ arbitrarily from
-    // their visible text, so `file:` is only permitted for `.unknown`,
-    // which is exclusively reached via the link regex match in
-    // `processLinks` where the target is the text the user saw.
-    switch (action.kind) {
-        .unknown, .osc8 => {
-            if (!internal_os.isUrlSchemeAllowed(action.url, action.kind == .unknown)) {
-                log.warn("refusing to open url with disallowed scheme kind={t} url={s}", .{
-                    action.kind,
-                    action.url,
-                });
-                return;
-            }
-        },
-        .text, .html => {},
-    }
-
     // If the apprt handles it then we're done.
     if (try self.rt_app.performAction(
         .{ .surface = self },
@@ -4760,6 +4741,23 @@ fn openUrl(
     // URL opener. We log a warning because we want well-behaved
     // apprts to handle this themselves.
     log.warn("apprt did not handle open URL action, falling back to default opener", .{});
+
+    // The fallback opener runs the target's default verb, which executes a
+    // local file, so filter it here. This deliberately sits after the apprt
+    // declined: an apprt that handles the action owns its own policy, and
+    // macOS in particular offers a graded allow/confirm/block prompt that an
+    // unconditional deny further up would pre-empt. Filesystem paths are
+    // accepted for `.unknown` because that target is derived from the text
+    // the user saw, while an OSC 8 target is arbitrary terminal output and
+    // is held to the scheme list alone.
+    if (!internal_os.isUrlAllowed(action.kind, action.url)) {
+        log.warn("refusing to open untrusted url kind={t} url={s}", .{
+            action.kind,
+            action.url,
+        });
+        return;
+    }
+
     try internal_os.open(
         action.kind,
         action.url,

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -4730,6 +4730,25 @@ fn openUrl(
     self: *Surface,
     action: apprt.action.OpenUrl,
 ) !void {
+    // Enforce a scheme allow-list before any apprt sees this so every
+    // apprt benefits, not just our own fallback opener. OSC 8 hyperlink
+    // targets are terminal-controlled and can differ arbitrarily from
+    // their visible text, so `file:` is only permitted for `.unknown`,
+    // which is exclusively reached via the link regex match in
+    // `processLinks` where the target is the text the user saw.
+    switch (action.kind) {
+        .unknown, .osc8 => {
+            if (!internal_os.isUrlSchemeAllowed(action.url, action.kind == .unknown)) {
+                log.warn("refusing to open url with disallowed scheme kind={t} url={s}", .{
+                    action.kind,
+                    action.url,
+                });
+                return;
+            }
+        },
+        .text, .html => {},
+    }
+
     // If the apprt handles it then we're done.
     if (try self.rt_app.performAction(
         .{ .surface = self },

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -2211,6 +2211,18 @@ pub const Application = extern struct {
 
     pub fn openUrlFallback(self: *Application, kind: apprt.action.OpenUrl.Kind, url: []const u8) void {
         _ = self;
+        // This apprt has no policy of its own (unlike macOS's graded
+        // allow/confirm/block prompt), so the scheme allow-list is the
+        // only thing standing between an untrusted target and the OS's
+        // default-verb opener.
+        if (!internal_os.isUrlAllowed(kind, url)) {
+            log.warn("refusing to open untrusted url kind={t} url={s}", .{
+                kind,
+                url,
+            });
+            return;
+        }
+
         // Fallback to the minimal cross-platform way of opening a URL.
         // This is always a safe fallback and enables for example Windows
         // to open URLs (GTK on Windows via WSL is a thing).

--- a/src/os/main.zig
+++ b/src/os/main.zig
@@ -53,6 +53,7 @@ pub const ensureLocale = locale.ensureLocale;
 pub const clickInterval = mouse.clickInterval;
 pub const open = openpkg.open;
 pub const OpenType = openpkg.Type;
+pub const isUrlSchemeAllowed = openpkg.isSchemeAllowed;
 pub const pipe = pipepkg.pipe;
 pub const closePipeEnd = pipepkg.closeEnd;
 pub const writePipeEnd = pipepkg.writeEnd;

--- a/src/os/main.zig
+++ b/src/os/main.zig
@@ -53,7 +53,7 @@ pub const ensureLocale = locale.ensureLocale;
 pub const clickInterval = mouse.clickInterval;
 pub const open = openpkg.open;
 pub const OpenType = openpkg.Type;
-pub const isUrlSchemeAllowed = openpkg.isSchemeAllowed;
+pub const isUrlAllowed = openpkg.isUrlAllowed;
 pub const pipe = pipepkg.pipe;
 pub const closePipeEnd = pipepkg.closeEnd;
 pub const writePipeEnd = pipepkg.writeEnd;
@@ -65,6 +65,7 @@ pub const getConfigEditCommand = edit.getConfigEditCommand;
 
 test {
     _ = file;
+    _ = openpkg;
     _ = stderr;
     _ = edit;
     _ = i18n;

--- a/src/os/open.zig
+++ b/src/os/open.zig
@@ -7,97 +7,241 @@ const global = @import("../global.zig");
 
 const log = std.log.scoped(.@"os-open");
 
-/// Schemes this opener is willing to hand off to the OS. This is the last
-/// line of defense before an OSC 8 hyperlink target or a regex-matched
-/// path/URL reaches `rundll32`, `open`, or `xdg-open`: without it, a link
-/// whose visible text looks like `https://...` but whose target is a local
-/// executable, UNC path, or `.desktop`/`.app` bundle would launch on click.
+/// Schemes this opener is willing to hand off to the OS.
 ///
-/// Keep this in sync with the scheme alternation in src/config/url.zig.
+/// This mirrors the scheme alternation in `src/config/url.zig` (the
+/// `url_schemes` constant) exactly: that regex decides what the terminal
+/// offers as a clickable link, so anything outside it can only reach us as
+/// an OSC 8 target, which is untrusted terminal output. A scheme added to
+/// that alternation must be added here too, or it will be detected as a
+/// link and then refused on click.
 const allowed_schemes = [_][]const u8{
     "http",
     "https",
     "mailto",
     "ftp",
-    "ftps",
+    "file",
     "ssh",
-    "sftp",
+    "git",
     "tel",
-    "news",
+    "magnet",
+    "ipfs",
+    "ipns",
     "gemini",
-    "irc",
-    "ircs",
+    "gopher",
+    "news",
 };
 
-/// Returns true if `url` is safe to pass to the default opener.
+/// Returns true if `url` is safe to hand to the platform's default opener.
 ///
-/// `allow_file` permits the `file:` scheme and should only be set when the
-/// caller can guarantee the URL is exactly the text the user saw (e.g. a
-/// path matched by the terminal's link regex). It must stay false for OSC 8
-/// hyperlinks, since their target can differ arbitrarily from the visible
-/// text that was clicked.
-pub fn isSchemeAllowed(url: []const u8, allow_file: bool) bool {
-    // The URL becomes an argv element to an external process. A leading
-    // dash could be misread as a flag by that process, so refuse it
-    // outright regardless of what follows.
-    if (url.len == 0 or url[0] == '-') return false;
+/// This is the last line of defense before a link target reaches
+/// `rundll32`, `open`, or `xdg-open`, all of which run the default verb and
+/// so will execute a local file. Without it, a hyperlink whose visible text
+/// looks like `https://...` but whose target is an executable, a UNC path,
+/// or a `.desktop`/`.app` bundle launches on click.
+///
+/// `.unknown` targets come from the link regex and are derived from the
+/// text the user saw, so filesystem paths are accepted alongside the scheme
+/// list; the regex matches bare paths as well as URLs. An `.osc8` target is
+/// chosen by the program that wrote the escape and bears no relation to the
+/// text that was clicked, so it is held to the scheme list alone, without
+/// `file:`.
+pub fn isUrlAllowed(kind: apprt.action.OpenUrl.Kind, url: []const u8) bool {
+    switch (kind) {
+        // Ghostty builds these targets itself (a config file to edit, a
+        // rendered help page), so there is no untrusted input to filter.
+        .text, .html => return true,
+        .unknown, .osc8 => {},
+    }
 
-    const colon = std.mem.indexOfScalar(u8, url, ':') orelse return false;
-    const scheme = url[0..colon];
-    if (!isValidSchemeSyntax(scheme)) return false;
+    // The target becomes an argv element of an external process, so a
+    // leading dash could be read as an option by that process. Leading
+    // whitespace is refused with it: nothing we detect as a link starts
+    // with a space, and allowing it would let " javascript:..." slip past
+    // the scheme parse below and be taken for a relative path.
+    if (url.len == 0 or url[0] == '-' or std.ascii.isWhitespace(url[0])) return false;
 
-    if (allow_file and std.ascii.eqlIgnoreCase(scheme, "file")) return true;
+    // Control characters never belong in a URL or in a path we would open,
+    // and on Windows nothing else stands between this and the shell's
+    // default verb.
+    if (hasControlChars(url)) return false;
 
+    return switch (kind) {
+        .unknown => hasAllowedScheme(url, .{ .file = true }) or isFilesystemPath(url),
+        .osc8 => hasAllowedScheme(url, .{ .file = false }),
+        .text, .html => unreachable,
+    };
+}
+
+/// True if `url` starts with a scheme from `allowed_schemes`. `file:` is
+/// gated separately because it is in the link regex but is only safe when
+/// the target came from the text the user saw.
+fn hasAllowedScheme(url: []const u8, opts: struct { file: bool }) bool {
+    const scheme = schemeOf(url) orelse return false;
     for (allowed_schemes) |allowed| {
+        if (!opts.file and std.ascii.eqlIgnoreCase(allowed, "file")) continue;
         if (std.ascii.eqlIgnoreCase(scheme, allowed)) return true;
     }
 
     return false;
 }
 
-/// RFC 3986 scheme syntax: ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
-fn isValidSchemeSyntax(scheme: []const u8) bool {
-    if (scheme.len == 0 or !std.ascii.isAlphabetic(scheme[0])) return false;
+/// True if `value` looks like a filesystem path rather than a URL. The link
+/// regex has three branches and two of them match bare paths, so refusing
+/// these would break opening `/etc/hosts`, `./notes.md`, `~/notes.md` or
+/// `src/config/url.zig`.
+fn isFilesystemPath(value: []const u8) bool {
+    // Handles `/etc/hosts` everywhere plus `C:\...` and `\\server\share`
+    // when we are running on Windows.
+    if (std.fs.path.isAbsolute(value)) return true;
+
+    // A drive-qualified path parses as a one letter scheme, so recognize it
+    // regardless of the host we are running on: the same string must be
+    // classified the same way by the tests on every platform.
+    if (value.len >= 3 and
+        std.ascii.isAlphabetic(value[0]) and
+        value[1] == ':' and
+        (value[2] == '\\' or value[2] == '/')) return true;
+
+    if (std.mem.startsWith(u8, value, "./")) return true;
+    if (std.mem.startsWith(u8, value, "../")) return true;
+    if (std.mem.startsWith(u8, value, "~/")) return true;
+
+    // Bare relative paths (`src/config/url.zig`) carry no scheme at all.
+    // A value that does parse as a scheme is a URL we chose not to allow,
+    // not a path, so it must not fall through to here.
+    return schemeOf(value) == null;
+}
+
+/// The scheme of `url`, or null if it does not begin with one. RFC 3986
+/// scheme syntax: ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ).
+fn schemeOf(url: []const u8) ?[]const u8 {
+    const colon = std.mem.indexOfScalar(u8, url, ':') orelse return null;
+    const scheme = url[0..colon];
+    if (scheme.len == 0 or !std.ascii.isAlphabetic(scheme[0])) return null;
     for (scheme[1..]) |c| {
         if (!std.ascii.isAlphanumeric(c) and c != '+' and c != '-' and c != '.') {
-            return false;
+            return null;
         }
     }
-    return true;
+
+    return scheme;
 }
 
-test "url scheme allow-list accepts the mirrored scheme list" {
-    for (allowed_schemes) |scheme| {
-        var buf: [64]u8 = undefined;
-        const url = try std.fmt.bufPrint(&buf, "{s}:example", .{scheme});
-        try std.testing.expect(isSchemeAllowed(url, false));
+/// True if `url` contains a C0 control character, DEL, or a C1 control
+/// character. C1 reaches us UTF-8 encoded, as 0xC2 followed by 0x80-0x9F.
+fn hasControlChars(url: []const u8) bool {
+    for (url, 0..) |c, i| {
+        if (std.ascii.isControl(c)) return true;
+        if (c == 0xc2 and
+            i + 1 < url.len and
+            url[i + 1] >= 0x80 and
+            url[i + 1] <= 0x9f) return true;
+    }
+
+    return false;
+}
+
+test "url allow-list accepts every scheme the link regex detects" {
+    // Spelled out rather than looped over `allowed_schemes` so that a
+    // scheme dropped from the list fails here instead of silently agreeing
+    // with itself.
+    const testing = std.testing;
+    try testing.expect(isUrlAllowed(.osc8, "http://example.com"));
+    try testing.expect(isUrlAllowed(.osc8, "https://example.com"));
+    try testing.expect(isUrlAllowed(.osc8, "mailto:test@example.com"));
+    try testing.expect(isUrlAllowed(.osc8, "ftp://example.com"));
+    try testing.expect(isUrlAllowed(.osc8, "ssh://example.com"));
+    try testing.expect(isUrlAllowed(.osc8, "git://example.com/repo.git"));
+    try testing.expect(isUrlAllowed(.osc8, "tel:+18005551234"));
+    try testing.expect(isUrlAllowed(.osc8, "magnet:?xt=urn:btih:1234567890"));
+    try testing.expect(isUrlAllowed(.osc8, "ipfs://QmSomeHashValue"));
+    try testing.expect(isUrlAllowed(.osc8, "ipns://QmSomeHashValue"));
+    try testing.expect(isUrlAllowed(.osc8, "gemini://example.com"));
+    try testing.expect(isUrlAllowed(.osc8, "gopher://example.com"));
+    try testing.expect(isUrlAllowed(.osc8, "news:comp.infosystems.www.servers.unix"));
+
+    // `file:` is in that alternation too, but only the regex path may open
+    // it: an OSC 8 target is not the text the user clicked.
+    try testing.expect(isUrlAllowed(.unknown, "file:///tmp/notes.md"));
+    try testing.expect(!isUrlAllowed(.osc8, "file:///Applications/Calculator.app"));
+}
+
+test "url allow-list matches schemes case-insensitively" {
+    const testing = std.testing;
+    try testing.expect(isUrlAllowed(.osc8, "HTTPS://example.com"));
+    try testing.expect(isUrlAllowed(.unknown, "File:///tmp/notes.md"));
+    try testing.expect(!isUrlAllowed(.osc8, "File:///tmp/notes.md"));
+}
+
+test "url allow-list rejects schemes that execute or reconfigure" {
+    const testing = std.testing;
+    for ([_][]const u8{
+        "javascript:alert(1)",
+        "data:text/html,<script>alert(1)</script>",
+        "ms-settings:windowsupdate",
+        "shell:startup",
+        "vbscript:msgbox(1)",
+    }) |url| {
+        try testing.expect(!isUrlAllowed(.osc8, url));
+        try testing.expect(!isUrlAllowed(.unknown, url));
     }
 }
 
-test "url scheme allow-list accepts https" {
-    try std.testing.expect(isSchemeAllowed("https://example.com", false));
+test "url allow-list accepts filesystem paths only from the link regex" {
+    const testing = std.testing;
+    for ([_][]const u8{
+        "/etc/hosts",
+        "./notes.md",
+        "../notes.md",
+        "~/notes.md",
+        "C:\\Users\\me\\notes.md",
+        "src/config/url.zig",
+    }) |path| {
+        try testing.expect(isUrlAllowed(.unknown, path));
+        try testing.expect(!isUrlAllowed(.osc8, path));
+    }
 }
 
-test "url scheme allow-list rejects file by default" {
-    try std.testing.expect(!isSchemeAllowed("file:///Applications/Calc.app", false));
+test "url allow-list rejects a UNC target from an OSC 8 link" {
+    const testing = std.testing;
+    try testing.expect(!isUrlAllowed(.osc8, "\\\\attacker\\share\\payload.exe"));
+    try testing.expect(!isUrlAllowed(.osc8, "//attacker/share/payload.exe"));
 }
 
-test "url scheme allow-list allows file when the caller opts in" {
-    try std.testing.expect(isSchemeAllowed("file:///Applications/Calc.app", true));
+test "url allow-list rejects a leading dash" {
+    const testing = std.testing;
+    try testing.expect(!isUrlAllowed(.unknown, "-rf"));
+    try testing.expect(!isUrlAllowed(.unknown, "--help=file:///etc/passwd"));
+    try testing.expect(!isUrlAllowed(.osc8, "-rf"));
 }
 
-test "url scheme allow-list rejects javascript" {
-    try std.testing.expect(!isSchemeAllowed("javascript:alert(1)", false));
-    try std.testing.expect(!isSchemeAllowed("javascript:alert(1)", true));
+test "url allow-list rejects leading whitespace" {
+    const testing = std.testing;
+    try testing.expect(!isUrlAllowed(.osc8, " https://example.com"));
+    try testing.expect(!isUrlAllowed(.unknown, " https://example.com"));
+    // Without the whitespace check this would parse as a scheme-less
+    // relative path and be opened.
+    try testing.expect(!isUrlAllowed(.unknown, " javascript:alert(1)"));
 }
 
-test "url scheme allow-list rejects a leading dash" {
-    try std.testing.expect(!isSchemeAllowed("-rf", false));
-    try std.testing.expect(!isSchemeAllowed("--help=file:///etc/passwd", true));
+test "url allow-list rejects control characters" {
+    const testing = std.testing;
+    try testing.expect(!isUrlAllowed(.osc8, "https://example.com/\x00"));
+    try testing.expect(!isUrlAllowed(.osc8, "https://example.com/\r\nx"));
+    try testing.expect(!isUrlAllowed(.osc8, "https://example.com/\x1b]0;x\x07"));
+    try testing.expect(!isUrlAllowed(.osc8, "https://example.com/\x7f"));
+    // C1, UTF-8 encoded.
+    try testing.expect(!isUrlAllowed(.unknown, "/tmp/notes\xc2\x9b.md"));
+    try testing.expect(!isUrlAllowed(.unknown, "/tmp/notes\xc2\x80.md"));
+    // 0xC2 followed by a continuation byte outside C1 is ordinary text.
+    try testing.expect(isUrlAllowed(.unknown, "/tmp/notes\xc2\xa9.md"));
 }
 
-test "url scheme allow-list rejects a scheme-less string" {
-    try std.testing.expect(!isSchemeAllowed("not a url", false));
+test "url allow-list leaves ghostty's own targets alone" {
+    const testing = std.testing;
+    try testing.expect(isUrlAllowed(.text, "/home/user/.config/ghostty/config"));
+    try testing.expect(isUrlAllowed(.html, "/tmp/ghostty-help.html"));
 }
 
 /// Open a URL in the default handling application.
@@ -121,11 +265,11 @@ pub fn open(
     }
 
     var spawn_opts: std.process.SpawnOptions = switch (builtin.os.tag) {
-        .linux, .freebsd => .{ .argv = &.{ "xdg-open", "--", url } },
+        .linux, .freebsd => .{ .argv = &.{ "xdg-open", url } },
         .windows => .{ .argv = &.{ "rundll32", "url.dll,FileProtocolHandler", url } },
         .macos => switch (kind) {
-            .text => .{ .argv = &.{ "open", "-t", "--", url } },
-            .html, .unknown => .{ .argv = &.{ "open", "--", url } },
+            .text => .{ .argv = &.{ "open", "-t", url } },
+            .html, .unknown => .{ .argv = &.{ "open", url } },
             .osc8 => unreachable,
         },
         .ios => return error.Unimplemented,

--- a/src/os/open.zig
+++ b/src/os/open.zig
@@ -7,6 +7,99 @@ const global = @import("../global.zig");
 
 const log = std.log.scoped(.@"os-open");
 
+/// Schemes this opener is willing to hand off to the OS. This is the last
+/// line of defense before an OSC 8 hyperlink target or a regex-matched
+/// path/URL reaches `rundll32`, `open`, or `xdg-open`: without it, a link
+/// whose visible text looks like `https://...` but whose target is a local
+/// executable, UNC path, or `.desktop`/`.app` bundle would launch on click.
+///
+/// Keep this in sync with the scheme alternation in src/config/url.zig.
+const allowed_schemes = [_][]const u8{
+    "http",
+    "https",
+    "mailto",
+    "ftp",
+    "ftps",
+    "ssh",
+    "sftp",
+    "tel",
+    "news",
+    "gemini",
+    "irc",
+    "ircs",
+};
+
+/// Returns true if `url` is safe to pass to the default opener.
+///
+/// `allow_file` permits the `file:` scheme and should only be set when the
+/// caller can guarantee the URL is exactly the text the user saw (e.g. a
+/// path matched by the terminal's link regex). It must stay false for OSC 8
+/// hyperlinks, since their target can differ arbitrarily from the visible
+/// text that was clicked.
+pub fn isSchemeAllowed(url: []const u8, allow_file: bool) bool {
+    // The URL becomes an argv element to an external process. A leading
+    // dash could be misread as a flag by that process, so refuse it
+    // outright regardless of what follows.
+    if (url.len == 0 or url[0] == '-') return false;
+
+    const colon = std.mem.indexOfScalar(u8, url, ':') orelse return false;
+    const scheme = url[0..colon];
+    if (!isValidSchemeSyntax(scheme)) return false;
+
+    if (allow_file and std.ascii.eqlIgnoreCase(scheme, "file")) return true;
+
+    for (allowed_schemes) |allowed| {
+        if (std.ascii.eqlIgnoreCase(scheme, allowed)) return true;
+    }
+
+    return false;
+}
+
+/// RFC 3986 scheme syntax: ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
+fn isValidSchemeSyntax(scheme: []const u8) bool {
+    if (scheme.len == 0 or !std.ascii.isAlphabetic(scheme[0])) return false;
+    for (scheme[1..]) |c| {
+        if (!std.ascii.isAlphanumeric(c) and c != '+' and c != '-' and c != '.') {
+            return false;
+        }
+    }
+    return true;
+}
+
+test "url scheme allow-list accepts the mirrored scheme list" {
+    for (allowed_schemes) |scheme| {
+        var buf: [64]u8 = undefined;
+        const url = try std.fmt.bufPrint(&buf, "{s}:example", .{scheme});
+        try std.testing.expect(isSchemeAllowed(url, false));
+    }
+}
+
+test "url scheme allow-list accepts https" {
+    try std.testing.expect(isSchemeAllowed("https://example.com", false));
+}
+
+test "url scheme allow-list rejects file by default" {
+    try std.testing.expect(!isSchemeAllowed("file:///Applications/Calc.app", false));
+}
+
+test "url scheme allow-list allows file when the caller opts in" {
+    try std.testing.expect(isSchemeAllowed("file:///Applications/Calc.app", true));
+}
+
+test "url scheme allow-list rejects javascript" {
+    try std.testing.expect(!isSchemeAllowed("javascript:alert(1)", false));
+    try std.testing.expect(!isSchemeAllowed("javascript:alert(1)", true));
+}
+
+test "url scheme allow-list rejects a leading dash" {
+    try std.testing.expect(!isSchemeAllowed("-rf", false));
+    try std.testing.expect(!isSchemeAllowed("--help=file:///etc/passwd", true));
+}
+
+test "url scheme allow-list rejects a scheme-less string" {
+    try std.testing.expect(!isSchemeAllowed("not a url", false));
+}
+
 /// Open a URL in the default handling application.
 ///
 /// Any output on stderr is logged as a warning in the application logs.
@@ -28,11 +121,11 @@ pub fn open(
     }
 
     var spawn_opts: std.process.SpawnOptions = switch (builtin.os.tag) {
-        .linux, .freebsd => .{ .argv = &.{ "xdg-open", url } },
+        .linux, .freebsd => .{ .argv = &.{ "xdg-open", "--", url } },
         .windows => .{ .argv = &.{ "rundll32", "url.dll,FileProtocolHandler", url } },
         .macos => switch (kind) {
-            .text => .{ .argv = &.{ "open", "-t", url } },
-            .html, .unknown => .{ .argv = &.{ "open", url } },
+            .text => .{ .argv = &.{ "open", "-t", "--", url } },
+            .html, .unknown => .{ .argv = &.{ "open", "--", url } },
             .osc8 => unreachable,
         },
         .ios => return error.Unimplemented,


### PR DESCRIPTION
Nothing checked the scheme of a URL before handing it to the OS opener. On Windows the fallback is `rundll32 url.dll,FileProtocolHandler <url>`, which runs the default verb, so an OSC 8 link whose visible text is an https URL and whose target is a local executable, a UNC path or a `.desktop`/`.app` launched on click. The Windows C# host has no `open_url` handler, so that fallback is the path it always takes.

`Surface.openUrl` now runs an allow-list right before the fallback opener, after the apprt has declined the action (macOS handles `open_url` itself with its own allow/confirm/block prompt and keeps that). The list mirrors the scheme alternation in `src/config/url.zig`. OSC 8 targets must carry an allowed scheme; the regex-matched `.open` path additionally accepts filesystem paths (absolute, `./`, `../`, `~/`, drive letters) and `file:` since the text the user clicked is the target. A leading dash, whitespace, and C0/C1 control characters are refused; refusals are logged. The GTK fallback opener gets the same guard; that hunk is not compiled on this host.

Also fixed on the way: the `src/os/open.zig` tests were never in the test root, so they had never run.

Test plan:
- [x] `zig build test -Dapp-runtime=none` with the url and open filters (121/126, 5 skipped), real RED with the helper stubbed
- [x] `zig fmt --check` on touched files

Follow-ups noted in review: `file:` with a remote authority is still accepted on the regex path (visible text, but it would reach a share); refusals on Windows are only a warn log until the C# host grows an `open_url` handler; the malformed-scheme fallback relies on the link regex's current shape.
