### PR TITLE
lanes: apply and verify the lane config from the repo, and lane the nightly's test legs

### DIFF
--- a/.agents/scripts/README.md
+++ b/.agents/scripts/README.md
@@ -130,7 +130,11 @@ human) working in this repo uses the same contract:
 - `nightly_fuzz.ps1` / `nightly_control.ps1` / `register_nightly_fuzz.ps1` -
   the 23:00 nightly run (tests + fuzz in a dedicated worktree, deduped P1
   issues on breaks, optional hibernate-after) and its control panel.
-  Register once per build machine from the main checkout.
+  Register once per build machine from the main checkout. The test legs
+  run under the `wintty-build` lane like any other caller of `just test`
+  and `just test-win`, so a missing incoda aborts the run instead of
+  landing a nightly build on top of a session's; a lane that never came
+  free files an infra issue, not a red test suite.
 
 Enforcement wiring is host-specific and lives with each host. For Claude
 Code, `.claude/settings.json` hooks call `pr_gate.py --hook` and

--- a/.agents/scripts/README.md
+++ b/.agents/scripts/README.md
@@ -84,9 +84,17 @@ human) working in this repo uses the same contract:
   decisions and exact commands while mutating nothing.
 - `just doctor` - verify everything the gates depend on: required tools on
   PATH, scripts where the hook wiring points, settings parseable, nightly
-  task registration. A Claude Code SessionStart hook runs the fast subset
-  at the start of every session, so a broken gate environment is loud
-  instead of silently absent.
+  task registration, and, where incoda is present, that the heavy job lanes
+  are configured the way `lanes.ps1` records. A Claude Code SessionStart
+  hook runs the fast subset at the start of every session, so a broken gate
+  environment is loud instead of silently absent.
+- `just lanes` - apply the heavy job lanes' configuration (`lanes.ps1`):
+  `wintty-build` with three slots, `wintty-desktop` and `wintty-publish`
+  with one, all three refusing a run without `--reason`, and the retired
+  `wintty` key closed with a message naming its replacements. incoda keeps
+  that state in its own directory where nothing in the repo could see it,
+  so the script is the record: apply touches only a lane that drifted, and
+  `-Check` (what `just doctor` runs) reports each drift and changes nothing.
 - `just gates-selftest` - prove the gates still catch what they exist for
   (recorded-PR replays, matcher escapes, exemption anchoring, the merge
   guard's refusal matrix and golden issue body) and that the nightly

--- a/.agents/scripts/README.md
+++ b/.agents/scripts/README.md
@@ -134,7 +134,17 @@ human) working in this repo uses the same contract:
   run under the `wintty-build` lane like any other caller of `just test`
   and `just test-win`, so a missing incoda aborts the run instead of
   landing a nightly build on top of a session's; a lane that never came
-  free files an infra issue, not a red test suite.
+  free files an infra issue, not a red test suite, and so does every other
+  way incoda can end a run without one (refused, unstartable, killed). The
+  legs wait two hours for the lane rather than incoda's default thirty
+  minutes, because a busy evening queues deeper than that and a timeout
+  would file an infra issue against a machine working as designed.
+- `lanes.ps1` - the heavy job lanes' configuration (AGENTS.md), applied by
+  `just lanes` and checked by `just doctor`. incoda keeps queue config in
+  its own state dir where the repo cannot see it, so this table is the
+  record; the descriptions are shared verbatim with `wintty-release`. Its
+  `-SelfTest` covers the drift rules and the apply argv without touching a
+  machine, and runs in `gates-selftest`.
 
 Enforcement wiring is host-specific and lives with each host. For Claude
 Code, `.claude/settings.json` hooks call `pr_gate.py --hook` and

--- a/.agents/scripts/doctor.py
+++ b/.agents/scripts/doctor.py
@@ -149,7 +149,15 @@ def lane_config(run=subprocess.run, which=shutil.which, environ=os.environ):
         for l in drift:
             problems.append(f"lane config {l} (just lanes)")
         if not drift:
-            problems.append("lane config drifted from .agents/scripts/lanes.ps1 (just lanes)")
+            # lanes.ps1 exits 1 for drift, but so does any unhandled error in
+            # it, and that one prints nothing on stdout: the reason is on
+            # stderr, which nothing here used to read. "lane config drifted"
+            # is then the wrong diagnosis for a machine that was never read
+            # at all, and it sends the reader to `just lanes`, which fails
+            # the same way.
+            said = " ".join((out.stderr or "").split()) or " ".join(lines)
+            problems.append("lane config drifted from .agents/scripts/lanes.ps1 (just lanes)"
+                            + (f"; lanes.ps1 said: {said}" if said else ""))
     else:
         problems.append("lane config could not be checked: " + (" ".join(lines) or f"lanes.ps1 exited {out.returncode}"))
     return problems, notes
@@ -190,24 +198,29 @@ def session_main():
     sys.exit(0)
 
 
-def full_main():
-    problems, notes = check()
+# The dependencies are injectable so the self-test can drive the whole
+# report: the roll-up below is a line of its own, and without it doctor
+# prints FAIL for a lane problem and still exits 0, which is a green gate
+# over a red machine.
+def full_main(checker=check, lanes=lane_config, debt_source=deferred_debt,
+              nightly=nightly_task_registered):
+    problems, notes = checker()
     for p in problems:
         print(f"FAIL {p}")
     for n in notes:
         print(f"warn {n}")
     try:
-        debt = deferred_debt()
+        debt = debt_source()
     except Exception:
         debt = []
     for e in debt:
         print(f"warn deferred signoff outstanding: {e.get('sha', '?')[:10]}  {e.get('reason', '')}")
-    reg = nightly_task_registered()
+    reg = nightly()
     if reg is True:
         print("ok   nightly task registered")
     elif reg is False:
         print("warn nightly task not registered on this machine (pwsh .agents/scripts/register_nightly_fuzz.ps1 from the main checkout)")
-    lane_problems, lane_notes = lane_config()
+    lane_problems, lane_notes = lanes()
     for n in lane_notes:
         print(f"{'warn' if ('missing' in n or 'not checked' in n) else 'ok  '} {n}")
     for p in lane_problems:
@@ -261,11 +274,11 @@ def self_test():
     # The lane check, with lanes.ps1 and incoda stood in for: what the
     # doctor makes of each exit code is the contract, since a drift that
     # lands as a note instead of a problem keeps `just doctor` green.
-    def fake_run(rc, stdout):
+    def fake_run(rc, stdout, stderr=""):
         def run(argv, **kw):
             if argv[1:] == ["version"]:
                 return subprocess.CompletedProcess(argv, 0, stdout="incoda vX.Y.Z\ncommit: none\n", stderr="")
-            return subprocess.CompletedProcess(argv, rc, stdout=stdout, stderr="")
+            return subprocess.CompletedProcess(argv, rc, stdout=stdout, stderr=stderr)
         return run
 
     problems, notes = lane_config(run=fake_run(0, "ok   lanes match\n"), which=all_present)
@@ -281,9 +294,40 @@ def self_test():
     report(len(problems) == 1 and "could not be checked" in problems[0],
            "an unreadable machine is a problem, not a pass")
 
+    # lanes.ps1 exits 1 for drift AND for any unhandled error in itself, and
+    # the second kind prints nothing on stdout. Reported as bare drift it
+    # sends the reader to `just lanes`, which dies the same way; the reason
+    # was on stderr the whole time.
+    problems, _ = lane_config(run=fake_run(1, "", "lanes.ps1: Index operation failed; the array index evaluated to null.\n"),
+                              which=all_present)
+    report(len(problems) == 1 and "array index evaluated to null" in problems[0],
+           "exit 1 with no drift lines carries lanes.ps1's stderr, not a bare 'drifted'")
+
     no_incoda = lambda name: None if name == "incoda" else "/usr/bin/" + name
     problems, notes = lane_config(run=fake_run(0, ""), which=no_incoda, environ={})
     report(not problems and any("incoda" in n for n in notes), "missing incoda is a note, not a problem")
+
+    # The whole report, not just check(): the lane problems are collected in
+    # their own list and rolled into the exit status by one line, and
+    # dropping that line leaves doctor printing FAIL and exiting 0 - a gate
+    # that is green over a machine it just called broken.
+    import contextlib
+    import io
+
+    def run_full(lane_result):
+        buf = io.StringIO()
+        try:
+            with contextlib.redirect_stdout(buf):
+                full_main(checker=lambda: ([], []), lanes=lambda: lane_result,
+                          debt_source=lambda: [], nightly=lambda: None)
+        except SystemExit as e:
+            return e.code, buf.getvalue()
+        return None, buf.getvalue()
+
+    code, out = run_full((["lane config drift wintty: not closed (just lanes)"], []))
+    report(code == 1 and "FAIL" in out, "a lane problem alone makes `just doctor` exit nonzero")
+    code, out = run_full(([], ["lanes match .agents/scripts/lanes.ps1"]))
+    report(code == 0 and "FAIL" not in out, "a healthy machine still exits 0")
 
     print("SELF-TEST " + ("FAILED" if failed else "PASSED"))
     sys.exit(1 if failed else 0)

--- a/.agents/scripts/doctor.py
+++ b/.agents/scripts/doctor.py
@@ -19,8 +19,9 @@ Modes:
                tools are suppressed so cross-platform clones do not get
                nagged about Windows-only legs.
   (default)    full human-readable report, including the optional tools
-               (signoff ladder, nightly) and, on Windows, whether the
-               nightly scheduled task is registered.
+               (signoff ladder, nightly), on Windows whether the nightly
+               scheduled task is registered, and where incoda is present
+               whether the heavy job lanes match what lanes.ps1 records.
   --self-test  exercise the check logic with injected resolvers.
 
 Run with: just doctor
@@ -96,6 +97,64 @@ def nightly_task_registered():
         return None
 
 
