### PR TITLE
diagnostics: hang watchdog + auto-minidump, native panic routing (#1033, #1034)

### DIFF
--- a/windows/Ghostty.Tests/Wiring/DiagnosticsWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/DiagnosticsWiringTests.cs
@@ -1,0 +1,70 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// The diagnostics' whole value is that they are running when the bad
+/// thing happens: a watchdog that never started and a stderr capture
+/// installed after libghostty booted record exactly nothing. These pins
+/// hold the wiring points -- the calls in App's constructor/OnLaunched
+/// and, for the capture, the ordering constraint that it runs before
+/// any native initialization.
+/// </summary>
+public class DiagnosticsWiringTests
+{
+    private static ShellSource App() => ShellSource.Load("Ghostty.App.xaml.cs");
+
+    [Fact]
+    public void AppInstallsTheStderrCaptureBeforeUnhandledHandlers()
+    {
+        var ctor = App().Constructors().Single(c =>
+            c.Initializer == null && c.Body is not null &&
+            c.Body.Statements.OfType<ExpressionStatementSyntax>()
+                .Any(s => s.Expression is InvocationExpressionSyntax i &&
+                          i.CalleeText() == "Diagnostics.NativeStderrCapture.Install"));
+
+        // The capture must precede InitializeComponent: libghostty writes
+        // to stderr during early boot (the log installer runs later),
+        // so a capture that lands after the native side initializes has
+        // already missed whatever it was installed to catch.
+        var install = ctor.Body!.Statements
+            .Select((s, i) => (Statement: s, Index: i))
+            .Single(t => t.Statement is ExpressionStatementSyntax e &&
+                         e.Expression is InvocationExpressionSyntax i &&
+                         i.CalleeText() == "Diagnostics.NativeStderrCapture.Install");
+        var initComponent = ctor.Body.Statements
+            .Select((s, i) => (Statement: s, Index: i))
+            .Single(t => t.Statement is ExpressionStatementSyntax e &&
+                         e.Expression is InvocationExpressionSyntax i &&
+                         i.CalleeText() == "InitializeComponent");
+        Assert.True(install.Index < initComponent.Index,
+            "the stderr capture must be installed before InitializeComponent");
+    }
+
+    [Fact]
+    public void OnLaunchedArmsTheHangWatchdogFirst()
+    {
+        var method = App().Method("OnLaunched");
+        var arm = method.Body!.Statements
+            .Select((s, i) => (Statement: s, Index: i))
+            .Single(t => t.Statement is ExpressionStatementSyntax e &&
+                         e.Expression is InvocationExpressionSyntax i &&
+                         i.CalleeText() == "Diagnostics.HangWatchdog.Start");
+
+        // First statement of the launch: the #1036 class of hang existed
+        // from the first frame, and a watchdog armed after a crashing
+        // early step would not have started at all.
+        Assert.Equal(0, arm.Index);
+    }
+}
+
+file static class DiagnosticsSyntaxQueries
+{
+    public static System.Collections.Generic.IEnumerable<ConstructorDeclarationSyntax> Constructors(
+        this ShellSource source) =>
+        source.Root.DescendantNodes().OfType<ConstructorDeclarationSyntax>();
+}

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -364,6 +364,14 @@ public partial class App : Application
             RequestedTheme = ApplicationTheme.Dark;
         }
 
+        // Native stderr -> file (#1034): libghostty's Zig panics print
+        // to a stderr the GUI process does not have; without this the
+        // only evidence of a native abort is the exit code. Must run
+        // before any libghostty initialization so early writes are
+        // captured too. Refuses politely when a real console is
+        // attached (terminal launches keep their console output).
+        Diagnostics.NativeStderrCapture.Install();
+
         InitializeComponent();
 
         // Surface unhandled exceptions to stderr AND to a file under
