### PR TITLE
os: refuse file urls that point at a remote host

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2202,6 +2202,31 @@ fn resolvePathForOpening(
 
         const resolved = try std.fs.path.resolve(self.alloc, &.{ terminal_pwd, path });
 
+        // The pwd was cleared as local when it was adopted, but that says
+        // nothing about where resolving against it lands. On Windows
+        // `std.fs.path.resolve` roots an extended-length UNC pwd at `\\?\UNC`
+        // rather than at `\\?\UNC\host`, so the host is an ordinary component
+        // and a `../` in the link pops it: an adopted `\\?\UNC\localhost\C$`
+        // plus a perfectly ordinary relative link yields
+        // `\\?\UNC\<attacker>\share\...`. The `accessAbsolute` below is
+        // already the damage -- it hands the current user's credentials to
+        // whatever is in the host slot -- so the question has to be asked
+        // again here, about the path that actually came out, and answered by
+        // the same predicate that admitted the pwd.
+        //
+        // A resolve that produced no absolute path at all (`C:foo` against a
+        // UNC pwd keeps its drive-relative form) is refused with it: nothing
+        // downstream can place it, and `accessAbsolute` asserts on it.
+        if (comptime builtin.os.tag == .windows) {
+            if (!std.fs.path.isAbsolute(resolved) or
+                !internal_os.posix_path.pathIsLocal(resolved))
+            {
+                log.warn("refusing link that does not resolve to a local path", .{});
+                self.alloc.free(resolved);
+                return null;
+            }
+        }
+
         std.Io.Dir.accessAbsolute(global.io(), resolved, .{}) catch {
             self.alloc.free(resolved);
             return null;

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2207,15 +2207,61 @@ const LinkPath = union(enum) {
 };
 
 /// Resolves a relative file path to an absolute path using the terminal's pwd.
+///
+/// The filesystem is consulted only for a path `resolveLinkPath` already
+/// admitted. `accessAbsolute` is a blocking probe made with the renderer mutex
+/// held (`processLinks` documents that requirement), so for a UNC pwd it is an
+/// SMB round trip the window waits on -- a share that went off-VPN stalls the
+/// renderer for the redirector's timeout. That is not new and is narrower than
+/// it was: before any of this the probe ran on whatever host the resolve
+/// produced, attacker-popped ones included, and it now runs only on the host
+/// the user's own working directory names. Moving the probe off the mutex is
+/// the real fix and is a separate change.
 fn resolvePathForOpening(
     self: *Surface,
     path: []const u8,
 ) Allocator.Error!LinkPath {
-    if (std.fs.path.isAbsolute(path)) return .unresolved;
+    const link_path = try resolveLinkPath(
+        self.alloc,
+        self.io.terminal.getPwd(),
+        path,
+    );
 
-    const terminal_pwd = self.io.terminal.getPwd() orelse return .unresolved;
+    const resolved = switch (link_path) {
+        .unresolved, .refused => return link_path,
+        .resolved => |resolved| resolved,
+    };
 
-    const resolved = try std.fs.path.resolve(self.alloc, &.{ terminal_pwd, path });
+    // A link that resolves to nothing was never a file link: it is the URL the
+    // regex matched, and the link text is what opens. A refusal is the other
+    // answer and was already returned above -- it must not arrive here and
+    // degrade into this one.
+    std.Io.Dir.accessAbsolute(global.io(), resolved, .{}) catch {
+        self.alloc.free(resolved);
+        return .unresolved;
+    };
+
+    return link_path;
+}
+
+/// What `link` resolves to against `terminal_pwd`, and whether we will touch
+/// the result at all.
+///
+/// This is `resolvePathForOpening` without the surface and without the
+/// filesystem, because a `Surface` cannot be constructed in a unit test and an
+/// untestable security decision is one that silently stops holding. `.resolved`
+/// here means "the path the link names", not "a file that exists"; the caller
+/// asks the filesystem that.
+fn resolveLinkPath(
+    alloc: Allocator,
+    terminal_pwd: ?[]const u8,
+    link: []const u8,
+) Allocator.Error!LinkPath {
+    if (std.fs.path.isAbsolute(link)) return .unresolved;
+
+    const cwd = terminal_pwd orelse return .unresolved;
+
+    const resolved = try std.fs.path.resolve(alloc, &.{ cwd, link });
 
     // Resolving is what can move the host, and moving it is the whole defect.
     // The pwd itself needs no defending: a UNC working directory is one the
@@ -2224,7 +2270,7 @@ fn resolvePathForOpening(
     // at `\\?\UNC` rather than at `\\?\UNC\host`, so the host is an ordinary
     // component and a `../` in the link pops it: an adopted
     // `\\?\UNC\localhost\C$` plus a perfectly ordinary relative link yields
-    // `\\?\UNC\<attacker>\share\...`. The `accessAbsolute` below is already
+    // `\\?\UNC\<attacker>\share\...`. The caller's `accessAbsolute` is already
     // the damage -- it hands the current user's credentials to whatever is in
     // the host slot -- so the result is measured against the pwd's own host
     // here, before it.
@@ -2234,21 +2280,16 @@ fn resolvePathForOpening(
     // downstream can place it, and `accessAbsolute` asserts on it.
     if (comptime builtin.os.tag == .windows) {
         if (!std.fs.path.isAbsolute(resolved) or
-            !internal_os.posix_path.pathHostUnchanged(terminal_pwd, resolved))
+            !internal_os.posix_path.pathHostUnchanged(cwd, resolved))
         {
             log.warn(
                 "refusing link that resolves off the working directory's host pwd={s} resolved={s}",
-                .{ terminal_pwd, resolved },
+                .{ cwd, resolved },
             );
-            self.alloc.free(resolved);
+            alloc.free(resolved);
             return .refused;
         }
     }
-
-    std.Io.Dir.accessAbsolute(global.io(), resolved, .{}) catch {
-        self.alloc.free(resolved);
-        return .unresolved;
-    };
 
     return .{ .resolved = resolved };
 }
@@ -7018,6 +7059,104 @@ test "DerivedConfig: a long click-repeat-interval does not overflow" {
     try testing.expectEqual(
         @as(u64, 5000 * std.time.ns_per_ms),
         derived.mouse_interval,
+    );
+}
+
+fn expectLinkRefused(alloc: Allocator, cwd: ?[]const u8, link: []const u8) !void {
+    switch (try resolveLinkPath(alloc, cwd, link)) {
+        .refused => {},
+        .unresolved => return error.TestExpectedRefusal,
+        .resolved => |resolved| {
+            alloc.free(resolved);
+            return error.TestExpectedRefusal;
+        },
+    }
+}
+
+fn expectLinkResolved(
+    alloc: Allocator,
+    expected: []const u8,
+    cwd: ?[]const u8,
+    link: []const u8,
+) !void {
+    switch (try resolveLinkPath(alloc, cwd, link)) {
+        .resolved => |resolved| {
+            defer alloc.free(resolved);
+            try std.testing.expectEqualStrings(expected, resolved);
+        },
+        .unresolved, .refused => return error.TestExpectedResolution,
+    }
+}
+
+fn expectLinkUnresolved(alloc: Allocator, cwd: ?[]const u8, link: []const u8) !void {
+    switch (try resolveLinkPath(alloc, cwd, link)) {
+        .unresolved => {},
+        .refused => return error.TestExpectedNoResolution,
+        .resolved => |resolved| {
+            alloc.free(resolved);
+            return error.TestExpectedNoResolution;
+        },
+    }
+}
+
+test "a link resolution that leaves the working directory's host is refused" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+    const alloc = std.testing.allocator;
+
+    // Every pwd here is one the terminal adopts and every link is the shape
+    // the URL regex matches. The resolve is what moves the host:
+    // `std.fs.path.resolve` roots an extended UNC pwd at `\\?\UNC`, so `../`
+    // pops the host out of the root like any other component.
+    try expectLinkRefused(
+        alloc,
+        "\\\\?\\UNC\\localhost\\C$\\Users\\me",
+        "../../../../evil.example.com/share/payload.exe",
+    );
+    // A drive-letter pwd cannot grow a host either.
+    try expectLinkRefused(
+        alloc,
+        "\\\\?\\C:\\Users\\me",
+        "../../../UNC/evil.example.com/share/x",
+    );
+    // Nor does it lose one: a resolve that walks a UNC pwd out to a drive is a
+    // change of host even though the result is local.
+    try expectLinkRefused(
+        alloc,
+        "\\\\?\\UNC\\localhost\\C$\\Users\\me",
+        "..\\..\\..\\..\\..\\C:\\x",
+    );
+    // A resolve that names no directory at all keeps its drive-relative form,
+    // which `accessAbsolute` asserts on rather than answers.
+    try expectLinkRefused(alloc, "\\\\?\\UNC\\localhost\\C$", "C:foo");
+
+    // The share the user configured keeps its own links: Windows already
+    // authenticated to that host to spawn the shell there.
+    try expectLinkResolved(
+        alloc,
+        "\\\\fileserver\\projects\\notes.md",
+        "\\\\fileserver\\projects",
+        "notes.md",
+    );
+    try expectLinkResolved(
+        alloc,
+        "C:\\Users\\me\\notes.md",
+        "C:\\Users\\me",
+        "notes.md",
+    );
+}
+
+test "a link resolution with nothing to resolve against" {
+    const alloc = std.testing.allocator;
+
+    // No pwd to resolve against, so the link text is what stands.
+    try expectLinkUnresolved(alloc, null, "notes.md");
+
+    // An absolute link is already the answer and is never resolved, so it can
+    // never be refused for a host it did not get from a pwd.
+    try expectLinkUnresolved(
+        alloc,
+        "C:\\Users\\me",
+        if (comptime builtin.os.tag == .windows) "C:\\Windows\\notepad.exe" else "/etc/hosts",
     );
 }
 

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2190,52 +2190,77 @@ pub fn pwd(
     return try alloc.dupe(u8, terminal_pwd);
 }
 
+/// What resolving a clicked link against the terminal's pwd came to.
+const LinkPath = union(enum) {
+    /// Nothing was resolved: the link is already absolute, there is no pwd, or
+    /// the resolved file does not exist. The link text is opened as it stands.
+    unresolved,
+
+    /// The resolved absolute path. Owned by the caller.
+    resolved: []const u8,
+
+    /// The link resolves somewhere we will not touch. Nothing may be opened:
+    /// the link text on its own would be resolved against ghostty's own
+    /// directory instead and could name a different file of the same name, and
+    /// quietly opening the wrong file is a worse answer than opening none.
+    refused,
+};
+
 /// Resolves a relative file path to an absolute path using the terminal's pwd.
 fn resolvePathForOpening(
     self: *Surface,
     path: []const u8,
-) Allocator.Error!?[]const u8 {
-    if (!std.fs.path.isAbsolute(path)) {
-        const terminal_pwd = self.io.terminal.getPwd() orelse {
-            return null;
-        };
+) Allocator.Error!LinkPath {
+    if (std.fs.path.isAbsolute(path)) return .unresolved;
 
-        const resolved = try std.fs.path.resolve(self.alloc, &.{ terminal_pwd, path });
+    const terminal_pwd = self.io.terminal.getPwd() orelse return .unresolved;
 
-        // The pwd was cleared as local when it was adopted, but that says
-        // nothing about where resolving against it lands. On Windows
-        // `std.fs.path.resolve` roots an extended-length UNC pwd at `\\?\UNC`
-        // rather than at `\\?\UNC\host`, so the host is an ordinary component
-        // and a `../` in the link pops it: an adopted `\\?\UNC\localhost\C$`
-        // plus a perfectly ordinary relative link yields
-        // `\\?\UNC\<attacker>\share\...`. The `accessAbsolute` below is
-        // already the damage -- it hands the current user's credentials to
-        // whatever is in the host slot -- so the question has to be asked
-        // again here, about the path that actually came out, and answered by
-        // the same predicate that admitted the pwd.
-        //
-        // A resolve that produced no absolute path at all (`C:foo` against a
-        // UNC pwd keeps its drive-relative form) is refused with it: nothing
-        // downstream can place it, and `accessAbsolute` asserts on it.
-        if (comptime builtin.os.tag == .windows) {
-            if (!std.fs.path.isAbsolute(resolved) or
-                !internal_os.posix_path.pathIsLocal(resolved))
-            {
-                log.warn("refusing link that does not resolve to a local path", .{});
-                self.alloc.free(resolved);
-                return null;
-            }
-        }
+    const resolved = try std.fs.path.resolve(self.alloc, &.{ terminal_pwd, path });
 
-        std.Io.Dir.accessAbsolute(global.io(), resolved, .{}) catch {
+    // Resolving is what can move the host, and moving it is the whole defect.
+    // The pwd itself needs no defending: a UNC working directory is one the
+    // user configured, and Windows already authenticated to it to spawn the
+    // shell there. But `std.fs.path.resolve` roots an extended-length UNC pwd
+    // at `\\?\UNC` rather than at `\\?\UNC\host`, so the host is an ordinary
+    // component and a `../` in the link pops it: an adopted
+    // `\\?\UNC\localhost\C$` plus a perfectly ordinary relative link yields
+    // `\\?\UNC\<attacker>\share\...`. The `accessAbsolute` below is already
+    // the damage -- it hands the current user's credentials to whatever is in
+    // the host slot -- so the result is measured against the pwd's own host
+    // here, before it.
+    //
+    // A resolve that produced no absolute path at all (`C:foo` against a UNC
+    // pwd keeps its drive-relative form) is refused with it: nothing
+    // downstream can place it, and `accessAbsolute` asserts on it.
+    if (comptime builtin.os.tag == .windows) {
+        if (!std.fs.path.isAbsolute(resolved) or
+            !internal_os.posix_path.pathHostUnchanged(terminal_pwd, resolved))
+        {
+            log.warn(
+                "refusing link that resolves off the working directory's host pwd={s} resolved={s}",
+                .{ terminal_pwd, resolved },
+            );
             self.alloc.free(resolved);
-            return null;
-        };
-
-        return resolved;
+            return .refused;
+        }
     }
 
-    return null;
+    std.Io.Dir.accessAbsolute(global.io(), resolved, .{}) catch {
+        self.alloc.free(resolved);
+        return .unresolved;
+    };
+
+    return .{ .resolved = resolved };
+}
+
+/// The URL `processLinks` opens for a link whose path resolution came to
+/// `link_path`, or null when nothing at all may be opened.
+fn urlForLinkPath(link_path: LinkPath, link: []const u8) ?[]const u8 {
+    return switch (link_path) {
+        .unresolved => link,
+        .resolved => |resolved| resolved,
+        .refused => null,
+    };
 }
 
 /// Returns the x/y coordinate of where the IME (Input Method Editor)
@@ -4732,10 +4757,17 @@ fn processLinks(self: *Surface, pos: apprt.CursorPos) !bool {
             });
             defer self.alloc.free(str);
 
-            const resolved_path = try self.resolvePathForOpening(str);
-            defer if (resolved_path) |p| self.alloc.free(p);
+            const link_path = try self.resolvePathForOpening(str);
+            defer switch (link_path) {
+                .resolved => |p| self.alloc.free(p),
+                .unresolved, .refused => {},
+            };
 
-            const url_to_open = resolved_path orelse str;
+            // A refusal opens nothing at all. The link text alone would be
+            // resolved against ghostty's own directory by the opener, so
+            // falling through to it turns "we would not open that" into "we
+            // opened something else", which is the worse of the two.
+            const url_to_open = urlForLinkPath(link_path, str) orelse return true;
             try self.openUrl(.{ .kind = .unknown, .url = url_to_open });
         },
 
@@ -6986,6 +7018,24 @@ test "DerivedConfig: a long click-repeat-interval does not overflow" {
     try testing.expectEqual(
         @as(u64, 5000 * std.time.ns_per_ms),
         derived.mouse_interval,
+    );
+}
+
+test "a refused link resolution opens nothing" {
+    const testing = std.testing;
+
+    // The refusal must not fall through to the link text: the opener resolves
+    // a relative argument against ghostty's own directory, so opening it would
+    // open a same-named file somewhere the user never pointed at.
+    try testing.expect(urlForLinkPath(.refused, "notes.md") == null);
+
+    try testing.expectEqualStrings(
+        "notes.md",
+        urlForLinkPath(.unresolved, "notes.md").?,
+    );
+    try testing.expectEqualStrings(
+        "C:\\Users\\me\\notes.md",
+        urlForLinkPath(.{ .resolved = "C:\\Users\\me\\notes.md" }, "notes.md").?,
     );
 }
 

--- a/src/os/open.zig
+++ b/src/os/open.zig
@@ -98,8 +98,17 @@ fn hasAllowedScheme(url: []const u8, opts: struct { file: bool }) bool {
 /// on where the authority starts: reading "the text up to the first slash"
 /// makes `file:////evil/share` look like an empty authority while the OS
 /// still finds the host. Counting the separators instead is what tells the
-/// two apart, and the count has to be taken after decoding, since the
-/// canonicalizer decodes `%2f` and `%5c` before it splits the URL.
+/// two apart.
+///
+/// That count is only meaningful if the run is spelled literally. A `%2f`
+/// or `%5c` in it lands in a different place depending on whether the
+/// canonicalizer decodes before or after it splits the URL, and we have no
+/// evidence either way, so any encoded separator in the run is refused
+/// outright: under one reading it is part of a longer run, under the other
+/// it is part of a host name, and both are remote. An escape that decodes
+/// to a blank or a control is refused for the same reason, since an opener
+/// that trims a leading blank turns `file:%20//evil/x` back into a UNC
+/// path.
 ///
 /// `url` is known to begin with the `file:` scheme, matched case
 /// insensitively.
@@ -116,6 +125,7 @@ fn isLocalFileUrl(url: []const u8) bool {
     var i: usize = 0;
     var separator_count: usize = 0;
     var has_backslash = false;
+    var has_encoded = false;
     while (i < rest.len) {
         switch (rest[i]) {
             '/' => i += 1,
@@ -126,16 +136,26 @@ fn isLocalFileUrl(url: []const u8) bool {
             '%' => {
                 if (i + 3 > rest.len) break;
                 const escape = rest[i..][0..3];
-                if (std.ascii.eqlIgnoreCase(escape, "%5c")) {
-                    has_backslash = true;
-                } else if (!std.ascii.eqlIgnoreCase(escape, "%2f")) break;
-                i += 3;
+                if (std.ascii.eqlIgnoreCase(escape, "%2f") or
+                    std.ascii.eqlIgnoreCase(escape, "%5c"))
+                {
+                    has_encoded = true;
+                    i += 3;
+                } else {
+                    const byte = decodeEscape(escape) orelse break;
+                    if (byte <= ' ' or byte == 0x7f) return false;
+                    break;
+                }
             },
             else => break,
         }
 
         separator_count += 1;
     }
+
+    // The run is only readable as a separator count if every step of it was
+    // literal; see the note above on the decode order.
+    if (has_encoded) return false;
 
     const after_run = rest[i..];
     return switch (separator_count) {
@@ -221,6 +241,15 @@ fn hasControlChars(url: []const u8) bool {
     return false;
 }
 
+/// The byte a three-character percent escape stands for, or null if the two
+/// characters after the `%` are not hex digits.
+fn decodeEscape(escape: *const [3]u8) ?u8 {
+    std.debug.assert(escape[0] == '%');
+    const high = std.fmt.charToDigit(escape[1], 16) catch return null;
+    const low = std.fmt.charToDigit(escape[2], 16) catch return null;
+    return high * 16 + low;
+}
+
 test "url allow-list accepts every scheme the link regex detects" {
     // Spelled out rather than looped over `allowed_schemes` so that a
     // scheme dropped from the list fails here instead of silently agreeing
@@ -292,11 +321,12 @@ test "url allow-list refuses file urls that hide a remote authority" {
     try testing.expect(isUrlAllowed(.unknown, "file:///tmp/a%2Fb.md"));
 }
 
-test "url allow-list counts encoded separators toward the leading run" {
+test "url allow-list refuses an encoded separator in the leading run" {
     const testing = std.testing;
-    // An encoded separator that continues the leading run is decoded before
-    // the target is resolved, so it lengthens the run exactly as a literal
-    // one does: these all reach the OS as four separators, a UNC host.
+    // Whether the canonicalizer decodes before or after it splits the URL
+    // decides where the authority of these starts, so both readings are
+    // refused rather than picked between: one of them is always remote.
+    try testing.expect(!isUrlAllowed(.unknown, "file://%2fevil/x"));
     try testing.expect(!isUrlAllowed(.unknown, "file:///%2fevil/share/a.exe"));
     try testing.expect(!isUrlAllowed(.unknown, "file:///%5cevil/share/a.exe"));
     try testing.expect(!isUrlAllowed(.unknown, "file:///%2Fevil/share/a.exe"));
@@ -320,6 +350,34 @@ test "url allow-list refuses a backslash in a file url with no authority" {
     // Two separators still name an authority, whichever way they lean.
     try testing.expect(!isUrlAllowed(.unknown, "file:\\\\evil\\share"));
     try testing.expect(isUrlAllowed(.unknown, "file:\\\\localhost\\share"));
+}
+
+test "url allow-list refuses an encoded blank before a file url's path" {
+    const testing = std.testing;
+    // Decoded these read as a blank followed by `//evil/x`, and an opener
+    // that trims the blank before resolving is left with a UNC path.
+    try testing.expect(!isUrlAllowed(.unknown, "file:%20//evil/x"));
+    try testing.expect(!isUrlAllowed(.unknown, "file:%09//evil/x"));
+    try testing.expect(!isUrlAllowed(.unknown, "file:%0a//evil/x"));
+    // A NUL truncates the target wherever it is honoured.
+    try testing.expect(!isUrlAllowed(.unknown, "file:%00//evil/x"));
+    // Past the leading run an encoded blank is ordinary data: a file name
+    // with a space in it is perfectly normal, and so is a query string.
+    try testing.expect(isUrlAllowed(.unknown, "file:///tmp/a%20b.txt"));
+    try testing.expect(isUrlAllowed(.osc8, "https://example.com/a%20b"));
+    try testing.expect(isUrlAllowed(.unknown, "https://example.com/a%20b"));
+}
+
+test "url allow-list ends a file url's separator run at the first other byte" {
+    const testing = std.testing;
+    // `%2e` decodes to `.`, so the run stops there and this is the local
+    // path `/../evil` rather than anything with an authority.
+    try testing.expect(isUrlAllowed(.unknown, "file:///%2e%2e/evil"));
+    // A truncated escape ends the run too. Three separators means no
+    // authority component; two makes `%` the authority, which is neither
+    // empty nor localhost.
+    try testing.expect(isUrlAllowed(.unknown, "file:///%2"));
+    try testing.expect(!isUrlAllowed(.unknown, "file://%"));
 }
 
 test "url allow-list rejects schemes that execute or reconfigure" {

--- a/src/os/open.zig
+++ b/src/os/open.zig
@@ -79,36 +79,80 @@ pub fn isUrlAllowed(kind: apprt.action.OpenUrl.Kind, url: []const u8) bool {
 fn hasAllowedScheme(url: []const u8, opts: struct { file: bool }) bool {
     const scheme = schemeOf(url) orelse return false;
     for (allowed_schemes) |allowed| {
-        if (!opts.file and std.ascii.eqlIgnoreCase(allowed, "file")) continue;
-        if (std.ascii.eqlIgnoreCase(scheme, allowed)) {
-            if (std.ascii.eqlIgnoreCase(scheme, "file") and !isLocalFileAuthority(url)) {
-                return false;
-            }
-            return true;
-        }
+        // `allowed` comes from the list above, so it is already lowercase.
+        if (!opts.file and std.mem.eql(u8, allowed, "file")) continue;
+        if (!std.ascii.eqlIgnoreCase(scheme, allowed)) continue;
+        if (std.mem.eql(u8, allowed, "file") and !isLocalFileUrl(url)) return false;
+        return true;
     }
 
     return false;
 }
 
-/// True if a `file:` URL's authority is empty or `localhost`
-/// (case-insensitively). The authority is the text between `file://` and
-/// the next `/` (or the end of the string). A non-local authority is a
-/// remote host name that, on Windows, `rundll32` resolves to a UNC path and
-/// executes the default verb against it, leaking the current user's NTLM
-/// credentials to that host.
-fn isLocalFileAuthority(url: []const u8) bool {
-    const prefix = "file://";
-    if (url.len < prefix.len or !std.ascii.eqlIgnoreCase(url[0..prefix.len], prefix)) {
-        // No `//` authority marker (e.g. `file:relative/path`): there is no
-        // syntax here for a remote host, so there is nothing to refuse.
-        return true;
+/// True if the `file:` URL `url` names something on this machine.
+///
+/// A remote authority is a host name that, on Windows, `rundll32` resolves
+/// to a UNC path and then runs the default verb against, leaking the current
+/// user's NTLM credentials to that host. What counts as the authority is
+/// decided by the OS canonicalizer, not by us, so this has to agree with it
+/// on where the authority starts: reading "the text up to the first slash"
+/// makes `file:////evil/share` look like an empty authority while the OS
+/// still finds the host. Counting the separators instead is what tells the
+/// two apart.
+///
+/// `url` is known to begin with the `file:` scheme, matched case
+/// insensitively.
+fn isLocalFileUrl(url: []const u8) bool {
+    const scheme = "file:";
+    std.debug.assert(url.len >= scheme.len and
+        std.ascii.eqlIgnoreCase(url[0..scheme.len], scheme));
+    const rest = url[scheme.len..];
+
+    // Backslashes are separators on Windows, so `file:\\evil\share` names
+    // the same host as `file://evil/share` and is counted the same way.
+    const separators = "/\\";
+    const first_sep = std.mem.indexOfAny(u8, rest, separators) orelse rest.len;
+
+    // Percent-encoded separators are not decoded by the count below but are
+    // decoded before the target is resolved, so `file:%2f%2fevil/share`
+    // would otherwise be read here as a plain relative path. Refuse them in
+    // the authority position rather than decoding: nothing we want to open
+    // needs an encoded separator before the path begins.
+    if (hasEncodedSeparator(rest[0..first_sep])) return false;
+
+    const separator_count = rest.len - std.mem.trimStart(u8, rest, separators).len;
+    return switch (separator_count) {
+        // `file:notes.md`, `file:/etc/hosts` and `file:///etc/hosts` have no
+        // authority component at all.
+        0, 1, 3 => true,
+
+        // `file://<authority>/path`: the only spelling with a host in it.
+        2 => authority: {
+            const after = rest[2..];
+            const end = std.mem.indexOfAny(u8, after, separators) orelse after.len;
+            const authority = after[0..end];
+            break :authority authority.len == 0 or
+                std.ascii.eqlIgnoreCase(authority, "localhost");
+        },
+
+        // Four or more: an empty authority to any naive parse, a UNC host to
+        // the OS. Nothing legitimate spells a local file this way.
+        else => false,
+    };
+}
+
+/// True if `text` contains a percent-encoded `/` or `\`.
+fn hasEncodedSeparator(text: []const u8) bool {
+    var i: usize = 0;
+    while (std.mem.indexOfScalarPos(u8, text, i, '%')) |at| {
+        if (at + 3 > text.len) return false;
+        const escape = text[at .. at + 3];
+        if (std.ascii.eqlIgnoreCase(escape, "%2f") or
+            std.ascii.eqlIgnoreCase(escape, "%5c")) return true;
+        i = at + 1;
     }
 
-    const rest = url[prefix.len..];
-    const authority_end = std.mem.indexOfScalar(u8, rest, '/') orelse rest.len;
-    const authority = rest[0..authority_end];
-    return authority.len == 0 or std.ascii.eqlIgnoreCase(authority, "localhost");
+    return false;
 }
 
 /// True if `value` looks like a filesystem path rather than a URL. The link
@@ -217,6 +261,31 @@ test "url allow-list refuses file urls with a remote authority" {
     // Scheme case-insensitivity must not open a bypass for the authority
     // check.
     try testing.expect(!isUrlAllowed(.unknown, "FILE://EVIL/x"));
+    // An OSC 8 target never reaches the authority check at all: `file:` is
+    // skipped for it entirely.
+    try testing.expect(!isUrlAllowed(.osc8, "file://localhost/x"));
+}
+
+test "url allow-list refuses file urls that hide a remote authority" {
+    const testing = std.testing;
+    // Reading the text up to the first slash as the authority makes these
+    // look empty, while the OS canonicalizer reads the extra slashes as a
+    // host name.
+    try testing.expect(!isUrlAllowed(.unknown, "file:////evil/share/a.exe"));
+    try testing.expect(!isUrlAllowed(.unknown, "file://///evil/share/a.exe"));
+    // Backslashes separate path components on Windows, so the same target
+    // spelled with them has to be refused too.
+    try testing.expect(!isUrlAllowed(.unknown, "file:\\\\evil\\share\\a.exe"));
+    try testing.expect(!isUrlAllowed(.unknown, "file://evil\\share\\a.exe"));
+    // A percent-encoded separator is invisible to a slash count but is
+    // decoded before the target is resolved.
+    try testing.expect(!isUrlAllowed(.unknown, "file:%2f%2fevil/share/x"));
+    try testing.expect(!isUrlAllowed(.unknown, "file:%5C%5Cevil/share/x"));
+    // Spellings that carry no authority component keep working.
+    try testing.expect(isUrlAllowed(.unknown, "file:/etc/hosts"));
+    try testing.expect(isUrlAllowed(.unknown, "file:///etc/hosts"));
+    // An encoded separator further along is ordinary path data.
+    try testing.expect(isUrlAllowed(.unknown, "file:///tmp/a%2Fb.md"));
 }
 
 test "url allow-list rejects schemes that execute or reconfigure" {

--- a/src/os/open.zig
+++ b/src/os/open.zig
@@ -80,10 +80,35 @@ fn hasAllowedScheme(url: []const u8, opts: struct { file: bool }) bool {
     const scheme = schemeOf(url) orelse return false;
     for (allowed_schemes) |allowed| {
         if (!opts.file and std.ascii.eqlIgnoreCase(allowed, "file")) continue;
-        if (std.ascii.eqlIgnoreCase(scheme, allowed)) return true;
+        if (std.ascii.eqlIgnoreCase(scheme, allowed)) {
+            if (std.ascii.eqlIgnoreCase(scheme, "file") and !isLocalFileAuthority(url)) {
+                return false;
+            }
+            return true;
+        }
     }
 
     return false;
+}
+
+/// True if a `file:` URL's authority is empty or `localhost`
+/// (case-insensitively). The authority is the text between `file://` and
+/// the next `/` (or the end of the string). A non-local authority is a
+/// remote host name that, on Windows, `rundll32` resolves to a UNC path and
+/// executes the default verb against it, leaking the current user's NTLM
+/// credentials to that host.
+fn isLocalFileAuthority(url: []const u8) bool {
+    const prefix = "file://";
+    if (url.len < prefix.len or !std.ascii.eqlIgnoreCase(url[0..prefix.len], prefix)) {
+        // No `//` authority marker (e.g. `file:relative/path`): there is no
+        // syntax here for a remote host, so there is nothing to refuse.
+        return true;
+    }
+
+    const rest = url[prefix.len..];
+    const authority_end = std.mem.indexOfScalar(u8, rest, '/') orelse rest.len;
+    const authority = rest[0..authority_end];
+    return authority.len == 0 or std.ascii.eqlIgnoreCase(authority, "localhost");
 }
 
 /// True if `value` looks like a filesystem path rather than a URL. The link
@@ -110,6 +135,12 @@ fn isFilesystemPath(value: []const u8) bool {
     // Bare relative paths (`src/config/url.zig`) carry no scheme at all.
     // A value that does parse as a scheme is a URL we chose not to allow,
     // not a path, so it must not fall through to here.
+    //
+    // A malformed scheme (one containing a space, say) also lands here as
+    // "no scheme" and gets treated as a path. That is safe only because the
+    // caller already refused leading whitespace: the link regex cannot
+    // produce a space-bearing match that does not already start with `/`,
+    // `./`, `../`, or `~/`, one of the path prefixes handled above.
     return schemeOf(value) == null;
 }
 
@@ -172,6 +203,20 @@ test "url allow-list matches schemes case-insensitively" {
     try testing.expect(isUrlAllowed(.osc8, "HTTPS://example.com"));
     try testing.expect(isUrlAllowed(.unknown, "File:///tmp/notes.md"));
     try testing.expect(!isUrlAllowed(.osc8, "File:///tmp/notes.md"));
+}
+
+test "url allow-list refuses file urls with a remote authority" {
+    const testing = std.testing;
+    try testing.expect(isUrlAllowed(.unknown, "file:///C:/x.txt"));
+    try testing.expect(isUrlAllowed(.unknown, "file:///etc/hosts"));
+    try testing.expect(isUrlAllowed(.unknown, "file://localhost/x"));
+    // A non-empty, non-localhost authority resolves to a UNC path on
+    // Windows and runs the default verb against that host.
+    try testing.expect(!isUrlAllowed(.unknown, "file://evil/share/a.exe"));
+    try testing.expect(!isUrlAllowed(.unknown, "file://evil"));
+    // Scheme case-insensitivity must not open a bypass for the authority
+    // check.
+    try testing.expect(!isUrlAllowed(.unknown, "FILE://EVIL/x"));
 }
 
 test "url allow-list rejects schemes that execute or reconfigure" {

--- a/src/os/open.zig
+++ b/src/os/open.zig
@@ -143,7 +143,7 @@ fn isLocalFileUrl(url: []const u8) bool {
                     i += 3;
                 } else {
                     const byte = decodeEscape(escape) orelse break;
-                    if (byte <= ' ' or byte == 0x7f) return false;
+                    if (byte < '!' or byte >= 0x7f) return false;
                     break;
                 }
             },
@@ -361,6 +361,11 @@ test "url allow-list refuses an encoded blank before a file url's path" {
     try testing.expect(!isUrlAllowed(.unknown, "file:%0a//evil/x"));
     // A NUL truncates the target wherever it is honoured.
     try testing.expect(!isUrlAllowed(.unknown, "file:%00//evil/x"));
+    // `%A0` decodes to U+00A0 (non-breaking space) on the wide-char path.
+    // If the opener's leading-blank trim is `iswspace`-based rather than
+    // `" \t"`-based, this collapses to a UNC path by the same mechanism as
+    // the plain-space case above.
+    try testing.expect(!isUrlAllowed(.unknown, "file:%A0//evil/x"));
     // Past the leading run an encoded blank is ordinary data: a file name
     // with a space in it is perfectly normal, and so is a query string.
     try testing.expect(isUrlAllowed(.unknown, "file:///tmp/a%20b.txt"));

--- a/src/os/open.zig
+++ b/src/os/open.zig
@@ -98,7 +98,8 @@ fn hasAllowedScheme(url: []const u8, opts: struct { file: bool }) bool {
 /// on where the authority starts: reading "the text up to the first slash"
 /// makes `file:////evil/share` look like an empty authority while the OS
 /// still finds the host. Counting the separators instead is what tells the
-/// two apart.
+/// two apart, and the count has to be taken after decoding, since the
+/// canonicalizer decodes `%2f` and `%5c` before it splits the URL.
 ///
 /// `url` is known to begin with the `file:` scheme, matched case
 /// insensitively.
@@ -108,29 +109,46 @@ fn isLocalFileUrl(url: []const u8) bool {
         std.ascii.eqlIgnoreCase(url[0..scheme.len], scheme));
     const rest = url[scheme.len..];
 
-    // Backslashes are separators on Windows, so `file:\\evil\share` names
-    // the same host as `file://evil/share` and is counted the same way.
-    const separators = "/\\";
-    const first_sep = std.mem.indexOfAny(u8, rest, separators) orelse rest.len;
+    // Walk the leading separator run, consuming a literal separator or one
+    // percent escape that decodes to a separator per step. The run ends at
+    // the first byte that is neither, so an encoded separator further along
+    // (`file:///tmp/a%2Fb.md`) stays ordinary path data.
+    var i: usize = 0;
+    var separator_count: usize = 0;
+    var has_backslash = false;
+    while (i < rest.len) {
+        switch (rest[i]) {
+            '/' => i += 1,
+            '\\' => {
+                has_backslash = true;
+                i += 1;
+            },
+            '%' => {
+                if (i + 3 > rest.len) break;
+                const escape = rest[i..][0..3];
+                if (std.ascii.eqlIgnoreCase(escape, "%5c")) {
+                    has_backslash = true;
+                } else if (!std.ascii.eqlIgnoreCase(escape, "%2f")) break;
+                i += 3;
+            },
+            else => break,
+        }
 
-    // Percent-encoded separators are not decoded by the count below but are
-    // decoded before the target is resolved, so `file:%2f%2fevil/share`
-    // would otherwise be read here as a plain relative path. Refuse them in
-    // the authority position rather than decoding: nothing we want to open
-    // needs an encoded separator before the path begins.
-    if (hasEncodedSeparator(rest[0..first_sep])) return false;
+        separator_count += 1;
+    }
 
-    const separator_count = rest.len - std.mem.trimStart(u8, rest, separators).len;
+    const after_run = rest[i..];
     return switch (separator_count) {
         // `file:notes.md`, `file:/etc/hosts` and `file:///etc/hosts` have no
-        // authority component at all.
-        0, 1, 3 => true,
+        // authority component at all. A backslash in the run means Windows
+        // reads it as a UNC path instead, and nothing here proves the
+        // canonicalizer folds the two spellings together.
+        0, 1, 3 => !has_backslash,
 
         // `file://<authority>/path`: the only spelling with a host in it.
         2 => authority: {
-            const after = rest[2..];
-            const end = std.mem.indexOfAny(u8, after, separators) orelse after.len;
-            const authority = after[0..end];
+            const end = std.mem.indexOfAny(u8, after_run, "/\\") orelse after_run.len;
+            const authority = after_run[0..end];
             break :authority authority.len == 0 or
                 std.ascii.eqlIgnoreCase(authority, "localhost");
         },
@@ -139,20 +157,6 @@ fn isLocalFileUrl(url: []const u8) bool {
         // the OS. Nothing legitimate spells a local file this way.
         else => false,
     };
-}
-
-/// True if `text` contains a percent-encoded `/` or `\`.
-fn hasEncodedSeparator(text: []const u8) bool {
-    var i: usize = 0;
-    while (std.mem.indexOfScalarPos(u8, text, i, '%')) |at| {
-        if (at + 3 > text.len) return false;
-        const escape = text[at .. at + 3];
-        if (std.ascii.eqlIgnoreCase(escape, "%2f") or
-            std.ascii.eqlIgnoreCase(escape, "%5c")) return true;
-        i = at + 1;
-    }
-
-    return false;
 }
 
 /// True if `value` looks like a filesystem path rather than a URL. The link
@@ -286,6 +290,36 @@ test "url allow-list refuses file urls that hide a remote authority" {
     try testing.expect(isUrlAllowed(.unknown, "file:///etc/hosts"));
     // An encoded separator further along is ordinary path data.
     try testing.expect(isUrlAllowed(.unknown, "file:///tmp/a%2Fb.md"));
+}
+
+test "url allow-list counts encoded separators toward the leading run" {
+    const testing = std.testing;
+    // An encoded separator that continues the leading run is decoded before
+    // the target is resolved, so it lengthens the run exactly as a literal
+    // one does: these all reach the OS as four separators, a UNC host.
+    try testing.expect(!isUrlAllowed(.unknown, "file:///%2fevil/share/a.exe"));
+    try testing.expect(!isUrlAllowed(.unknown, "file:///%5cevil/share/a.exe"));
+    try testing.expect(!isUrlAllowed(.unknown, "file:///%2Fevil/share/a.exe"));
+    try testing.expect(!isUrlAllowed(.unknown, "file:///%5Cevil/share/a.exe"));
+    try testing.expect(!isUrlAllowed(.unknown, "file:/%2f%2f%2fevil/share/a.exe"));
+    try testing.expect(!isUrlAllowed(.unknown, "file:/%2F%2F%2Fevil/share/a.exe"));
+    // The run ends at the first byte that is not a separator, so an encoded
+    // separator after it is ordinary path data.
+    try testing.expect(isUrlAllowed(.unknown, "file:///tmp/a%2Fb.md"));
+    try testing.expect(isUrlAllowed(.unknown, "file:///tmp/a%5Cb.md"));
+}
+
+test "url allow-list refuses a backslash in a file url with no authority" {
+    const testing = std.testing;
+    // Without an authority component the run has to be all forward slashes.
+    // A backslash in it is how Windows spells a UNC path, and we have no
+    // evidence that the canonicalizer treats the two the same here.
+    try testing.expect(!isUrlAllowed(.unknown, "file://\\evil/share"));
+    try testing.expect(!isUrlAllowed(.unknown, "file:\\\\\\evil\\share"));
+    try testing.expect(!isUrlAllowed(.unknown, "file:/%5cevil/share"));
+    // Two separators still name an authority, whichever way they lean.
+    try testing.expect(!isUrlAllowed(.unknown, "file:\\\\evil\\share"));
+    try testing.expect(isUrlAllowed(.unknown, "file:\\\\localhost\\share"));
 }
 
 test "url allow-list rejects schemes that execute or reconfigure" {

--- a/src/os/posix_path.zig
+++ b/src/os/posix_path.zig
@@ -4,6 +4,9 @@
 //! whether it is a raw path or a URL, and which machine it names.
 const std = @import("std");
 const Allocator = std.mem.Allocator;
+const hostname = @import("hostname.zig");
+
+const log = std.log.scoped(.posix_path);
 
 pub const Error = error{ UnknownDistro, UnknownRoot, InvalidPath } || Allocator.Error;
 
@@ -216,6 +219,48 @@ pub fn isLocalShareHost(host: []const u8) bool {
         if (std.ascii.eqlIgnoreCase(host, local)) return true;
     }
     return false;
+}
+
+/// Whether a UNC path's server is this machine.
+///
+/// The share pseudo-hosts are decided by name alone; the real computer name
+/// needs the OS, and gets `hostname.isLocal`. A failure to ask the OS reads
+/// as remote, as does a share written in a case the OS does not report the
+/// computer name in -- `\\mypc\x` against a `MYPC` -- because `isLocal`
+/// compares exactly. That is the safe direction to be wrong in: refusing a
+/// share that was ours costs a nuisance, admitting one that was not costs a
+/// credential.
+pub fn hostIsLocal(host: []const u8) bool {
+    if (isLocalShareHost(host)) return true;
+    return hostname.isLocal(host) catch |err| {
+        log.warn("failed to get hostname for UNC validation: {}", .{err});
+        return false;
+    };
+}
+
+/// Whether an absolute Windows `path` names this machine.
+///
+/// This is the whole question a caller holding a path asks, and it is one
+/// function so that the two places that ask -- the pwd a child reports, and
+/// the path a clicked link resolves to -- cannot answer it differently.
+///
+/// Asking twice is not redundant, because `std.fs.path.resolveWindows` does
+/// not read an extended-length UNC path the way Windows does: it roots
+/// `\\?\UNC\host\share` at `\\?\UNC`, which leaves the host as an ordinary
+/// component that `..` can pop, so a path that named this machine when it was
+/// admitted can name another one after something is resolved against it. The
+/// host slot of the result is what Windows will authenticate to, so the
+/// result is what has to be asked about.
+///
+/// A `\\` form that names no directory we will place (`error.InvalidPath`,
+/// which is where those popped-apart shapes land) is not local: nothing
+/// legitimate spells a local path that way.
+pub fn pathIsLocal(path: []const u8) bool {
+    const host = pathHost(path) catch return false;
+    return switch (host) {
+        .local => true,
+        .server => |name| hostIsLocal(name),
+    };
 }
 
 /// Translate the path component of an OSC 7 `file://` URL reported by a
@@ -474,6 +519,146 @@ test "posix_path: isLocalShareHost admits only hosts that never reach the wire" 
     try std.testing.expect(!isLocalShareHost(""));
     // A prefix of a local name is not a local name.
     try std.testing.expect(!isLocalShareHost("wsl.localhost.evil.example.com"));
+}
+
+test "posix_path: pathIsLocal answers for the whole path" {
+    try std.testing.expect(pathIsLocal("C:\\Users\\alex"));
+    try std.testing.expect(pathIsLocal("\\\\?\\C:\\Users\\alex"));
+    try std.testing.expect(pathIsLocal("\\\\localhost\\C$\\Users\\alex"));
+    try std.testing.expect(pathIsLocal("\\\\wsl.localhost\\Ubuntu\\home\\alex"));
+    try std.testing.expect(pathIsLocal("\\\\?\\UNC\\localhost\\C$"));
+
+    try std.testing.expect(!pathIsLocal("\\\\evil.example.com\\share"));
+    try std.testing.expect(!pathIsLocal("\\\\?\\UNC\\evil.example.com\\share"));
+    // A `\\` form naming no directory we can place is not local either.
+    try std.testing.expect(!pathIsLocal("\\\\"));
+    try std.testing.expect(!pathIsLocal("\\\\?\\evil.example.com\\share"));
+}
+
+// The link-open path resolves a clicked relative link against the reported
+// pwd and then touches the result, which is what authenticates to a UNC
+// host. `std.fs.path.resolveWindows` roots `\\?\UNC\host\share` at `\\?\UNC`,
+// so the host is a component `..` pops: a pwd that was local when it was
+// adopted stops being local, and only a second look at the resolved path
+// sees it. Every pwd below passes the adoption check and every link is an
+// ordinary relative link the URL regex is meant to match.
+test "posix_path: a relative link can resolve off an adopted extended UNC pwd" {
+    const alloc = std.testing.allocator;
+
+    const Case = struct { pwd: []const u8, link: []const u8, resolved: []const u8 };
+    const cases = [_]Case{
+        .{
+            .pwd = "\\\\?\\UNC\\localhost\\C$\\Users\\me",
+            .link = "../../../../evil.example.com/share/payload.exe",
+            .resolved = "\\\\?\\UNC\\evil.example.com\\share\\payload.exe",
+        },
+        // One `../` is enough from the share root.
+        .{
+            .pwd = "\\\\?\\UNC\\localhost",
+            .link = "../evil.example.com/share/payload.exe",
+            .resolved = "\\\\?\\UNC\\evil.example.com\\share\\payload.exe",
+        },
+        .{
+            .pwd = "\\\\?\\unc\\localhost\\C$\\Users\\me",
+            .link = "../../../../evil.example.com/share/payload.exe",
+            .resolved = "\\\\?\\unc\\evil.example.com\\share\\payload.exe",
+        },
+        // The device-namespace spelling reaches the same place.
+        .{
+            .pwd = "\\\\.\\UNC\\127.0.0.1\\C$\\tmp",
+            .link = "../../../evil.example.com/share/payload.exe",
+            .resolved = "\\\\.\\UNC\\evil.example.com\\share\\payload.exe",
+        },
+    };
+
+    for (cases) |c| {
+        // The pwd is one we adopt: the hole is the resolve, not the pwd.
+        try std.testing.expect(isWindowsAbsolute(c.pwd));
+        try std.testing.expect(pathIsLocal(c.pwd));
+
+        const resolved = try std.fs.path.resolveWindows(alloc, &.{ c.pwd, c.link });
+        defer alloc.free(resolved);
+        try std.testing.expectEqualStrings(c.resolved, resolved);
+        try std.testing.expect(!pathIsLocal(resolved));
+    }
+
+    // A `\\?\C:` pwd walked past its root degrades to an extended prefix
+    // introducing neither `UNC\` nor a drive. Windows cannot open it, and it
+    // is refused rather than guessed at.
+    {
+        const resolved = try std.fs.path.resolveWindows(alloc, &.{
+            "\\\\?\\C:\\Users\\me",
+            "../../../../../evil.example.com/share/payload.exe",
+        });
+        defer alloc.free(resolved);
+        try std.testing.expectEqualStrings("\\\\?\\evil.example.com\\share\\payload.exe", resolved);
+        try std.testing.expect(!pathIsLocal(resolved));
+    }
+}
+
+test "posix_path: ordinary link resolution stays local" {
+    const alloc = std.testing.allocator;
+
+    const Case = struct { pwd: []const u8, link: []const u8, resolved: []const u8 };
+    const cases = [_]Case{
+        // Relative links under a drive-letter pwd.
+        .{ .pwd = "C:\\Users\\me", .link = "notes.md", .resolved = "C:\\Users\\me\\notes.md" },
+        .{ .pwd = "C:\\Users\\me", .link = "./src/main.zig", .resolved = "C:\\Users\\me\\src\\main.zig" },
+        .{ .pwd = "C:\\Users\\me\\src", .link = "../notes.md", .resolved = "C:\\Users\\me\\notes.md" },
+        // `..` past the drive root clamps at the root.
+        .{ .pwd = "C:\\Users\\me", .link = "../../../../a/b", .resolved = "C:\\a\\b" },
+        // A drive-relative link on the pwd's own drive is still that drive.
+        .{ .pwd = "C:\\Users\\me", .link = "C:foo", .resolved = "C:\\Users\\me\\foo" },
+        // A legitimately-adopted local UNC pwd: inside the share...
+        .{
+            .pwd = "\\\\localhost\\C$\\Users\\me",
+            .link = "../other/notes.md",
+            .resolved = "\\\\localhost\\C$\\Users\\other\\notes.md",
+        },
+        // ...and past the share root, where resolveWindows clamps because it
+        // reads this spelling's root correctly.
+        .{
+            .pwd = "\\\\localhost\\C$\\Users\\me",
+            .link = "../../../../../a/b",
+            .resolved = "\\\\localhost\\C$\\a\\b",
+        },
+        .{
+            .pwd = "\\\\wsl.localhost\\Ubuntu\\home\\alex",
+            .link = "../bob/notes.md",
+            .resolved = "\\\\wsl.localhost\\Ubuntu\\home\\bob\\notes.md",
+        },
+        // The extended-length spelling of a drive root.
+        .{
+            .pwd = "\\\\?\\C:\\Users\\me",
+            .link = "notes.md",
+            .resolved = "\\\\?\\C:\\Users\\me\\notes.md",
+        },
+        // Inside an extended UNC pwd, where nothing was popped.
+        .{
+            .pwd = "\\\\?\\UNC\\localhost\\C$\\Users\\me",
+            .link = "../other/notes.md",
+            .resolved = "\\\\?\\UNC\\localhost\\C$\\Users\\other\\notes.md",
+        },
+    };
+
+    for (cases) |c| {
+        const resolved = try std.fs.path.resolveWindows(alloc, &.{ c.pwd, c.link });
+        defer alloc.free(resolved);
+        try std.testing.expectEqualStrings(c.resolved, resolved);
+        try std.testing.expect(std.fs.path.isAbsoluteWindows(resolved));
+        try std.testing.expect(pathIsLocal(resolved));
+    }
+
+    // A drive-relative link naming a drive other than the pwd's keeps its
+    // drive-relative form, which names no directory and which the OS access
+    // check asserts on. `pathIsLocal` cannot see that -- the absolute check
+    // beside it is what refuses these.
+    {
+        const resolved = try std.fs.path.resolveWindows(alloc, &.{ "\\\\?\\UNC\\localhost\\C$", "C:foo" });
+        defer alloc.free(resolved);
+        try std.testing.expectEqualStrings("C:foo", resolved);
+        try std.testing.expect(!std.fs.path.isAbsoluteWindows(resolved));
+    }
 }
 
 fn expectLocal(path: []const u8) !void {

--- a/src/os/posix_path.zig
+++ b/src/os/posix_path.zig
@@ -273,16 +273,10 @@ pub fn hostIsLocal(host: []const u8) bool {
 /// Whether an absolute Windows `path` names this machine.
 ///
 /// This is the whole question a caller holding a path asks, and it is one
-/// function so that the two places that ask -- the pwd a child reports, and
-/// the path a clicked link resolves to -- cannot answer it differently.
-///
-/// Asking twice is not redundant, because `std.fs.path.resolveWindows` does
-/// not read an extended-length UNC path the way Windows does: it roots
-/// `\\?\UNC\host\share` at `\\?\UNC`, which leaves the host as an ordinary
-/// component that `..` can pop, so a path that named this machine when it was
-/// admitted can name another one after something is resolved against it. The
-/// host slot of the result is what Windows will authenticate to, so the
-/// result is what has to be asked about.
+/// function so that no two callers can answer it differently. It is the right
+/// question for a path that is about to be adopted on the strength of bytes
+/// alone; a path that came out of a resolve is a different question, and
+/// `pathHostUnchanged` below is that one.
 ///
 /// A form that names no directory we will place (`error.InvalidPath`, which
 /// is where those popped-apart shapes land, and where a leading separator run
@@ -293,6 +287,41 @@ pub fn pathIsLocal(path: []const u8) bool {
     return switch (host) {
         .local => true,
         .server => |name| hostIsLocal(name),
+    };
+}
+
+/// Whether `resolved`, the product of resolving something against `pwd`, still
+/// names the machine `pwd` names.
+///
+/// This, and not "is the result local", is the question the link-open path has
+/// to ask. A working directory may legitimately be a UNC share: nothing checks
+/// the host of `working-directory`, and there is no reason to -- the user chose
+/// it, and Windows authenticates to it the moment the shell is spawned there.
+/// Refusing that share's own relative links would break a real setup while
+/// protecting nothing.
+///
+/// What must never happen is the resolve *moving* the host, which
+/// `std.fs.path.resolveWindows` makes possible: it roots
+/// `\\?\UNC\host\share` at `\\?\UNC`, leaving the host an ordinary component
+/// that a `../` in the link can pop, so a directory that named one machine
+/// yields a path naming another. The pwd's host is therefore the standard the
+/// result is held to, and a resolve that changed it is refused.
+///
+/// Both sides are read with the strict parse, so a path whose leading
+/// separator run Windows would take for a UNC root but we would not is refused
+/// rather than compared. So is either side naming no directory at all.
+pub fn pathHostUnchanged(pwd: []const u8, resolved: []const u8) bool {
+    const before = hostOfAnyPath(pwd) catch return false;
+    const after = hostOfAnyPath(resolved) catch return false;
+    return switch (before) {
+        .local => switch (after) {
+            .local => true,
+            .server => false,
+        },
+        .server => |a| switch (after) {
+            .local => false,
+            .server => |b| std.ascii.eqlIgnoreCase(a, b),
+        },
     };
 }
 
@@ -632,6 +661,14 @@ test "posix_path: a relative link can resolve off an adopted extended UNC pwd" {
             .link = "../../../evil.example.com/share/payload.exe",
             .resolved = "\\\\.\\UNC\\evil.example.com\\share\\payload.exe",
         },
+        // The pwd can carry the `..` itself, in which case the link needs
+        // none: the host the pwd names is still `localhost`, and the host the
+        // resolve produces is not.
+        .{
+            .pwd = "\\\\?\\UNC\\localhost\\C$\\..\\..\\evil.example.com\\share",
+            .link = "notes.md",
+            .resolved = "\\\\?\\UNC\\evil.example.com\\share\\notes.md",
+        },
     };
 
     for (cases) |c| {
@@ -643,6 +680,7 @@ test "posix_path: a relative link can resolve off an adopted extended UNC pwd" {
         defer alloc.free(resolved);
         try std.testing.expectEqualStrings(c.resolved, resolved);
         try std.testing.expect(!pathIsLocal(resolved));
+        try std.testing.expect(!pathHostUnchanged(c.pwd, resolved));
     }
 
     // A `\\?\C:` pwd walked past its root degrades to an extended prefix
@@ -656,7 +694,82 @@ test "posix_path: a relative link can resolve off an adopted extended UNC pwd" {
         defer alloc.free(resolved);
         try std.testing.expectEqualStrings("\\\\?\\evil.example.com\\share\\payload.exe", resolved);
         try std.testing.expect(!pathIsLocal(resolved));
+        try std.testing.expect(!pathHostUnchanged("\\\\?\\C:\\Users\\me", resolved));
     }
+}
+
+// A working directory may legitimately name a UNC share -- `working-directory`
+// takes one and no layer host-checks it -- and that share's own relative links
+// have to keep opening. Only a resolve that moves the host is a refusal.
+test "posix_path: a remote working directory keeps its own links" {
+    const alloc = std.testing.allocator;
+
+    const Case = struct { pwd: []const u8, link: []const u8, resolved: []const u8 };
+    const kept = [_]Case{
+        .{
+            .pwd = "\\\\fileserver\\projects",
+            .link = "notes.md",
+            .resolved = "\\\\fileserver\\projects\\notes.md",
+        },
+        .{
+            .pwd = "\\\\fileserver\\projects\\src",
+            .link = "../docs/readme.md",
+            .resolved = "\\\\fileserver\\projects\\docs\\readme.md",
+        },
+        // `..` past the share root clamps there, so the host cannot move.
+        .{
+            .pwd = "\\\\fileserver\\projects",
+            .link = "../../elsewhere/notes.md",
+            .resolved = "\\\\fileserver\\projects\\elsewhere\\notes.md",
+        },
+        // The share is written in whatever case the shell reported it in.
+        .{
+            .pwd = "\\\\FileServer\\projects",
+            .link = "notes.md",
+            .resolved = "\\\\FileServer\\projects\\notes.md",
+        },
+    };
+
+    for (kept) |c| {
+        const resolved = try std.fs.path.resolveWindows(alloc, &.{ c.pwd, c.link });
+        defer alloc.free(resolved);
+        try std.testing.expectEqualStrings(c.resolved, resolved);
+        // The predicate this replaced refuses every one of these.
+        try std.testing.expect(!pathIsLocal(resolved));
+        try std.testing.expect(pathHostUnchanged(c.pwd, resolved));
+    }
+
+    // The extended spelling of the same remote share is where the host can
+    // still be popped, and it is refused whether or not the pwd was local.
+    {
+        const resolved = try std.fs.path.resolveWindows(alloc, &.{
+            "\\\\?\\UNC\\fileserver\\projects\\src",
+            "../../../evil.example.com/share/payload.exe",
+        });
+        defer alloc.free(resolved);
+        try std.testing.expectEqualStrings(
+            "\\\\?\\UNC\\evil.example.com\\share\\payload.exe",
+            resolved,
+        );
+        try std.testing.expect(!pathHostUnchanged("\\\\?\\UNC\\fileserver\\projects\\src", resolved));
+    }
+
+    // A drive-letter pwd cannot grow a host: a link that synthesises one is a
+    // change of host like any other.
+    {
+        const resolved = try std.fs.path.resolveWindows(alloc, &.{
+            "\\\\?\\C:\\Users\\me",
+            "../../../UNC/evil.example.com/share/x",
+        });
+        defer alloc.free(resolved);
+        try std.testing.expectEqualStrings("\\\\?\\UNC\\evil.example.com\\share\\x", resolved);
+        try std.testing.expect(!pathHostUnchanged("\\\\?\\C:\\Users\\me", resolved));
+    }
+
+    // Neither side is compared when its leading separator run is one Windows
+    // reads as a UNC root and we do not.
+    try std.testing.expect(!pathHostUnchanged("C:\\Users\\me", "//evil.example.com/share/x"));
+    try std.testing.expect(!pathHostUnchanged("//evil.example.com/share", "//evil.example.com/share/x"));
 }
 
 test "posix_path: ordinary link resolution stays local" {
@@ -710,6 +823,7 @@ test "posix_path: ordinary link resolution stays local" {
         try std.testing.expectEqualStrings(c.resolved, resolved);
         try std.testing.expect(std.fs.path.isAbsoluteWindows(resolved));
         try std.testing.expect(pathIsLocal(resolved));
+        try std.testing.expect(pathHostUnchanged(c.pwd, resolved));
     }
 
     // A drive-relative link naming a drive other than the pwd's keeps its

--- a/src/os/posix_path.zig
+++ b/src/os/posix_path.zig
@@ -655,12 +655,6 @@ test "posix_path: a relative link can resolve off an adopted extended UNC pwd" {
             .link = "../../../../evil.example.com/share/payload.exe",
             .resolved = "\\\\?\\unc\\evil.example.com\\share\\payload.exe",
         },
-        // The device-namespace spelling reaches the same place.
-        .{
-            .pwd = "\\\\.\\UNC\\127.0.0.1\\C$\\tmp",
-            .link = "../../../evil.example.com/share/payload.exe",
-            .resolved = "\\\\.\\UNC\\evil.example.com\\share\\payload.exe",
-        },
         // The pwd can carry the `..` itself, in which case the link needs
         // none: the host the pwd names is still `localhost`, and the host the
         // resolve produces is not.
@@ -682,6 +676,13 @@ test "posix_path: a relative link can resolve off an adopted extended UNC pwd" {
         try std.testing.expect(!pathIsLocal(resolved));
         try std.testing.expect(!pathHostUnchanged(c.pwd, resolved));
     }
+
+    // The device namespace spells the same escape -- `\\.\UNC\host\share`
+    // reaches a server exactly as `\\?\UNC\host\share` does -- but it never
+    // reaches the resolve, because a device path is refused as a pwd outright
+    // and so is never adopted. The row is asserted here rather than in the
+    // table above, whose premise is a pwd we DO adopt.
+    try std.testing.expect(!pathIsLocal("\\\\.\\UNC\\127.0.0.1\\C$\\tmp"));
 
     // A `\\?\C:` pwd walked past its root degrades to an extended prefix
     // introducing neither `UNC\` nor a drive. Windows cannot open it, and it

--- a/src/os/posix_path.zig
+++ b/src/os/posix_path.zig
@@ -741,10 +741,22 @@ test "posix_path: a remote working directory keeps its own links" {
     }
 
     // Windows host names are case-insensitive, so a host that differs only in
-    // case has not moved. No resolve produces that on its own -- `resolveWindows`
-    // copies the pwd's root through verbatim, which is why the mixed-case row
-    // above compares equal byte for byte -- so this assertion is the only thing
-    // holding the compare to host semantics instead of plain equality.
+    // case has not moved. A resolve does reach that shape. `resolveWindows`
+    // copies the pwd's root through verbatim only while the link stays under it,
+    // and an extended-UNC root is one a `../` pops -- the premise of this whole
+    // file -- after which the link re-supplies the host in whatever case it
+    // likes. The link text is attacker-supplied, so the case-insensitive compare
+    // is load-bearing on a production-reachable input rather than defensive
+    // only, and the resolve that produces it is asserted here first.
+    {
+        const resolved = try std.fs.path.resolveWindows(alloc, &.{
+            "\\\\?\\UNC\\fileserver\\projects\\src",
+            "../../../FILESERVER/projects/x",
+        });
+        defer alloc.free(resolved);
+        try std.testing.expectEqualStrings("\\\\?\\UNC\\FILESERVER\\projects\\x", resolved);
+        try std.testing.expect(pathHostUnchanged("\\\\?\\UNC\\fileserver\\projects\\src", resolved));
+    }
     try std.testing.expect(pathHostUnchanged(
         "\\\\FileServer\\projects",
         "\\\\fileserver\\projects\\notes.md",

--- a/src/os/posix_path.zig
+++ b/src/os/posix_path.zig
@@ -740,6 +740,16 @@ test "posix_path: a remote working directory keeps its own links" {
         try std.testing.expect(pathHostUnchanged(c.pwd, resolved));
     }
 
+    // Windows host names are case-insensitive, so a host that differs only in
+    // case has not moved. No resolve produces that on its own -- `resolveWindows`
+    // copies the pwd's root through verbatim, which is why the mixed-case row
+    // above compares equal byte for byte -- so this assertion is the only thing
+    // holding the compare to host semantics instead of plain equality.
+    try std.testing.expect(pathHostUnchanged(
+        "\\\\FileServer\\projects",
+        "\\\\fileserver\\projects\\notes.md",
+    ));
+
     // The extended spelling of the same remote share is where the host can
     // still be popped, and it is refused whether or not the pwd was local.
     {
@@ -765,6 +775,22 @@ test "posix_path: a remote working directory keeps its own links" {
         defer alloc.free(resolved);
         try std.testing.expectEqualStrings("\\\\?\\UNC\\evil.example.com\\share\\x", resolved);
         try std.testing.expect(!pathHostUnchanged("\\\\?\\C:\\Users\\me", resolved));
+    }
+
+    // ...and the reverse: a pwd that names a host holds the result to it, so a
+    // resolve that walks out of the UNC root and lands on an ordinary drive is
+    // refused too. That direction refuses something *local*, which is the one
+    // shape where "did the host change" is stricter than "is the result local",
+    // and it is the arm nothing else here exercises.
+    {
+        const resolved = try std.fs.path.resolveWindows(alloc, &.{
+            "\\\\?\\UNC\\localhost\\C$\\Users\\me",
+            "..\\..\\..\\..\\..\\C:\\x",
+        });
+        defer alloc.free(resolved);
+        try std.testing.expectEqualStrings("\\\\?\\C:\\x", resolved);
+        try std.testing.expect(pathIsLocal(resolved));
+        try std.testing.expect(!pathHostUnchanged("\\\\?\\UNC\\localhost\\C$\\Users\\me", resolved));
     }
 
     // Neither side is compared when its leading separator run is one Windows

--- a/src/os/posix_path.zig
+++ b/src/os/posix_path.zig
@@ -199,6 +199,38 @@ fn hostOf(s: []const u8) error{InvalidPath}!PathHost {
     return .{ .server = s[0..end] };
 }
 
+/// Whether `c` separates path components. Windows accepts either character
+/// anywhere a separator can appear, the leading run included.
+fn isSeparator(c: u8) bool {
+    return c == '\\' or c == '/';
+}
+
+/// `pathHost`, for a path that did not arrive through `isWindowsAbsolute`.
+///
+/// `pathHost` parses the one UNC spelling a reported pwd can have, a literal
+/// `\\`, because that is the only one its caller can be handed. Windows is
+/// looser: any two leading separators start a UNC root, so `//host/share`,
+/// `///host/share`, `/\host\share` and `\/host/share` all reach the SMB
+/// redirector, while `pathHost` reads every one of them as an ordinary rooted
+/// local path.
+///
+/// Teaching the pwd parser spellings a pwd cannot have would only give it more
+/// ways to disagree with Windows, and two parsers disagreeing about where a
+/// separator run ends is exactly what the earlier holes here were. So a
+/// leading separator run that is not exactly `\\` is refused outright instead:
+/// nothing local needs to be spelled that way.
+fn hostOfAnyPath(path: []const u8) error{InvalidPath}!PathHost {
+    if (path.len >= 2 and
+        isSeparator(path[0]) and
+        isSeparator(path[1]) and
+        !(path[0] == '\\' and path[1] == '\\'))
+    {
+        return error.InvalidPath;
+    }
+
+    return pathHost(path);
+}
+
 /// Whether `host` is a Windows share host that resolves without leaving this
 /// machine, and so can never carry a credential off it.
 ///
@@ -252,11 +284,12 @@ pub fn hostIsLocal(host: []const u8) bool {
 /// host slot of the result is what Windows will authenticate to, so the
 /// result is what has to be asked about.
 ///
-/// A `\\` form that names no directory we will place (`error.InvalidPath`,
-/// which is where those popped-apart shapes land) is not local: nothing
-/// legitimate spells a local path that way.
+/// A form that names no directory we will place (`error.InvalidPath`, which
+/// is where those popped-apart shapes land, and where a leading separator run
+/// only Windows reads as UNC lands too) is not local: nothing legitimate
+/// spells a local path that way.
 pub fn pathIsLocal(path: []const u8) bool {
-    const host = pathHost(path) catch return false;
+    const host = hostOfAnyPath(path) catch return false;
     return switch (host) {
         .local => true,
         .server => |name| hostIsLocal(name),
@@ -533,6 +566,36 @@ test "posix_path: pathIsLocal answers for the whole path" {
     // A `\\` form naming no directory we can place is not local either.
     try std.testing.expect(!pathIsLocal("\\\\"));
     try std.testing.expect(!pathIsLocal("\\\\?\\evil.example.com\\share"));
+}
+
+test "posix_path: pathIsLocal refuses a UNC root spelled with any separators" {
+    // Windows starts a UNC root on any two leading separators, and every one
+    // of these reaches the SMB redirector. Reading them as rooted local paths
+    // is how a path parser and Windows come to disagree.
+    try std.testing.expect(!pathIsLocal("//evil.example.com/share/x"));
+    try std.testing.expect(!pathIsLocal("///evil.example.com/share/x"));
+    try std.testing.expect(!pathIsLocal("/\\evil.example.com\\share\\x"));
+    try std.testing.expect(!pathIsLocal("\\/evil.example.com/share/x"));
+    try std.testing.expect(!pathIsLocal("\\\\/evil.example.com/share/x"));
+    try std.testing.expect(!pathIsLocal("/\\/evil.example.com/share/x"));
+    // The host is not consulted: these spellings are not parsed at all, so a
+    // local-looking one is refused with the rest.
+    try std.testing.expect(!pathIsLocal("//localhost/C$/x"));
+    try std.testing.expect(!pathIsLocal("/\\wsl.localhost\\Ubuntu\\home"));
+    // A bare run names nothing.
+    try std.testing.expect(!pathIsLocal("//"));
+    try std.testing.expect(!pathIsLocal("/\\"));
+    try std.testing.expect(!pathIsLocal("\\/"));
+
+    // One leading separator is a path rooted on the current drive, which is
+    // this machine by construction. Only a run of two starts a host.
+    try std.testing.expect(pathIsLocal("/etc/hosts"));
+    try std.testing.expect(pathIsLocal("\\Users\\me"));
+    try std.testing.expect(pathIsLocal("/"));
+    try std.testing.expect(pathIsLocal("\\"));
+    // ...and the literal `\\` spelling still parses as it always did.
+    try std.testing.expect(pathIsLocal("\\\\localhost\\C$\\x"));
+    try std.testing.expect(pathIsLocal("\\\\?\\UNC\\localhost\\C$"));
 }
 
 // The link-open path resolves a clicked relative link against the reported

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -1766,7 +1766,7 @@ pub const StreamHandler = struct {
                 };
                 switch (host) {
                     .local => {},
-                    .server => |name| if (!uncHostIsLocal(name)) {
+                    .server => |name| if (!internal_os.posix_path.hostIsLocal(name)) {
                         log.warn("reported pwd (OSC 7/9;9/7777) UNC host ({s}) must be local", .{name});
                         return;
                     },
@@ -1854,24 +1854,6 @@ pub const StreamHandler = struct {
             path;
 
         return self.setPwdReported(reported);
-    }
-
-    /// Whether a UNC path's server is this machine. The share pseudo-hosts
-    /// (`wsl.localhost`, loopback) are decided by name alone; the real
-    /// computer name needs the OS, and gets the same `hostname.isLocal` the
-    /// URL arm uses.
-    ///
-    /// `isLocal` compares the computer name exactly, so a share written in a
-    /// case the OS does not report it in -- `\\mypc\x` against a `MYPC` --
-    /// reads as remote and the cwd is simply not adopted. That is the safe
-    /// direction to be wrong in; a spawn at the profile's directory is a
-    /// nuisance, and one at an attacker's is a credential.
-    fn uncHostIsLocal(host: []const u8) bool {
-        if (internal_os.posix_path.isLocalShareHost(host)) return true;
-        return internal_os.hostname.isLocal(host) catch |err| {
-            log.warn("failed to get hostname for UNC validation: {}", .{err});
-            return false;
-        };
     }
 
     /// Whether `path` can be a directory name at all, as opposed to bytes a


### PR DESCRIPTION
Follow-up to the parent branch's URL scheme allow-list. On the regex link path a `file:` URL was accepted regardless of its authority, so a link whose visible text reads as an https URL but whose target is `file://host/share/a.exe` reached the Windows opener, which resolves it to a UNC path and runs the default verb against a remote host, leaking credentials on the way.

A `file:` URL is now accepted only when it names no host: the separator run after the scheme must be all literal forward slashes, and a run of exactly two must be followed by an empty authority or `localhost`.

Getting there took three attempts, which is worth recording. The first parse read the authority as the text up to the first slash, so `file:////host/share` looked like an empty authority while Windows reads four slashes as a UNC host. The second counted decoded separators but anchored its encoded-separator check at the first literal slash, which is index zero for every `file:/...` URL, so `file:///%2fhost/share` slipped through to the same place. The rule is now fail-closed instead: any percent-encoded separator in the leading run is refused outright, because we cannot prove whether the opener decodes before or after it splits the URL. An escape that ends the run and decodes to anything non-printable is refused too, which closes the leading-encoded-blank spelling.

Ordinary paths are unaffected: `file:///C:/x.txt`, `file:///etc/hosts`, `file://localhost/x` and an encoded space or slash later in the path all still open.

Test plan:
- [x] `zig build test -Dapp-runtime=none` with the url and open filters (127/132, 5 skipped); every round produced a failing test first on the exact bypass it closed
- [x] `zig fmt --check` on the touched file

Known scope: one level of decoding only, so `%252f` is left to the OS; the Windows C# host has no open-url handler of its own, so it reaches this check through the fallback opener.