+def incoda_path(which=shutil.which, environ=os.environ):
+    """The justfile's lookup: PATH, then the installer's location."""
+    found = which("incoda")
+    if found:
+        return found
+    local = environ.get("LOCALAPPDATA")
+    if local:
+        candidate = os.path.join(local, "Programs", "incoda", "incoda.exe")
+        if os.path.isfile(candidate):
+            return candidate
+    return None
+
+
+def lane_config(run=subprocess.run, which=shutil.which, environ=os.environ):
+    """Returns (problems, notes) for the heavy job lanes (AGENTS.md).
+
+    incoda's queue configuration lives in its own state dir, where nothing
+    in the repo can see it, so a lane that quietly lost its slots or its
+    close would otherwise stay wrong until a collision found it. lanes.ps1
+    is the record; its -Check exits 1 with one line per drift, 2 when it
+    could not read the machine. A missing incoda is a note, like the other
+    optional tools, so a clone that is not the development machine stays
+    quiet; drift where incoda is present is a problem."""
+    problems, notes = [], []
+    inc = incoda_path(which, environ)
+    if not inc:
+        notes.append("optional tool missing (heavy job lanes need it): incoda")
+        return problems, notes
+    try:
+        version = run([inc, "version"], capture_output=True, text=True, timeout=15)
+        first = (version.stdout or "").strip().splitlines()
+        notes.append(f"{first[0] if first else 'incoda (version unknown)'} at {inc}")
+    except Exception as e:
+        problems.append(f"incoda at {inc} could not report its version: {e}")
+        return problems, notes
+    if not which("pwsh"):
+        notes.append("lane config not checked: pwsh missing, lanes.ps1 needs it")
+        return problems, notes
+    try:
+        out = run(["pwsh", "-NoProfile", "-File", os.path.join(SCRIPT_DIR, "lanes.ps1"), "-Check"],
+                  capture_output=True, text=True, timeout=60)
+    except Exception as e:
+        problems.append(f"lane config could not be checked: {e}")
+        return problems, notes
+    lines = [l.strip() for l in (out.stdout or "").splitlines() if l.strip()]
+    if out.returncode == 0:
+        notes.append("lanes match .agents/scripts/lanes.ps1")
+    elif out.returncode == 1:
+        drift = [l for l in lines if l.startswith("drift ")]
+        for l in drift:
+            problems.append(f"lane config {l} (just lanes)")
+        if not drift:
+            problems.append("lane config drifted from .agents/scripts/lanes.ps1 (just lanes)")
+    else:
+        problems.append("lane config could not be checked: " + (" ".join(lines) or f"lanes.ps1 exited {out.returncode}"))
+    return problems, notes
+
+
 def deferred_debt():
     """Outstanding deferred signoffs. Reported at session start because a
     skip nobody is reminded of is indistinguishable from a pass."""
@@ -148,6 +207,12 @@ def full_main():
         print("ok   nightly task registered")
     elif reg is False:
         print("warn nightly task not registered on this machine (pwsh .agents/scripts/register_nightly_fuzz.ps1 from the main checkout)")
+    lane_problems, lane_notes = lane_config()
+    for n in lane_notes:
+        print(f"{'warn' if ('missing' in n or 'not checked' in n) else 'ok  '} {n}")
+    for p in lane_problems:
+        print(f"FAIL {p}")
+    problems += lane_problems
     if not problems:
         print("ok   gates wired and required tools present")
     sys.exit(1 if problems else 0)
@@ -192,6 +257,33 @@ def self_test():
 
         problems, _ = check(which=all_present, settings_path=good, script_dir=td)
         report(any("gate script missing" in p for p in problems), "missing gate script is a problem")
+
+    # The lane check, with lanes.ps1 and incoda stood in for: what the
+    # doctor makes of each exit code is the contract, since a drift that
+    # lands as a note instead of a problem keeps `just doctor` green.
+    def fake_run(rc, stdout):
+        def run(argv, **kw):
+            if argv[1:] == ["version"]:
+                return subprocess.CompletedProcess(argv, 0, stdout="incoda vX.Y.Z\ncommit: none\n", stderr="")
+            return subprocess.CompletedProcess(argv, rc, stdout=stdout, stderr="")
+        return run
+
+    problems, notes = lane_config(run=fake_run(0, "ok   lanes match\n"), which=all_present)
+    report(not problems and any("lanes match" in n for n in notes) and any("incoda vX.Y.Z" in n for n in notes),
+           "matching lanes are a note carrying incoda's version")
+
+    problems, _ = lane_config(run=fake_run(1, "drift wintty-build: slots 2, want 3\ndrift wintty: not closed\nrun 'just lanes'\n"),
+                              which=all_present)
+    report(len(problems) == 2 and all("drift" in p and "just lanes" in p for p in problems),
+           "each drift line is its own problem naming the fix")
+
+    problems, _ = lane_config(run=fake_run(2, "incoda status --all --json exited 3: boom\n"), which=all_present)
+    report(len(problems) == 1 and "could not be checked" in problems[0],
+           "an unreadable machine is a problem, not a pass")
+
+    no_incoda = lambda name: None if name == "incoda" else "/usr/bin/" + name
+    problems, notes = lane_config(run=fake_run(0, ""), which=no_incoda, environ={})
+    report(not problems and any("incoda" in n for n in notes), "missing incoda is a note, not a problem")
 
     print("SELF-TEST " + ("FAILED" if failed else "PASSED"))
     sys.exit(1 if failed else 0)

--- a/.agents/scripts/lanes.ps1
+++ b/.agents/scripts/lanes.ps1
@@ -1,0 +1,159 @@
+#requires -Version 7
+<#
+    The heavy job lanes' configuration, applied from the repo and verified
+    against the machine.
+
+    incoda keeps its queue configuration (slots, descriptions, whether a
+    --reason is required, which keys are closed) in its own state dir, so
+    until this script existed nothing in the repo recorded it: AGENTS.md
+    described the lanes, and whether the box agreed was anyone's word. That
+    is how a claim that the old `wintty` key was closed passed review while
+    the key still took jobs. The table below is now the record; `just lanes`
+    applies it and `just doctor` checks the live state against it.
+
+    Apply mode only touches a lane that drifts, so on a machine that already
+    matches it changes nothing and writes no config event into any lane's
+    log. -Check reads `incoda status --all --json` and changes nothing.
+
+    Exit codes: 0 the lanes match (or, in apply mode, match after applying);
+    1 drift, one line per finding; 2 the check itself could not run (incoda
+    not found, status unreadable). The lookup is the justfile's: PATH, then
+    the installer's location under %LOCALAPPDATA%.
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$Check   # report drift and exit; apply nothing
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+# incoda's exit code is read explicitly below; a nonzero one must not become
+# a terminating error before it can be reported.
+$PSNativeCommandUseErrorActionPreference = $false
+
+# What AGENTS.md ("Heavy job lanes") promises. wintty-desktop and
+# wintty-publish carry no --slots: incoda's default is one, and one is the
+# point of those lanes.
+$lanes = @(
+    [ordered]@{
+        key = 'wintty-build'; slots = 3; requireReason = $true
+        description = 'CPU and RAM: zig and dotnet builds and tests, signoff ladders, materialize'
+    }
+    [ordered]@{
+        key = 'wintty-desktop'; slots = 1; requireReason = $true
+        description = 'the interactive desktop, alone: GUI harnesses, pixel capture, env-guard theme flips'
+    }
+    [ordered]@{
+        key = 'wintty-publish'; slots = 1; requireReason = $true
+        description = 'release channels, signing, the installed app: cuts and uploads'
+    }
+    [ordered]@{
+        key = 'wintty'
+        closed = 'retired: use wintty-build for builds and tests, wintty-desktop for harnesses, wintty-publish for release cuts (AGENTS.md, heavy job lanes)'
+    }
+)
+
+$inc = (Get-Command incoda -ErrorAction SilentlyContinue)?.Source ?? (Join-Path $env:LOCALAPPDATA 'Programs\incoda\incoda.exe')
+if (-not (Test-Path $inc)) {
+    Write-Host 'incoda not found on PATH or in Programs\incoda: the heavy job lanes need it (AGENTS.md; https://github.com/deblasis/incoda)'
+    exit 2
+}
+
+# A property read that returns $null for a key the JSON did not carry:
+# incoda's config object only has the keys that were set, and under strict
+# mode a missing property is an error rather than a null.
+function Get-Prop($obj, [string]$name) {
+    if ($null -ne $obj -and $obj.PSObject.Properties[$name]) { $obj.$name } else { $null }
+}
+
+function Read-Queues {
+    $global:LASTEXITCODE = $null
+    $raw = & $inc status --all --json 2>&1 | Out-String
+    if (($LASTEXITCODE ?? 1) -ne 0) {
+        Write-Host "incoda status --all --json exited $LASTEXITCODE`: $($raw.Trim())"
+        exit 2
+    }
+    try { $status = $raw | ConvertFrom-Json } catch {
+        Write-Host "incoda status --all --json did not return JSON: $($raw.Trim())"
+        exit 2
+    }
+    $byKey = @{}
+    foreach ($q in @(Get-Prop $status 'queues')) { $byKey[(Get-Prop $q 'key')] = $q }
+    $byKey
+}
+
+# The drift lines for one lane against its live queue, empty when it
+# matches. The exact text is what doctor prints, so it names the fix.
+function Get-Drift($lane, $queue) {
+    $key = $lane.key
+    if ($null -eq $queue -or -not (Get-Prop $queue 'exists')) {
+        if ($lane.Contains('closed')) { return @("$key`: not closed (the key does not exist, so a run would create it open)") }
+        return @("$key`: missing")
+    }
+    $cfg = Get-Prop $queue 'config'
+    $closed = Get-Prop $cfg 'closed'
+    if ($lane.Contains('closed')) {
+        if ([string]::IsNullOrEmpty($closed)) { return @("$key`: not closed") }
+        if ($closed -ne $lane.closed) { return @("$key`: closed with a different message: '$closed'") }
+        return @()
+    }
+    $drift = @()
+    if (-not [string]::IsNullOrEmpty($closed)) { $drift += "$key`: closed ('$closed'), want open" }
+    # 0 is incoda's "use the default", and the default is 1.
+    $slots = Get-Prop $cfg 'slots'
+    if ($null -eq $slots -or $slots -le 0) { $slots = 1 }
+    if ($slots -ne $lane.slots) { $drift += "$key`: slots $slots, want $($lane.slots)" }
+    if ($lane.requireReason -and -not (Get-Prop $cfg 'require_reason')) { $drift += "$key`: a run without --reason is accepted, want refused" }
+    $desc = Get-Prop $cfg 'description'
+    if ($desc -ne $lane.description) { $drift += "$key`: description '$desc', want '$($lane.description)'" }
+    $drift
+}
+
+# Every call site wraps the result in @(): a function returning an empty
+# array hands the caller $null, and strict mode has no .Count on that.
+function Get-AllDrift($queues) {
+    $all = @()
+    foreach ($lane in $lanes) { $all += @(Get-Drift $lane $queues[$lane.key]) }
+    $all
+}
+
+$summary = "lanes match: wintty-build (3 slots), wintty-desktop and wintty-publish require a --reason; wintty is closed"
+
+if ($Check) {
+    $drift = @(Get-AllDrift (Read-Queues))
+    foreach ($d in $drift) { Write-Host "drift $d" }
+    if ($drift.Count -gt 0) { Write-Host "run 'just lanes' to apply the configuration from .agents/scripts/lanes.ps1"; exit 1 }
+    Write-Host "ok   $summary"
+    exit 0
+}
+
+$queues = Read-Queues
+$applied = 0
+foreach ($lane in $lanes) {
+    $drift = @(Get-Drift $lane $queues[$lane.key])
+    if ($drift.Count -eq 0) { Write-Host "ok      $($lane.key)"; continue }
+    foreach ($d in $drift) { Write-Host "drift   $d" }
+    # --open on a lane that is already open is a no-op, and a lane that
+    # somehow got closed is drift this has to heal rather than report twice.
+    $cargs = if ($lane.Contains('closed')) {
+        @('config', $lane.key, '--close', $lane.closed)
+    } elseif ($lane.slots -ne 1) {
+        @('config', $lane.key, '--slots', $lane.slots, '--description', $lane.description, '--require-reason', '--open')
+    } else {
+        @('config', $lane.key, '--description', $lane.description, '--require-reason', '--open')
+    }
+    $global:LASTEXITCODE = $null
+    & $inc @cargs
+    if (($LASTEXITCODE ?? 1) -ne 0) { Write-Host "incoda config $($lane.key) exited $LASTEXITCODE"; exit 2 }
+    Write-Host "applied $($lane.key)"
+    $applied++
+}
+
+# Read back rather than trust the exit code: the check is the contract, and
+# a config that took but did not land is exactly the drift this exists for.
+$after = @(Get-AllDrift (Read-Queues))
+foreach ($d in $after) { Write-Host "drift $d (still, after applying)" }
+if ($after.Count -gt 0) { exit 1 }
+if ($applied -eq 0) { Write-Host "ok   $summary (nothing applied)" } else { Write-Host "ok   $summary ($applied applied)" }
+exit 0