@@ -457,6 +465,13 @@ public partial class App : Application
 
     protected override void OnLaunched(LaunchActivatedEventArgs args)
     {
+        // UI-thread stall watchdog (#1033): a hang writes no exception
+        // anywhere, so this records it -- a crash.log entry plus a full
+        // minidump of the still-hung process under
+        // %LOCALAPPDATA%\Wintty\hangs\. First thing in the launch: the
+        // #1036 class of hang existed from the first frame.
+        Diagnostics.HangWatchdog.Start(DispatcherQueue.GetForCurrentThread());
+
         // Set the explicit AppUserModelID. This MUST happen before
         // any shell interop call (jump list registration, taskbar
         // icon operations, toast notifications).

--- a/windows/Ghostty/Diagnostics/HangWatchdog.cs
+++ b/windows/Ghostty/Diagnostics/HangWatchdog.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Microsoft.UI.Dispatching;
+
+namespace Ghostty.Diagnostics;
+
+/// <summary>
+/// Detects a stalled UI thread and leaves evidence behind (#1033).
+///
+/// When the UI thread blocks on a native lock or a full mailbox queue
+/// (the #1036 class), the window goes "not responding" forever and the
+/// app writes nothing: the unhandled-exception handlers never run for a
+/// hang, and a support report of "it froze" starts from zero. This
+/// watchdog closes that gap: a UI-thread heartbeat counter is advanced
+/// by a dispatcher timer, and a background thread checks it. If the
+/// counter has not moved for the stall window, the watchdog appends a
+/// crash.log entry and captures a full minidump of the still-hung
+/// process -- the same evidence class that took a three-hour ad-hoc
+/// debug session to collect by hand.
+///
+/// One capture per stall: after firing, the watchdog disarms itself
+/// (the UI thread is not going to un-hang on its own; a second dump of
+/// the same stacks helps nobody) and keeps a marker so the stall is
+/// still visible in the log if the process is later killed.
+/// </summary>
+internal static class HangWatchdog
+{
+    /// <summary>How long the UI thread must be silent before this is a
+    /// stall worth recording. Long enough that any legitimate long
+    /// operation on a dispatcher frame (a synchronous dialog pump, a
+    /// slow layout) is not mistaken for one.</summary>
+    private static readonly TimeSpan StallThreshold = TimeSpan.FromSeconds(20);
+
+    /// <summary>How often the background thread samples the heartbeat.
+    /// Two samples per threshold so a stall is caught within ~1.5x the
+    /// threshold.</summary>
+    private static readonly TimeSpan SampleInterval = TimeSpan.FromSeconds(10);
+
+    private static long _heartbeat;
+    private static int _armed;
+    private static DispatcherQueueTimer? _heartbeatTimer;
+    private static Thread? _watchThread;
+
+    /// <summary>
+    /// Arm the watchdog. Call once, on the UI thread, once the
+    /// dispatcher exists -- the heartbeat timer needs it. Idempotent.
+    /// </summary>
+    public static void Start(DispatcherQueue dispatcher)
+    {
+        if (Interlocked.Exchange(ref _armed, 1) == 1) return;
+
+        // The heartbeat: a lightweight repeating timer on the UI thread.
+        // DispatcherQueueTimer runs on the thread that owns the queue,
+        // so the tick IS the proof the thread is pumping.
+        _heartbeatTimer = dispatcher.CreateTimer();
+        _heartbeatTimer.Interval = TimeSpan.FromMilliseconds(250);
+        _heartbeatTimer.Tick += (_, _) => Interlocked.Increment(ref _heartbeat);
+        _heartbeatTimer.Start();
+
+        _watchThread = new Thread(WatchLoop)
+        {
+            Name = "hang-watchdog",
+            IsBackground = true,
+        };
+        _watchThread.Start();
+    }
+
+    private static void WatchLoop()
+    {
+        long lastSeen = Volatile.Read(ref _heartbeat);
+        var lastChange = Stopwatch.StartNew();
+        while (true)
+        {
+            Thread.Sleep(SampleInterval);
+            var beat = Volatile.Read(ref _heartbeat);
+            if (beat != lastSeen)
+            {
+                lastSeen = beat;
+                lastChange.Restart();
+                continue;
+            }
+
+            if (lastChange.Elapsed < StallThreshold) continue;
+
+            // The UI thread has not pumped for the threshold. Record.
+            RecordStall(lastChange.Elapsed);
+            return; // one capture per process; see class doc.
+        }
+    }
+
+    private static void RecordStall(TimeSpan stalledFor)
+    {
+        var pid = Environment.ProcessId;
+        var (logPath, dumpPath) = Paths(pid);
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(logPath)!);
+            File.AppendAllText(
+                logPath,
+                $"{DateTimeOffset.UtcNow:O} [UI-THREAD STALL]\n" +
+                $"The UI thread has not pumped for {stalledFor.TotalSeconds:N0}s; " +
+                $"capturing {dumpPath}\n\n");
+        }
+        catch { /* diagnostics must not throw */ }
+
+        CaptureMinidump(pid, dumpPath);
+
+        try
+        {
+            File.AppendAllText(
+                logPath,
+                $"{DateTimeOffset.UtcNow:O} [UI-THREAD STALL] minidump " +
+                (File.Exists(dumpPath) ? $"written ({new FileInfo(dumpPath).Length:N0} bytes)" : "FAILED") +
+                "\n\n");
+        }
+        catch { }
+    }
+
+    private static (string Log, string Dump) Paths(int pid)
+    {
+        var root = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            Ghostty.Core.AppIdentity.StateDirName);
+        return (
+            Path.Combine(root, "crash.log"),
+            Path.Combine(root, "hangs", $"hang-{pid}-{DateTimeOffset.UtcNow:yyyyMMdd-HHmmss}.dmp"));
+    }
+
+    // ---- minidump capture ------------------------------------------------
+
+    private const uint MiniDumpWithFullMemory = 0x2;
+    private const uint MiniDumpWithHandleData = 0x4;
+    private const uint MiniDumpWithFullMemoryInfo = 0x800;
+    private const uint MiniDumpWithThreadInfo = 0x1000;
+
+    /// <summary>
+    /// dbghelp's MiniDumpWriteDump called in-process. In-process on
+    /// purpose: comsvcs' rundll32 dumper writes an Administrators-only
+    /// DACL nobody can read without elevating (verified while chasing
+    /// #1036), and the dump then can't even be copied out for support.
+    /// </summary>
+    private static void CaptureMinidump(int pid, string path)
+    {
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            using var proc = Process.GetProcessById(pid);
+            using var fs = new FileStream(
+                path, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
+            // 0x1806: full memory + handle data + full memory info + thread info.
+            _ = MiniDumpWriteDump(
+                proc.Handle, (uint)pid, fs.SafeFileHandle.DangerousGetHandle(),
+                0x1806, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+        }
+        catch { /* diagnostics must not throw */ }
+    }
+
+    [DllImport("dbghelp.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool MiniDumpWriteDump(
+        IntPtr hProcess, uint processId, IntPtr hFile, uint dumpType,
+        IntPtr exceptionParam, IntPtr userStreamParam, IntPtr callbackParam);
+}

--- a/windows/Ghostty/Diagnostics/NativeStderrCapture.cs
+++ b/windows/Ghostty/Diagnostics/NativeStderrCapture.cs
@@ -1,0 +1,94 @@
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Ghostty.Diagnostics;
+
+/// <summary>
+/// Route the native side's stderr into a file (#1034).
+///
+/// libghostty's Zig panics print their message and backtrace to stderr
+/// and then abort; in a GUI process there is no stderr (GetStdHandle
+/// fails, the writes vanish), so a native abort's entire evidence is
+/// the exit code. The libghostty log installer works around this for
+/// LOG lines by giving the Zig logger a file, but the default panic
+/// handler and a few early-boot writes still go to the raw handle.
+///
+/// This capture installs the file as the process stderr before any
+/// native code runs: open (rotating, capped) the log, SetStdHandle,
+/// and every later stderr write -- panic text included -- lands in it.
+/// Best-effort by design: a failure to install leaves the app exactly
+/// as it was, silent, and that is not worth failing startup over.
+/// </summary>
+internal static partial class NativeStderrCapture
+{
+    /// <summary>
+    /// Cap on the capture file. Panics are a few KB; anything past this
+    /// is a chatty native write we do not need to keep across launches,
+    /// so the file truncates at the cap rather than growing forever.
+    /// </summary>
+    private const long MaxBytes = 8 * 1024 * 1024;
+
+    private static string LogPath => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        Ghostty.Core.AppIdentity.StateDirName,
+        "native-stderr.log");
+
+    /// <summary>
+    /// Install the capture. Call as early as possible in GUI startup --
+    /// before libghostty initialization -- so early boot writes and any
+    /// later panic both land in the file. Safe to call when a real
+    /// stderr exists (terminal launches): it refuses rather than
+    /// stealing the developer's console output.
+    /// </summary>
+    public static void Install()
+    {
+        try
+        {
+            // A console-attached launch has a working stderr; leave it
+            // alone so `wintty.exe` from a terminal still prints there.
+            // GetFileType==DISK/CHAR distinguishes a real handle from
+            // the GUI subsystem's null; simplest robust check is the
+            // combination .NET already resolved.
+            var existing = GetStdHandle(StdErrorHandle);
+            if (existing != IntPtr.Zero && !Console.IsErrorRedirected && Console.Error != StreamWriter.Null)
+                return;
+
+            var path = LogPath;
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+
+            // Rotate at the cap: truncate rather than rename -- simpler
+            // than rename racing a concurrent writer, and the
+            // interesting content (the panic) is always at the tail,
+            // which truncation preserves.
+            if (File.Exists(path) && new FileInfo(path).Length > MaxBytes)
+                File.WriteAllText(path, string.Empty);
+
+            // FileShare.ReadWrite so a concurrently-running second
+            // window of the same process does not open-exclusively us.
+            var fs = new FileStream(
+                path, FileMode.Append, FileAccess.Write, FileShare.ReadWrite);
+            // Deliberately leaked: the handle must outlive everything
+            // that might write to stderr for the process's lifetime.
+            bool added = false;
+            fs.SafeFileHandle.DangerousAddRef(ref added);
+            if (!added) return;
+            if (!SetStdHandle(StdErrorHandle, fs.SafeFileHandle.DangerousGetHandle()))
+                throw new Win32Exception();
+        }
+        catch
+        {
+            // Best-effort by contract: silent on failure.
+        }
+    }
+
+    private const int StdErrorHandle = -12; // STD_ERROR_HANDLE
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    private static partial IntPtr GetStdHandle(int nStdHandle);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool SetStdHandle(int nStdHandle, IntPtr hHandle);
+}


### PR DESCRIPTION
The supportability gap the #1036 debug session exposed: hangs write nothing, native aborts vanish into discarded stderr.

- **HangWatchdog (#1033)**: UI-thread heartbeat (dispatcher timer) + background sampler; a 20s stall appends to crash.log and captures a full in-process minidump to %LOCALAPPDATA%\Wintty\hangs\ (dbghelp MiniDumpWriteDump -- in-process because comsvcs writes Administrator-only files; verified while collecting the #1036 evidence). One capture per stall.
- **NativeStderrCapture (#1034)**: installs %LOCALAPPDATA%\Wintty\native-stderr.log as the process stderr before InitializeComponent, so Zig panic messages + backtraces (and early native writes) survive the GUI's missing stderr. Refuses politely when a real console is attached. 8MB cap with tail-preserving truncation.
- Wiring guards pin both call sites and the before-InitializeComponent ordering; the ordering pin caught its author on first run.

Would have collapsed the #1036 three-hour session into one repro with evidence on disk.