### PR TITLE
windows: fix reader shutdown hang, pseudoconsole std handles and cmd.exe script quoting

### DIFF
--- a/src/Command.zig
+++ b/src/Command.zig
@@ -820,37 +820,95 @@ fn createWindowsEnvBlock(allocator: mem.Allocator, env_map: *const EnvMap) ![]u1
     return try allocator.realloc(result, i);
 }
 
-/// Copied from Zig. This function could be made public in child_process.zig instead.
+/// Index of the `/C` or `/K` switch when `argv` is a cmd.exe invocation
+/// with a single script after it, which is the shape a wrapped shell
+/// command has. Returns null for anything else, including an argv that
+/// already carries `/S`: that caller has taken over the quoting.
+fn windowsCmdScriptSwitch(argv: []const []const u8) ?usize {
+    if (argv.len < 3) return null;
+
+    const exe = std.fs.path.basenameWindows(argv[0]);
+    if (!std.ascii.eqlIgnoreCase(exe, "cmd.exe") and
+        !std.ascii.eqlIgnoreCase(exe, "cmd")) return null;
+
+    // The script is the last argument, so the switch is the one before.
+    const i = argv.len - 2;
+    const sw = argv[i];
+    if (sw.len != 2 or sw[0] != '/') return null;
+    switch (std.ascii.toLower(sw[1])) {
+        'c', 'k' => {},
+        else => return null,
+    }
+
+    // Everything between the program and the switch must be another
+    // plain cmd.exe switch for this to be the shape we recognize.
+    for (argv[1..i]) |arg| {
+        if (arg.len != 2 or arg[0] != '/') return null;
+        if (std.ascii.toLower(arg[1]) == 's') return null;
+    }
+
+    return i;
+}
+
+/// Serialize `arg` with the MS C runtime quoting rules, which
+/// CommandLineToArgvW (and so almost every Windows program) reverses.
+fn windowsQuoteArg(writer: *std.Io.Writer, arg: []const u8) !void {
+    if (mem.indexOfAny(u8, arg, " \t\n\"") == null) {
+        try writer.writeAll(arg);
+        return;
+    }
+    try writer.writeByte('"');
+    var backslash_count: usize = 0;
+    for (arg) |byte| {
+        switch (byte) {
+            '\\' => backslash_count += 1,
+            '"' => {
+                try writer.splatByteAll('\\', backslash_count * 2 + 1);
+                try writer.writeByte('"');
+                backslash_count = 0;
+            },
+            else => {
+                try writer.splatByteAll('\\', backslash_count);
+                try writer.writeByte(byte);
+                backslash_count = 0;
+            },
+        }
+    }
+    try writer.splatByteAll('\\', backslash_count * 2);
+    try writer.writeByte('"');
+}
+
+/// Build the `lpCommandLine` for `argv`.
+///
+/// Arguments are quoted with the C runtime rules, except the script of a
+/// cmd.exe `/C` (or `/K`) invocation. cmd.exe parses that tail with its
+/// own rules: it has no `\"` escape, and it removes one leading and one
+/// trailing quote from the line. C runtime quoting therefore reaches the
+/// child as literal backslashes, and, once the escaped quotes make the
+/// outer pair no longer the only pair, a command truncated at the last
+/// quote. Such a script is passed through verbatim inside one quote pair
+/// with `/S`, which is documented to strip exactly that pair and run the
+/// rest as written.
 fn windowsCreateCommandLine(allocator: mem.Allocator, argv: []const []const u8) ![:0]u8 {
     var buf: std.Io.Writer.Allocating = .init(allocator);
     defer buf.deinit();
     const writer = &buf.writer;
 
+    const cmd_switch = windowsCmdScriptSwitch(argv);
+
     for (argv, 0..) |arg, arg_i| {
         if (arg_i != 0) try writer.writeByte(' ');
-        if (mem.indexOfAny(u8, arg, " \t\n\"") == null) {
+
+        if (cmd_switch) |i| if (arg_i == i) {
+            try writer.writeAll("/S ");
             try writer.writeAll(arg);
-            continue;
-        }
-        try writer.writeByte('"');
-        var backslash_count: usize = 0;
-        for (arg) |byte| {
-            switch (byte) {
-                '\\' => backslash_count += 1,
-                '"' => {
-                    try writer.splatByteAll('\\', backslash_count * 2 + 1);
-                    try writer.writeByte('"');
-                    backslash_count = 0;
-                },
-                else => {
-                    try writer.splatByteAll('\\', backslash_count);
-                    try writer.writeByte(byte);
-                    backslash_count = 0;
-                },
-            }
-        }
-        try writer.splatByteAll('\\', backslash_count * 2);
-        try writer.writeByte('"');
+            try writer.writeAll(" \"");
+            try writer.writeAll(argv[i + 1]);
+            try writer.writeByte('"');
+            break;
+        };
+
+        try windowsQuoteArg(writer, arg);
     }
 
     return buf.toOwnedSliceSentinel(0);
@@ -868,6 +926,77 @@ test "windowsStdioMode: a pseudoconsole child takes neither std handles nor inhe
     const explicit = windowsStdioMode(false);
     try testing.expect(explicit.use_std_handles);
     try testing.expect(explicit.inherit_handles);
+}
+
+test "windowsCreateCommandLine: a cmd.exe script keeps its own quoting" {
+    const alloc = testing.allocator;
+
+    const line = try windowsCreateCommandLine(alloc, &.{
+        "C:\\Windows\\System32\\cmd.exe",
+        "/c",
+        "chcp 65001 >nul && dir \"C:\\Program Files\"",
+    });
+    defer alloc.free(line);
+
+    try testing.expectEqualStrings(
+        "C:\\Windows\\System32\\cmd.exe /S /c " ++
+            "\"chcp 65001 >nul && dir \"C:\\Program Files\"\"",
+        line,
+    );
+}
+
+test "windowsCreateCommandLine: a cmd.exe script without quotes is unchanged by /S" {
+    const alloc = testing.allocator;
+
+    const line = try windowsCreateCommandLine(alloc, &.{
+        "cmd.exe",
+        "/C",
+        "echo hi | more",
+    });
+    defer alloc.free(line);
+
+    try testing.expectEqualStrings("cmd.exe /S /C \"echo hi | more\"", line);
+}
+
+test "windowsCreateCommandLine: a caller supplied /S owns its own quoting" {
+    const alloc = testing.allocator;
+
+    const line = try windowsCreateCommandLine(alloc, &.{
+        "cmd.exe",
+        "/s",
+        "/c",
+        "echo hi",
+    });
+    defer alloc.free(line);
+
+    try testing.expectEqualStrings("cmd.exe /s /c \"echo hi\"", line);
+}
+
+test "windowsCreateCommandLine: everything else keeps the C runtime quoting" {
+    const alloc = testing.allocator;
+
+    // pwsh parses its command line with CommandLineToArgvW, so a quote
+    // inside an argument must arrive backslash escaped.
+    const pwsh = try windowsCreateCommandLine(alloc, &.{
+        "pwsh.exe",
+        "-Command",
+        "Get-ChildItem \"C:\\Program Files\"",
+    });
+    defer alloc.free(pwsh);
+    try testing.expectEqualStrings(
+        "pwsh.exe -Command \"Get-ChildItem \\\"C:\\Program Files\\\"\"",
+        pwsh,
+    );
+
+    // A bare cmd.exe with no script is not a `/C` invocation.
+    const bare = try windowsCreateCommandLine(alloc, &.{"cmd.exe"});
+    defer alloc.free(bare);
+    try testing.expectEqualStrings("cmd.exe", bare);
+
+    // Neither is one whose trailing switch is not /C or /K.
+    const query = try windowsCreateCommandLine(alloc, &.{ "cmd.exe", "/q", "arg one" });
+    defer alloc.free(query);
+    try testing.expectEqualStrings("cmd.exe /q \"arg one\"", query);
 }
 
 test "createNullDelimitedEnvMap" {

--- a/src/Command.zig
+++ b/src/Command.zig
@@ -386,6 +386,32 @@ fn winJoinEnv(arena: Allocator, name: []const u8, suffix: []const u16) ![]u16 {
     return out;
 }
 
+/// How a Windows spawn hands standard I/O to the child.
+const WindowsStdioMode = struct {
+    /// Whether `STARTF_USESTDHANDLES` belongs in `STARTUPINFO.dwFlags`.
+    use_std_handles: bool,
+
+    /// The `bInheritHandles` argument to `CreateProcessW`.
+    inherit_handles: bool,
+};
+
+/// A pseudoconsole child takes its standard handles from the console it
+/// is attached to. `STARTF_USESTDHANDLES` would override those with the
+/// three NULL handles that path has, and nothing in it is passed by
+/// inheritance either, so inheriting is only a way to leak whatever
+/// inheritable handles this process happens to hold. The explicit-handle
+/// path needs both: the child sees the three handles we name, and only
+/// because it inherits them (bounded by the handle list attribute).
+fn windowsStdioMode(has_pseudo_console: bool) WindowsStdioMode {
+    return if (has_pseudo_console) .{
+        .use_std_handles = false,
+        .inherit_handles = false,
+    } else .{
+        .use_std_handles = true,
+        .inherit_handles = true,
+    };
+}
+
 fn startWindows(self: *Command, arena: Allocator) !void {
     const cwd_w = if (self.cwd) |cwd| try std.unicode.utf8ToUtf16LeAllocZ(arena, cwd) else null;
 
@@ -550,13 +576,18 @@ fn startWindows(self: *Command, arena: Allocator) !void {
         break :b .{ attribute_list_buf.ptr, stdin, stdout, stderr };
     };
 
+    const stdio_mode = windowsStdioMode(self.pseudo_console != null);
+
     var startup_info_ex = windows.STARTUPINFOEX{
         .StartupInfo = .{
             .cb = @sizeOf(windows.STARTUPINFOEX),
             .hStdError = stderr,
             .hStdOutput = stdout,
             .hStdInput = stdin,
-            .dwFlags = windows.STARTF_USESTDHANDLES,
+            .dwFlags = if (stdio_mode.use_std_handles)
+                windows.STARTF_USESTDHANDLES
+            else
+                0,
             .lpReserved = null,
             .lpDesktop = null,
             .lpTitle = null,
@@ -591,7 +622,7 @@ fn startWindows(self: *Command, arena: Allocator) !void {
         command_line_w.ptr,
         null,
         null,
-        windows.TRUE,
+        if (stdio_mode.inherit_handles) windows.TRUE else windows.FALSE,
         flags,
         if (env_w) |w| w.ptr else null,
         if (cwd_w) |w| w.ptr else null,
@@ -823,6 +854,20 @@ fn windowsCreateCommandLine(allocator: mem.Allocator, argv: []const []const u8) 
     }
 
     return buf.toOwnedSliceSentinel(0);
+}
+
+test "windowsStdioMode: a pseudoconsole child takes neither std handles nor inheritance" {
+    // A ConPTY child gets its standard handles from the pseudoconsole it
+    // is attached to, and nothing in that spawn is passed by inheritance.
+    const conpty = windowsStdioMode(true);
+    try testing.expect(!conpty.use_std_handles);
+    try testing.expect(!conpty.inherit_handles);
+
+    // The explicit-handle spawn is the opposite: the child only sees the
+    // three handles we name, and only if it inherits them.
+    const explicit = windowsStdioMode(false);
+    try testing.expect(explicit.use_std_handles);
+    try testing.expect(explicit.inherit_handles);
 }
 
 test "createNullDelimitedEnvMap" {

--- a/src/Command.zig
+++ b/src/Command.zig
@@ -822,8 +822,7 @@ fn createWindowsEnvBlock(allocator: mem.Allocator, env_map: *const EnvMap) ![]u1
 
 /// Index of the `/C` or `/K` switch when `argv` is a cmd.exe invocation
 /// with a single script after it, which is the shape a wrapped shell
-/// command has. Returns null for anything else, including an argv that
-/// already carries `/S`: that caller has taken over the quoting.
+/// command has. Returns null for anything else.
 fn windowsCmdScriptSwitch(argv: []const []const u8) ?usize {
     if (argv.len < 3) return null;
 
@@ -844,7 +843,6 @@ fn windowsCmdScriptSwitch(argv: []const []const u8) ?usize {
     // plain cmd.exe switch for this to be the shape we recognize.
     for (argv[1..i]) |arg| {
         if (arg.len != 2 or arg[0] != '/') return null;
-        if (std.ascii.toLower(arg[1]) == 's') return null;
     }
 
     return i;
@@ -882,13 +880,18 @@ fn windowsQuoteArg(writer: *std.Io.Writer, arg: []const u8) !void {
 ///
 /// Arguments are quoted with the C runtime rules, except the script of a
 /// cmd.exe `/C` (or `/K`) invocation. cmd.exe parses that tail with its
-/// own rules: it has no `\"` escape, and it removes one leading and one
-/// trailing quote from the line. C runtime quoting therefore reaches the
-/// child as literal backslashes, and, once the escaped quotes make the
-/// outer pair no longer the only pair, a command truncated at the last
-/// quote. Such a script is passed through verbatim inside one quote pair
-/// with `/S`, which is documented to strip exactly that pair and run the
-/// rest as written.
+/// own rules and has no `\"` escape, so C runtime quoting reaches the
+/// child as literal backslashes and truncates the command at the last
+/// escaped quote. Such a script is written verbatim inside a single
+/// quote pair instead.
+///
+/// One pair is all cmd needs. It keeps a line's quoting untouched only
+/// when the line holds exactly two quotes, no `&<>()@^|` between them,
+/// and the text between them names an executable; otherwise it strips
+/// the outer pair and runs the rest as written. A script that carries
+/// its own quotes or a metacharacter fails that test and is stripped
+/// back to what the user wrote, and a script that passes it is a bare
+/// quoted program path, which is meant to stay quoted.
 fn windowsCreateCommandLine(allocator: mem.Allocator, argv: []const []const u8) ![:0]u8 {
     var buf: std.Io.Writer.Allocating = .init(allocator);
     defer buf.deinit();
@@ -900,7 +903,6 @@ fn windowsCreateCommandLine(allocator: mem.Allocator, argv: []const []const u8) 
         if (arg_i != 0) try writer.writeByte(' ');
 
         if (cmd_switch) |i| if (arg_i == i) {
-            try writer.writeAll("/S ");
             try writer.writeAll(arg);
             try writer.writeAll(" \"");
             try writer.writeAll(argv[i + 1]);
@@ -938,14 +940,16 @@ test "windowsCreateCommandLine: a cmd.exe script keeps its own quoting" {
     });
     defer alloc.free(line);
 
+    // Four quotes, so cmd strips the outer pair and hands the rest to
+    // its own tokenizer exactly as the user wrote it.
     try testing.expectEqualStrings(
-        "C:\\Windows\\System32\\cmd.exe /S /c " ++
+        "C:\\Windows\\System32\\cmd.exe /c " ++
             "\"chcp 65001 >nul && dir \"C:\\Program Files\"\"",
         line,
     );
 }
 
-test "windowsCreateCommandLine: a cmd.exe script without quotes is unchanged by /S" {
+test "windowsCreateCommandLine: a cmd.exe script without quotes gets one pair" {
     const alloc = testing.allocator;
 
     const line = try windowsCreateCommandLine(alloc, &.{
@@ -955,21 +959,43 @@ test "windowsCreateCommandLine: a cmd.exe script without quotes is unchanged by 
     });
     defer alloc.free(line);
 
-    try testing.expectEqualStrings("cmd.exe /S /C \"echo hi | more\"", line);
+    // Two quotes, but the pipe between them is a cmd metacharacter, so
+    // the pair is stripped and the script runs as written.
+    try testing.expectEqualStrings("cmd.exe /C \"echo hi | more\"", line);
 }
 
-test "windowsCreateCommandLine: a caller supplied /S owns its own quoting" {
+test "windowsCreateCommandLine: a bare quoted program path stays quoted" {
+    const alloc = testing.allocator;
+
+    const line = try windowsCreateCommandLine(alloc, &.{
+        "cmd.exe",
+        "/c",
+        "C:\\Program Files\\app.exe",
+    });
+    defer alloc.free(line);
+
+    // The one case where cmd preserves the quoting instead of stripping
+    // it, which is what a program path with a space needs.
+    try testing.expectEqualStrings("cmd.exe /c \"C:\\Program Files\\app.exe\"", line);
+}
+
+test "windowsCreateCommandLine: a caller supplied /S still gets the verbatim script" {
     const alloc = testing.allocator;
 
     const line = try windowsCreateCommandLine(alloc, &.{
         "cmd.exe",
         "/s",
         "/c",
-        "echo hi",
+        "dir \"C:\\Program Files\"",
     });
     defer alloc.free(line);
 
-    try testing.expectEqualStrings("cmd.exe /s /c \"echo hi\"", line);
+    // `/S` only makes the outer-pair strip unconditional, which is what
+    // the verbatim script already relies on.
+    try testing.expectEqualStrings(
+        "cmd.exe /s /c \"dir \"C:\\Program Files\"\"",
+        line,
+    );
 }
 
 test "windowsCreateCommandLine: everything else keeps the C runtime quoting" {

--- a/src/Command.zig
+++ b/src/Command.zig
@@ -823,6 +823,19 @@ fn createWindowsEnvBlock(allocator: mem.Allocator, env_map: *const EnvMap) ![]u1
 /// Index of the `/C` or `/K` switch when `argv` is a cmd.exe invocation
 /// with a single script after it, which is the shape a wrapped shell
 /// command has. Returns null for anything else.
+///
+/// Two deliberate narrownesses, both of which fail closed to the CRT
+/// quoting that was here before:
+///
+///   - The program is recognized by basename, not by the module
+///     `resolveWindowsProgram` actually loads. A user program named
+///     `cmd.exe` would get its last argument written verbatim, which
+///     `CommandLineToArgvW` would then mis-parse.
+///   - A `/C` with more than one argument after it does not match, so
+///     `["cmd.exe", "/c", "prog", "arg one"]` is CRT-quoted and cmd
+///     mis-parses it the way this function exists to avoid. Nothing in
+///     the tree produces that shape: the wrap always joins the tail
+///     into one script.
 fn windowsCmdScriptSwitch(argv: []const []const u8) ?usize {
     if (argv.len < 3) return null;
 

--- a/src/Command.zig
+++ b/src/Command.zig
@@ -965,31 +965,65 @@ test "windowsCreateCommandLine: a cmd.exe script keeps its own quoting" {
 test "windowsCreateCommandLine: a cmd.exe script without quotes gets one pair" {
     const alloc = testing.allocator;
 
-    const line = try windowsCreateCommandLine(alloc, &.{
+    // Two quotes, but the pipe between them is a cmd metacharacter, so
+    // the pair is stripped and the script runs as written.
+    //
+    // A script with no quotes of its own is byte identical under either
+    // rule, so this case pins the shape and nothing else. The quoted
+    // case below is the one that tells the two rules apart.
+    const plain = try windowsCreateCommandLine(alloc, &.{
         "cmd.exe",
         "/C",
         "echo hi | more",
     });
-    defer alloc.free(line);
+    defer alloc.free(plain);
+    try testing.expectEqualStrings("cmd.exe /C \"echo hi | more\"", plain);
 
-    // Two quotes, but the pipe between them is a cmd metacharacter, so
-    // the pair is stripped and the script runs as written.
-    try testing.expectEqualStrings("cmd.exe /C \"echo hi | more\"", line);
+    // The same pipeline with a quoted argument. C runtime quoting would
+    // write the inner quotes as \", which cmd has no escape for and
+    // would hand to `echo` as literal backslashes.
+    const quoted = try windowsCreateCommandLine(alloc, &.{
+        "cmd.exe",
+        "/C",
+        "echo \"hi there\" | more",
+    });
+    defer alloc.free(quoted);
+    try testing.expectEqualStrings(
+        "cmd.exe /C \"echo \"hi there\" | more\"",
+        quoted,
+    );
 }
 
 test "windowsCreateCommandLine: a bare quoted program path stays quoted" {
     const alloc = testing.allocator;
 
-    const line = try windowsCreateCommandLine(alloc, &.{
+    // The one case where cmd preserves the quoting instead of stripping
+    // it, which is what a program path with a space needs.
+    //
+    // Like the plain pipeline above, a script carrying no quotes is byte
+    // identical under either rule, so the pre-quoted case below is what
+    // discriminates.
+    const bare = try windowsCreateCommandLine(alloc, &.{
         "cmd.exe",
         "/c",
         "C:\\Program Files\\app.exe",
     });
-    defer alloc.free(line);
+    defer alloc.free(bare);
+    try testing.expectEqualStrings("cmd.exe /c \"C:\\Program Files\\app.exe\"", bare);
 
-    // The one case where cmd preserves the quoting instead of stripping
-    // it, which is what a program path with a space needs.
-    try testing.expectEqualStrings("cmd.exe /c \"C:\\Program Files\\app.exe\"", line);
+    // A user who quoted the path themselves and added an argument gets
+    // exactly the quotes they wrote. Four quotes, so cmd strips the
+    // outer pair and the inner pair is what keeps the path together.
+    const prequoted = try windowsCreateCommandLine(alloc, &.{
+        "cmd.exe",
+        "/c",
+        "\"C:\\Program Files\\app.exe\" --flag",
+    });
+    defer alloc.free(prequoted);
+    try testing.expectEqualStrings(
+        "cmd.exe /c \"\"C:\\Program Files\\app.exe\" --flag\"",
+        prequoted,
+    );
 }
 
 test "windowsCreateCommandLine: a caller supplied /S still gets the verbatim script" {

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -49,6 +49,13 @@ const FlatpakHostCommand = if (!build_config.flatpak) struct {
 /// The subprocess state for our exec backend.
 subprocess: Subprocess,
 
+/// The shutdown handshake with the Windows reader thread. The reader is
+/// handed a pointer to this before the thread data exists, so it lives
+/// here rather than on the thread data. Unused on POSIX, where the quit
+/// pipe is part of the reader's poll set.
+read_quit: if (builtin.os.tag == .windows) ReadThread.Quit else void =
+    if (builtin.os.tag == .windows) .{} else {},
+
 /// Initialize the exec state. This will NOT start it, this only sets
 /// up the internal state necessary to start it later.
 pub fn init(
@@ -187,11 +194,19 @@ pub fn threadEnter(
     io.write_limit.reset();
 
     // Start our read thread
-    const read_thread = try std.Thread.spawn(
-        .{},
-        if (builtin.os.tag == .windows) ReadThread.threadMainWindows else ReadThread.threadMainPosix,
-        .{ pty_fds.read, io, pipe[0] },
-    );
+    if (comptime builtin.os.tag == .windows) self.read_quit = .{};
+    const read_thread = if (comptime builtin.os.tag == .windows)
+        try std.Thread.spawn(
+            .{},
+            ReadThread.threadMainWindows,
+            .{ pty_fds.read, io, pipe[0], &self.read_quit },
+        )
+    else
+        try std.Thread.spawn(
+            .{},
+            ReadThread.threadMainPosix,
+            .{ pty_fds.read, io, pipe[0] },
+        );
     read_thread.setName(global.io(), "io-reader") catch {};
 
     // Setup our threadata backend state to be our own
@@ -287,13 +302,24 @@ pub fn threadExit(self: *Exec, td: *termio.Termio.ThreadData) void {
     }
 
     if (comptime builtin.os.tag == .windows) {
-        // Interrupt the blocking read so the thread can see the quit message
-        if (windows.exp.kernel32.CancelIoEx(exec.read_thread_fd, null) == windows.FALSE) {
-            switch (windows.GetLastError()) {
-                .NOT_FOUND => {},
-                else => |err| log.warn("error interrupting read thread err={}", .{err}),
-            }
-        }
+        // Ask the reader to stop, then interrupt its blocking read.
+        //
+        // CancelIoEx only cancels a read that is already pending. If the
+        // reader is inside processOutput when we call it there is nothing
+        // to cancel, and the read it issues next blocks until a writer
+        // goes away, which cannot happen before we return: the
+        // pseudoconsole that owns the write end is closed after this
+        // join. So keep interrupting until the reader acknowledges.
+        self.read_quit.request();
+
+        const cancel: ReadThread.WindowsCancel = .{
+            .fd = exec.read_thread_fd,
+            .quit = &self.read_quit,
+        };
+        if (!ReadThread.cancelUntilAcked(
+            &cancel,
+            ReadThread.cancel_max_attempts,
+        )) log.warn("read thread did not acknowledge the quit request", .{});
     }
 
     exec.read_thread.join();
@@ -2106,9 +2132,205 @@ pub const ReadThread = struct {
         return true;
     }
 
-    fn threadMainWindows(fd: posix.fd_t, io: *termio.Termio, quit: posix.fd_t) void {
+    /// The shutdown handshake between `threadExit` and the Windows
+    /// reader thread. Lives on the Exec (not the thread data) because
+    /// the reader is handed a pointer to it before the thread data
+    /// exists.
+    pub const Quit = struct {
+        /// Set by threadExit to ask the reader to stop.
+        stop: std.atomic.Value(bool) = .init(false),
+
+        /// Set by the reader on its way out, so threadExit knows it no
+        /// longer needs interrupting.
+        done: std.atomic.Value(bool) = .init(false),
+
+        pub fn request(self: *Quit) void {
+            self.stop.store(true, .release);
+        }
+
+        pub fn requested(self: *const Quit) bool {
+            return self.stop.load(.acquire);
+        }
+
+        pub fn ack(self: *Quit) void {
+            self.done.store(true, .release);
+        }
+
+        pub fn acked(self: *const Quit) bool {
+            return self.done.load(.acquire);
+        }
+    };
+
+    /// The outcome of a single read in the Windows reader loop.
+    const WindowsRead = union(enum) {
+        /// Bytes for the terminal.
+        data: []const u8,
+
+        /// The read was interrupted by CancelIoEx, which only
+        /// threadExit calls.
+        aborted,
+
+        /// Every writer closed the pipe.
+        eof,
+
+        /// Unrecoverable read error. Already logged.
+        failed,
+    };
+
+    /// The Windows reader loop. Factored out of `threadMainWindows` so
+    /// the shutdown handshake can be exercised without a real pty;
+    /// `ops` supplies `read`, `process` and `quitRequested`.
+    fn readLoopWindows(ops: anytype) void {
+        while (true) {
+            // A quit request can land while we are in `process`, when
+            // there is no pending read for CancelIoEx to interrupt, so
+            // look for one before every read rather than only after an
+            // interrupted one. Otherwise the read we issue next blocks
+            // until a writer goes away, which cannot happen while
+            // threadExit is waiting on us.
+            if (ops.quitRequested()) {
+                log.info("read thread got quit signal", .{});
+                return;
+            }
+
+            switch (ops.read()) {
+                .data => |d| ops.process(d),
+
+                // Only threadExit interrupts us, so the quit check at
+                // the top of the loop is where this is acted on.
+                .aborted => {},
+
+                .eof, .failed => return,
+            }
+        }
+    }
+
+    /// Interrupt a reader blocked in a read until it acknowledges the
+    /// quit request. Returns false if it never did.
+    fn cancelUntilAcked(ops: anytype, max_attempts: usize) bool {
+        // One interrupt is not enough: CancelIoEx cancels reads that are
+        // already pending, and the reader may be parsing output rather
+        // than reading. Repeat until one of the interrupts lands while it
+        // is blocked, or it finishes on its own.
+        for (0..max_attempts) |_| {
+            if (ops.acked()) return true;
+            ops.cancel();
+            if (ops.acked()) return true;
+            ops.sleep();
+        }
+
+        return ops.acked();
+    }
+
+    /// How long to wait between interrupt attempts, and how many to make
+    /// before giving up and joining anyway. The reader normally
+    /// acknowledges on the first attempt; the budget only matters when it
+    /// is busy parsing a large batch of output.
+    const cancel_interval_ms = 2;
+    const cancel_max_attempts = 500;
+
+    /// The real read surface for `readLoopWindows`.
+    const WindowsReader = struct {
+        fd: posix.fd_t,
+        io: *termio.Termio,
+        quit: *Quit,
+        buf: [windows_read_capacity]u8 = undefined,
+
+        fn read(self: *WindowsReader) WindowsRead {
+            var n: windows.DWORD = 0;
+            if (windows.exp.kernel32.ReadFile(
+                self.fd,
+                &self.buf,
+                self.buf.len,
+                &n,
+                null,
+            ) == windows.FALSE) {
+                const err = windows.GetLastError();
+                switch (err) {
+                    // CancelIoEx was called (threadExit signaling shutdown)
+                    .OPERATION_ABORTED => return .aborted,
+
+                    // All writers closed the write end of the pipe.
+                    // The child has exited and the PTY output pipe is done.
+                    .BROKEN_PIPE => {
+                        log.info("io reader: pipe EOF (BROKEN_PIPE), child exited", .{});
+                        return .eof;
+                    },
+
+                    else => {
+                        // Any other error is unexpected. Log it and stop
+                        // rather than hitting unreachable (which is UB in
+                        // ReleaseFast and a panic in Debug).
+                        log.err("io reader error err={}", .{err});
+                        return .failed;
+                    },
+                }
+            }
+
+            if (n == 0) {
+                // ReadFile succeeded with zero bytes: all writers have closed.
+                log.info("io reader: zero-byte read, pipe EOF", .{});
+                return .eof;
+            }
+
+            return .{ .data = self.buf[0..n] };
+        }
+
+        fn process(self: *WindowsReader, data: []const u8) void {
+            @call(.always_inline, termio.Termio.processOutput, .{ self.io, data });
+
+            // See threadMainPosix: hand the renderer state mutex
+            // off if the renderer is waiting, since this loop
+            // would otherwise starve it under heavy output.
+            self.io.renderer_state.yieldToDemand(global.io());
+        }
+
+        fn quitRequested(self: *const WindowsReader) bool {
+            return self.quit.requested();
+        }
+    };
+
+    /// The real interrupt surface for `cancelUntilAcked`.
+    const WindowsCancel = struct {
+        fd: posix.fd_t,
+        quit: *const Quit,
+
+        fn cancel(self: *const WindowsCancel) void {
+            if (windows.exp.kernel32.CancelIoEx(self.fd, null) == windows.FALSE) {
+                switch (windows.GetLastError()) {
+                    // Nothing was pending, so the reader is either
+                    // between reads or already done.
+                    .NOT_FOUND => {},
+                    else => |err| log.warn("error interrupting read thread err={}", .{err}),
+                }
+            }
+        }
+
+        fn acked(self: *const WindowsCancel) bool {
+            return self.quit.acked();
+        }
+
+        fn sleep(_: *const WindowsCancel) void {
+            std.Io.sleep(
+                global.io(),
+                .fromMilliseconds(cancel_interval_ms),
+                .awake,
+            ) catch {};
+        }
+    };
+
+    fn threadMainWindows(
+        fd: posix.fd_t,
+        io: *termio.Termio,
+        quit: posix.fd_t,
+        quit_state: *Quit,
+    ) void {
         // Always close our end of the pipe when we exit.
         defer internal_os.closePipeEnd(quit);
+
+        // Stop threadExit from interrupting a thread that is on its way
+        // out. This must be the last thing that runs.
+        defer quit_state.ack();
 
         // Setup our crash metadata
         crash.sentry.thread_state = .{
@@ -2117,60 +2339,12 @@ pub const ReadThread = struct {
         };
         defer crash.sentry.thread_state = null;
 
-        var buf: [windows_read_capacity]u8 = undefined;
-        while (true) {
-            while (true) {
-                var n: windows.DWORD = 0;
-                if (windows.exp.kernel32.ReadFile(fd, &buf, buf.len, &n, null) == windows.FALSE) {
-                    const err = windows.GetLastError();
-                    switch (err) {
-                        // CancelIoEx was called (threadExit signaling shutdown)
-                        .OPERATION_ABORTED => break,
-
-                        // All writers closed the write end of the pipe.
-                        // The child has exited and the PTY output pipe is done.
-                        .BROKEN_PIPE => {
-                            log.info("io reader: pipe EOF (BROKEN_PIPE), child exited", .{});
-                            return;
-                        },
-
-                        else => {
-                            // Any other error is unexpected. Log it and return
-                            // rather than hitting unreachable (which is UB in
-                            // ReleaseFast and a panic in Debug).
-                            log.err("io reader error err={}", .{err});
-                            return;
-                        },
-                    }
-                }
-
-                if (n == 0) {
-                    // ReadFile succeeded with zero bytes: all writers have closed.
-                    log.info("io reader: zero-byte read, pipe EOF", .{});
-                    return;
-                }
-
-                @call(.always_inline, termio.Termio.processOutput, .{ io, buf[0..n] });
-
-                // See threadMainPosix: hand the renderer state mutex
-                // off if the renderer is waiting, since this loop
-                // would otherwise starve it under heavy output.
-                io.renderer_state.yieldToDemand(global.io());
-            }
-
-            var quit_bytes: windows.DWORD = 0;
-            if (windows.exp.kernel32.PeekNamedPipe(quit, null, 0, null, &quit_bytes, null) == windows.FALSE) {
-                const err = windows.GetLastError();
-                log.err("quit pipe reader error err={}", .{err});
-                // Return rather than crash; the loop will clean up via defer.
-                return;
-            }
-
-            if (quit_bytes > 0) {
-                log.info("read thread got quit signal", .{});
-                return;
-            }
-        }
+        var reader: WindowsReader = .{
+            .fd = fd,
+            .io = io,
+            .quit = quit_state,
+        };
+        readLoopWindows(&reader);
     }
 };
 
@@ -4580,4 +4754,115 @@ test "terminfoDir has nothing to derive from a bare resources dir" {
     var buf: [std.fs.max_path_bytes]u8 = undefined;
     try testing.expect(terminfoDir(&buf, null) == null);
     try testing.expect(terminfoDir(&buf, "ghostty") == null);
+}
+
+test "ReadThread windows: a quit request during output processing stops the loop" {
+    const testing = std.testing;
+
+    // Models the shutdown race. The reader is inside processOutput when
+    // threadExit asks it to quit, so CancelIoEx finds no pending read to
+    // cancel and the reader is never interrupted. Its next read then has
+    // nothing to return and nothing to break it: the pty write end stays
+    // open until the pseudoconsole is closed, which only happens after
+    // the join this loop is holding up.
+    const Ops = struct {
+        quit: bool = false,
+        reads: usize = 0,
+        processed: usize = 0,
+        blocked: bool = false,
+
+        fn read(self: *@This()) ReadThread.WindowsRead {
+            self.reads += 1;
+            if (self.reads == 1) return .{ .data = "hello" };
+
+            // A read issued after the quit request would block forever.
+            // Record it and unwind so the test can report instead of hang.
+            self.blocked = true;
+            return .failed;
+        }
+
+        fn process(self: *@This(), data: []const u8) void {
+            self.processed += data.len;
+            self.quit = true;
+        }
+
+        fn quitRequested(self: *const @This()) bool {
+            return self.quit;
+        }
+    };
+
+    var ops: Ops = .{};
+    ReadThread.readLoopWindows(&ops);
+
+    try testing.expect(!ops.blocked);
+    try testing.expectEqual(@as(usize, 5), ops.processed);
+    try testing.expectEqual(@as(usize, 1), ops.reads);
+}
+
+test "ReadThread windows: an interrupted read without a quit request keeps reading" {
+    const testing = std.testing;
+
+    // CancelIoEx is only called on shutdown, but a spurious abort must
+    // not silently drop the rest of the child's output.
+    const Ops = struct {
+        reads: usize = 0,
+        processed: usize = 0,
+
+        fn read(self: *@This()) ReadThread.WindowsRead {
+            self.reads += 1;
+            return switch (self.reads) {
+                1 => .aborted,
+                2 => .{ .data = "hi" },
+                else => .eof,
+            };
+        }
+
+        fn process(self: *@This(), data: []const u8) void {
+            self.processed += data.len;
+        }
+
+        fn quitRequested(_: *const @This()) bool {
+            return false;
+        }
+    };
+
+    var ops: Ops = .{};
+    ReadThread.readLoopWindows(&ops);
+
+    try testing.expectEqual(@as(usize, 3), ops.reads);
+    try testing.expectEqual(@as(usize, 2), ops.processed);
+}
+
+test "ReadThread windows: the reader is interrupted until it acknowledges" {
+    const testing = std.testing;
+
+    // The reader only acknowledges once one of the interrupts lands while
+    // it is actually blocked in a read, so a single CancelIoEx is not
+    // enough.
+    const Ops = struct {
+        cancels: usize = 0,
+        sleeps: usize = 0,
+        ack_after: usize,
+
+        fn cancel(self: *@This()) void {
+            self.cancels += 1;
+        }
+
+        fn acked(self: *const @This()) bool {
+            return self.cancels >= self.ack_after;
+        }
+
+        fn sleep(self: *@This()) void {
+            self.sleeps += 1;
+        }
+    };
+
+    var ops: Ops = .{ .ack_after = 3 };
+    try testing.expect(ReadThread.cancelUntilAcked(&ops, 500));
+    try testing.expectEqual(@as(usize, 3), ops.cancels);
+
+    // A reader that never acknowledges must not spin forever.
+    var stuck: Ops = .{ .ack_after = std.math.maxInt(usize) };
+    try testing.expect(!ReadThread.cancelUntilAcked(&stuck, 4));
+    try testing.expectEqual(@as(usize, 4), stuck.cancels);
 }

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -4861,3 +4861,99 @@ test "ReadThread windows: the reader is interrupted until it acknowledges" {
     try testing.expect(!ReadThread.cancelUntilAcked(&stuck, 4));
     try testing.expectEqual(@as(usize, 4), stuck.cancels);
 }
+
+test "ReadThread windows: a blocked real read is interrupted and decoded" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+
+    // The loops above run on fakes; this runs the two syscall wrappers
+    // they stand in for. An anonymous pipe with an idle writer parks a
+    // reader in ReadFile the same way an idle pty does, so the only way
+    // out is an interrupt from the thread calling threadExit.
+    var read_end: windows.HANDLE = undefined;
+    var write_end: windows.HANDLE = undefined;
+    if (windows.exp.kernel32.CreatePipe(
+        &read_end,
+        &write_end,
+        null,
+        0,
+    ) == windows.FALSE) return error.CreatePipeFailed;
+    defer windows.CloseHandle(read_end);
+    var write_open = true;
+    defer if (write_open) windows.CloseHandle(write_end);
+
+    var quit: ReadThread.Quit = .{};
+
+    // Wraps the real reader so the test can see which outcome each read
+    // decoded, and when the thread is parked in one.
+    const Ops = struct {
+        inner: ReadThread.WindowsReader,
+        in_read: std.atomic.Value(bool) = .init(false),
+        aborts: usize = 0,
+
+        fn threadMain(self: *@This()) void {
+            defer self.inner.quit.ack();
+            ReadThread.readLoopWindows(self);
+        }
+
+        fn read(self: *@This()) ReadThread.WindowsRead {
+            self.in_read.store(true, .release);
+            const result = self.inner.read();
+            switch (result) {
+                .aborted => self.aborts += 1,
+                else => {},
+            }
+            return result;
+        }
+
+        fn process(_: *@This(), _: []const u8) void {
+            // Nobody writes to the pipe, so no read returns data and the
+            // reader's terminal pointer is never followed.
+            unreachable;
+        }
+
+        fn quitRequested(self: *const @This()) bool {
+            return self.inner.quitRequested();
+        }
+    };
+
+    var ops: Ops = .{ .inner = .{
+        .fd = read_end,
+        .io = undefined,
+        .quit = &quit,
+    } };
+
+    var cancel: ReadThread.WindowsCancel = .{
+        .fd = read_end,
+        .quit = &quit,
+    };
+
+    // No read has been issued yet, so this is the NOT_FOUND path. It has
+    // to be swallowed, and must not be mistaken for an acknowledgement.
+    cancel.cancel();
+    try testing.expect(!cancel.acked());
+
+    const thread = try std.Thread.spawn(.{}, Ops.threadMain, .{&ops});
+    while (!ops.in_read.load(.acquire)) std.Thread.yield() catch {};
+
+    quit.request();
+    const acked = ReadThread.cancelUntilAcked(
+        &cancel,
+        ReadThread.cancel_max_attempts,
+    );
+
+    // A failing assertion must not hang the suite in join(), so if the
+    // interrupt never landed give the reader the EOF it would otherwise
+    // wait for forever.
+    if (!acked) {
+        windows.CloseHandle(write_end);
+        write_open = false;
+    }
+    thread.join();
+    try testing.expect(acked);
+
+    // The read that was parked came back as OPERATION_ABORTED rather
+    // than an error or a spurious EOF, and the loop then saw the quit.
+    try testing.expect(ops.aborts >= 1);
+}

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -171,7 +171,11 @@ pub fn threadEnter(
     // Create our pipe that we'll use to kill our read thread.
     // pipe[0] is the read end, pipe[1] is the write end.
     const pipe = try internal_os.pipe();
-    errdefer internal_os.closePipeEnd(pipe[0]);
+
+    // The read end goes to the read thread, which closes it itself, so we
+    // only clean it up while we are still the ones holding it.
+    var own_read_end = true;
+    errdefer if (own_read_end) internal_os.closePipeEnd(pipe[0]);
     errdefer internal_os.closePipeEnd(pipe[1]);
 
     // Setup our stream so that we can write.
@@ -208,6 +212,16 @@ pub fn threadEnter(
             .{ pty_fds.read, io, pipe[0] },
         );
     read_thread.setName(global.io(), "io-reader") catch {};
+    own_read_end = false;
+
+    // From here on the reader holds &self.read_quit and the Termio, so a
+    // later failure has to bring it down before either goes away. This
+    // wakes the reader the same way threadExit does, so it cannot block
+    // on a read that nothing will interrupt.
+    errdefer {
+        self.stopReadThread(pipe[1], pty_fds.read);
+        read_thread.join();
+    }
 
     // Setup our threadata backend state to be our own
     td.backend = .{ .exec = .{
@@ -277,22 +291,20 @@ pub fn threadEnter(
     }
 }
 
-pub fn threadExit(self: *Exec, td: *termio.Termio.ThreadData) void {
-    assert(td.backend == .exec);
-    const exec = &td.backend.exec;
-
-    if (exec.exited) self.subprocess.externalExit();
-    self.subprocess.stop();
-
-    // Quit our read thread after exiting the subprocess so that
-    // we don't get stuck waiting for data to stop flowing if it is
-    // a particularly noisy process.
-    //
+/// Ask the read thread to stop and wake it up so it can notice.
+///
+/// Both threadExit and the error path in threadEnter have to do this
+/// before they join, so it lives in one place: a reader left running
+/// holds a pointer into this Exec and into the Termio that owns it.
+///
+/// This never waits for the reader to exit, only for it to be wakeable.
+/// The caller joins.
+fn stopReadThread(self: *Exec, quit_pipe: posix.fd_t, read_fd: posix.fd_t) void {
     // Windows cannot poll the pty handle and this pipe together, so the
     // reader there watches the quit flag below instead and never reads
     // the pipe. A write would wake nobody.
     if (comptime builtin.os.tag != .windows) {
-        switch (internal_os.writePipeEnd(exec.read_thread_pipe, "x")) {
+        switch (internal_os.writePipeEnd(quit_pipe, "x")) {
             .ok => {},
 
             // A broken pipe means our read thread is closed already,
@@ -313,13 +325,13 @@ pub fn threadExit(self: *Exec, td: *termio.Termio.ThreadData) void {
         // CancelIoEx only cancels a read that is already pending. If the
         // reader is inside processOutput when we call it there is nothing
         // to cancel, and the read it issues next blocks until a writer
-        // goes away, which cannot happen before we return: the
-        // pseudoconsole that owns the write end is closed after this
-        // join. So keep interrupting until the reader acknowledges.
+        // goes away, which cannot happen before the caller's join: the
+        // pseudoconsole that owns the write end is closed after it. So
+        // keep interrupting until the reader acknowledges.
         self.read_quit.request();
 
         var cancel: ReadThread.WindowsCancel = .{
-            .fd = exec.read_thread_fd,
+            .fd = read_fd,
             .quit = &self.read_quit,
         };
         if (!ReadThread.cancelUntilAcked(
@@ -327,6 +339,19 @@ pub fn threadExit(self: *Exec, td: *termio.Termio.ThreadData) void {
             ReadThread.cancel_max_attempts,
         )) log.warn("read thread did not acknowledge the quit request", .{});
     }
+}
+
+pub fn threadExit(self: *Exec, td: *termio.Termio.ThreadData) void {
+    assert(td.backend == .exec);
+    const exec = &td.backend.exec;
+
+    if (exec.exited) self.subprocess.externalExit();
+    self.subprocess.stop();
+
+    // Quit our read thread after exiting the subprocess so that
+    // we don't get stuck waiting for data to stop flowing if it is
+    // a particularly noisy process.
+    self.stopReadThread(exec.read_thread_pipe, exec.read_thread_fd);
 
     exec.read_thread.join();
 

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -3091,8 +3091,8 @@ fn appendSuffix(
 /// correctly: tokens like `C:\Program Files` are re-wrapped in quotes
 /// when joined back. cmd.exe re-tokenizes the script itself, so those
 /// quotes have to reach it exactly as written here; that is why
-/// `windowsCreateCommandLine` in Command.zig hands the script to
-/// `cmd /S /C` inside a single quote pair instead of escaping it again.
+/// `windowsCreateCommandLine` in Command.zig writes the script verbatim
+/// inside a single quote pair instead of escaping it again.
 ///
 /// When `flag_idx+1 == args.len` (flag is the last arg, so there is
 /// nothing to wrap) we leave argv alone rather than fabricate a bare

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -287,18 +287,24 @@ pub fn threadExit(self: *Exec, td: *termio.Termio.ThreadData) void {
     // Quit our read thread after exiting the subprocess so that
     // we don't get stuck waiting for data to stop flowing if it is
     // a particularly noisy process.
-    switch (internal_os.writePipeEnd(exec.read_thread_pipe, "x")) {
-        .ok => {},
+    //
+    // Windows cannot poll the pty handle and this pipe together, so the
+    // reader there watches the quit flag below instead and never reads
+    // the pipe. A write would wake nobody.
+    if (comptime builtin.os.tag != .windows) {
+        switch (internal_os.writePipeEnd(exec.read_thread_pipe, "x")) {
+            .ok => {},
 
-        // A broken pipe means our read thread is closed already, which
-        // is completely fine since that is what we were trying to
-        // achieve.
-        .broken_pipe => {},
+            // A broken pipe means our read thread is closed already,
+            // which is completely fine since that is what we were
+            // trying to achieve.
+            .broken_pipe => {},
 
-        .failed => log.warn(
-            "error writing to read thread quit pipe",
-            .{},
-        ),
+            .failed => log.warn(
+                "error writing to read thread quit pipe",
+                .{},
+            ),
+        }
     }
 
     if (comptime builtin.os.tag == .windows) {
@@ -312,7 +318,7 @@ pub fn threadExit(self: *Exec, td: *termio.Termio.ThreadData) void {
         // join. So keep interrupting until the reader acknowledges.
         self.read_quit.request();
 
-        const cancel: ReadThread.WindowsCancel = .{
+        var cancel: ReadThread.WindowsCancel = .{
             .fd = exec.read_thread_fd,
             .quit = &self.read_quit,
         };
@@ -2212,20 +2218,30 @@ pub const ReadThread = struct {
         // already pending, and the reader may be parsing output rather
         // than reading. Repeat until one of the interrupts lands while it
         // is blocked, or it finishes on its own.
-        for (0..max_attempts) |_| {
+        for (0..max_attempts) |attempt| {
             if (ops.acked()) return true;
             ops.cancel();
             if (ops.acked()) return true;
-            ops.sleep();
+            ops.wait(attempt);
         }
 
         return ops.acked();
     }
 
-    /// How long to wait between interrupt attempts, and how many to make
-    /// before giving up and joining anyway. The reader normally
-    /// acknowledges on the first attempt; the budget only matters when it
-    /// is busy parsing a large batch of output.
+    /// How many interrupt attempts spin before we start sleeping between
+    /// them. The reader normally acknowledges on the first attempt, and
+    /// the case that needs a second one is a batch of output it is a few
+    /// microseconds from finishing, so the first attempts hand the core
+    /// over rather than paying a scheduler round trip.
+    const cancel_yield_attempts = 8;
+
+    /// How long to wait between the remaining interrupt attempts, and how
+    /// many to make before giving up and joining anyway. The interval is
+    /// a floor, not a period: without a raised timer resolution the
+    /// scheduler rounds it up to a tick, so a full budget is on the order
+    /// of seconds rather than the millisecond product. That only ever
+    /// costs anything if the reader is stuck somewhere that is not the
+    /// read, and the join that follows would then hang outright.
     const cancel_interval_ms = 2;
     const cancel_max_attempts = 500;
 
@@ -2295,13 +2311,22 @@ pub const ReadThread = struct {
         fd: posix.fd_t,
         quit: *const Quit,
 
-        fn cancel(self: *const WindowsCancel) void {
+        /// A failure that is not NOT_FOUND will repeat on every attempt,
+        /// so report it once instead of hundreds of times.
+        reported: bool = false,
+
+        fn cancel(self: *WindowsCancel) void {
             if (windows.exp.kernel32.CancelIoEx(self.fd, null) == windows.FALSE) {
                 switch (windows.GetLastError()) {
                     // Nothing was pending, so the reader is either
                     // between reads or already done.
                     .NOT_FOUND => {},
-                    else => |err| log.warn("error interrupting read thread err={}", .{err}),
+                    else => |err| {
+                        if (!self.reported) {
+                            self.reported = true;
+                            log.warn("error interrupting read thread err={}", .{err});
+                        }
+                    },
                 }
             }
         }
@@ -2310,7 +2335,12 @@ pub const ReadThread = struct {
             return self.quit.acked();
         }
 
-        fn sleep(_: *const WindowsCancel) void {
+        fn wait(_: *WindowsCancel, attempt: usize) void {
+            if (attempt < cancel_yield_attempts) {
+                std.Thread.yield() catch {};
+                return;
+            }
+
             std.Io.sleep(
                 global.io(),
                 .fromMilliseconds(cancel_interval_ms),
@@ -2329,7 +2359,9 @@ pub const ReadThread = struct {
         defer internal_os.closePipeEnd(quit);
 
         // Stop threadExit from interrupting a thread that is on its way
-        // out. This must be the last thing that runs.
+        // out. Registered as a defer so it runs on every return path,
+        // including the error ones, and never leaves threadExit spending
+        // its whole budget on a reader that has already stopped.
         defer quit_state.ack();
 
         // Setup our crash metadata
@@ -3247,7 +3279,7 @@ fn buildWrappedScript(
 }
 
 /// Serialize `arg` into `writer` using the MS C runtime quoting rules
-/// (CommandLineToArgvW inverse). Matches `windowsCreateCommandLine` in
+/// (CommandLineToArgvW inverse). Matches `windowsQuoteArg` in
 /// Command.zig byte-for-byte; we duplicate here rather than cross-
 /// module to avoid leaking an internal helper, and the per-arg surface
 /// area is small enough that drift is easy to audit.
@@ -4836,7 +4868,7 @@ test "ReadThread windows: the reader is interrupted until it acknowledges" {
     // enough.
     const Ops = struct {
         cancels: usize = 0,
-        sleeps: usize = 0,
+        waits: usize = 0,
         ack_after: usize,
 
         fn cancel(self: *@This()) void {
@@ -4847,8 +4879,8 @@ test "ReadThread windows: the reader is interrupted until it acknowledges" {
             return self.cancels >= self.ack_after;
         }
 
-        fn sleep(self: *@This()) void {
-            self.sleeps += 1;
+        fn wait(self: *@This(), _: usize) void {
+            self.waits += 1;
         }
     };
 

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -3087,17 +3087,12 @@ fn appendSuffix(
 /// only to the quoted (`true`) path.
 ///
 /// Quoted path: the tail is re-serialized with MS-C-runtime quoting
-/// rules (matching `windowsCreateCommandLine` in Command.zig) so args
-/// that originally contained spaces or quotes round-trip correctly:
-/// tokens like `C:\Program Files` are re-wrapped in quotes when joined
-/// back. The resulting command line survives cmd's two-rule `/C`
-/// interaction documented in `cmd /?`: when our wrapped arg contains
-/// any embedded quotes (because we re-quoted a path with spaces),
-/// `lpCommandLine` has inner `"` characters and cmd falls into rule 1
-/// ("preserve quoting as seen"). When it contains none, the outermost
-/// quoting `windowsCreateCommandLine` adds is trivially symmetric and
-/// rule 2 ("strip outer quotes") is safe to apply. Either way cmd sees
-/// the same tokens the user originally wrote.
+/// rules so args that originally contained spaces or quotes round-trip
+/// correctly: tokens like `C:\Program Files` are re-wrapped in quotes
+/// when joined back. cmd.exe re-tokenizes the script itself, so those
+/// quotes have to reach it exactly as written here; that is why
+/// `windowsCreateCommandLine` in Command.zig hands the script to
+/// `cmd /S /C` inside a single quote pair instead of escaping it again.
 ///
 /// When `flag_idx+1 == args.len` (flag is the last arg, so there is
 /// nothing to wrap) we leave argv alone rather than fabricate a bare

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -2263,10 +2263,12 @@ pub const ReadThread = struct {
     /// How long to wait between the remaining interrupt attempts, and how
     /// many to make before giving up and joining anyway. The interval is
     /// a floor, not a period: without a raised timer resolution the
-    /// scheduler rounds it up to a tick, so a full budget is on the order
-    /// of seconds rather than the millisecond product. That only ever
-    /// costs anything if the reader is stuck somewhere that is not the
-    /// read, and the join that follows would then hang outright.
+    /// scheduler rounds a 2 ms sleep up to a ~15.6 ms tick, so spending
+    /// the whole budget blocks the IO thread for something like eight
+    /// seconds, not one. The budget is diagnostic rather than a recovery
+    /// mechanism: it exists to get the warning into the log, because the
+    /// join that follows hangs outright in the only case that reaches
+    /// the end of it.
     const cancel_interval_ms = 2;
     const cancel_max_attempts = 500;
 

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -3144,10 +3144,11 @@ fn appendSuffix(
 /// only to the quoted (`true`) path.
 ///
 /// Quoted path: the tail is re-serialized with MS-C-runtime quoting
-/// rules so args that originally contained spaces or quotes round-trip
-/// correctly: tokens like `C:\Program Files` are re-wrapped in quotes
-/// when joined back. cmd.exe re-tokenizes the script itself, so those
-/// quotes have to reach it exactly as written here; that is why
+/// rules, so a token that contains whitespace is re-wrapped in quotes
+/// when joined back and `C:\Program Files` survives the round trip. A
+/// token containing a literal double quote does not: see the limits on
+/// `writeQuotedArg`. Whatever we write, cmd.exe re-tokenizes the script
+/// itself, so it has to reach cmd byte for byte; that is why
 /// `windowsCreateCommandLine` in Command.zig writes the script verbatim
 /// inside a single quote pair instead of escaping it again.
 ///
@@ -3310,11 +3311,18 @@ fn buildWrappedScript(
 /// area is small enough that drift is easy to audit.
 ///
 /// Note cmd.exe uses its OWN parser for `/C` tokenization (special
-/// chars `& | < > ^ ( )`, not CRT-style backslash escaping). The round
-/// trip works here because each individual arg survives both parsers
-/// identically: our quoted output has no unescaped cmd metacharacters,
-/// and cmd's rules don't consume backslashes. Do not extend this to
-/// emit cmd-specific escape sequences without adding tests.
+/// chars `& | < > ^ ( )`, not CRT-style backslash escaping), so only
+/// part of this survives a trip through cmd. A whitespace-bearing token
+/// does: the quotes we add are the ones cmd wants, our output has no
+/// unescaped cmd metacharacters, and cmd does not consume backslashes.
+/// A token containing a literal double quote does NOT: we escape it as
+/// `\"`, cmd has no backslash escape and toggles quoting on the quote
+/// itself, so the token is mangled and the quote state is inverted for
+/// everything after it, which can flip whether a later `&` or `|`
+/// separates commands. Fixing that means a second serializer using
+/// cmd's own rules (a doubled `""`) for the cmd path only. Do not
+/// extend this to emit cmd-specific escape sequences without adding
+/// tests.
 fn writeQuotedArg(writer: *std.Io.Writer, arg: []const u8) !void {
     if (std.mem.indexOfAny(u8, arg, " \t\n\"") == null) {
         try writer.writeAll(arg);
@@ -4295,7 +4303,9 @@ test "writeQuotedArg: MS C runtime quoting edge cases" {
         .{ .in = "C:\\Program Files", .out = "\"C:\\Program Files\"" },
         // Embedded tab/newline: still quotes.
         .{ .in = "a\tb", .out = "\"a\tb\"" },
-        // Embedded quote: escape as \", no outer backslash needed.
+        // Embedded quote: escape as \", no outer backslash needed. This
+        // is correct for CommandLineToArgvW and wrong for cmd.exe, which
+        // has no backslash escape; see the limits on writeQuotedArg.
         .{ .in = "a\"b", .out = "\"a\\\"b\"" },
         // Trailing backslash in a quoted arg: double the backslash run
         // so the closing quote isn't escaped.


### PR DESCRIPTION
Three Windows spawn and shutdown fixes found by the audit, plus the tests that grip them.

## What changed

**The Windows reader shutdown no longer hangs.** `stopReadThread` used to rely on a
quit pipe the Windows reader never read. The loop now checks `quitRequested()` at the
top of every iteration and the interrupt is retried until the reader actually stops.

**A pseudoconsole child no longer gets std handles forced onto it.** A ConPTY child
takes its standard handles from the console it is attached to. `STARTF_USESTDHANDLES`
was overriding those with the three NULL handles that path carries, and
`bInheritHandles = TRUE` was only a way to leak whatever inheritable handles this
process happened to hold. `windowsStdioMode` now picks per path.

**A `cmd.exe` script reaches cmd as the user wrote it.** cmd parses the tail of a
`/C` with its own rules and has no `\"` escape, so C runtime quoting arrived as
literal backslashes and truncated the command at the last escaped quote. The script
of a recognized `cmd.exe /C <script>` is now written verbatim inside one quote pair.

**`threadEnter` joins the read thread when it fails after spawning it.**

## Where the tests run

Everything here is in `src/Command.zig` and `src/termio/Exec.zig`, both of which are
in the main test binary. `zig build test -Dapp-runtime=none` is the gate, and it is a
real one for this PR.

## Round-2 review fix

Two of the four `cmd.exe` quoting tests passed with the verbatim-script path fully
reverted: their scripts carry no quotes of their own, so the C runtime quoter emits
byte-identical output for those inputs. They read as coverage and were not. Each now
carries a second case whose script has quotes — the only input the two rules disagree
on — and the comments say which half pins the shape and which half discriminates.

Proof, on `zig build test -Dapp-runtime=none -Dtest-filter=windowsCreateCommandLine`
with `windowsCmdScriptSwitch` neutered to always return null (production site only,
tests untouched): 84/84 pass before, and after the revert all four fail by name,
including the two that used to survive it.

```
error: 'Command.test.windowsCreateCommandLine: a cmd.exe script keeps its own quoting' failed
error: 'Command.test.windowsCreateCommandLine: a cmd.exe script without quotes gets one pair' failed
error: 'Command.test.windowsCreateCommandLine: a bare quoted program path stays quoted' failed
error: 'Command.test.windowsCreateCommandLine: a caller supplied /S still gets the verbatim script' failed
```

## Known and not fixed here

**`writeQuotedArg` in `Exec.zig` still escapes a literal `"` as `\"`.**
`buildWrappedScript` composes the script with C runtime rules, and
`windowsCreateCommandLine` then writes that script verbatim — so for a token
containing a literal double quote the `\"` reaches cmd, which has no backslash
escape, and the quote state is inverted for everything after it. That can change
whether a later `&` or `|` separates commands. The outer path was made byte-exact
precisely so the script reaches cmd unmangled; the inner path mangles it first.
Fixing it needs a second serializer using cmd's own doubled-`""` rules, with its own
tests, and it belongs in its own PR. The trigger is narrow (a token needs a literal
double quote) and it crosses no privilege boundary: the script is wholly
user-supplied, and no untrusted input reaches `lpCommandLine` — OSC 7's cwd goes to
`lpCurrentDirectory`.

**The quit pipe is now dead weight on Windows.** `threadEnter` still creates it on
every platform and `threadMainWindows` only closes it. Both ends are released, so it
is not a leak, but the shutdown path reads as if the pipe were still the quit channel.

**The interrupt budget costs about eight seconds before a hang it does not prevent.**
`cancel_max_attempts = 500` at `cancel_interval_ms = 2` spends roughly 7.7 s on the
IO thread before logging and falling through to a `join()` that hangs anyway. The
realistic way to reach the end of that budget is a reader wedged on
`renderer_state.mutex` — the open lost-wake P1. There this converts an immediate hang
into a hang preceded by an eight-second stall. Not a regression in outcome, but do
not diagnose that stall as a new fault.

**Shutdown drops slightly more trailing output.** Checking `quitRequested()` at the
top of the loop means one read the old loop would have issued is not issued. That is
the trade that removes the hang, and it is bounded by one read.