--- a/.agents/scripts/lanes.ps1
+++ b/.agents/scripts/lanes.ps1
@@ -15,6 +15,13 @@
     matches it changes nothing and writes no config event into any lane's
     log. -Check reads `incoda status --all --json` and changes nothing.
 
+    These three keys are shared with wintty-release, which builds the same
+    thing on the same box under the same names. Description equality is a
+    drift trigger, so if that repo ever grows its own applier it must carry
+    these strings character for character: two appliers with different prose
+    would each see the other's description as drift, heal it, and write a
+    config event into the lane's log on every run, forever.
+
     Exit codes: 0 the lanes match (or, in apply mode, match after applying);
     1 drift, one line per finding; 2 the check itself could not run (incoda
     not found, status unreadable). The lookup is the justfile's: PATH, then
@@ -23,7 +30,8 @@
 
 [CmdletBinding()]
 param(
-    [switch]$Check   # report drift and exit; apply nothing
+    [switch]$Check,    # report drift and exit; apply nothing
+    [switch]$SelfTest  # exercise the drift and argv logic; touch no machine state
 )
 
 Set-StrictMode -Version Latest
@@ -32,9 +40,7 @@ $ErrorActionPreference = 'Stop'
 # a terminating error before it can be reported.
 $PSNativeCommandUseErrorActionPreference = $false
 
