### PR TITLE
fuzz-suite: keep run output out of the definition scan

### DIFF
--- a/windows/scripts/fuzz-suite.ps1
+++ b/windows/scripts/fuzz-suite.ps1
@@ -1363,7 +1363,27 @@ $dupRoot = $PSScriptRoot
 # under it and missed lib/fuzz-selftest/ entirely -- which is where the guards
 # for the other five checks live, and which dot-sources back into a scanned
 # lib, so the blind spot ran in both directions.
-$dupScanFiles = @(Get-ChildItem -LiteralPath $dupRoot -Filter '*.ps1' -File -Recurse)
+#
+# Run output is skipped, because it is not source. This script writes every
+# run under fuzz-out/ (-OutRoot's default), and -SelfTest stages a whole
+# second copy of the suite there to drive the tier-layer cases: a run in
+# flight therefore puts a duplicate of every scanned file INSIDE the scanned
+# tree. A concurrent -List then read the copy as a genuine redefinition --
+# lib/wintty-process.ps1 shadowing itself, once per function it defines --
+# and a fixture deleted between the enumeration and the parse came back as
+# "does not parse". Neither is a defect in anything tracked, and nothing
+# tracked is ever written there, so the check loses no reach. Both the
+# default root and whatever -OutRoot was pointed at are skipped: a caller who
+# moves it inside this directory would otherwise walk straight back in.
+$dupSkip = @((Join-Path $dupRoot 'fuzz-out'), $OutRoot) | ForEach-Object {
+    [IO.Path]::GetFullPath($_).TrimEnd([IO.Path]::DirectorySeparatorChar) +
+        [IO.Path]::DirectorySeparatorChar
+}
+$dupScanFiles = @(Get-ChildItem -LiteralPath $dupRoot -Filter '*.ps1' -File -Recurse |
+    Where-Object {
+        $path = $_.FullName
+        @($dupSkip).Where({ $path.StartsWith($_, [StringComparison]::OrdinalIgnoreCase) }).Count -eq 0
+    })
 
 # Keyed by path relative to this directory, because recursion makes a leaf
 # ambiguous: lib/pro/x.ps1 and x.ps1 are two files with one leaf.

--- a/windows/scripts/fuzz-suite.ps1
+++ b/windows/scripts/fuzz-suite.ps1
@@ -1375,9 +1375,13 @@ $dupRoot = $PSScriptRoot
 # tracked is ever written there, so the check loses no reach. Both the
 # default root and whatever -OutRoot was pointed at are skipped: a caller who
 # moves it inside this directory would otherwise walk straight back in.
+# Resolved through the session state, not [IO.Path]::GetFullPath: .NET
+# resolves a relative path against the PROCESS working directory, which in
+# PowerShell is not the session's location, so a relative -OutRoot would
+# produce a prefix that matches nothing and silently skip nothing.
 $dupSkip = @((Join-Path $dupRoot 'fuzz-out'), $OutRoot) | ForEach-Object {
-    [IO.Path]::GetFullPath($_).TrimEnd([IO.Path]::DirectorySeparatorChar) +
-        [IO.Path]::DirectorySeparatorChar
+    $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($_).
+        TrimEnd([IO.Path]::DirectorySeparatorChar) + [IO.Path]::DirectorySeparatorChar
 }
 $dupScanFiles = @(Get-ChildItem -LiteralPath $dupRoot -Filter '*.ps1' -File -Recurse |
     Where-Object {


### PR DESCRIPTION
Integrity check 6 walked every `.ps1` under `windows/scripts` recursively, and the suite writes its own runs under `windows/scripts/fuzz-out`. `-SelfTest` stages a full copy of the suite there for the tier-layer cases, so while one is in flight the scanned tree holds a second copy of every file in it, and a concurrent `just fuzz-list` refused with a wall of spurious duplicates (`lib/wintty-process.ps1` shadowing itself) or with "does not parse" for a fixture deleted between the enumeration and the parse.

The scan now skips the run-output root, both at its default location and wherever `-OutRoot` was pointed. Nothing tracked is written there, so check 6 keeps its full reach over the scripts it exists to police.

Test plan:
- [x] Before the fix: `-SelfTest` in the background, `-List` in a loop - `-List` failed on iteration 18 with the duplicate refusal naming `fuzz-out/.../layer/layer-scripts/lib/*.ps1`.
- [x] After the fix: same reproduction - 62 `-List` iterations while `-SelfTest` ran, all exit 0, `-SelfTest` exit 0.
- [x] `just fuzz-list` alone: exit 0.
- [x] `just fuzz-selftest` alone: SELFTEST OK (12 exit paths, 63 tier layer cases, 3 refusal cases).
- [x] `-List` with a full 116-file in-flight layer copy planted under `fuzz-out/`: exit 0.
- [x] Check 6 still fires: a scratch `lib/scratch-dup-probe.ps1` defining one function twice was refused with `defines Test-ScratchDupProbe 2 times, at lines 5 and 9`, then deleted.