### PR TITLE
benchmark: preload corpora, free screen clones, wire up duration mode

### DIFF
--- a/src/benchmark/ApcParser.zig
+++ b/src/benchmark/ApcParser.zig
@@ -29,6 +29,17 @@ pub const Options = struct {
     /// use stdin by default but I find that a hanging CLI command
     /// with no interaction is a bit annoying.
     data: ?[]const u8 = null,
+
+    /// `cli.args.parse` allocates `[]const u8` fields (like `data`
+    /// above) out of this arena when present; without it, allocations
+    /// go through an internal allocator that's never freed. See
+    /// `deinit`.
+    _arena: ?std.heap.ArenaAllocator = null,
+
+    pub fn deinit(self: *Options) void {
+        if (self._arena) |arena| arena.deinit();
+        self.* = undefined;
+    }
 };
 
 const Stream = terminalpkg.Stream(Handler);

--- a/src/benchmark/CApi.zig
+++ b/src/benchmark/CApi.zig
@@ -18,7 +18,7 @@ export fn ghostty_benchmark_cli(
         return false;
     };
 
-    cli.mainAction(
+    _ = cli.mainAction(
         global.alloc(),
         action,
         .{ .string = std.mem.sliceTo(args, 0) },

--- a/src/benchmark/CodepointWidth.zig
+++ b/src/benchmark/CodepointWidth.zig
@@ -47,6 +47,17 @@ pub const Options = struct {
     /// use stdin by default but I find that a hanging CLI command
     /// with no interaction is a bit annoying.
     data: ?[]const u8 = null,
+
+    /// `cli.args.parse` allocates `[]const u8` fields (like `data`
+    /// above) out of this arena when present; without it, allocations
+    /// go through an internal allocator that's never freed. See
+    /// `deinit`.
+    _arena: ?std.heap.ArenaAllocator = null,
+
+    pub fn deinit(self: *Options) void {
+        if (self._arena) |arena| arena.deinit();
+        self.* = undefined;
+    }
 };
 
 pub const Mode = enum {
@@ -132,7 +143,9 @@ fn teardown(ptr: *anyopaque) void {
         f.close(global.io());
         self.data_f = null;
     }
-    if (self.data.len > 0) self.alloc.free(self.data);
+    // `Allocator.free` is a no-op on a zero-length slice, so this is
+    // safe even for the `simd` mode, which never populates `data`.
+    self.alloc.free(self.data);
     self.data = &.{};
 }
 

--- a/src/benchmark/CodepointWidth.zig
+++ b/src/benchmark/CodepointWidth.zig
@@ -11,6 +11,7 @@ const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
 const Benchmark = @import("Benchmark.zig");
 const options = @import("options.zig");
+const compat_file = @import("../lib/compat/file.zig");
 const UTF8Decoder = @import("../terminal/UTF8Decoder.zig");
 const simd = @import("../simd/main.zig");
 const table = @import("../unicode/main.zig").table;
@@ -18,10 +19,23 @@ const global = @import("../global.zig");
 
 const log = std.log.scoped(.@"terminal-stream-bench");
 
-opts: Options,
+/// Prevent a malformed or accidentally enormous corpus from consuming
+/// unbounded memory during benchmark setup.
+const max_data_size = 64 * 1024 * 1024;
 
-/// The file, opened in the setup function.
+opts: Options,
+alloc: Allocator,
+
+/// The file, opened in the setup function. Used only by the `simd`
+/// mode's step, which reads directly from disk on every call. That
+/// mode measures a dead code path scheduled for removal separately, so
+/// it's left untouched here rather than folded into the preload below.
 data_f: ?std.Io.File = null,
+
+/// Complete contents of the input corpus for the `noop`, `wcwidth` and
+/// `table` modes, read once in `setup` so the timed step measures
+/// codepoint-width throughput rather than file IO.
+data: []u8 = &.{},
 
 pub const Options = struct {
     /// The type of codepoint width calculation to use.
@@ -58,7 +72,7 @@ pub fn create(
 ) !*CodepointWidth {
     const ptr = try alloc.create(CodepointWidth);
     errdefer alloc.destroy(ptr);
-    ptr.* = .{ .opts = opts };
+    ptr.* = .{ .opts = opts, .alloc = alloc };
     return ptr;
 }
 
@@ -82,13 +96,34 @@ pub fn benchmark(self: *CodepointWidth) Benchmark {
 fn setup(ptr: *anyopaque) Benchmark.Error!void {
     const self: *CodepointWidth = @ptrCast(@alignCast(ptr));
 
-    // Open our data file to prepare for reading. We can do more
-    // validation here eventually.
-    assert(self.data_f == null);
-    self.data_f = options.dataFile(self.opts.data) catch |err| {
-        log.warn("error opening data file err={}", .{err});
-        return error.BenchmarkFailed;
-    };
+    switch (self.opts.mode) {
+        // Unchanged: this mode reads from `data_f` directly inside its
+        // step. See the field doc comment for why.
+        .simd => {
+            assert(self.data_f == null);
+            self.data_f = options.dataFile(self.opts.data) catch |err| {
+                log.warn("error opening data file err={}", .{err});
+                return error.BenchmarkFailed;
+            };
+        },
+        .noop, .wcwidth, .table => {
+            assert(self.data.len == 0);
+            const f = (options.dataFile(self.opts.data) catch |err| {
+                log.warn("error opening data file err={}", .{err});
+                return error.BenchmarkFailed;
+            }) orelse return;
+            defer f.close(global.io());
+
+            self.data = compat_file.readToEndAlloc(
+                f,
+                self.alloc,
+                max_data_size,
+            ) catch |err| {
+                log.warn("error reading data file err={}", .{err});
+                return error.BenchmarkFailed;
+            };
+        },
+    }
 }
 
 fn teardown(ptr: *anyopaque) void {
@@ -97,6 +132,8 @@ fn teardown(ptr: *anyopaque) void {
         f.close(global.io());
         self.data_f = null;
     }
+    if (self.data.len > 0) self.alloc.free(self.data);
+    self.data = &.{};
 }
 
 fn stepNoop(ptr: *anyopaque) Benchmark.Error!void {
@@ -113,26 +150,12 @@ fn stepWcwidth(ptr: *anyopaque) Benchmark.Error!void {
 
     const self: *CodepointWidth = @ptrCast(@alignCast(ptr));
 
-    const f = self.data_f orelse return;
-    var read_buf: [4096]u8 align(std.atomic.cache_line) = undefined;
-    var f_reader = f.reader(global.io(), &read_buf);
-    var r = &f_reader.interface;
-
     var d: UTF8Decoder = .{};
-    var buf: [4096]u8 align(std.atomic.cache_line) = undefined;
-    while (true) {
-        const n = r.readSliceShort(&buf) catch {
-            log.warn("error reading data file err={?}", .{f_reader.err});
-            return error.BenchmarkFailed;
-        };
-        if (n == 0) break; // EOF reached
-
-        for (buf[0..n]) |c| {
-            const cp_, const consumed = d.next(c);
-            assert(consumed);
-            if (cp_) |cp| {
-                std.mem.doNotOptimizeAway(wcwidth(cp));
-            }
+    for (self.data) |c| {
+        const cp_, const consumed = d.next(c);
+        assert(consumed);
+        if (cp_) |cp| {
+            std.mem.doNotOptimizeAway(wcwidth(cp));
         }
     }
 }
@@ -140,31 +163,17 @@ fn stepWcwidth(ptr: *anyopaque) Benchmark.Error!void {
 fn stepTable(ptr: *anyopaque) Benchmark.Error!void {
     const self: *CodepointWidth = @ptrCast(@alignCast(ptr));
 
-    const f = self.data_f orelse return;
-    var read_buf: [4096]u8 align(std.atomic.cache_line) = undefined;
-    var f_reader = f.reader(global.io(), &read_buf);
-    var r = &f_reader.interface;
-
     var d: UTF8Decoder = .{};
-    var buf: [4096]u8 align(std.atomic.cache_line) = undefined;
-    while (true) {
-        const n = r.readSliceShort(&buf) catch {
-            log.warn("error reading data file err={?}", .{f_reader.err});
-            return error.BenchmarkFailed;
-        };
-        if (n == 0) break; // EOF reached
-
-        for (buf[0..n]) |c| {
-            const cp_, const consumed = d.next(c);
-            assert(consumed);
-            if (cp_) |cp| {
-                // This is the same trick we do in terminal.zig so we
-                // keep it here.
-                std.mem.doNotOptimizeAway(if (cp <= 0xFF)
-                    1
-                else
-                    table.get(@intCast(cp)).width);
-            }
+    for (self.data) |c| {
+        const cp_, const consumed = d.next(c);
+        assert(consumed);
+        if (cp_) |cp| {
+            // This is the same trick we do in terminal.zig so we
+            // keep it here.
+            std.mem.doNotOptimizeAway(if (cp <= 0xFF)
+                1
+            else
+                table.get(@intCast(cp)).width);
         }
     }
 }
@@ -205,4 +214,19 @@ test CodepointWidth {
 
     const bench = impl.benchmark();
     _ = try bench.run(.once);
+}
+
+test "CodepointWidth stepTable consumes preloaded data without a file" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const impl: *CodepointWidth = try .create(alloc, .{ .mode = .table });
+    defer impl.destroy(alloc);
+
+    // `stepTable` must work entirely off `self.data`; `data_f` stays
+    // null for this mode. This only passes if `setup`'s preload
+    // contract holds for non-simd modes.
+    impl.data = try alloc.dupe(u8, "hello");
+    try stepTable(impl);
+    teardown(impl);
 }

--- a/src/benchmark/CodepointWidth.zig
+++ b/src/benchmark/CodepointWidth.zig
@@ -19,9 +19,11 @@ const global = @import("../global.zig");
 
 const log = std.log.scoped(.@"terminal-stream-bench");
 
-/// Prevent a malformed or accidentally enormous corpus from consuming
-/// unbounded memory during benchmark setup.
-const max_data_size = 64 * 1024 * 1024;
+/// Cap on the corpus preloaded in `setup`. This benchmark used to
+/// stream its input in chunks and had no limit at all, so the cap is
+/// only a guard against a malformed or accidentally enormous file and
+/// is set well above any corpus a developer would pass on purpose.
+const max_data_size = 1024 * 1024 * 1024;
 
 opts: Options,
 alloc: Allocator,
@@ -130,7 +132,12 @@ fn setup(ptr: *anyopaque) Benchmark.Error!void {
                 self.alloc,
                 max_data_size,
             ) catch |err| {
-                log.warn("error reading data file err={}", .{err});
+                // Name the cap: a corpus over it fails with
+                // StreamTooLong, which on its own reads like an IO error.
+                log.warn("error reading data file err={} max_bytes={}", .{
+                    err,
+                    max_data_size,
+                });
                 return error.BenchmarkFailed;
             };
         },

--- a/src/benchmark/CodepointWidth.zig
+++ b/src/benchmark/CodepointWidth.zig
@@ -28,15 +28,8 @@ const max_data_size = 1024 * 1024 * 1024;
 opts: Options,
 alloc: Allocator,
 
-/// The file, opened in the setup function. Used only by the `simd`
-/// mode's step, which reads directly from disk on every call. That
-/// mode measures a dead code path scheduled for removal separately, so
-/// it's left untouched here rather than folded into the preload below.
-data_f: ?std.Io.File = null,
-
-/// Complete contents of the input corpus for the `noop`, `wcwidth` and
-/// `table` modes, read once in `setup` so the timed step measures
-/// codepoint-width throughput rather than file IO.
+/// Complete contents of the input corpus, read once in `setup` so the
+/// timed step measures codepoint-width throughput rather than file IO.
 data: []u8 = &.{},
 
 pub const Options = struct {
@@ -109,49 +102,35 @@ pub fn benchmark(self: *CodepointWidth) Benchmark {
 fn setup(ptr: *anyopaque) Benchmark.Error!void {
     const self: *CodepointWidth = @ptrCast(@alignCast(ptr));
 
-    switch (self.opts.mode) {
-        // Unchanged: this mode reads from `data_f` directly inside its
-        // step. See the field doc comment for why.
-        .simd => {
-            assert(self.data_f == null);
-            self.data_f = options.dataFile(self.opts.data) catch |err| {
-                log.warn("error opening data file err={}", .{err});
-                return error.BenchmarkFailed;
-            };
-        },
-        .noop, .wcwidth, .table => {
-            assert(self.data.len == 0);
-            const f = (options.dataFile(self.opts.data) catch |err| {
-                log.warn("error opening data file err={}", .{err});
-                return error.BenchmarkFailed;
-            }) orelse return;
-            defer f.close(global.io());
+    // Preload the entire data file into memory so the timed steps below
+    // measure width calculation, not file IO. Every mode reads the same
+    // buffer, so no mode depends on the file handle staying open.
+    assert(self.data.len == 0);
+    const f = (options.dataFile(self.opts.data) catch |err| {
+        log.warn("error opening data file err={}", .{err});
+        return error.BenchmarkFailed;
+    }) orelse return;
+    defer f.close(global.io());
 
-            self.data = compat_file.readToEndAlloc(
-                f,
-                self.alloc,
-                max_data_size,
-            ) catch |err| {
-                // Name the cap: a corpus over it fails with
-                // StreamTooLong, which on its own reads like an IO error.
-                log.warn("error reading data file err={} max_bytes={}", .{
-                    err,
-                    max_data_size,
-                });
-                return error.BenchmarkFailed;
-            };
-        },
-    }
+    self.data = compat_file.readToEndAlloc(
+        f,
+        self.alloc,
+        max_data_size,
+    ) catch |err| {
+        // Name the cap: a corpus over it fails with FileTooBig,
+        // which on its own reads like an IO error.
+        log.warn("error reading data file err={} max_bytes={}", .{
+            err,
+            max_data_size,
+        });
+        return error.BenchmarkFailed;
+    };
 }
 
 fn teardown(ptr: *anyopaque) void {
     const self: *CodepointWidth = @ptrCast(@alignCast(ptr));
-    if (self.data_f) |f| {
-        f.close(global.io());
-        self.data_f = null;
-    }
     // `Allocator.free` is a no-op on a zero-length slice, so this is
-    // safe even for the `simd` mode, which never populates `data`.
+    // safe even when `setup` never populated `data`.
     self.alloc.free(self.data);
     self.data = &.{};
 }
@@ -201,26 +180,12 @@ fn stepTable(ptr: *anyopaque) Benchmark.Error!void {
 fn stepSimd(ptr: *anyopaque) Benchmark.Error!void {
     const self: *CodepointWidth = @ptrCast(@alignCast(ptr));
 
-    const f = self.data_f orelse return;
-    var read_buf: [4096]u8 align(std.atomic.cache_line) = undefined;
-    var f_reader = f.reader(global.io(), &read_buf);
-    var r = &f_reader.interface;
-
     var d: UTF8Decoder = .{};
-    var buf: [4096]u8 align(std.atomic.cache_line) = undefined;
-    while (true) {
-        const n = r.readSliceShort(&buf) catch {
-            log.warn("error reading data file err={?}", .{f_reader.err});
-            return error.BenchmarkFailed;
-        };
-        if (n == 0) break; // EOF reached
-
-        for (buf[0..n]) |c| {
-            const cp_, const consumed = d.next(c);
-            assert(consumed);
-            if (cp_) |cp| {
-                std.mem.doNotOptimizeAway(simd.codepointWidth(cp));
-            }
+    for (self.data) |c| {
+        const cp_, const consumed = d.next(c);
+        assert(consumed);
+        if (cp_) |cp| {
+            std.mem.doNotOptimizeAway(simd.codepointWidth(cp));
         }
     }
 }
@@ -243,9 +208,9 @@ test "CodepointWidth stepTable consumes preloaded data without a file" {
     const impl: *CodepointWidth = try .create(alloc, .{ .mode = .table });
     defer impl.destroy(alloc);
 
-    // `stepTable` must work entirely off `self.data`; `data_f` stays
-    // null for this mode. This only passes if `setup`'s preload
-    // contract holds for non-simd modes.
+    // `stepTable` must work entirely off `self.data`, with no file
+    // handle at all. This only passes if `setup`'s preload contract
+    // holds.
     impl.data = try alloc.dupe(u8, "hello");
     try stepTable(impl);
     teardown(impl);

--- a/src/benchmark/GraphemeBreak.zig
+++ b/src/benchmark/GraphemeBreak.zig
@@ -37,6 +37,17 @@ pub const Options = struct {
     /// use stdin by default but I find that a hanging CLI command
     /// with no interaction is a bit annoying.
     data: ?[]const u8 = null,
+
+    /// `cli.args.parse` allocates `[]const u8` fields (like `data`
+    /// above) out of this arena when present; without it, allocations
+    /// go through an internal allocator that's never freed. See
+    /// `deinit`.
+    _arena: ?std.heap.ArenaAllocator = null,
+
+    pub fn deinit(self: *Options) void {
+        if (self._arena) |arena| arena.deinit();
+        self.* = undefined;
+    }
 };
 
 pub const Mode = enum {
@@ -99,7 +110,9 @@ fn setup(ptr: *anyopaque) Benchmark.Error!void {
 
 fn teardown(ptr: *anyopaque) void {
     const self: *GraphemeBreak = @ptrCast(@alignCast(ptr));
-    if (self.data.len > 0) self.alloc.free(self.data);
+    // `Allocator.free` is a no-op on a zero-length slice, so this is
+    // safe even when `setup` never populated `data`.
+    self.alloc.free(self.data);
     self.data = &.{};
 }
 

--- a/src/benchmark/GraphemeBreak.zig
+++ b/src/benchmark/GraphemeBreak.zig
@@ -8,6 +8,7 @@ const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
 const Benchmark = @import("Benchmark.zig");
 const options = @import("options.zig");
+const compat_file = @import("../lib/compat/file.zig");
 const UTF8Decoder = @import("../terminal/UTF8Decoder.zig");
 const unicode = @import("../unicode/main.zig");
 const uucode = @import("uucode");
@@ -15,10 +16,16 @@ const global = @import("../global.zig");
 
 const log = std.log.scoped(.@"terminal-stream-bench");
 
-opts: Options,
+/// Prevent a malformed or accidentally enormous corpus from consuming
+/// unbounded memory during benchmark setup.
+const max_data_size = 64 * 1024 * 1024;
 
-/// The file, opened in the setup function.
-data_f: ?std.Io.File = null,
+opts: Options,
+alloc: Allocator,
+
+/// Complete contents of the input corpus, read once in `setup` so the
+/// timed step measures grapheme-break throughput rather than file IO.
+data: []u8 = &.{},
 
 pub const Options = struct {
     /// The type of codepoint width calculation to use.
@@ -49,7 +56,7 @@ pub fn create(
 ) !*GraphemeBreak {
     const ptr = try alloc.create(GraphemeBreak);
     errdefer alloc.destroy(ptr);
-    ptr.* = .{ .opts = opts };
+    ptr.* = .{ .opts = opts, .alloc = alloc };
     return ptr;
 }
 
@@ -71,72 +78,52 @@ pub fn benchmark(self: *GraphemeBreak) Benchmark {
 fn setup(ptr: *anyopaque) Benchmark.Error!void {
     const self: *GraphemeBreak = @ptrCast(@alignCast(ptr));
 
-    // Open our data file to prepare for reading. We can do more
-    // validation here eventually.
-    assert(self.data_f == null);
-    self.data_f = options.dataFile(self.opts.data) catch |err| {
+    // Preload the entire data file into memory so the timed step
+    // below measures grapheme-break throughput, not file IO.
+    assert(self.data.len == 0);
+    const f = (options.dataFile(self.opts.data) catch |err| {
         log.warn("error opening data file err={}", .{err});
+        return error.BenchmarkFailed;
+    }) orelse return;
+    defer f.close(global.io());
+
+    self.data = compat_file.readToEndAlloc(
+        f,
+        self.alloc,
+        max_data_size,
+    ) catch |err| {
+        log.warn("error reading data file err={}", .{err});
         return error.BenchmarkFailed;
     };
 }
 
 fn teardown(ptr: *anyopaque) void {
     const self: *GraphemeBreak = @ptrCast(@alignCast(ptr));
-    if (self.data_f) |f| {
-        f.close(global.io());
-        self.data_f = null;
-    }
+    if (self.data.len > 0) self.alloc.free(self.data);
+    self.data = &.{};
 }
 
 fn stepNoop(ptr: *anyopaque) Benchmark.Error!void {
     const self: *GraphemeBreak = @ptrCast(@alignCast(ptr));
 
-    const f = self.data_f orelse return;
-    var read_buf: [4096]u8 align(std.atomic.cache_line) = undefined;
-    var f_reader = f.reader(global.io(), &read_buf);
-    var r = &f_reader.interface;
-
     var d: UTF8Decoder = .{};
-    var buf: [4096]u8 align(std.atomic.cache_line) = undefined;
-    while (true) {
-        const n = r.readSliceShort(&buf) catch {
-            log.warn("error reading data file err={?}", .{f_reader.err});
-            return error.BenchmarkFailed;
-        };
-        if (n == 0) break; // EOF reached
-
-        for (buf[0..n]) |c| {
-            _ = d.next(c);
-        }
+    for (self.data) |c| {
+        _ = d.next(c);
     }
 }
 
 fn stepTable(ptr: *anyopaque) Benchmark.Error!void {
     const self: *GraphemeBreak = @ptrCast(@alignCast(ptr));
 
-    const f = self.data_f orelse return;
-    var read_buf: [4096]u8 align(std.atomic.cache_line) = undefined;
-    var f_reader = f.reader(global.io(), &read_buf);
-    var r = &f_reader.interface;
-
     var d: UTF8Decoder = .{};
     var state: uucode.grapheme.BreakState = .default;
     var cp1: u21 = 0;
-    var buf: [4096]u8 align(std.atomic.cache_line) = undefined;
-    while (true) {
-        const n = r.readSliceShort(&buf) catch {
-            log.warn("error reading data file err={?}", .{f_reader.err});
-            return error.BenchmarkFailed;
-        };
-        if (n == 0) break; // EOF reached
-
-        for (buf[0..n]) |c| {
-            const cp_, const consumed = d.next(c);
-            assert(consumed);
-            if (cp_) |cp2| {
-                std.mem.doNotOptimizeAway(unicode.graphemeBreak(cp1, @intCast(cp2), &state));
-                cp1 = cp2;
-            }
+    for (self.data) |c| {
+        const cp_, const consumed = d.next(c);
+        assert(consumed);
+        if (cp_) |cp2| {
+            std.mem.doNotOptimizeAway(unicode.graphemeBreak(cp1, @intCast(cp2), &state));
+            cp1 = cp2;
         }
     }
 }
@@ -150,4 +137,20 @@ test GraphemeBreak {
 
     const bench = impl.benchmark();
     _ = try bench.run(.once);
+}
+
+test "GraphemeBreak stepTable consumes preloaded data without a file" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const impl: *GraphemeBreak = try .create(alloc, .{ .mode = .table });
+    defer impl.destroy(alloc);
+
+    // `stepTable` must work entirely off `self.data`. There's no
+    // `data_f` to read from anymore, so this only passes if `setup`'s
+    // preload contract holds: the corpus is fully in memory before the
+    // timed step runs.
+    impl.data = try alloc.dupe(u8, "e\u{301}"); // e + combining acute accent
+    try stepTable(impl);
+    teardown(impl);
 }

--- a/src/benchmark/GraphemeBreak.zig
+++ b/src/benchmark/GraphemeBreak.zig
@@ -16,9 +16,11 @@ const global = @import("../global.zig");
 
 const log = std.log.scoped(.@"terminal-stream-bench");
 
-/// Prevent a malformed or accidentally enormous corpus from consuming
-/// unbounded memory during benchmark setup.
-const max_data_size = 64 * 1024 * 1024;
+/// Cap on the corpus preloaded in `setup`. This benchmark used to
+/// stream its input in chunks and had no limit at all, so the cap is
+/// only a guard against a malformed or accidentally enormous file and
+/// is set well above any corpus a developer would pass on purpose.
+const max_data_size = 1024 * 1024 * 1024;
 
 opts: Options,
 alloc: Allocator,
@@ -103,7 +105,12 @@ fn setup(ptr: *anyopaque) Benchmark.Error!void {
         self.alloc,
         max_data_size,
     ) catch |err| {
-        log.warn("error reading data file err={}", .{err});
+        // Name the cap: a corpus over it fails with StreamTooLong,
+        // which on its own reads like an IO error.
+        log.warn("error reading data file err={} max_bytes={}", .{
+            err,
+            max_data_size,
+        });
         return error.BenchmarkFailed;
     };
 }

--- a/src/benchmark/GraphemeBreak.zig
+++ b/src/benchmark/GraphemeBreak.zig
@@ -105,7 +105,7 @@ fn setup(ptr: *anyopaque) Benchmark.Error!void {
         self.alloc,
         max_data_size,
     ) catch |err| {
-        // Name the cap: a corpus over it fails with StreamTooLong,
+        // Name the cap: a corpus over it fails with FileTooBig,
         // which on its own reads like an IO error.
         log.warn("error reading data file err={} max_bytes={}", .{
             err,

--- a/src/benchmark/IsSymbol.zig
+++ b/src/benchmark/IsSymbol.zig
@@ -30,6 +30,17 @@ pub const Options = struct {
     /// use stdin by default but I find that a hanging CLI command
     /// with no interaction is a bit annoying.
     data: ?[]const u8 = null,
+
+    /// `cli.args.parse` allocates `[]const u8` fields (like `data`
+    /// above) out of this arena when present; without it, allocations
+    /// go through an internal allocator that's never freed. See
+    /// `deinit`.
+    _arena: ?std.heap.ArenaAllocator = null,
+
+    pub fn deinit(self: *Options) void {
+        if (self._arena) |arena| arena.deinit();
+        self.* = undefined;
+    }
 };
 
 pub const Mode = enum {

--- a/src/benchmark/OscParser.zig
+++ b/src/benchmark/OscParser.zig
@@ -38,6 +38,17 @@ pub const Options = struct {
     /// use stdin by default but I find that a hanging CLI command
     /// with no interaction is a bit annoying.
     data: ?[]const u8 = null,
+
+    /// `cli.args.parse` allocates `[]const u8` fields (like `data`
+    /// above) out of this arena when present; without it, allocations
+    /// go through an internal allocator that's never freed. See
+    /// `deinit`.
+    _arena: ?std.heap.ArenaAllocator = null,
+
+    pub fn deinit(self: *Options) void {
+        if (self._arena) |arena| arena.deinit();
+        self.* = undefined;
+    }
 };
 
 /// Create a new terminal stream handler for the given arguments.
@@ -93,7 +104,9 @@ fn setup(ptr: *anyopaque) Benchmark.Error!void {
 
 fn teardown(ptr: *anyopaque) void {
     const self: *OscParser = @ptrCast(@alignCast(ptr));
-    if (self.data.len > 0) self.alloc.free(self.data);
+    // `Allocator.free` is a no-op on a zero-length slice, so this is
+    // safe even when `setup` never populated `data`.
+    self.alloc.free(self.data);
     self.data = &.{};
 }
 
@@ -109,6 +122,13 @@ fn step(ptr: *anyopaque) Benchmark.Error!void {
         );
         offset += record_len_size;
 
+        // Before the corpus was preloaded into `data`, this bounds
+        // check guarded a fixed on-stack read buffer, rejecting any
+        // record that claimed to be larger than that buffer. Now that
+        // the whole corpus lives in memory, the same check instead
+        // validates the length prefix against what's actually left in
+        // the corpus -- a different guarantee (a well-formed record
+        // stream) rather than a fixed per-record size cap.
         if (len > self.data.len - offset) return error.BenchmarkFailed;
         const record = self.data[offset .. offset + len];
         offset += len;

--- a/src/benchmark/OscParser.zig
+++ b/src/benchmark/OscParser.zig
@@ -7,14 +7,27 @@ const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
 const Benchmark = @import("Benchmark.zig");
 const options = @import("options.zig");
+const compat_file = @import("../lib/compat/file.zig");
 const Parser = @import("../terminal/osc.zig").Parser;
 const log = std.log.scoped(.@"osc-parser-bench");
 const global = @import("../global.zig");
 
-opts: Options,
+/// Prevent a malformed or accidentally enormous corpus from consuming
+/// unbounded memory during benchmark setup.
+const max_data_size = 64 * 1024 * 1024;
 
-/// The file, opened in the setup function.
-data_f: ?std.Io.File = null,
+/// Byte width of the little-endian length prefix preceding each record
+/// in the corpus. Matches `takeInt(usize, ...)`'s prior on-disk format.
+const record_len_size = @sizeOf(usize);
+
+opts: Options,
+alloc: Allocator,
+
+/// Complete contents of the input corpus, read once in `setup` so the
+/// timed step measures OSC parser throughput rather than file IO. The
+/// corpus is a sequence of `record_len_size`-byte little-endian length
+/// prefixes each followed by that many bytes of OSC payload.
+data: []u8 = &.{},
 
 parser: Parser,
 
@@ -36,7 +49,7 @@ pub fn create(
     errdefer alloc.destroy(ptr);
     ptr.* = .{
         .opts = opts,
-        .data_f = null,
+        .alloc = alloc,
         .parser = .init(alloc),
     };
     return ptr;
@@ -58,11 +71,21 @@ pub fn benchmark(self: *OscParser) Benchmark {
 fn setup(ptr: *anyopaque) Benchmark.Error!void {
     const self: *OscParser = @ptrCast(@alignCast(ptr));
 
-    // Open our data file to prepare for reading. We can do more
-    // validation here eventually.
-    assert(self.data_f == null);
-    self.data_f = options.dataFile(self.opts.data) catch |err| {
+    // Preload the entire data file into memory so the timed step below
+    // measures OSC parser throughput, not file IO.
+    assert(self.data.len == 0);
+    const f = (options.dataFile(self.opts.data) catch |err| {
         log.warn("error opening data file err={}", .{err});
+        return error.BenchmarkFailed;
+    }) orelse return;
+    defer f.close(global.io());
+
+    self.data = compat_file.readToEndAlloc(
+        f,
+        self.alloc,
+        max_data_size,
+    ) catch |err| {
+        log.warn("error reading data file err={}", .{err});
         return error.BenchmarkFailed;
     };
     self.parser.reset();
@@ -70,38 +93,27 @@ fn setup(ptr: *anyopaque) Benchmark.Error!void {
 
 fn teardown(ptr: *anyopaque) void {
     const self: *OscParser = @ptrCast(@alignCast(ptr));
-    if (self.data_f) |f| {
-        f.close(global.io());
-        self.data_f = null;
-    }
+    if (self.data.len > 0) self.alloc.free(self.data);
+    self.data = &.{};
 }
 
 fn step(ptr: *anyopaque) Benchmark.Error!void {
     const self: *OscParser = @ptrCast(@alignCast(ptr));
 
-    const f = self.data_f orelse return;
-    var read_buf: [4096]u8 align(std.atomic.cache_line) = undefined;
-    var r = f.reader(global.io(), &read_buf);
+    var offset: usize = 0;
+    while (offset + record_len_size <= self.data.len) {
+        const len = std.mem.readInt(
+            usize,
+            self.data[offset..][0..record_len_size],
+            .little,
+        );
+        offset += record_len_size;
 
-    var osc_buf: [4096]u8 align(std.atomic.cache_line) = undefined;
-    while (true) {
-        r.interface.fill(@bitSizeOf(usize) / 8) catch |err| switch (err) {
-            error.EndOfStream => return,
-            error.ReadFailed => return error.BenchmarkFailed,
-        };
-        const len = r.interface.takeInt(usize, .little) catch |err| switch (err) {
-            error.EndOfStream => return,
-            error.ReadFailed => return error.BenchmarkFailed,
-        };
+        if (len > self.data.len - offset) return error.BenchmarkFailed;
+        const record = self.data[offset .. offset + len];
+        offset += len;
 
-        if (len > osc_buf.len) return error.BenchmarkFailed;
-
-        r.interface.readSliceAll(osc_buf[0..len]) catch |err| switch (err) {
-            error.EndOfStream => return,
-            error.ReadFailed => return error.BenchmarkFailed,
-        };
-
-        for (osc_buf[0..len]) |c| @call(.always_inline, Parser.next, .{ &self.parser, c });
+        for (record) |c| @call(.always_inline, Parser.next, .{ &self.parser, c });
         std.mem.doNotOptimizeAway(self.parser.end(std.ascii.control_code.bel));
         self.parser.reset();
     }
@@ -116,4 +128,40 @@ test OscParser {
 
     const bench = impl.benchmark();
     _ = try bench.run(.once);
+}
+
+test "OscParser step consumes preloaded records without a file" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const impl: *OscParser = try .create(alloc, .{});
+    defer impl.destroy(alloc);
+
+    // Build one length-prefixed OSC record in memory, matching the
+    // corpus format `step` expects. There's no file involved, so this
+    // only passes if `setup`'s preload contract holds: the corpus is
+    // fully in memory before the timed step runs.
+    const payload = "0;hello";
+    var buf: [record_len_size + payload.len]u8 = undefined;
+    std.mem.writeInt(usize, buf[0..record_len_size], payload.len, .little);
+    @memcpy(buf[record_len_size..], payload);
+
+    impl.data = try alloc.dupe(u8, &buf);
+    try step(impl);
+    teardown(impl);
+}
+
+test "OscParser step rejects a record length past the end of the corpus" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const impl: *OscParser = try .create(alloc, .{});
+    defer impl.destroy(alloc);
+
+    var buf: [record_len_size]u8 = undefined;
+    std.mem.writeInt(usize, &buf, 1, .little); // claims 1 byte, but none follow
+
+    impl.data = try alloc.dupe(u8, &buf);
+    try testing.expectError(error.BenchmarkFailed, step(impl));
+    teardown(impl);
 }

--- a/src/benchmark/OscParser.zig
+++ b/src/benchmark/OscParser.zig
@@ -12,9 +12,11 @@ const Parser = @import("../terminal/osc.zig").Parser;
 const log = std.log.scoped(.@"osc-parser-bench");
 const global = @import("../global.zig");
 
-/// Prevent a malformed or accidentally enormous corpus from consuming
-/// unbounded memory during benchmark setup.
-const max_data_size = 64 * 1024 * 1024;
+/// Cap on the corpus preloaded in `setup`. This benchmark used to
+/// stream its input in chunks and had no limit at all, so the cap is
+/// only a guard against a malformed or accidentally enormous file and
+/// is set well above any corpus a developer would pass on purpose.
+const max_data_size = 1024 * 1024 * 1024;
 
 /// Byte width of the little-endian length prefix preceding each record
 /// in the corpus. Matches `takeInt(usize, ...)`'s prior on-disk format.
@@ -96,7 +98,12 @@ fn setup(ptr: *anyopaque) Benchmark.Error!void {
         self.alloc,
         max_data_size,
     ) catch |err| {
-        log.warn("error reading data file err={}", .{err});
+        // Name the cap: a corpus over it fails with StreamTooLong,
+        // which on its own reads like an IO error.
+        log.warn("error reading data file err={} max_bytes={}", .{
+            err,
+            max_data_size,
+        });
         return error.BenchmarkFailed;
     };
     self.parser.reset();

--- a/src/benchmark/OscParser.zig
+++ b/src/benchmark/OscParser.zig
@@ -84,6 +84,10 @@ pub fn benchmark(self: *OscParser) Benchmark {
 fn setup(ptr: *anyopaque) Benchmark.Error!void {
     const self: *OscParser = @ptrCast(@alignCast(ptr));
 
+    // Reset before the early return below: with no `--data` there is
+    // nothing to preload, but the parser must still start clean.
+    self.parser.reset();
+
     // Preload the entire data file into memory so the timed step below
     // measures OSC parser throughput, not file IO.
     assert(self.data.len == 0);
@@ -98,7 +102,7 @@ fn setup(ptr: *anyopaque) Benchmark.Error!void {
         self.alloc,
         max_data_size,
     ) catch |err| {
-        // Name the cap: a corpus over it fails with StreamTooLong,
+        // Name the cap: a corpus over it fails with FileTooBig,
         // which on its own reads like an IO error.
         log.warn("error reading data file err={} max_bytes={}", .{
             err,
@@ -106,7 +110,6 @@ fn setup(ptr: *anyopaque) Benchmark.Error!void {
         });
         return error.BenchmarkFailed;
     };
-    self.parser.reset();
 }
 
 fn teardown(ptr: *anyopaque) void {

--- a/src/benchmark/ScreenClone.zig
+++ b/src/benchmark/ScreenClone.zig
@@ -171,7 +171,7 @@ fn stepClone(ptr: *anyopaque) Benchmark.Error!void {
     // properly capture our speeds.
     for (0..1000) |_| {
         const s: *terminalpkg.Screen = self.terminal.screens.active;
-        const copy = s.clone(
+        var copy = s.clone(
             s.io,
             s.alloc,
             .{ .viewport = .{} },
@@ -180,10 +180,12 @@ fn stepClone(ptr: *anyopaque) Benchmark.Error!void {
             log.warn("error cloning screen err={}", .{err});
             return error.BenchmarkFailed;
         };
-        std.mem.doNotOptimizeAway(copy);
 
-        // Note: we purposely do not free memory because we don't want
-        // to benchmark that. We'll free when the benchmark exits.
+        // Free each clone before the next iteration. `step` can run
+        // many times in `.duration` mode, and an unfreed clone here
+        // grows without bound for as long as the benchmark runs.
+        defer copy.deinit();
+        std.mem.doNotOptimizeAway(&copy);
     }
 }
 
@@ -301,4 +303,23 @@ fn stepRenderPartial(ptr: *anyopaque) Benchmark.Error!void {
         };
         std.mem.doNotOptimizeAway(&state);
     }
+}
+
+test "ScreenClone stepClone frees every clone" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const impl: *ScreenClone = try .create(alloc, .{
+        .mode = .clone,
+        .@"terminal-rows" = 4,
+        .@"terminal-cols" = 10,
+    });
+    defer impl.destroy(alloc);
+
+    // `testing.allocator` fails the test on any leak. Before the fix,
+    // `stepClone` allocated 1000 clones per call and never freed them,
+    // which would grow without bound if `step` ran more than once
+    // (e.g. under `.duration` mode).
+    try stepClone(impl);
+    try stepClone(impl);
 }

--- a/src/benchmark/ScreenClone.zig
+++ b/src/benchmark/ScreenClone.zig
@@ -42,6 +42,17 @@ pub const Options = struct {
     /// cloning. This data can switch to alt screen if it wants. The time
     /// to read this is not part of the benchmark.
     data: ?[]const u8 = null,
+
+    /// `cli.args.parse` allocates `[]const u8` fields (like `data`
+    /// above) out of this arena when present; without it, allocations
+    /// go through an internal allocator that's never freed. See
+    /// `deinit`.
+    _arena: ?std.heap.ArenaAllocator = null,
+
+    pub fn deinit(self: *Options) void {
+        if (self._arena) |arena| arena.deinit();
+        self.* = undefined;
+    }
 };
 
 pub const Mode = enum {

--- a/src/benchmark/ScreenClone.zig
+++ b/src/benchmark/ScreenClone.zig
@@ -192,9 +192,17 @@ fn stepClone(ptr: *anyopaque) Benchmark.Error!void {
             return error.BenchmarkFailed;
         };
 
-        // Free each clone before the next iteration. `step` can run
-        // many times in `.duration` mode, and an unfreed clone here
-        // grows without bound for as long as the benchmark runs.
+        // The original author purposely did not free here, so that the
+        // number measured only the clone. That is no longer affordable:
+        // `step` runs until the deadline in `.duration` mode, so an
+        // unfreed clone per iteration grows without bound for as long
+        // as the benchmark runs. `Benchmark.run` times the whole `step`
+        // call and offers no per-iteration hook outside the timer, so
+        // there is nowhere to put the free that escapes measurement.
+        //
+        // The number this mode reports is therefore clone *plus*
+        // teardown of the cloned page list, and is not comparable with
+        // one recorded before this commit.
         defer copy.deinit();
         std.mem.doNotOptimizeAway(&copy);
     }

--- a/src/benchmark/TerminalParser.zig
+++ b/src/benchmark/TerminalParser.zig
@@ -23,6 +23,17 @@ pub const Options = struct {
     /// use stdin by default but I find that a hanging CLI command
     /// with no interaction is a bit annoying.
     data: ?[]const u8 = null,
+
+    /// `cli.args.parse` allocates `[]const u8` fields (like `data`
+    /// above) out of this arena when present; without it, allocations
+    /// go through an internal allocator that's never freed. See
+    /// `deinit`.
+    _arena: ?std.heap.ArenaAllocator = null,
+
+    pub fn deinit(self: *Options) void {
+        if (self._arena) |arena| arena.deinit();
+        self.* = undefined;
+    }
 };
 
 pub fn create(

--- a/src/benchmark/TerminalResize.zig
+++ b/src/benchmark/TerminalResize.zig
@@ -65,6 +65,17 @@ pub const Options = struct {
     /// (not part of the benchmark) to build the screen contents that
     /// get resized.
     data: ?[]const u8 = null,
+
+    /// `cli.args.parse` allocates `[]const u8` fields (like `data`
+    /// above) out of this arena when present; without it, allocations
+    /// go through an internal allocator that's never freed. See
+    /// `deinit`.
+    _arena: ?std.heap.ArenaAllocator = null,
+
+    pub fn deinit(self: *Options) void {
+        if (self._arena) |arena| arena.deinit();
+        self.* = undefined;
+    }
 };
 
 pub const Mode = enum {

--- a/src/benchmark/TerminalStream.zig
+++ b/src/benchmark/TerminalStream.zig
@@ -63,6 +63,17 @@ pub const Options = struct {
     /// use stdin by default but I find that a hanging CLI command
     /// with no interaction is a bit annoying.
     data: ?[]const u8 = null,
+
+    /// `cli.args.parse` allocates `[]const u8` fields (like `data`
+    /// above) out of this arena when present; without it, allocations
+    /// go through an internal allocator that's never freed. See
+    /// `deinit`.
+    _arena: ?std.heap.ArenaAllocator = null,
+
+    pub fn deinit(self: *Options) void {
+        if (self._arena) |arena| arena.deinit();
+        self.* = undefined;
+    }
 };
 
 /// Create a new terminal stream handler for the given arguments.
@@ -136,7 +147,9 @@ fn setup(ptr: *anyopaque) Benchmark.Error!void {
 
 fn teardown(ptr: *anyopaque) void {
     const self: *TerminalStream = @ptrCast(@alignCast(ptr));
-    if (self.data.len > 0) self.alloc.free(self.data);
+    // `Allocator.free` is a no-op on a zero-length slice, so this is
+    // safe even when `setup` never populated `data`.
+    self.alloc.free(self.data);
     self.data = &.{};
 }
 

--- a/src/benchmark/TerminalStream.zig
+++ b/src/benchmark/TerminalStream.zig
@@ -17,18 +17,32 @@ const Allocator = std.mem.Allocator;
 const terminalpkg = @import("../terminal/main.zig");
 const Benchmark = @import("Benchmark.zig");
 const options = @import("options.zig");
+const compat_file = @import("../lib/compat/file.zig");
 const Terminal = terminalpkg.Terminal;
 const Stream = terminalpkg.TerminalStream;
 const global = @import("../global.zig");
 
 const log = std.log.scoped(.@"terminal-stream-bench");
 
+/// Prevent a malformed or accidentally enormous corpus from consuming
+/// unbounded memory during benchmark setup.
+const max_data_size = 64 * 1024 * 1024;
+
+/// Chunk size used to feed the stream in `step`. This matches the read
+/// buffer size used by the real IO thread (see termio Exec.zig
+/// buffer_capacity) so that the benchmark exercises the stream with
+/// realistic chunk sizes, even though the data itself is preloaded (see
+/// `setup`) instead of read from disk during the timed step.
+const step_chunk_size = 64 * 1024;
+
 opts: Options,
 terminal: Terminal,
 stream: Stream,
+alloc: Allocator,
 
-/// The file, opened in the setup function.
-data_f: ?std.Io.File = null,
+/// Complete contents of the input corpus, read once in `setup` so the
+/// timed step measures stream throughput rather than file IO.
+data: []u8 = &.{},
 
 pub const Options = struct {
     /// The size of the terminal. This affects benchmarking when
@@ -61,6 +75,7 @@ pub fn create(
 
     ptr.* = .{
         .opts = opts,
+        .alloc = alloc,
         .terminal = try .init(global.io(), alloc, .{
             .rows = opts.@"terminal-rows",
             .cols = opts.@"terminal-cols",
@@ -100,50 +115,39 @@ fn setup(ptr: *anyopaque) Benchmark.Error!void {
     // Always reset our terminal state
     self.terminal.fullReset();
 
-    // Open our data file to prepare for reading. We can do more validation
-    // here eventually.
-    assert(self.data_f == null);
-    self.data_f = options.dataFile(self.opts.data) catch |err| {
+    // Preload the entire data file into memory so the timed step below
+    // measures stream throughput, not file IO.
+    assert(self.data.len == 0);
+    const f = (options.dataFile(self.opts.data) catch |err| {
         log.warn("error opening data file err={}", .{err});
+        return error.BenchmarkFailed;
+    }) orelse return;
+    defer f.close(global.io());
+
+    self.data = compat_file.readToEndAlloc(
+        f,
+        self.alloc,
+        max_data_size,
+    ) catch |err| {
+        log.warn("error reading data file err={}", .{err});
         return error.BenchmarkFailed;
     };
 }
 
 fn teardown(ptr: *anyopaque) void {
     const self: *TerminalStream = @ptrCast(@alignCast(ptr));
-    if (self.data_f) |f| {
-        f.close(global.io());
-        self.data_f = null;
-    }
+    if (self.data.len > 0) self.alloc.free(self.data);
+    self.data = &.{};
 }
 
 fn step(ptr: *anyopaque) Benchmark.Error!void {
     const self: *TerminalStream = @ptrCast(@alignCast(ptr));
 
-    // Get our buffered reader so we're not predominantly
-    // waiting on file IO. It'd be better to move this fully into
-    // memory. If we're IO bound though that should show up on
-    // the benchmark results and... I know writing this that we
-    // aren't currently IO bound.
-    const f = self.data_f orelse return;
-
-    // Unbuffered: readSliceShort below reads directly into `buf`,
-    // avoiding a per-chunk memcpy through an intermediate reader
-    // buffer that would pollute the measurement.
-    var f_reader = f.reader(global.io(), &.{});
-    const r = &f_reader.interface;
-
-    // This buffer size matches the read buffer size used by the
-    // real IO thread (see termio Exec.zig buffer_capacity) so that
-    // the benchmark exercises the stream with realistic chunk sizes.
-    var buf: [64 * 1024]u8 = undefined;
-    while (true) {
-        const n = r.readSliceShort(&buf) catch {
-            log.warn("error reading data file err={?}", .{f_reader.err});
-            return error.BenchmarkFailed;
-        };
-        if (n == 0) break; // EOF reached
-        self.stream.nextSlice(buf[0..n]);
+    var offset: usize = 0;
+    while (offset < self.data.len) {
+        const end = @min(offset + step_chunk_size, self.data.len);
+        self.stream.nextSlice(self.data[offset..end]);
+        offset = end;
     }
 }
 
@@ -164,4 +168,27 @@ test TerminalStream {
 
     const tracked_bench = tracked.benchmark();
     _ = try tracked_bench.run(.once);
+}
+
+test "TerminalStream step consumes preloaded data without touching the file" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const impl: *TerminalStream = try .create(alloc, .{});
+    defer impl.destroy(alloc);
+
+    // `step` must work entirely off `self.data`. There's no `data_f`
+    // field to read from anymore, so this only compiles and passes if
+    // `setup`'s preload contract holds: the corpus is fully in memory
+    // before the timed step runs.
+    impl.data = try alloc.dupe(u8, "hello\r\nworld");
+    try step(impl);
+
+    // The stream moved the cursor to the second row, proving the
+    // in-memory data was actually parsed.
+    try testing.expect(impl.terminal.screens.active.cursor.y > 0);
+
+    // teardown is what actually frees `self.data` normally; call it
+    // directly here since we bypassed `setup`.
+    teardown(impl);
 }

--- a/src/benchmark/TerminalStream.zig
+++ b/src/benchmark/TerminalStream.zig
@@ -142,7 +142,7 @@ fn setup(ptr: *anyopaque) Benchmark.Error!void {
         self.alloc,
         max_data_size,
     ) catch |err| {
-        // Name the cap: a corpus over it fails with StreamTooLong,
+        // Name the cap: a corpus over it fails with FileTooBig,
         // which on its own reads like an IO error.
         log.warn("error reading data file err={} max_bytes={}", .{
             err,

--- a/src/benchmark/TerminalStream.zig
+++ b/src/benchmark/TerminalStream.zig
@@ -24,9 +24,11 @@ const global = @import("../global.zig");
 
 const log = std.log.scoped(.@"terminal-stream-bench");
 
-/// Prevent a malformed or accidentally enormous corpus from consuming
-/// unbounded memory during benchmark setup.
-const max_data_size = 64 * 1024 * 1024;
+/// Cap on the corpus preloaded in `setup`. This benchmark used to
+/// stream its input in chunks and had no limit at all, so the cap is
+/// only a guard against a malformed or accidentally enormous file and
+/// is set well above any corpus a developer would pass on purpose.
+const max_data_size = 1024 * 1024 * 1024;
 
 /// Chunk size used to feed the stream in `step`. This matches the read
 /// buffer size used by the real IO thread (see termio Exec.zig
@@ -140,7 +142,12 @@ fn setup(ptr: *anyopaque) Benchmark.Error!void {
         self.alloc,
         max_data_size,
     ) catch |err| {
-        log.warn("error reading data file err={}", .{err});
+        // Name the cap: a corpus over it fails with StreamTooLong,
+        // which on its own reads like an IO error.
+        log.warn("error reading data file err={} max_bytes={}", .{
+            err,
+            max_data_size,
+        });
         return error.BenchmarkFailed;
     };
 }

--- a/src/benchmark/cli.zig
+++ b/src/benchmark/cli.zig
@@ -264,3 +264,125 @@ test "mainActionImpl accepts --duration-ms alongside action-specific flags" {
         .{ .string = "--terminal-rows=4 --terminal-cols=4 --duration-ms=1" },
     );
 }
+
+// The tests below drive `mainAction` end to end against a real file on
+// disk: argv collection, the `RunOptions`/`Options` split, `create`,
+// `setup`, `step` and `teardown`. Every other test for the preload fix
+// (in CodepointWidth.zig, GraphemeBreak.zig, OscParser.zig and
+// TerminalStream.zig) sets `self.data` by hand and calls `step`
+// directly, which proves `step` can consume preloaded data but never
+// proves `setup` actually preloads it -- `options.dataFile` and
+// `compat_file.readToEndAlloc` are never reached that way. These do
+// reach them: a real temp file is opened by `setup`, so the preload
+// path we fixed is what's under test, not assumed.
+
+/// Writes `contents` to a file named "data" inside `tmp` and returns
+/// its path, valid for the lifetime of `buf`. Used to hand `mainAction`
+/// a `--data=<path>` argument that points at a real file.
+fn writeTmpDataFile(
+    tmp: *std.testing.TmpDir,
+    contents: []const u8,
+    buf: []u8,
+) ![]const u8 {
+    const io = std.testing.io;
+    try tmp.dir.writeFile(io, .{ .sub_path = "data", .data = contents });
+    const n = try tmp.dir.realPathFile(io, "data", buf);
+    return buf[0..n];
+}
+
+test "mainAction preloads a real codepoint-width corpus through setup" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const path = try writeTmpDataFile(&tmp, "hello world", &path_buf);
+
+    const args = try std.fmt.allocPrint(alloc, "--mode=table --data={s}", .{path});
+    defer alloc.free(args);
+
+    try mainAction(alloc, .@"codepoint-width", .{ .string = args });
+}
+
+test "mainAction preloads a real grapheme-break corpus through setup" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const path = try writeTmpDataFile(&tmp, "e\u{301} world", &path_buf);
+
+    const args = try std.fmt.allocPrint(alloc, "--mode=table --data={s}", .{path});
+    defer alloc.free(args);
+
+    try mainAction(alloc, .@"grapheme-break", .{ .string = args });
+}
+
+test "mainAction preloads a real osc-parser corpus through setup" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // Matches OscParser's corpus format: a `@sizeOf(usize)`-byte
+    // little-endian length prefix followed by that many bytes of OSC
+    // payload (see the `data` field doc comment in OscParser.zig).
+    const payload = "0;hello";
+    const record_len_size = @sizeOf(usize);
+    var record: [record_len_size + payload.len]u8 = undefined;
+    std.mem.writeInt(usize, record[0..record_len_size], payload.len, .little);
+    @memcpy(record[record_len_size..], payload);
+
+    var path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const path = try writeTmpDataFile(&tmp, &record, &path_buf);
+
+    const args = try std.fmt.allocPrint(alloc, "--data={s}", .{path});
+    defer alloc.free(args);
+
+    try mainAction(alloc, .@"osc-parser", .{ .string = args });
+}
+
+test "mainAction preloads a real terminal-stream corpus through setup" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const path = try writeTmpDataFile(&tmp, "hello\r\nworld", &path_buf);
+
+    const args = try std.fmt.allocPrint(
+        alloc,
+        "--terminal-rows=4 --terminal-cols=10 --data={s}",
+        .{path},
+    );
+    defer alloc.free(args);
+
+    try mainAction(alloc, .@"terminal-stream", .{ .string = args });
+}
+
+test "mainAction opens a real data file for screen-clone through setup" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const path = try writeTmpDataFile(&tmp, "hello\r\nworld", &path_buf);
+
+    const args = try std.fmt.allocPrint(
+        alloc,
+        "--terminal-rows=4 --terminal-cols=10 --data={s}",
+        .{path},
+    );
+    defer alloc.free(args);
+
+    // screen-clone's `setup` doesn't preload into a `data` field like
+    // the others -- it streams the file straight into the terminal
+    // before the timed clone loop -- but it still opens a real file via
+    // `options.dataFile`, which is what this proves actually happens.
+    try mainAction(alloc, .@"screen-clone", .{ .string = args });
+}

--- a/src/benchmark/cli.zig
+++ b/src/benchmark/cli.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const cli = @import("../cli.zig");
 const global = @import("../global.zig");
+const Benchmark = @import("Benchmark.zig");
 
 /// The available actions for the CLI. This is the list of available
 /// benchmarks. View docs for each individual one in the predictably
@@ -86,15 +87,28 @@ fn mainActionImpl(
     alloc: Allocator,
     args: Args,
 ) !void {
-    // First, parse our CLI options.
-    const Options = BenchmarkImpl.Options;
-    var opts: Options = .{};
-    defer if (@hasDecl(Options, "deinit")) opts.deinit();
+    // Collect every raw CLI argument once, as independent copies so
+    // they outlive whichever source iterator produced them (the
+    // process argv iterator frees its backing buffer on `deinit`, and
+    // a string iterator similarly owns its buffer). We need two full
+    // passes over this same argv below: one for the flags shared by
+    // every benchmark action (currently just `--duration-ms`), and one
+    // for the per-action `Options`, which must never see
+    // `--duration-ms` since it has no field for it and (unlike
+    // `RunOptions`) no `_diagnostics` list to tolerate an unrecognized
+    // flag instead of erroring.
+    var raw_args: std.ArrayList([]const u8) = .empty;
+    defer {
+        for (raw_args.items) |arg| alloc.free(arg);
+        raw_args.deinit(alloc);
+    }
     switch (args) {
         .cli => |process_args| {
             var iter = try cli.args.argsIterator(alloc, process_args);
             defer iter.deinit();
-            try cli.args.parse(Options, alloc, &opts, &iter);
+            while (iter.next()) |arg| {
+                try raw_args.append(alloc, try alloc.dupe(u8, arg));
+            }
         },
         .string => |str| {
             var iter = try std.process.Args.IteratorGeneral(.{}).init(
@@ -102,8 +116,39 @@ fn mainActionImpl(
                 str,
             );
             defer iter.deinit();
-            try cli.args.parse(Options, alloc, &opts, &iter);
+            while (iter.next()) |arg| {
+                try raw_args.append(alloc, try alloc.dupe(u8, arg));
+            }
         },
+    }
+
+    // Parse the flags shared by every benchmark action against a
+    // permissive struct first. Its `_diagnostics` field means
+    // action-specific flags it doesn't recognize just land there
+    // instead of causing a parse error.
+    var run_opts: RunOptions = .{};
+    defer run_opts.deinit();
+    {
+        var iter: SliceArgIterator = .{ .items = raw_args.items };
+        try cli.args.parse(RunOptions, alloc, &run_opts, &iter);
+    }
+
+    // Parse the action-specific options from the same argv with
+    // `--duration-ms` filtered out first (see the comment above
+    // `raw_args`).
+    const Options = BenchmarkImpl.Options;
+    var opts: Options = .{};
+    defer if (@hasDecl(Options, "deinit")) opts.deinit();
+    {
+        var filtered: std.ArrayList([]const u8) = .empty;
+        defer filtered.deinit(alloc);
+        for (raw_args.items) |arg| {
+            if (isDurationMsFlag(arg)) continue;
+            try filtered.append(alloc, arg);
+        }
+
+        var iter: SliceArgIterator = .{ .items = filtered.items };
+        try cli.args.parse(Options, alloc, &opts, &iter);
     }
 
     // Create our implementation
@@ -112,5 +157,110 @@ fn mainActionImpl(
 
     // Initialize our benchmark
     const b = impl.benchmark();
-    _ = try b.run(.once);
+    _ = try b.run(runMode(run_opts.@"duration-ms"));
+}
+
+/// True if `arg` is the `--duration-ms` flag, with or without a value.
+/// This is the one flag every benchmark action's own `Options` must
+/// not see (it has no field for it, and no `_diagnostics` list to
+/// tolerate an unknown one).
+fn isDurationMsFlag(arg: []const u8) bool {
+    const key = if (std.mem.indexOfScalar(u8, arg, '=')) |idx|
+        arg[0..idx]
+    else
+        arg;
+    return std.mem.eql(u8, key, "--duration-ms");
+}
+
+/// A `cli.args.parse`-compatible iterator (just needs a `next`
+/// returning `?[]const u8`) over an already-collected list of argument
+/// strings. Lets `mainActionImpl` parse the same argv twice (once per
+/// struct below) without re-reading the process's real argv or
+/// re-tokenizing a string each time.
+const SliceArgIterator = struct {
+    items: []const []const u8,
+    index: usize = 0,
+
+    pub fn next(self: *SliceArgIterator) ?[]const u8 {
+        if (self.index >= self.items.len) return null;
+        defer self.index += 1;
+        return self.items[self.index];
+    }
+};
+
+/// Flags accepted for every benchmark action, independent of the
+/// per-action `Options` parsed above.
+const RunOptions = struct {
+    _arena: ?std.heap.ArenaAllocator = null,
+    _diagnostics: cli.DiagnosticList = .{},
+
+    /// Run the benchmark step repeatedly for this many milliseconds
+    /// instead of running it exactly once. 0 (the default) runs the
+    /// step exactly once.
+    @"duration-ms": u64 = 0,
+
+    pub fn deinit(self: *RunOptions) void {
+        if (self._arena) |arena| arena.deinit();
+        self.* = undefined;
+    }
+};
+
+fn runMode(duration_ms: u64) Benchmark.RunMode {
+    return if (duration_ms > 0)
+        .{ .duration = duration_ms * std.time.ns_per_ms }
+    else
+        .once;
+}
+
+test "runMode defaults to running once" {
+    try std.testing.expectEqual(Benchmark.RunMode.once, runMode(0));
+}
+
+test "runMode converts duration-ms to nanoseconds" {
+    switch (runMode(5)) {
+        .duration => |ns| try std.testing.expectEqual(
+            @as(u64, 5 * std.time.ns_per_ms),
+            ns,
+        ),
+        .once => return error.TestUnexpectedResult,
+    }
+}
+
+test "RunOptions parses duration-ms and ignores unrelated action flags" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var opts: RunOptions = .{};
+    defer opts.deinit();
+
+    var iter = try std.process.Args.IteratorGeneral(.{}).init(
+        alloc,
+        "--terminal-rows=80 --duration-ms=5 --data=-",
+    );
+    defer iter.deinit();
+    try cli.args.parse(RunOptions, alloc, &opts, &iter);
+
+    try testing.expectEqual(@as(u64, 5), opts.@"duration-ms");
+}
+
+test "isDurationMsFlag matches with and without a value, not lookalikes" {
+    const testing = std.testing;
+    try testing.expect(isDurationMsFlag("--duration-ms"));
+    try testing.expect(isDurationMsFlag("--duration-ms=5"));
+    try testing.expect(!isDurationMsFlag("--duration-msx"));
+    try testing.expect(!isDurationMsFlag("--duration"));
+    try testing.expect(!isDurationMsFlag("--data=--duration-ms"));
+}
+
+test "mainActionImpl accepts --duration-ms alongside action-specific flags" {
+    // Regression test: an action's `Options` (TerminalStream's, here)
+    // has no `_diagnostics` field, so if `--duration-ms` ever reached
+    // its parser unfiltered this would fail with error.InvalidField
+    // instead of actually running the benchmark in duration mode.
+    const testing = std.testing;
+    try mainAction(
+        testing.allocator,
+        .@"terminal-stream",
+        .{ .string = "--terminal-rows=4 --terminal-cols=4 --duration-ms=1" },
+    );
 }

--- a/src/benchmark/cli.zig
+++ b/src/benchmark/cli.zig
@@ -4,6 +4,8 @@ const cli = @import("../cli.zig");
 const global = @import("../global.zig");
 const Benchmark = @import("Benchmark.zig");
 
+const log = std.log.scoped(.benchmark);
+
 /// The available actions for the CLI. This is the list of available
 /// benchmarks. View docs for each individual one in the predictably
 /// named files.
@@ -134,8 +136,18 @@ fn mainActionImpl(
     var run_opts: RunOptions = .{};
     defer run_opts.deinit();
     {
-        var iter: SliceArgIterator = .{ .items = raw_args.items };
+        var iter = cli.args.sliceIterator(raw_args.items);
         try cli.args.parse(RunOptions, alloc, &run_opts, &iter);
+    }
+
+    // That same `_diagnostics` field also swallows errors on the one
+    // flag `RunOptions` owns: `--duration-ms=abc` records a diagnostic
+    // and leaves the field at 0, which would silently degrade the run
+    // to `.once` and report a number for the wrong thing.
+    for (run_opts._diagnostics.items()) |diag| {
+        if (!std.mem.eql(u8, diag.key, "duration-ms")) continue;
+        log.warn("--duration-ms: {s}", .{diag.message});
+        return error.InvalidDurationMs;
     }
 
     // Parse the action-specific options from the same argv with
@@ -152,7 +164,7 @@ fn mainActionImpl(
             try filtered.append(alloc, arg);
         }
 
-        var iter: SliceArgIterator = .{ .items = filtered.items };
+        var iter = cli.args.sliceIterator(filtered.items);
         try cli.args.parse(Options, alloc, &opts, &iter);
     }
 
@@ -169,6 +181,10 @@ fn mainActionImpl(
 /// This is the one flag every benchmark action's own `Options` must
 /// not see (it has no field for it, and no `_diagnostics` list to
 /// tolerate an unknown one).
+///
+/// Only the `--duration-ms=<value>` form is recognized. `cli.args.parse`
+/// does not support values separated by a space, so `--duration-ms 5`
+/// is not a form this needs to match.
 fn isDurationMsFlag(arg: []const u8) bool {
     const key = if (std.mem.indexOfScalar(u8, arg, '=')) |idx|
         arg[0..idx]
@@ -176,22 +192,6 @@ fn isDurationMsFlag(arg: []const u8) bool {
         arg;
     return std.mem.eql(u8, key, "--duration-ms");
 }
-
-/// A `cli.args.parse`-compatible iterator (just needs a `next`
-/// returning `?[]const u8`) over an already-collected list of argument
-/// strings. Lets `mainActionImpl` parse the same argv twice (once per
-/// struct below) without re-reading the process's real argv or
-/// re-tokenizing a string each time.
-const SliceArgIterator = struct {
-    items: []const []const u8,
-    index: usize = 0,
-
-    pub fn next(self: *SliceArgIterator) ?[]const u8 {
-        if (self.index >= self.items.len) return null;
-        defer self.index += 1;
-        return self.items[self.index];
-    }
-};
 
 /// Flags accepted for every benchmark action, independent of the
 /// per-action `Options` parsed above.
@@ -211,8 +211,15 @@ const RunOptions = struct {
 };
 
 fn runMode(duration_ms: u64) Benchmark.RunMode {
+    // Saturate rather than overflow: `ghostty-bench` is built
+    // ReleaseFast unconditionally, where an unchecked multiply here is
+    // undefined behaviour rather than a panic.
     return if (duration_ms > 0)
-        .{ .duration = duration_ms * std.time.ns_per_ms }
+        .{ .duration = std.math.mul(
+            u64,
+            duration_ms,
+            std.time.ns_per_ms,
+        ) catch std.math.maxInt(u64) }
     else
         .once;
 }
@@ -248,6 +255,18 @@ test "RunOptions parses duration-ms and ignores unrelated action flags" {
     try testing.expectEqual(@as(u64, 5), opts.@"duration-ms");
 }
 
+test "runMode saturates instead of overflowing" {
+    // duration_ms * ns_per_ms overflows u64 above this value.
+    const too_big: u64 = (std.math.maxInt(u64) / std.time.ns_per_ms) + 1;
+    switch (runMode(too_big)) {
+        .duration => |ns| try std.testing.expectEqual(
+            std.math.maxInt(u64),
+            ns,
+        ),
+        .once => return error.TestUnexpectedResult,
+    }
+}
+
 test "isDurationMsFlag matches with and without a value, not lookalikes" {
     const testing = std.testing;
     try testing.expect(isDurationMsFlag("--duration-ms"));
@@ -278,6 +297,25 @@ test "mainActionImpl accepts --duration-ms alongside action-specific flags" {
     // and no other test can see the difference because the CLI has no
     // other observable output.
     try testing.expect(result.iterations > 1);
+}
+
+test "mainActionImpl rejects a malformed --duration-ms instead of running once" {
+    // `RunOptions._diagnostics` exists so unrecognized action flags
+    // don't fail the parse. Without an explicit check it also absorbs
+    // errors on `--duration-ms` itself, and the run silently degrades
+    // to `.once` -- a number reported for the wrong thing.
+    const testing = std.testing;
+    for ([_][]const u8{
+        "--terminal-rows=4 --terminal-cols=4 --duration-ms=abc",
+        "--terminal-rows=4 --terminal-cols=4 --duration-ms=-5",
+        "--terminal-rows=4 --terminal-cols=4 --duration-ms=99999999999999999999",
+    }) |args| {
+        try testing.expectError(error.InvalidDurationMs, mainAction(
+            testing.allocator,
+            .@"terminal-stream",
+            .{ .string = args },
+        ));
+    }
 }
 
 // The tests below drive `mainAction` end to end against a real file on

--- a/src/benchmark/cli.zig
+++ b/src/benchmark/cli.zig
@@ -57,7 +57,7 @@ pub fn main(minimal: std.process.Init.Minimal) !void {
     const alloc = std.heap.c_allocator;
     const action_ = try cli.action.detectArgs(Action, alloc, minimal.args);
     const action = action_ orelse return error.NoAction;
-    try mainAction(alloc, action, .{ .cli = minimal.args });
+    _ = try mainAction(alloc, action, .{ .cli = minimal.args });
 }
 
 /// Arguments that can be passed to the benchmark.
@@ -69,15 +69,20 @@ pub const Args = union(enum) {
     string: []const u8,
 };
 
+/// Runs the benchmark and returns its result. The CLI itself doesn't
+/// use the result -- the benchmark prints what it measures -- but
+/// returning it is the only way a test can see how the run was
+/// configured, in particular whether `--duration-ms` really made the
+/// step run more than once.
 pub fn mainAction(
     alloc: Allocator,
     action: Action,
     args: Args,
-) !void {
+) !Benchmark.RunResult {
     switch (action) {
         inline else => |comptime_action| {
             const BenchmarkImpl = Action.Struct(comptime_action);
-            try mainActionImpl(BenchmarkImpl, alloc, args);
+            return try mainActionImpl(BenchmarkImpl, alloc, args);
         },
     }
 }
@@ -86,7 +91,7 @@ fn mainActionImpl(
     comptime BenchmarkImpl: type,
     alloc: Allocator,
     args: Args,
-) !void {
+) !Benchmark.RunResult {
     // Collect every raw CLI argument once, as independent copies so
     // they outlive whichever source iterator produced them (the
     // process argv iterator frees its backing buffer on `deinit`, and
@@ -157,7 +162,7 @@ fn mainActionImpl(
 
     // Initialize our benchmark
     const b = impl.benchmark();
-    _ = try b.run(runMode(run_opts.@"duration-ms"));
+    return try b.run(runMode(run_opts.@"duration-ms"));
 }
 
 /// True if `arg` is the `--duration-ms` flag, with or without a value.
@@ -257,12 +262,22 @@ test "mainActionImpl accepts --duration-ms alongside action-specific flags" {
     // has no `_diagnostics` field, so if `--duration-ms` ever reached
     // its parser unfiltered this would fail with error.InvalidField
     // instead of actually running the benchmark in duration mode.
+    //
+    // 50ms is long enough that a step this small -- an empty corpus, so
+    // the step does nothing -- cannot fill it in one iteration, without
+    // making the test slow.
     const testing = std.testing;
-    try mainAction(
+    const result = try mainAction(
         testing.allocator,
         .@"terminal-stream",
-        .{ .string = "--terminal-rows=4 --terminal-cols=4 --duration-ms=1" },
+        .{ .string = "--terminal-rows=4 --terminal-cols=4 --duration-ms=50" },
     );
+
+    // The flag has to reach `Benchmark.run`, not just parse: parsing it
+    // and then still running the step once is exactly what this replaced,
+    // and no other test can see the difference because the CLI has no
+    // other observable output.
+    try testing.expect(result.iterations > 1);
 }
 
 // The tests below drive `mainAction` end to end against a real file on
@@ -302,7 +317,7 @@ test "mainAction preloads a real codepoint-width corpus through setup" {
     const args = try std.fmt.allocPrint(alloc, "--mode=table --data={s}", .{path});
     defer alloc.free(args);
 
-    try mainAction(alloc, .@"codepoint-width", .{ .string = args });
+    _ = try mainAction(alloc, .@"codepoint-width", .{ .string = args });
 }
 
 test "mainAction preloads a real grapheme-break corpus through setup" {
@@ -317,7 +332,7 @@ test "mainAction preloads a real grapheme-break corpus through setup" {
     const args = try std.fmt.allocPrint(alloc, "--mode=table --data={s}", .{path});
     defer alloc.free(args);
 
-    try mainAction(alloc, .@"grapheme-break", .{ .string = args });
+    _ = try mainAction(alloc, .@"grapheme-break", .{ .string = args });
 }
 
 test "mainAction preloads a real osc-parser corpus through setup" {
@@ -342,7 +357,7 @@ test "mainAction preloads a real osc-parser corpus through setup" {
     const args = try std.fmt.allocPrint(alloc, "--data={s}", .{path});
     defer alloc.free(args);
 
-    try mainAction(alloc, .@"osc-parser", .{ .string = args });
+    _ = try mainAction(alloc, .@"osc-parser", .{ .string = args });
 }
 
 test "mainAction preloads a real terminal-stream corpus through setup" {
@@ -361,7 +376,7 @@ test "mainAction preloads a real terminal-stream corpus through setup" {
     );
     defer alloc.free(args);
 
-    try mainAction(alloc, .@"terminal-stream", .{ .string = args });
+    _ = try mainAction(alloc, .@"terminal-stream", .{ .string = args });
 }
 
 test "mainAction opens a real data file for screen-clone through setup" {
@@ -384,7 +399,7 @@ test "mainAction opens a real data file for screen-clone through setup" {
     // the others -- it streams the file straight into the terminal
     // before the timed clone loop -- but it still opens a real file via
     // `options.dataFile`, which is what this proves actually happens.
-    try mainAction(alloc, .@"screen-clone", .{ .string = args });
+    _ = try mainAction(alloc, .@"screen-clone", .{ .string = args });
 }
 
 // The remaining benchmark actions that take a `--data` path. Their
@@ -404,7 +419,7 @@ test "mainAction opens a real data file for apc-parser through setup" {
     const args = try std.fmt.allocPrint(alloc, "--data={s}", .{path});
     defer alloc.free(args);
 
-    try mainAction(alloc, .@"apc-parser", .{ .string = args });
+    _ = try mainAction(alloc, .@"apc-parser", .{ .string = args });
 }
 
 test "mainAction opens a real data file for is-symbol through setup" {
@@ -419,7 +434,7 @@ test "mainAction opens a real data file for is-symbol through setup" {
     const args = try std.fmt.allocPrint(alloc, "--mode=table --data={s}", .{path});
     defer alloc.free(args);
 
-    try mainAction(alloc, .@"is-symbol", .{ .string = args });
+    _ = try mainAction(alloc, .@"is-symbol", .{ .string = args });
 }
 
 test "mainAction opens a real data file for terminal-parser through setup" {
@@ -434,7 +449,7 @@ test "mainAction opens a real data file for terminal-parser through setup" {
     const args = try std.fmt.allocPrint(alloc, "--data={s}", .{path});
     defer alloc.free(args);
 
-    try mainAction(alloc, .@"terminal-parser", .{ .string = args });
+    _ = try mainAction(alloc, .@"terminal-parser", .{ .string = args });
 }
 
 test "mainAction replays a real data file for terminal-resize through setup" {
@@ -456,5 +471,5 @@ test "mainAction replays a real data file for terminal-resize through setup" {
     );
     defer alloc.free(args);
 
-    try mainAction(alloc, .@"terminal-resize", .{ .string = args });
+    _ = try mainAction(alloc, .@"terminal-resize", .{ .string = args });
 }

--- a/src/benchmark/cli.zig
+++ b/src/benchmark/cli.zig
@@ -386,3 +386,75 @@ test "mainAction opens a real data file for screen-clone through setup" {
     // `options.dataFile`, which is what this proves actually happens.
     try mainAction(alloc, .@"screen-clone", .{ .string = args });
 }
+
+// The remaining benchmark actions that take a `--data` path. Their
+// `Options` were the last ones without an `_arena`, so passing a real
+// path leaked the parser's copy of it; driving `mainAction` on
+// `testing.allocator` is what catches that.
+
+test "mainAction opens a real data file for apc-parser through setup" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const path = try writeTmpDataFile(&tmp, "\x1b_Gi=1,a=q;abc\x1b\\", &path_buf);
+
+    const args = try std.fmt.allocPrint(alloc, "--data={s}", .{path});
+    defer alloc.free(args);
+
+    try mainAction(alloc, .@"apc-parser", .{ .string = args });
+}
+
+test "mainAction opens a real data file for is-symbol through setup" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const path = try writeTmpDataFile(&tmp, "a\u{2665}b", &path_buf);
+
+    const args = try std.fmt.allocPrint(alloc, "--mode=table --data={s}", .{path});
+    defer alloc.free(args);
+
+    try mainAction(alloc, .@"is-symbol", .{ .string = args });
+}
+
+test "mainAction opens a real data file for terminal-parser through setup" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const path = try writeTmpDataFile(&tmp, "hello\x1b[31mworld", &path_buf);
+
+    const args = try std.fmt.allocPrint(alloc, "--data={s}", .{path});
+    defer alloc.free(args);
+
+    try mainAction(alloc, .@"terminal-parser", .{ .string = args });
+}
+
+test "mainAction replays a real data file for terminal-resize through setup" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const path = try writeTmpDataFile(&tmp, "hello\r\nworld", &path_buf);
+
+    // Small dimensions and fill, matching TerminalResize's own test, so
+    // the reflow loop stays fast in a debug build.
+    const args = try std.fmt.allocPrint(
+        alloc,
+        "--mode=cols --terminal-rows=10 --terminal-cols=20 " ++
+            "--fill-lines=50 --data={s}",
+        .{path},
+    );
+    defer alloc.free(args);
+
+    try mainAction(alloc, .@"terminal-resize", .{ .string = args });
+}

--- a/src/benchmark/main.zig
+++ b/src/benchmark/main.zig
@@ -1,6 +1,8 @@
 pub const cli = @import("cli.zig");
 pub const Benchmark = @import("Benchmark.zig");
 pub const CApi = @import("CApi.zig");
+pub const ApcParser = @import("ApcParser.zig");
+pub const OscParser = @import("OscParser.zig");
 pub const TerminalStream = @import("TerminalStream.zig");
 pub const CodepointWidth = @import("CodepointWidth.zig");
 pub const GraphemeBreak = @import("GraphemeBreak.zig");


### PR DESCRIPTION
The benchmarks under `src/benchmark` were measuring the wrong things, one run mode could not be selected at all, and the option parser leaked.

What was wrong:

- `terminal-stream`, `codepoint-width`, `grapheme-break` and `osc-parser` read their corpus from disk in chunks inside the timed step, so every number included file IO. Worse, the file offset persisted across steps, so every step after the first read zero bytes -- invisible while each benchmark ran its step exactly once.
- `screen-clone` allocated a thousand screen clones per step and never freed them, so a run that steps more than once grows without bound.
- `Benchmark.RunMode.duration` existed but nothing could select it: the CLI hardcoded `.once` and there was no flag to ask for anything else.
- `cli.args.parse` dupes `[]const u8` option values out of an `_arena` field when the options struct has one, and falls back to an allocator nothing ever frees when it does not. Nine of the benchmark option structs had no `_arena`, so every run that passed `--data=<path>` leaked the parser's copy of the path.

What changed:

- Those four benchmarks read the corpus once in `setup` and the timed step consumes it from memory. The read is capped at 1 GiB as a guard against a malformed input, and the warning names the limit when a file exceeds it. The remaining data-driven actions (`apc-parser`, `is-symbol`, `terminal-parser`) still read inside their step and are left for a separate change.
- `screen-clone` frees each clone before the next iteration.
- `--duration-ms` is new. Flags shared by every action are parsed from the full argument list against a struct that has a diagnostics list, so an unrecognized action flag lands there instead of erroring; the per-action options are then parsed from a copy of the same argument list with `--duration-ms` filtered out, because those structs have no field for it and no diagnostics list to absorb it.
- `mainAction` returns the `RunResult`. Nothing else can observe how the run was configured, so without it a change that parsed `--duration-ms` and still ran the step once would look fine. The CLI itself ignores the result.
- The nine option structs with a string field got the same `_arena` field the four others already had.

`terminal-stream` already routes through the full readonly terminal stream handler, so that part of the original report did not apply and it was left alone.

Round-2 review fixes:

- `codepoint-width` no longer carves `simd` out of the preload. All four modes read the same buffer and `data_f` is gone, which fixes the same stale-offset bug for `simd` that the other three modes get fixed here, and removes this branch's dependency on `Mode.simd` existing. See the note on #1032 below.
- A malformed `--duration-ms` used to be swallowed. `RunOptions._diagnostics` is what lets an unrecognized action flag land somewhere instead of erroring, but nothing ever read the list, so it also absorbed errors on the one flag `RunOptions` owns: `--duration-ms=abc`, `=-5` and `=99999999999999999999` each recorded a diagnostic, left the field at 0, and silently degraded the run to a single iteration. The list is now inspected after the parse and the run fails with `error.InvalidDurationMs`.
- `screen-clone --mode=clone` now measures the free as well as the clone, and the code says so rather than leaving the change silent. The free is not optional: the step runs until the deadline in duration mode, so an unfreed clone per iteration grows without bound. `Benchmark.run` times the whole step call and has no per-iteration hook outside the timer, so there is nowhere to put the free that escapes measurement. **A `screen-clone --mode=clone` number taken from this commit is not comparable with one recorded before it** -- it is clone plus teardown of the cloned page list. The original author's "we purposely do not free" comment was replaced by one recording that trade.
- The corpus-cap comment named `StreamTooLong` in four files. `compat_file.readToEndAlloc` returns `FileTooBig`. Fixed in all four.
- `SliceArgIterator` reinvented `cli.args.SliceIterator`, which is already `pub` in the module this file imports. Deleted in favour of `cli.args.sliceIterator`.
- `runMode` multiplied `duration_ms * ns_per_ms` unchecked, and `ghostty-bench` is built `ReleaseFast` unconditionally, where an overflow there is undefined behaviour rather than a panic. It saturates now.
- `osc-parser`'s `setup` returned before resetting the parser when no `--data` was given. The reset moved above the early return.
- `src/benchmark/main.zig` did not re-export `ApcParser` or `OscParser`.

Ordering against #1032 (`fix/audit-simd`), which deletes `CodepointWidth.Mode.simd`:

Before the fix above, this branch added a `.simd =>` prong to a new switch in `setup`, and git auto-merged the two branches **with no conflict at all**, in either order, into a byte-identical tree that does not compile (`error: enum 'benchmark.CodepointWidth.Mode' has no member named 'simd'`). Nothing would have warned whoever did the merge.

Now nothing in this branch names `.simd`, and the two branches produce one conflict in either order, a single hunk in `src/benchmark/CodepointWidth.zig`: this branch's rewritten `stepSimd` against #1032's deletion of it. **Resolve it by taking the deletion -- drop `stepSimd` entirely.** Everything else in that file auto-merges correctly: the `simd` import, the enum member and the dispatch prong all come out, and this branch's preload `setup`, `teardown` and step rewrites all stay. Both orders resolve to the same tree (`02ec26d6d153582f12df7218f8bc14aceea227cc`), and that tree builds green.

Test plan:

- [x] `zig build --summary all test -Dapp-runtime=none -Dtest-filter=benchmark`: 87/87 steps succeeded, 121 pass / 1 skip / 122 total. The skip is the `Benchmark` decltest, which skips on Windows because it asserts on a timer.
- [x] Every converted benchmark has a test that writes a real file and drives it through the CLI with `--data=`, so `setup` really opens and reads it rather than the test setting the field by hand.
- [x] The option tests run on `std.testing.allocator`, which fails on the leak described above.
- [x] The duration test asserts the run stepped more than once; putting `.once` back into the run call fails it.
- [x] The malformed-duration test covers a non-numeric value, a negative value and a value that overflows the `u64` parse.
- [x] Merged against `fix/audit-simd` in both orders, conflict resolved by taking the deletion: 87/87 steps succeeded, 121 pass / 1 skip / 122 total in both.
- [x] `zig fmt --check` on every touched file.

Known and deliberately not fixed here: `Benchmark.RunResult.iterations` is a `u32` and nothing prints `RunResult`, so a long `--duration-ms` run in the always-`ReleaseFast` bench binary can wrap the counter with nothing to observe it. Both pre-date this change; this is what first makes them reachable from the CLI.