-# What AGENTS.md ("Heavy job lanes") promises. wintty-desktop and
-# wintty-publish carry no --slots: incoda's default is one, and one is the
-# point of those lanes.
+# What AGENTS.md ("Heavy job lanes") promises.
 $lanes = @(
     [ordered]@{
         key = 'wintty-build'; slots = 3; requireReason = $true
@@ -54,12 +60,6 @@ $lanes = @(
     }
 )
 
-$inc = (Get-Command incoda -ErrorAction SilentlyContinue)?.Source ?? (Join-Path $env:LOCALAPPDATA 'Programs\incoda\incoda.exe')
-if (-not (Test-Path $inc)) {
-    Write-Host 'incoda not found on PATH or in Programs\incoda: the heavy job lanes need it (AGENTS.md; https://github.com/deblasis/incoda)'
-    exit 2
-}
-
 # A property read that returns $null for a key the JSON did not carry:
 # incoda's config object only has the keys that were set, and under strict
 # mode a missing property is an error rather than a null.
@@ -67,19 +67,20 @@ function Get-Prop($obj, [string]$name) {
     if ($null -ne $obj -and $obj.PSObject.Properties[$name]) { $obj.$name } else { $null }
 }
 
-function Read-Queues {
-    $global:LASTEXITCODE = $null
-    $raw = & $inc status --all --json 2>&1 | Out-String
-    if (($LASTEXITCODE ?? 1) -ne 0) {
-        Write-Host "incoda status --all --json exited $LASTEXITCODE`: $($raw.Trim())"
-        exit 2
-    }
-    try { $status = $raw | ConvertFrom-Json } catch {
-        Write-Host "incoda status --all --json did not return JSON: $($raw.Trim())"
-        exit 2
-    }
+# The key->queue map for one status payload. Split out from Read-Queues so
+# the self-test can hand it a payload directly, and because the empty cases
+# are the ones that bite: a `queues` that is absent or JSON null reaches
+# this as @($null), a ONE-element array whose element indexes the hashtable
+# to a null key, which throws. That throw would leave the script exiting 1
+# with its message on stderr, and doctor reads exit 1 as drift, so a machine
+# that was never read at all would be reported as a lane that drifted.
+function ConvertTo-QueueMap($status) {
     $byKey = @{}
-    foreach ($q in @(Get-Prop $status 'queues')) { $byKey[(Get-Prop $q 'key')] = $q }
+    foreach ($q in @(Get-Prop $status 'queues')) {
+        $key = Get-Prop $q 'key'
+        if ([string]::IsNullOrEmpty($key)) { continue }
+        $byKey[$key] = $q
+    }
     $byKey
 }
 
@@ -118,7 +119,148 @@ function Get-AllDrift($queues) {
     $all
 }
 
-$summary = "lanes match: wintty-build (3 slots), wintty-desktop and wintty-publish require a --reason; wintty is closed"
+# The argv that heals one lane. `incoda config` MERGES into the stored
+# configuration rather than replacing it - measured: set --slots 5, then
+# apply without --slots, and it reads back 5 - so every field this script
+# has an opinion about has to be on the command line every time. Leaving
+# --slots off the one-slot lanes meant a wintty-desktop that had drifted to
+# 5 was reported by -Check, "healed" by an apply that never mentioned
+# slots, and reported again on the next run, forever.
+function Get-ApplyArgs($lane) {
+    # --open on a lane that is already open is a no-op, and a lane that
+    # somehow got closed is drift this has to heal rather than report twice.
+    if ($lane.Contains('closed')) { return @('config', $lane.key, '--close', $lane.closed) }
+    @('config', $lane.key, '--slots', $lane.slots, '--description', $lane.description, '--require-reason', '--open')
+}
+
+$summary = "lanes match: wintty-build has 3 slots, wintty-desktop and wintty-publish 1, all three refuse a run without --reason; wintty is closed"
+
+if ($SelfTest) {
+    # No incoda, no state dir, no machine: everything below is the pure
+    # logic, exercised against hand-written payloads. It runs before the
+    # incoda lookup so `just gates-selftest` passes on a clone that has
+    # never heard of the lanes.
+    $script:failed = $false
+    function Assert-Ok([bool]$ok, [string]$label) {
+        if (-not $ok) { Write-Host "SELF-TEST FAILED: $label"; $script:failed = $true }
+    }
+    $build = $lanes[0]
+    $desktop = $lanes[1]
+    $retired = $lanes[3]
+    function New-Queue($config) { [pscustomobject]@{ key = 'q'; exists = $true; config = $config } }
+
+    # The empty payloads. `queues: []` is what a fresh state dir reports and
+    # is fine; absent and null are the shapes that used to throw, and a
+    # throw here is exit 1 with the reason on stderr, which doctor reads as
+    # drift. An entry with no key is dropped rather than indexing to null.
+    Assert-Ok ((ConvertTo-QueueMap ([pscustomobject]@{ queues = @() })).Count -eq 0) 'an empty queue list is an empty map'
+    Assert-Ok ((ConvertTo-QueueMap ([pscustomobject]@{ queues = $null })).Count -eq 0) 'a null queue list must not index the map to a null key'
+    Assert-Ok ((ConvertTo-QueueMap ([pscustomobject]@{ schema = 1 })).Count -eq 0) 'a payload with no queues list must not throw'
+    Assert-Ok ((ConvertTo-QueueMap $null).Count -eq 0) 'a null payload must not throw'
+    Assert-Ok ((ConvertTo-QueueMap ([pscustomobject]@{ queues = @([pscustomobject]@{ exists = $true }) })).Count -eq 0) 'a queue with no key is dropped'
+    $map = ConvertTo-QueueMap ([pscustomobject]@{ queues = @([pscustomobject]@{ key = 'wintty-build'; exists = $true }) })
+    Assert-Ok ($map.Count -eq 1 -and $null -ne $map['wintty-build']) 'a real queue lands under its key'
+
+    # Get-Drift, one condition at a time. The text is doctor's output, so
+    # the assertions are on the finding, not on the exact sentence.
+    $matching = New-Queue ([pscustomobject]@{ slots = 3; require_reason = $true; description = $build.description })
+    Assert-Ok (@(Get-Drift $build $matching).Count -eq 0) 'a lane that matches has no drift'
+    Assert-Ok (@(Get-Drift $build $null) -join '' -match 'missing') 'a missing key is drift'
+    Assert-Ok (@(Get-Drift $build ([pscustomobject]@{ key = 'x'; exists = $false })) -join '' -match 'missing') 'a key that does not exist is drift'
+    # A queue with no config object at all: every field falls back, so all
+    # three of this lane's opinions are drift, and none of them may throw.
+    $noConfig = [pscustomobject]@{ key = 'wintty-build'; exists = $true }
+    $bare = @(Get-Drift $build $noConfig)
+    Assert-Ok ($bare.Count -eq 3 -and ($bare -join '') -match 'slots 1, want 3' -and ($bare -join '') -match 'without --reason') 'a queue with no config object drifts on every field'
+    $wrongSlots = @(Get-Drift $build (New-Queue ([pscustomobject]@{ slots = 5; require_reason = $true; description = $build.description })))
+    Assert-Ok ($wrongSlots.Count -eq 1 -and $wrongSlots[0] -match 'slots 5, want 3') 'wrong slots is drift'
+    $zeroSlots = @(Get-Drift $desktop (New-Queue ([pscustomobject]@{ slots = 0; require_reason = $true; description = $desktop.description })))
+    Assert-Ok ($zeroSlots.Count -eq 0) "incoda's 0 means the default, and the default is one slot"
+    $noReason = @(Get-Drift $build (New-Queue ([pscustomobject]@{ slots = 3; require_reason = $false; description = $build.description })))
+    Assert-Ok ($noReason.Count -eq 1 -and $noReason[0] -match 'without --reason') 'a lane that accepts a reasonless run is drift'
+    $wrongDesc = @(Get-Drift $build (New-Queue ([pscustomobject]@{ slots = 3; require_reason = $true; description = 'something else' })))
+    Assert-Ok ($wrongDesc.Count -eq 1 -and $wrongDesc[0] -match 'description') 'a changed description is drift'
+    $closedOpenLane = @(Get-Drift $build (New-Queue ([pscustomobject]@{ slots = 3; require_reason = $true; description = $build.description; closed = 'nope' })))
+    Assert-Ok ($closedOpenLane.Count -eq 1 -and $closedOpenLane[0] -match 'want open') 'an open lane that got closed is drift'
+
+    # The retired key, whose whole point is that it stays closed with a
+    # message naming the replacements.
+    Assert-Ok (@(Get-Drift $retired (New-Queue ([pscustomobject]@{ closed = $retired.closed }))).Count -eq 0) 'the retired key closed with its message matches'
+    Assert-Ok (@(Get-Drift $retired (New-Queue ([pscustomobject]@{ slots = 1 }))) -join '' -match 'not closed') 'the retired key left open is drift'
+    Assert-Ok (@(Get-Drift $retired $null) -join '' -match 'not closed') 'the retired key missing is drift, because a run would create it open'
+    $otherMsg = @(Get-Drift $retired (New-Queue ([pscustomobject]@{ closed = 'closed for another reason' })))
+    Assert-Ok ($otherMsg.Count -eq 1 -and $otherMsg[0] -match 'different message') 'the retired key closed with other prose is drift'
+
+    # The apply argv, for every shape of lane. --slots is the one that went
+    # missing: incoda merges, so a lane left out of the argv keeps whatever
+    # it drifted to and -Check never goes green again.
+    foreach ($l in @($build, $desktop)) {
+        $a = @(Get-ApplyArgs $l)
+        $slotIdx = [array]::IndexOf($a, '--slots')
+        Assert-Ok ($a[0] -eq 'config' -and $a[1] -eq $l.key) "$($l.key): the apply argv configures its own key"
+        Assert-Ok ($slotIdx -ge 0 -and [int]$a[$slotIdx + 1] -eq $l.slots) "$($l.key): --slots is always passed, because incoda config merges rather than replaces"
+        Assert-Ok ($a -contains '--require-reason' -and $a -contains '--open') "$($l.key): the apply argv requires a reason and opens the lane"
+        $descIdx = [array]::IndexOf($a, '--description')
+        Assert-Ok ($descIdx -ge 0 -and $a[$descIdx + 1] -eq $l.description) "$($l.key): the description applied is the one drift is measured against"
+    }
+    $closedArgs = @(Get-ApplyArgs $retired)
+    $closeIdx = [array]::IndexOf($closedArgs, '--close')
+    Assert-Ok ($closedArgs[0] -eq 'config' -and $closedArgs[1] -eq 'wintty') 'the retired key is configured by name'
+    Assert-Ok ($closeIdx -ge 0 -and $closedArgs[$closeIdx + 1] -eq $retired.closed) 'the retired key is closed with the message drift is measured against'
+    Assert-Ok (-not ($closedArgs -contains '--open')) 'the retired key is never reopened'
+
+    # Applying what the table says must leave nothing to report, or apply
+    # mode would loop: heal, read back, still drift, exit 1.
+    $healed = ConvertTo-QueueMap ([pscustomobject]@{ queues = @(
+        [pscustomobject]@{ key = 'wintty-build'; exists = $true; config = [pscustomobject]@{ slots = 3; require_reason = $true; description = $lanes[0].description } }
+        [pscustomobject]@{ key = 'wintty-desktop'; exists = $true; config = [pscustomobject]@{ slots = 1; require_reason = $true; description = $lanes[1].description } }
+        [pscustomobject]@{ key = 'wintty-publish'; exists = $true; config = [pscustomobject]@{ slots = 1; require_reason = $true; description = $lanes[2].description } }
+        [pscustomobject]@{ key = 'wintty'; exists = $true; config = [pscustomobject]@{ closed = $lanes[3].closed } }
+    ) })
+    Assert-Ok (@(Get-AllDrift $healed).Count -eq 0) 'a machine configured from this table reports no drift'
+    $drifted = ConvertTo-QueueMap ([pscustomobject]@{ queues = @(
+        [pscustomobject]@{ key = 'wintty-build'; exists = $true; config = [pscustomobject]@{ slots = 1; require_reason = $true; description = $lanes[0].description } }
+    ) })
+    Assert-Ok (@(Get-AllDrift $drifted).Count -eq 4) 'one drifted lane and three missing ones are four findings'
+
+    if ($script:failed) { Write-Host 'SELF-TEST FAILED'; exit 1 }
+    Write-Host 'SELF-TEST PASSED'
+    exit 0
+}
+
+# %LOCALAPPDATA% is unset on any host that is not Windows, and Join-Path
+# refuses a null path with an error about parameter binding rather than
+# about incoda, which is not a useful thing to read.
+$installed = if ($env:LOCALAPPDATA) { Join-Path $env:LOCALAPPDATA 'Programs\incoda\incoda.exe' } else { $null }
+$inc = (Get-Command incoda -ErrorAction SilentlyContinue)?.Source ?? $installed
+if (-not $inc -or -not (Test-Path $inc)) {
+    Write-Host 'incoda not found on PATH or in Programs\incoda: the heavy job lanes need it (AGENTS.md; https://github.com/deblasis/incoda)'
+    exit 2
+}
+
+function Read-Queues {
+    # stderr goes to its own file rather than into the pipeline: folded in
+    # with 2>&1 it lands inside $raw, and one line of lane chatter or a
+    # deprecation warning would turn a perfectly healthy machine into "did
+    # not return JSON" and exit 2. --no-color for the same reason, since a
+    # colored status is not JSON either.
+    $errFile = [System.IO.Path]::GetTempFileName()
+    try {
+        $global:LASTEXITCODE = $null
+        $raw = & $inc status --all --json --no-color 2>$errFile | Out-String
+        $rc = $LASTEXITCODE ?? 1
+        $err = (Get-Content $errFile -Raw -ErrorAction SilentlyContinue) ?? ''
+    } finally { Remove-Item $errFile -Force -ErrorAction SilentlyContinue }
+    if ($rc -ne 0) {
+        Write-Host "incoda status --all --json exited $rc`: $(($err + ' ' + $raw).Trim())"
+        exit 2
+    }
+    try { $status = $raw | ConvertFrom-Json } catch {
+        Write-Host "incoda status --all --json did not return JSON: $($raw.Trim()) $($err.Trim())"
+        exit 2
+    }
+    ConvertTo-QueueMap $status
+}
 
 if ($Check) {
     $drift = @(Get-AllDrift (Read-Queues))
@@ -134,15 +276,7 @@ foreach ($lane in $lanes) {
     $drift = @(Get-Drift $lane $queues[$lane.key])
     if ($drift.Count -eq 0) { Write-Host "ok      $($lane.key)"; continue }
     foreach ($d in $drift) { Write-Host "drift   $d" }
-    # --open on a lane that is already open is a no-op, and a lane that
-    # somehow got closed is drift this has to heal rather than report twice.
-    $cargs = if ($lane.Contains('closed')) {
-        @('config', $lane.key, '--close', $lane.closed)
-    } elseif ($lane.slots -ne 1) {
-        @('config', $lane.key, '--slots', $lane.slots, '--description', $lane.description, '--require-reason', '--open')
-    } else {
-        @('config', $lane.key, '--description', $lane.description, '--require-reason', '--open')
-    }
+    $cargs = Get-ApplyArgs $lane
     $global:LASTEXITCODE = $null
     & $inc @cargs
     if (($LASTEXITCODE ?? 1) -ne 0) { Write-Host "incoda config $($lane.key) exited $LASTEXITCODE"; exit 2 }

--- a/.agents/scripts/nightly_fuzz.ps1
+++ b/.agents/scripts/nightly_fuzz.ps1
@@ -170,28 +170,114 @@ function Get-IncodaPath {
 # its `incoda run` prefix would still pass every other check in this file
 # and only show up as a machine falling over at 23:00.
 function Get-LegArgs([string]$Recipe, [string]$Reason, [string]$Justfile, [string]$WorkTree) {
-    @('run', '--queue', 'wintty-build', '--reason', $Reason, '--',
+    # --wait 2h, spelled out rather than left to incoda's 30-minute default.
+    # The build lane runs three at a time and a busy evening queues deep:
+    # measured with 3 holders and 8 waiters, tickets that had waited 34, 27
+    # and 26 minutes were still acquiring normally. At the default those
+    # legs would have timed out and filed an infra issue against a machine
+    # that was working exactly as designed. Not a negative wait (incoda's
+    # "wait forever"): a nightly that hangs on the queue into the working
+    # day never reaches the code that files the issue saying it could not
+    # run, so it fails silently and steals the desktop besides. A finite
+    # wait plus the could-not-run classification below is the honest pair.
+    @('run', '--queue', 'wintty-build', '--wait', '2h', '--reason', $Reason, '--',
       'just', '--justfile', $Justfile, '--working-directory', $WorkTree, $Recipe)
 }
 
-# What a laned test leg's exit code means. incoda passes the child's own
-# status through unchanged, so every code here is `just`'s except 121:
-# --wait elapsed while the run was still queued, which means the lane was
-# never granted and the recipe never started. Filing that as a red test
-# suite would put a product title on a scheduling problem - the same
-# mistake, the other way round, that Get-FuzzOutcome exists to prevent.
-# A function for the same reason: the self-test asserts against THIS
-# mapping, not a copy of it.
+# Running one leg, separated from deciding what to run so the self-test can
+# exercise each half. This half is where a leg's own output has to go
+# somewhere other than the return value: a native command inside a function
+# sends its stdout to the caller, so without Out-Host the "exit code" would
+# come back as an array of every line the build printed with the status
+# tacked on the end, and every comparison against it would be nonsense.
+# Out-Host is also what Start-Transcript records, so the log tail an issue
+# quotes is unchanged.
+$script:LegRunner = {
+    param($exe, $argv)
+    $global:LASTEXITCODE = $null
+    & $exe @argv | Out-Host
+    $LASTEXITCODE ?? 1
+}
+
+# One leg, wrapped. Both call sites go through here so the self-test can run
+# a leg with an injected runner and see the argv that would have been
+# executed: asserting Get-LegArgs alone proved only that a builder nobody
+# had to call built the right list, and a call site reverted to a bare
+# `just` would have kept every assertion green.
+function Invoke-Leg {
+    param(
+        [string]$Recipe,
+        [string]$Reason,
+        [string]$Justfile,
+        [string]$WorkTree,
+        [scriptblock]$Runner
+    )
+    $legArgs = Get-LegArgs $Recipe $Reason $Justfile $WorkTree
+    [int](& ($Runner ?? $script:LegRunner) $script:incoda $legArgs)
+}
+
+# incoda's own exit codes, from its `--help` table and AGENTS.md ("heavy
+# job lanes"). `run` passes the child's status through unchanged, so any
+# code NOT in this list is `just`'s own and means the recipe ran and
+# reached a verdict. Every code in it means the opposite: the recipe never
+# started, or was stopped from outside, so nothing about the product was
+# measured. Filing one of these as a red test suite puts a product title on
+# a scheduling problem - the same mistake, the other way round, that
+# Get-FuzzOutcome exists to prevent, and until this list existed only 121
+# was spared: a lane kill (124) or a run refused by a closed queue (120)
+# was filed as "the test suite failed".
+#   120 usage error: a closed queue, a missing --reason, a bad flag
+#   121 --wait elapsed while still queued
+#   122 the state dir or its file locking is unusable
+#   123 the lane was acquired but the command could not be started
+#   124 the run was killed through the lane (incoda kill)
+#   125 a kill went unacknowledged
+#   130 incoda was interrupted while queueing
+# The overlap is real and deliberate: a `just` recipe could in principle
+# exit 124 itself. Reading the ambiguous codes as could-not-run files an
+# infra issue for something that might have been a product break, which is
+# the safe direction - it never invents a product bug, and the issue it
+# does file names the exit code.
+$script:LaneExitCodes = @(120, 121, 122, 123, 124, 125, 130)
+
+# What a laned test leg's exit code means. A function so the self-test
+# asserts against THIS mapping, not a copy of it.
 function Get-LegOutcome {
     param($Code)
     # $null explicitly: an exit code that was never collected means the leg
     # was not observed, not that it passed.
     if ($null -eq $Code) { return 'could-not-run' }
+    $c = [int]$Code
+    if ($c -eq 0) { return 'pass' }
+    if ($script:LaneExitCodes -contains $c) { return 'could-not-run' }
+    'fail'
+}
+
+# The sentence a could-not-run leg's issue carries. Per code, because "the
+# lane was never granted within the wait" is simply untrue of a job someone
+# killed, and an issue that misdescribes what happened sends whoever reads
+# it looking at the queue depth instead of at the kill reason on stderr.
+function Get-LegNote {
+    param($Code)
+    if ($null -eq $Code) { return 'No exit code was collected, so the leg was never observed and nothing was judged.' }
+    $tail = 'This is a runner problem, not a product break: nothing was judged.'
     switch ([int]$Code) {
-        0       { 'pass' }
-        121     { 'could-not-run' }
-        default { 'fail' }
+        121 { "The wintty-build lane was not granted within incoda's wait, so the recipe never started. $tail" }
+        124 { "The run was killed through the lane (incoda kill); the reason is on its stderr. $tail" }
+        120 { "incoda refused the run (a closed queue, a missing --reason, or a bad flag), so the recipe never started. $tail" }
+        123 { "The lane was acquired but the command could not be started. $tail" }
+        default { "incoda could not carry the run (see its exit-code table), so the recipe never reached a verdict. $tail" }
     }
+}
+
+# Whether the branch went unverified. A leg that could not run is no more a
+# green than a red one, so both keep the deferred ledger unsettled. The
+# fuzz leg is the odd one: a skip records a string ('skipped-locked'), not
+# an int, and a skip is not a failure - hence the [int] test rather than a
+# bare -ne 0. A function so the self-test can state that directly.
+function Test-LegFailed {
+    param($TestRc, $TestWinRc, $FuzzRc)
+    ($TestRc -ne 0) -or ($TestWinRc -ne 0) -or ($FuzzRc -is [int] -and $FuzzRc -ne 0)
 }
 
 if ($SelfTest) {
@@ -229,24 +315,106 @@ if ($SelfTest) {
     # never collected must not coerce to 0 and pass as a clean night.
     if ((Get-FuzzOutcome $null) -ne 'harness') { Write-Host 'SELF-TEST FAILED: an uncollected exit code must not read as a clean run'; $failed = $true }
 
-    # The test legs' lane wrap and its exit codes. The wrap is asserted as
-    # argv because that is what silently goes missing; the mapping is
-    # asserted one code at a time, for the same reason as the fuzz table.
+    # The test legs' lane wrap and its exit codes. The wrap is asserted
+    # twice over: once as the argv a leg actually executes, and once
+    # against this file's own source at both call sites, because argv from
+    # a builder nobody is obliged to call is not evidence that the shipped
+    # legs are wrapped.
     $legArgs = @(Get-LegArgs 'test' 'nightly zig tests' 'C:\wt\justfile' 'C:\wt')
     $sep = [array]::IndexOf($legArgs, '--')
+    $waitIdx = [array]::IndexOf($legArgs, '--wait')
+    $reasonIdx = [array]::IndexOf($legArgs, '--reason')
     if ($legArgs[0] -ne 'run' -or $legArgs[1] -ne '--queue' -or $legArgs[2] -ne 'wintty-build') {
         Write-Host "SELF-TEST FAILED: a test leg must run under the wintty-build lane, got '$($legArgs -join ' ')'"; $failed = $true
     }
-    if ($legArgs[3] -ne '--reason' -or -not $legArgs[4]) {
+    if ($reasonIdx -lt 0 -or -not $legArgs[$reasonIdx + 1]) {
         Write-Host 'SELF-TEST FAILED: the lane refuses a run without --reason, so the leg must carry one'; $failed = $true
     }
     if ($sep -lt 0 -or $legArgs[$sep + 1] -ne 'just' -or $legArgs[-1] -ne 'test') {
         Write-Host "SELF-TEST FAILED: the wrapped command must be the just recipe, got '$($legArgs -join ' ')'"; $failed = $true
     }
+    # The wait is stated, longer than incoda's 30-minute default, and
+    # finite. A negative wait is incoda's "wait forever": the nightly would
+    # hang on the queue into the working day and never reach the code that
+    # files the issue saying it could not run.
+    if ($waitIdx -lt 0 -or $waitIdx -gt $sep) {
+        Write-Host 'SELF-TEST FAILED: a test leg must state its own --wait, not inherit incoda''s 30-minute default'; $failed = $true
+    } elseif ($legArgs[$waitIdx + 1] -notmatch '^\d+(\.\d+)?[hm]?$' -or [double]($legArgs[$waitIdx + 1] -replace '[hm]$','') -le 0) {
+        Write-Host "SELF-TEST FAILED: --wait must be a positive finite duration, got '$($legArgs[$waitIdx + 1])' (negative means wait forever)"; $failed = $true
+    }
+
+    # Both legs, as they are actually invoked. The runner stands in for
+    # incoda and reports what it was handed, so a call site that lost its
+    # wrap fails here rather than at 23:00 on a machine nobody is watching.
+    foreach ($leg in @(
+        @{ recipe = 'test';     reason = 'nightly zig tests' }
+        @{ recipe = 'test-win'; reason = 'nightly windows tests' }
+    )) {
+        $seen = $null
+        $rc = Invoke-Leg -Recipe $leg.recipe -Reason $leg.reason -Justfile 'C:\wt\justfile' -WorkTree 'C:\wt' -Runner {
+            param($exe, $argv) $script:seen = $argv; 121
+        }
+        $seen = @($seen)
+        if ($rc -ne 121) { Write-Host "SELF-TEST FAILED: a leg must report the status of the run it made, got $rc"; $failed = $true }
+        if ($seen[0] -ne 'run' -or $seen[2] -ne 'wintty-build' -or $seen[-1] -ne $leg.recipe) {
+            Write-Host "SELF-TEST FAILED: the $($leg.recipe) leg must execute a wintty-build run of that recipe, got '$($seen -join ' ')'"; $failed = $true
+        }
+    }
+    # The runner the legs actually use, against a real child that prints
+    # and then fails. A leg's status has to come back as one integer: a
+    # native command inside a function writes its stdout to the caller, so
+    # a runner that let it would return the whole build log with the code
+    # at the end, and `$testRc -ne 0` on an array is not the question
+    # anyone meant to ask.
+    $realRc = & $script:LegRunner 'pwsh' @('-NoProfile', '-Command', "'self-test: a leg''s output belongs in the transcript, not in its exit code'; exit 7")
+    if (@($realRc).Count -ne 1 -or $realRc -ne 7) {
+        Write-Host "SELF-TEST FAILED: a leg must report one exit code and let its output go to the transcript, got '$($realRc -join ', ')'"; $failed = $true
+    }
+
+    # And that this file's two shipped call sites really are those legs. A
+    # leg reverted to a bare `just --justfile ... test` would satisfy every
+    # assertion above, which is precisely the failure the wrap exists for.
+    $src = Get-Content $PSCommandPath -Raw
+    foreach ($recipe in @('test', 'test-win')) {
+        if ($src -notmatch [regex]::Escape("Invoke-Leg -Recipe '$recipe'")) {
+            Write-Host "SELF-TEST FAILED: the $recipe leg must be invoked through Invoke-Leg, so it cannot lose its lane"; $failed = $true
+        }
+    }
+    if ($src -match '(?m)^\s*(just|& \$incoda)\s.*--working-directory\s+\$wt\s+test(-win)?\s*$') {
+        Write-Host 'SELF-TEST FAILED: a test leg is running outside Invoke-Leg, so its lane wrap is not guarded'; $failed = $true
+    }
+    # The issue-filing arms, likewise: an `if ($testRc -ne 0)` in place of
+    # the switch would file every lane-level code as a red test suite.
+    # Assembled rather than written out, for the same reason as $arm below:
+    # spelled literally, the assertion would find itself and pass over a
+    # call site that no longer consults Get-LegOutcome at all.
+    foreach ($v in @('testRc', 'testWinRc')) {
+        $needle = 'switch (Get-LegOutcome $' + $v + ')'
+        if ($src -notmatch [regex]::Escape($needle)) {
+            Write-Host "SELF-TEST FAILED: missing '$needle'; both legs must decide what to file through Get-LegOutcome"; $failed = $true
+        }
+    }
+    # Built from two pieces so this line is not itself a third match: the
+    # source being counted is this same file.
+    $arm = "'could-not-run'" + ' { File-Issue'
+    if (([regex]::Matches($src, [regex]::Escape($arm))).Count -ne 2) {
+        Write-Host 'SELF-TEST FAILED: both legs must file an infra issue for a run that never happened, not a red test suite'; $failed = $true
+    }
+
+    # incoda's exit codes, one at a time. Every one of them means the
+    # recipe never reached a verdict; before this, only 121 was spared and
+    # a lane kill was filed as "the test suite failed".
     foreach ($c in @(
         @{ code = 0;   want = 'pass';          why = '0 is a green leg' }
         @{ code = 1;   want = 'fail';          why = 'the child ran and failed' }
+        @{ code = 2;   want = 'fail';          why = 'a child status incoda passed through is the recipe''s verdict' }
+        @{ code = 120; want = 'could-not-run'; why = 'incoda 120 is a usage error: a closed queue or a missing --reason, so the recipe never started' }
         @{ code = 121; want = 'could-not-run'; why = 'incoda 121 means the lane was never granted, so the recipe never started' }
+        @{ code = 122; want = 'could-not-run'; why = 'incoda 122 means the state dir is unusable, so nothing was queued' }
+        @{ code = 123; want = 'could-not-run'; why = 'incoda 123 means the lane was taken but the command never started' }
+        @{ code = 124; want = 'could-not-run'; why = 'incoda 124 means someone killed the run through the lane' }
+        @{ code = 125; want = 'could-not-run'; why = 'incoda 125 is an unacknowledged kill, not a product break' }
+        @{ code = 130; want = 'could-not-run'; why = 'incoda 130 means it was interrupted while queueing' }
     )) {
         $got = Get-LegOutcome $c.code
         if ($got -ne $c.want) {
@@ -255,6 +423,37 @@ if ($SelfTest) {
         }
     }
     if ((Get-LegOutcome $null) -ne 'could-not-run') { Write-Host 'SELF-TEST FAILED: an uncollected leg exit code must not read as a pass'; $failed = $true }
+    # A killed run and a queue that never came free are different events,
+    # and an issue that describes one as the other sends its reader to the
+    # wrong place.
+    if ((Get-LegNote 124) -notmatch 'killed') { Write-Host 'SELF-TEST FAILED: a killed leg must say so, not report a queue timeout'; $failed = $true }
+    if ((Get-LegNote 121) -notmatch 'never granted|not granted') { Write-Host 'SELF-TEST FAILED: a timed-out leg must say the lane was never granted'; $failed = $true }
+    if ((Get-LegNote 124) -eq (Get-LegNote 121)) { Write-Host 'SELF-TEST FAILED: a kill and a queue timeout must not carry the same note'; $failed = $true }
+    foreach ($c in @(120, 121, 122, 123, 124, 125, 130, $null)) {
+        if ((Get-LegNote $c) -notmatch 'not a product break|nothing was judged') {
+            Write-Host "SELF-TEST FAILED: the note for exit $c must say nothing about the product was judged"; $failed = $true
+        }
+    }
+
+    # The roll-up into the exit status and the deferred ledger. A leg that
+    # could not run leaves the branch just as unverified as a red one, and
+    # a fuzz leg that was skipped records a string, not a failure.
+    foreach ($c in @(
+        @{ t = 0;   w = 0; f = 0;     want = $false; why = 'three greens settle the ledger' }
+        @{ t = 1;   w = 0; f = 0;     want = $true;  why = 'a red zig leg is a failure' }
+        @{ t = 0;   w = 1; f = 0;     want = $true;  why = 'a red windows leg is a failure' }
+        @{ t = 0;   w = 0; f = 2;     want = $true;  why = 'fuzz findings are a failure' }
+        @{ t = 121; w = 0; f = 0;     want = $true;  why = 'a leg that never ran verified nothing, so the ledger stays unsettled' }
+        @{ t = 124; w = 0; f = 0;     want = $true;  why = 'a killed leg verified nothing either' }
+        @{ t = 0;   w = 0; f = $null; want = $false; why = 'a fuzz leg that never ran is a skip, and the tests still passed' }
+        @{ t = 0;   w = 0; f = 'skipped-locked'; want = $false; why = 'a recorded skip is a string, not a nonzero status' }
+    )) {
+        $got = Test-LegFailed $c.t $c.w $c.f
+        if ($got -ne $c.want) {
+            Write-Host "SELF-TEST FAILED: legs ($($c.t), $($c.w), $($c.f ?? 'null')) read as failed=$got, expected $($c.want) ($($c.why))"
+            $failed = $true
+        }
+    }
 
     # The self-test dir must be disjoint from the real logs, or a run of the
     # self-test would wipe the user's saved options.
@@ -279,8 +478,11 @@ if ($missing) {
 # wintty-build lane, and a leg that cannot take it must refuse rather than
 # run unlaned next to a session's build. Not in $missing above because the
 # lookup is not just PATH.
-$incoda = Get-IncodaPath
-if (-not $incoda) {
+# $script: explicitly, because Invoke-Leg reads it by that name: an
+# unqualified assignment here would work by accident of top-level scope and
+# break silently the moment this moved inside anything.
+$script:incoda = Get-IncodaPath
+if (-not $script:incoda) {
     Write-Status 'aborted-missing-tools'
     Add-Content $log 'nightly: aborting, incoda is not on PATH or in Programs\incoda; the test legs run under the wintty-build lane and must not run unlaned (AGENTS.md, heavy job lanes; https://github.com/deblasis/incoda)'
     exit 1
@@ -407,8 +609,7 @@ $legClock = [System.Diagnostics.Stopwatch]::StartNew()
 # reproduced from the report.
 $env:WINTTY_TEST_SEED = '0x{0:x}' -f (Get-Random -Minimum 1 -Maximum 2147483647)
 Write-Host "nightly: WINTTY_TEST_SEED=$env:WINTTY_TEST_SEED"
-& $incoda @(Get-LegArgs 'test' 'nightly zig tests' (Join-Path $wt 'justfile') $wt)
-$testRc = $LASTEXITCODE ?? 1
+$testRc = Invoke-Leg -Recipe 'test' -Reason 'nightly zig tests' -Justfile (Join-Path $wt 'justfile') -WorkTree $wt
 $testSeconds = [int]$legClock.Elapsed.TotalSeconds
 $script:status.results['zig-tests'] = $testRc
 Write-Host "nightly: zig tests rc=$testRc"
@@ -416,8 +617,7 @@ Write-Host "nightly: zig tests rc=$testRc"
 Write-Status 'windows-tests'
 $global:LASTEXITCODE = $null
 $legClock.Restart()
-& $incoda @(Get-LegArgs 'test-win' 'nightly windows tests' (Join-Path $wt 'justfile') $wt)
-$testWinRc = $LASTEXITCODE ?? 1
+$testWinRc = Invoke-Leg -Recipe 'test-win' -Reason 'nightly windows tests' -Justfile (Join-Path $wt 'justfile') -WorkTree $wt
 $testWinSeconds = [int]$legClock.Elapsed.TotalSeconds
 $script:status.results['windows-tests'] = $testWinRc
 Write-Host "nightly: windows tests rc=$testWinRc"
@@ -437,14 +637,13 @@ if ((Test-Path $legCache) -and $script:sha -and (Test-Path $envSnapshot)) {
     }
 }
 
-$laneNote = 'The wintty-build lane was not granted within incoda''s wait, so the recipe never started. This is a runner problem, not a product break: nothing was judged.'
 switch (Get-LegOutcome $testRc) {
     'fail'          { File-Issue '[nightly] zig test suite failed on windows branch' "``just test`` exited $testRc (WINTTY_TEST_SEED=$env:WINTTY_TEST_SEED)." }
-    'could-not-run' { File-Issue '[nightly] infra: the zig test leg never ran' "incoda exited $testRc. $laneNote" }
+    'could-not-run' { File-Issue '[nightly] infra: the zig test leg never ran' "incoda exited $testRc. $(Get-LegNote $testRc)" }
 }
 switch (Get-LegOutcome $testWinRc) {
     'fail'          { File-Issue '[nightly] Windows test suite failed on windows branch' "``just test-win`` exited $testWinRc." }
-    'could-not-run' { File-Issue '[nightly] infra: the Windows test leg never ran' "incoda exited $testWinRc. $laneNote" }
+    'could-not-run' { File-Issue '[nightly] infra: the Windows test leg never ran' "incoda exited $testWinRc. $(Get-LegNote $testWinRc)" }
 }
 
 $wakeLockNote = 'If this machine wakes from hibernation to the lock screen every night (sign-in on wake), the fuzz leg can never run; the appliance flow needs sign-in on wake disabled to get fuzz coverage.'
@@ -487,9 +686,7 @@ if (-not $lastSuccess -or ((Get-Date) - $lastSuccess).TotalDays -gt 7) {
     File-Issue '[nightly] fuzz starvation: no successful fuzz run in 7 days' "The GUI fuzz leg has been skipped or failing for over a week; fuzz coverage is effectively off. $wakeLockNote"
 }
 
-# A leg that could not run is no more a green than a red one: the branch
-# went unverified either way, so it keeps the deferred ledger unsettled.
-$legFailed = ($testRc -ne 0) -or ($testWinRc -ne 0) -or ($fuzzRc -is [int] -and $fuzzRc -ne 0)
+$legFailed = Test-LegFailed $testRc $testWinRc $fuzzRc
 
 # Deferred signoffs are merges made on credit against exactly this run. A
 # green pass over the whole branch is what they were borrowing, so it settles

--- a/.agents/scripts/nightly_fuzz.ps1
+++ b/.agents/scripts/nightly_fuzz.ps1
@@ -191,11 +191,14 @@ function Get-LegArgs([string]$Recipe, [string]$Reason, [string]$Justfile, [strin
 # come back as an array of every line the build printed with the status
 # tacked on the end, and every comparison against it would be nonsense.
 # Out-Host is also what Start-Transcript records, so the log tail an issue
-# quotes is unchanged.
+# quotes is unchanged. stderr is merged in for the same reason: incoda says
+# who killed a run and why on stderr, and the 124 note below sends the
+# reader to a transcript that would not otherwise contain it. Merging
+# cannot pollute the return value, because Out-Host consumes both streams.
 $script:LegRunner = {
     param($exe, $argv)
     $global:LASTEXITCODE = $null
-    & $exe @argv | Out-Host
+    & $exe @argv 2>&1 | Out-Host
     $LASTEXITCODE ?? 1
 }
 
@@ -610,6 +613,10 @@ $legClock = [System.Diagnostics.Stopwatch]::StartNew()
 $env:WINTTY_TEST_SEED = '0x{0:x}' -f (Get-Random -Minimum 1 -Maximum 2147483647)
 Write-Host "nightly: WINTTY_TEST_SEED=$env:WINTTY_TEST_SEED"
 $testRc = Invoke-Leg -Recipe 'test' -Reason 'nightly zig tests' -Justfile (Join-Path $wt 'justfile') -WorkTree $wt
+# Wall time around the whole wrapped leg, so on a busy box it carries the
+# queue wait as well as the run. The record calls it observed seconds and
+# nothing reads it as a budget, but do not quote it as how long the leg
+# takes.
 $testSeconds = [int]$legClock.Elapsed.TotalSeconds
 $script:status.results['zig-tests'] = $testRc
 Write-Host "nightly: zig tests rc=$testRc"

--- a/.agents/scripts/nightly_fuzz.ps1
+++ b/.agents/scripts/nightly_fuzz.ps1
@@ -27,6 +27,15 @@
 # infra-titled issue instead of masquerading as product breaks, and the
 # script exits nonzero when any leg failed.
 #
+# The test legs run under the wintty-build lane (AGENTS.md, heavy job
+# lanes): `just test` and `just test-win` are single-class recipes that stay
+# lane-free inside so they run on any host, so their caller wraps them, and
+# the nightly is a caller like any other. `just fuzz` takes its own two
+# lanes per phase and is called bare. incoda is therefore preflighted with
+# the rest: an unlaned nightly would drop a full zig build and a dotnet test
+# run next to whatever a session is already building, which is the collision
+# the lanes exist to prevent.
+#
 # Hibernate only happens for scheduled runs (or -HibernateAfter), only when
 # the saved config allows it, and only after the same continuous-idle check,
 # so the machine is never hibernated under someone using it.
@@ -146,6 +155,45 @@ function Get-FuzzOutcome {
     }
 }
 
+# incoda's lookup, the justfile's: PATH, then the installer's location. The
+# agent shell this was written under had the latter and not the former.
+function Get-IncodaPath {
+    $found = (Get-Command incoda -ErrorAction SilentlyContinue)?.Source
+    if ($found) { return $found }
+    $installed = Join-Path $env:LOCALAPPDATA 'Programs\incoda\incoda.exe'
+    if (Test-Path $installed) { return $installed }
+    return $null
+}
+
+# The argv for one laned test leg. Built here rather than inline so the
+# self-test can assert the wrap is actually there: a leg that quietly lost
+# its `incoda run` prefix would still pass every other check in this file
+# and only show up as a machine falling over at 23:00.
+function Get-LegArgs([string]$Recipe, [string]$Reason, [string]$Justfile, [string]$WorkTree) {
+    @('run', '--queue', 'wintty-build', '--reason', $Reason, '--',
+      'just', '--justfile', $Justfile, '--working-directory', $WorkTree, $Recipe)
+}
+
+# What a laned test leg's exit code means. incoda passes the child's own
+# status through unchanged, so every code here is `just`'s except 121:
+# --wait elapsed while the run was still queued, which means the lane was
+# never granted and the recipe never started. Filing that as a red test
+# suite would put a product title on a scheduling problem - the same
+# mistake, the other way round, that Get-FuzzOutcome exists to prevent.
+# A function for the same reason: the self-test asserts against THIS
+# mapping, not a copy of it.
+function Get-LegOutcome {
+    param($Code)
+    # $null explicitly: an exit code that was never collected means the leg
+    # was not observed, not that it passed.
+    if ($null -eq $Code) { return 'could-not-run' }
+    switch ([int]$Code) {
+        0       { 'pass' }
+        121     { 'could-not-run' }
+        default { 'fail' }
+    }
+}
+
 if ($SelfTest) {
     $failed = $false
     $idle = [NightlyIdleProbe]::MinutesIdle()
@@ -181,6 +229,33 @@ if ($SelfTest) {
     # never collected must not coerce to 0 and pass as a clean night.
     if ((Get-FuzzOutcome $null) -ne 'harness') { Write-Host 'SELF-TEST FAILED: an uncollected exit code must not read as a clean run'; $failed = $true }
 
+    # The test legs' lane wrap and its exit codes. The wrap is asserted as
+    # argv because that is what silently goes missing; the mapping is
+    # asserted one code at a time, for the same reason as the fuzz table.
+    $legArgs = @(Get-LegArgs 'test' 'nightly zig tests' 'C:\wt\justfile' 'C:\wt')
+    $sep = [array]::IndexOf($legArgs, '--')
+    if ($legArgs[0] -ne 'run' -or $legArgs[1] -ne '--queue' -or $legArgs[2] -ne 'wintty-build') {
+        Write-Host "SELF-TEST FAILED: a test leg must run under the wintty-build lane, got '$($legArgs -join ' ')'"; $failed = $true
+    }
+    if ($legArgs[3] -ne '--reason' -or -not $legArgs[4]) {
+        Write-Host 'SELF-TEST FAILED: the lane refuses a run without --reason, so the leg must carry one'; $failed = $true
+    }
+    if ($sep -lt 0 -or $legArgs[$sep + 1] -ne 'just' -or $legArgs[-1] -ne 'test') {
+        Write-Host "SELF-TEST FAILED: the wrapped command must be the just recipe, got '$($legArgs -join ' ')'"; $failed = $true
+    }
+    foreach ($c in @(
+        @{ code = 0;   want = 'pass';          why = '0 is a green leg' }
+        @{ code = 1;   want = 'fail';          why = 'the child ran and failed' }
+        @{ code = 121; want = 'could-not-run'; why = 'incoda 121 means the lane was never granted, so the recipe never started' }
+    )) {
+        $got = Get-LegOutcome $c.code
+        if ($got -ne $c.want) {
+            Write-Host "SELF-TEST FAILED: leg exit $($c.code) mapped to '$got', expected '$($c.want)' ($($c.why))"
+            $failed = $true
+        }
+    }
+    if ((Get-LegOutcome $null) -ne 'could-not-run') { Write-Host 'SELF-TEST FAILED: an uncollected leg exit code must not read as a pass'; $failed = $true }
+
     # The self-test dir must be disjoint from the real logs, or a run of the
     # self-test would wipe the user's saved options.
     if ($logDir -eq (Join-Path $repoRoot '.agents\nightly-logs')) { Write-Host 'SELF-TEST FAILED: not sandboxed'; $failed = $true }
@@ -197,6 +272,17 @@ $missing = @('git', 'gh', 'just', 'pwsh') | Where-Object { -not (Get-Command $_ 
 if ($missing) {
     Write-Status 'aborted-missing-tools'
     Add-Content $log "nightly: aborting, tools not on PATH in this session: $($missing -join ', ')"
+    exit 1
+}
+
+# incoda is required for the same reason: the test legs must hold the
+# wintty-build lane, and a leg that cannot take it must refuse rather than
+# run unlaned next to a session's build. Not in $missing above because the
+# lookup is not just PATH.
+$incoda = Get-IncodaPath
+if (-not $incoda) {
+    Write-Status 'aborted-missing-tools'
+    Add-Content $log 'nightly: aborting, incoda is not on PATH or in Programs\incoda; the test legs run under the wintty-build lane and must not run unlaned (AGENTS.md, heavy job lanes; https://github.com/deblasis/incoda)'
     exit 1
 }
 
@@ -321,7 +407,7 @@ $legClock = [System.Diagnostics.Stopwatch]::StartNew()
 # reproduced from the report.
 $env:WINTTY_TEST_SEED = '0x{0:x}' -f (Get-Random -Minimum 1 -Maximum 2147483647)
 Write-Host "nightly: WINTTY_TEST_SEED=$env:WINTTY_TEST_SEED"
-just --justfile (Join-Path $wt 'justfile') --working-directory $wt test
+& $incoda @(Get-LegArgs 'test' 'nightly zig tests' (Join-Path $wt 'justfile') $wt)
 $testRc = $LASTEXITCODE ?? 1
 $testSeconds = [int]$legClock.Elapsed.TotalSeconds
 $script:status.results['zig-tests'] = $testRc
@@ -330,7 +416,7 @@ Write-Host "nightly: zig tests rc=$testRc"
 Write-Status 'windows-tests'
 $global:LASTEXITCODE = $null
 $legClock.Restart()
-just --justfile (Join-Path $wt 'justfile') --working-directory $wt test-win
+& $incoda @(Get-LegArgs 'test-win' 'nightly windows tests' (Join-Path $wt 'justfile') $wt)
 $testWinRc = $LASTEXITCODE ?? 1
 $testWinSeconds = [int]$legClock.Elapsed.TotalSeconds
 $script:status.results['windows-tests'] = $testWinRc
@@ -351,8 +437,15 @@ if ((Test-Path $legCache) -and $script:sha -and (Test-Path $envSnapshot)) {
     }
 }
 
-if ($testRc -ne 0) { File-Issue '[nightly] zig test suite failed on windows branch' "``just test`` exited $testRc (WINTTY_TEST_SEED=$env:WINTTY_TEST_SEED)." }
-if ($testWinRc -ne 0) { File-Issue '[nightly] Windows test suite failed on windows branch' "``just test-win`` exited $testWinRc." }
+$laneNote = 'The wintty-build lane was not granted within incoda''s wait, so the recipe never started. This is a runner problem, not a product break: nothing was judged.'
+switch (Get-LegOutcome $testRc) {
+    'fail'          { File-Issue '[nightly] zig test suite failed on windows branch' "``just test`` exited $testRc (WINTTY_TEST_SEED=$env:WINTTY_TEST_SEED)." }
+    'could-not-run' { File-Issue '[nightly] infra: the zig test leg never ran' "incoda exited $testRc. $laneNote" }
+}
+switch (Get-LegOutcome $testWinRc) {
+    'fail'          { File-Issue '[nightly] Windows test suite failed on windows branch' "``just test-win`` exited $testWinRc." }
+    'could-not-run' { File-Issue '[nightly] infra: the Windows test leg never ran' "incoda exited $testWinRc. $laneNote" }
+}
 
 $wakeLockNote = 'If this machine wakes from hibernation to the lock screen every night (sign-in on wake), the fuzz leg can never run; the appliance flow needs sign-in on wake disabled to get fuzz coverage.'
 
@@ -394,6 +487,8 @@ if (-not $lastSuccess -or ((Get-Date) - $lastSuccess).TotalDays -gt 7) {
     File-Issue '[nightly] fuzz starvation: no successful fuzz run in 7 days' "The GUI fuzz leg has been skipped or failing for over a week; fuzz coverage is effectively off. $wakeLockNote"
 }
 
+# A leg that could not run is no more a green than a red one: the branch
+# went unverified either way, so it keeps the deferred ledger unsettled.
 $legFailed = ($testRc -ne 0) -or ($testWinRc -ne 0) -or ($fuzzRc -is [int] -and $fuzzRc -ne 0)
 
 # Deferred signoffs are merges made on credit against exactly this run. A

--- a/.agents/scripts/register_nightly_fuzz.ps1
+++ b/.agents/scripts/register_nightly_fuzz.ps1
@@ -13,11 +13,16 @@ if (-not (Test-Path $target)) { throw "nightly_fuzz.ps1 not found next to this s
 
 $action = New-ScheduledTaskAction -Execute 'pwsh.exe' `
     -Argument "-NoProfile -ExecutionPolicy Bypass -File `"$target`" -Scheduled"
-# The limit must clear the worst case: up to 3h of idle-wait plus the full
-# ladder, the fuzz suite's own idle-wait, and the hibernate wait.
+# The limit must clear the worst case: up to 3h of idle-wait, then up to 2h
+# of incoda queue wait per wrapped test leg (two of them), then the full
+# ladder, the fuzz suite's own idle-wait, and the hibernate wait. The two
+# waits correlate: a box busy enough to keep the user active is a box with
+# a deep build lane. Task Scheduler ends an overrun by killing the process
+# tree, which is a nightly that dies filing nothing, so this budget is
+# deliberately loose rather than tight.
 $trigger = New-ScheduledTaskTrigger -Daily -At 23:00
 $settings = New-ScheduledTaskSettingsSet -StartWhenAvailable -WakeToRun `
-    -ExecutionTimeLimit (New-TimeSpan -Hours 6) `
+    -ExecutionTimeLimit (New-TimeSpan -Hours 10) `
     -MultipleInstances IgnoreNew
 
 Register-ScheduledTask -TaskName 'wintty-nightly-quality' `

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,8 @@ desktop lanes together and alone, `incoda run --queue
 wintty-build,wintty-desktop --exclusive -- <cmd...>`: it waits for every
 holder to leave and keeps the machine to itself while it runs. The old
 `wintty` key is retired: closed on the box, it refuses every run with a
-message naming these.
+message naming these. This configuration is applied from the repo by `just
+lanes` (`.agents/scripts/lanes.ps1`) and verified by `just doctor`.
 
 ```
 incoda run --queue wintty-build --reason "what this is" -- <cmd...>

--- a/justfile
+++ b/justfile
@@ -257,6 +257,12 @@ inc := '(Get-Command incoda -ErrorAction SilentlyContinue)?.Source ?? (Join-Path
 # --reason requirement, the retired `wintty` key closed) from
 # .agents/scripts/lanes.ps1, the one record of it in the repo; only a lane
 # that drifted is touched. `just doctor` runs the same script's -Check.
+#
+# [windows] like every other lane recipe: it writes machine-global state
+# through an incoda whose fallback location is under %LOCALAPPDATA%, which
+# exists nowhere else. The script's own -SelfTest needs neither and runs
+# cross-platform in `gates-selftest`.
+[windows]
 lanes:
     pwsh -NoProfile -File .agents/scripts/lanes.ps1
 
@@ -1748,8 +1754,9 @@ gitversion-selftest:
     pwsh -NoProfile -File .agents/scripts/gitversion_selftest.ps1
 
 # Recorded-PR replays, matcher escapes, exemption anchoring, the merge
-# guard's refusal matrix and golden issue body, and the nightly scripts'
-# helpers roundtripping. `gitversion-selftest` runs first.
+# guard's refusal matrix and golden issue body, the nightly scripts'
+# helpers roundtripping, and the lane table's drift and apply argv.
+# `gitversion-selftest` runs first.
 #
 # Prove the gates still catch what they exist for.
 gates-selftest: gitversion-selftest
@@ -1763,6 +1770,7 @@ gates-selftest: gitversion-selftest
     python .agents/scripts/leg_cache.py --self-test
     pwsh -NoProfile -File .agents/scripts/nightly_fuzz.ps1 -SelfTest
     pwsh -NoProfile -File .agents/scripts/nightly_control.ps1 -SelfTest
+    pwsh -NoProfile -File .agents/scripts/lanes.ps1 -SelfTest
 
 # Prove the shipping-build gate refuses a leak in a real Release evaluation (#929)
 [windows]

--- a/justfile
+++ b/justfile
@@ -253,6 +253,13 @@ test-win:
 # body's pwsh, so a `just test` on a Linux host never runs it.
 inc := '(Get-Command incoda -ErrorAction SilentlyContinue)?.Source ?? (Join-Path $env:LOCALAPPDATA "Programs\incoda\incoda.exe")'
 
+# Apply the lane configuration AGENTS.md promises (slots, descriptions, the
+# --reason requirement, the retired `wintty` key closed) from
+# .agents/scripts/lanes.ps1, the one record of it in the repo; only a lane
+# that drifted is touched. `just doctor` runs the same script's -Check.
+lanes:
+    pwsh -NoProfile -File .agents/scripts/lanes.ps1
+
 # The build phase of a harness recipe, under the build lane. Every harness
 # recipe depends on this instead of on `build-dll build-win` directly: the
 # lane a build needs (CPU and RAM, three at a time) is not the lane a
@@ -1709,7 +1716,9 @@ resignoff-bot *args:
 
 # Check that everything the gates depend on is present and wired: tools on
 # PATH, scripts where the hooks point, settings parseable, nightly task
-# registration. A SessionStart hook runs the fast subset automatically.
+# registration, and where incoda is present, that the heavy job lanes match
+# .agents/scripts/lanes.ps1. A SessionStart hook runs the fast subset
+# automatically.
 doctor:
     python .agents/scripts/doctor.py
 


### PR DESCRIPTION
The lane configuration AGENTS.md promises lives in incoda's own state dir, where nothing in the repo could see it, which is how a claim that the retired `wintty` key was closed reached review while the key still took jobs. `.agents/scripts/lanes.ps1` is now the record: `just lanes` applies it and touches only a lane that drifted, `-Check` reports drift and changes nothing, and `just doctor` runs that check and reports incoda's path and version.

Separately, the nightly ran `just test` and `just test-win` unlaned. Those are single-class recipes the caller wraps, so the nightly now wraps them under `wintty-build`; incoda joins the tool preflight so a leg that cannot take the lane refuses instead of running unlaned. incoda passes the child's status through unchanged, and 121 (the lane was never granted) files an infra issue rather than a red test suite, while still leaving the run not-green.

Test plan:

- [x] `pwsh .agents/scripts/lanes.ps1 -Check` exits 0 against the live config
- [x] `just lanes` is a no-op here: `incoda queues` identical before and after, "nothing applied"
- [x] apply and drift paths exercised against a throwaway `INCODA_DIR`: missing lanes created, wrong slots / missing `--require-reason` / wrong description / reopened `wintty` each reported and repaired, read-back green
- [x] `just doctor` passes and reports `incoda v0.3.0` and matching lanes
- [x] `just gates-selftest` green (includes `doctor.py --self-test` and `nightly_fuzz.ps1 -SelfTest`)
- [x] `just -n lanes`, `just --evaluate`
- [x] incoda exit passthrough and 121 verified against the throwaway state dir
- [x] nightly refusal path: with incoda hidden, the run aborts `aborted-missing-tools` rc=1 before doing anything
- [x] self-test mutation-checked: dropping the lane wrap, the `--reason`, or the 121 arm each fails `-SelfTest`
- [ ] a real nightly run (no heavy build was run in this session)
