### PR TITLE
renderer: upload only the changed part of the atlas and stop drawing idle frames

### DIFF
--- a/src/font/Atlas.zig
+++ b/src/font/Atlas.zig
@@ -407,6 +407,11 @@ fn markDirtyAll(self: *Atlas) void {
 /// The box is a bounding box over regions that may be far apart, so it can
 /// cover bytes the consumer already has. Uploading those again is wasted
 /// work, never wrong.
+///
+/// The dirty fields are plain, not atomic: they only mean anything read
+/// together. A caller must hold at least the shared lock that guards
+/// `data` (for the renderer, `font.SharedGrid.lock`) across this call and
+/// the upload it describes, the same discipline reading `data` needs.
 pub fn dirtySince(self: *const Atlas, modified_last: usize) ?Region {
     if (modified_last >= self.modified.load(.monotonic)) return null;
 

--- a/src/font/Atlas.zig
+++ b/src/font/Atlas.zig
@@ -95,10 +95,6 @@ const dirty_restart_rows_divisor = 4;
 /// (GL_MAX_RECTANGLE_TEXTURE_SIZE) and can be lower than the ordinary 2D
 /// texture limit. Starting here means no device ever gets an atlas it cannot
 /// hold, even before a renderer has attached.
-///
-/// Metal never calls `setMaxSize`: it cannot be built on the machine this
-/// branch is developed on, and 8192 is already its worst case, so it keeps
-/// the default until someone can compile and test the call.
 pub const default_max_size: u32 = 8192;
 
 pub const Format = enum(u8) {

--- a/src/font/Atlas.zig
+++ b/src/font/Atlas.zig
@@ -65,6 +65,30 @@ resized: std.atomic.Value(usize) = .{ .raw = 0 },
 /// atlas coordinates must drop that cache when this changes.
 generation: std.atomic.Value(usize) = .{ .raw = 0 },
 
+/// Bounding box of everything modified since `modified` was `dirty_base`,
+/// or a zero-sized region when we are not tracking one. See `dirtySince`,
+/// which is how a consumer reads this.
+///
+/// A consumer never clears it. The atlas is shared: several renderers, each
+/// with several frames in flight, upload it to the GPU independently and at
+/// different times, so from here there is no way to know which of them was
+/// the last one that still needed it.
+dirty: Region = .{ .x = 0, .y = 0, .width = 0, .height = 0 },
+
+/// The `modified` count the `dirty` box started accumulating from. A
+/// consumer that is at least this up to date can catch up with the box;
+/// one that is further behind has to take the whole atlas instead.
+dirty_base: usize = 0,
+
+/// The `dirty` box is thrown away and started over once it would span more
+/// than this fraction of the atlas's rows.
+///
+/// Since no consumer can clear the box, it would otherwise only ever grow,
+/// and a box that spans most of the atlas has stopped saving anything over
+/// uploading all of it. Starting over costs the consumers that have not
+/// caught up a full upload, which is what they were doing anyway.
+const dirty_restart_rows_divisor = 4;
+
 /// The default value of `max_size`: the smallest maximum any backend we
 /// support reports. Metal devices below the apple3 family stop at 8192, and
 /// the OpenGL atlas is a rectangle texture, whose limit is its own
@@ -303,6 +327,7 @@ pub fn set(self: *Atlas, reg: Region, data: []const u8) void {
         );
     }
 
+    self.markDirty(reg);
     _ = self.modified.fetchAdd(1, .monotonic);
 }
 
@@ -334,7 +359,73 @@ pub fn setFromLarger(
         );
     }
 
+    self.markDirty(reg);
     _ = self.modified.fetchAdd(1, .monotonic);
+}
+
+/// Fold `reg` into the dirty box.
+///
+/// Call this before bumping `modified`, so that the count read here is the
+/// one a consumer must already have reached for the box to be of any use
+/// to it.
+fn markDirty(self: *Atlas, reg: Region) void {
+    if (reg.width == 0 or reg.height == 0) return;
+
+    const restart = restart: {
+        if (self.dirty.width == 0 or self.dirty.height == 0) break :restart true;
+        const y_min = @min(self.dirty.y, reg.y);
+        const y_max = @max(self.dirty.y + self.dirty.height, reg.y + reg.height);
+        break :restart (y_max - y_min) > self.size / dirty_restart_rows_divisor;
+    };
+
+    if (restart) {
+        self.dirty = reg;
+        self.dirty_base = self.modified.load(.monotonic);
+        return;
+    }
+
+    const x_min = @min(self.dirty.x, reg.x);
+    const y_min = @min(self.dirty.y, reg.y);
+    const x_max = @max(self.dirty.x + self.dirty.width, reg.x + reg.width);
+    const y_max = @max(self.dirty.y + self.dirty.height, reg.y + reg.height);
+    self.dirty = .{
+        .x = x_min,
+        .y = y_min,
+        .width = x_max - x_min,
+        .height = y_max - y_min,
+    };
+}
+
+/// Record that every byte of the atlas changed, which is what `clear` and
+/// `grow` do. A box that covers everything is of use to any consumer, no
+/// matter how far behind, so the base goes back to the start.
+fn markDirtyAll(self: *Atlas) void {
+    self.dirty = .{ .x = 0, .y = 0, .width = self.size, .height = self.size };
+    self.dirty_base = 0;
+}
+
+/// The region a consumer whose last upload happened at `modified_last` (a
+/// value it previously read from `modified`) has to upload to catch up, or
+/// null if it has nothing left to upload.
+///
+/// The box is a bounding box over regions that may be far apart, so it can
+/// cover bytes the consumer already has. Uploading those again is wasted
+/// work, never wrong.
+pub fn dirtySince(self: *const Atlas, modified_last: usize) ?Region {
+    if (modified_last >= self.modified.load(.monotonic)) return null;
+
+    // Behind the box, or no box at all: it does not describe the changes
+    // this consumer missed, so it has to take everything.
+    if (modified_last < self.dirty_base or
+        self.dirty.width == 0 or
+        self.dirty.height == 0) return .{
+        .x = 0,
+        .y = 0,
+        .width = self.size,
+        .height = self.size,
+    };
+
+    return self.dirty;
 }
 
 /// Set the ceiling `grow` refuses to pass, for a caller that has queried
@@ -401,6 +492,10 @@ pub fn grow(self: *Atlas, alloc: Allocator, size_new: u32) GrowError!void {
         .width = size_new - size_old,
     });
 
+    // Every byte moved to a new address at a new stride, and the box the
+    // copy above left behind is in the old coordinate space.
+    self.markDirtyAll();
+
     // We are both modified and resized
     _ = self.modified.fetchAdd(1, .monotonic);
     _ = self.resized.fetchAdd(1, .monotonic);
@@ -408,6 +503,7 @@ pub fn grow(self: *Atlas, alloc: Allocator, size_new: u32) GrowError!void {
 
 // Empty the atlas. This doesn't reclaim any previously allocated memory.
 pub fn clear(self: *Atlas) void {
+    self.markDirtyAll();
     _ = self.modified.fetchAdd(1, .monotonic);
     @memset(self.data, 0);
     self.nodes.clearRetainingCapacity();
@@ -986,6 +1082,110 @@ test "setMaxSize" {
         GrowError.AtlasTooLarge,
         atlas.grow(alloc, 16),
     );
+}
+
+test "dirtySince covers the regions that were written" {
+    const alloc = testing.allocator;
+    var atlas = try init(alloc, 64, .grayscale);
+    defer atlas.deinit(alloc);
+
+    // Nothing has been uploaded yet, so everything is outstanding.
+    {
+        const dirty = atlas.dirtySince(0).?;
+        try testing.expectEqual(@as(u32, 0), dirty.x);
+        try testing.expectEqual(@as(u32, 0), dirty.y);
+        try testing.expectEqual(@as(u32, 64), dirty.width);
+        try testing.expectEqual(@as(u32, 64), dirty.height);
+    }
+
+    // Once a consumer has uploaded that, it has nothing left to do.
+    const synced = atlas.modified.load(.monotonic);
+    try testing.expectEqual(@as(?Region, null), atlas.dirtySince(synced));
+
+    // A single write is exactly the region that was written.
+    const first = try atlas.reserve(alloc, 2, 3);
+    atlas.set(first, &[_]u8{0} ** 6);
+    {
+        const dirty = atlas.dirtySince(synced).?;
+        try testing.expectEqual(first.x, dirty.x);
+        try testing.expectEqual(first.y, dirty.y);
+        try testing.expectEqual(@as(u32, 2), dirty.width);
+        try testing.expectEqual(@as(u32, 3), dirty.height);
+    }
+
+    // A second write extends the box to just cover both.
+    const second = try atlas.reserve(alloc, 4, 2);
+    atlas.set(second, &[_]u8{0} ** 8);
+    {
+        const dirty = atlas.dirtySince(synced).?;
+        try testing.expectEqual(@min(first.x, second.x), dirty.x);
+        try testing.expectEqual(@min(first.y, second.y), dirty.y);
+        try testing.expectEqual(
+            @max(first.x + first.width, second.x + second.width),
+            dirty.x + dirty.width,
+        );
+        try testing.expectEqual(
+            @max(first.y + first.height, second.y + second.height),
+            dirty.y + dirty.height,
+        );
+    }
+
+    // And it clears once a consumer has caught up again.
+    try testing.expectEqual(
+        @as(?Region, null),
+        atlas.dirtySince(atlas.modified.load(.monotonic)),
+    );
+}
+
+test "dirtySince gives the whole atlas to a consumer that fell behind" {
+    const alloc = testing.allocator;
+    var atlas = try init(alloc, 64, .grayscale);
+    defer atlas.deinit(alloc);
+
+    const behind = atlas.modified.load(.monotonic);
+
+    const small = try atlas.reserve(alloc, 4, 2);
+    atlas.set(small, &[_]u8{0} ** 8);
+    try testing.expectEqual(@as(u32, 2), atlas.dirtySince(behind).?.height);
+
+    // A write that would stretch the box across a quarter of the atlas
+    // makes it start over, which puts `behind` out of its reach.
+    const tall = try atlas.reserve(alloc, 4, 40);
+    atlas.set(tall, &[_]u8{0} ** (4 * 40));
+    {
+        const dirty = atlas.dirtySince(behind).?;
+        try testing.expectEqual(@as(u32, 64), dirty.width);
+        try testing.expectEqual(@as(u32, 64), dirty.height);
+    }
+
+    // A consumer that is current with the restart gets the small box.
+    const dirty = atlas.dirtySince(atlas.modified.load(.monotonic) - 1).?;
+    try testing.expectEqual(@as(u32, 40), dirty.height);
+}
+
+test "dirtySince covers everything after a reset or a grow" {
+    const alloc = testing.allocator;
+    var atlas = try init(alloc, 64, .grayscale);
+    defer atlas.deinit(alloc);
+
+    const reg = try atlas.reserve(alloc, 2, 2);
+    atlas.set(reg, &[_]u8{ 1, 2, 3, 4 });
+
+    const synced = atlas.modified.load(.monotonic);
+    atlas.reset();
+    {
+        const dirty = atlas.dirtySince(synced).?;
+        try testing.expectEqual(@as(u32, 64), dirty.width);
+        try testing.expectEqual(@as(u32, 64), dirty.height);
+    }
+
+    const grown = atlas.modified.load(.monotonic);
+    try atlas.grow(alloc, 128);
+    {
+        const dirty = atlas.dirtySince(grown).?;
+        try testing.expectEqual(@as(u32, 128), dirty.width);
+        try testing.expectEqual(@as(u32, 128), dirty.height);
+    }
 }
 
 test "reset empties the atlas and bumps the generation" {

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -1144,22 +1144,22 @@ pub inline fn beginFrame(
     return frame;
 }
 
+/// Show the last frame again, for a wakeup that produced nothing new.
+/// Nothing to do here, the same as Metal.
+///
+/// Presenting without rendering does not repeat the last frame. `Present`
+/// on a flip-model chain queues the *current back buffer*, which with three
+/// buffers is the one last written three presents ago, so the screen jumps
+/// back to a stale frame (or to whatever an untouched buffer holds, early
+/// on). It also advances the swap chain's back buffer index without the
+/// renderer advancing its own frame state, which leaves the two paired up
+/// differently from then on -- see the note in directx12/Texture.zig about
+/// staging buffers outliving the wait that was supposed to cover them.
+///
+/// Nothing needs the repeat anyway: the frame we last presented stays
+/// composited by DWM until we present another one.
 pub fn presentLastTarget(self: *DirectX12) !void {
-    // Called when no redraw is needed -- re-present the current frame.
-    // No new GPU work is submitted, so the existing fence values remain
-    // valid and the next beginFrame will wait correctly.
-    if (self.swap_chain3) |sc3| {
-        // Sync interval 1: see drawFrameEnd for the rationale.
-        const hr = sc3.Present(1, 0);
-        if (hr == com.DXGI_ERROR_DEVICE_REMOVED or hr == com.DXGI_ERROR_DEVICE_HUNG or hr == com.DXGI_ERROR_DEVICE_RESET) {
-            self.handleDeviceRemoved();
-            return error.PresentFailed;
-        }
-        if (com.FAILED(hr)) {
-            log.err("presentLastTarget failed: 0x{x}", .{@as(u32, @bitCast(hr))});
-            return error.PresentFailed;
-        }
-    }
+    _ = self;
 }
 
 fn handleDeviceRemoved(self: *DirectX12) void {

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -779,7 +779,19 @@ pub fn drawFrameStart(self: *DirectX12) void {
     const dev_ptr = &(self.dev orelse return);
     // A removed device's fence reports a value that means nothing; the
     // recovery path tears the whole queue down instead.
-    if (dev_ptr.removed()) return;
+    //
+    // Say so on the way out rather than dropping the answer. With
+    // `presentLastTarget` a no-op here, this is the only thing that
+    // touches the device on a wakeup that draws nothing, so it is the
+    // only place an idle TDR can be noticed before the next real frame.
+    // `deviceLost` is polled a few lines below the call to this, so
+    // recovery starts in the same `drawFrame`. Only the first wakeup
+    // announces it: attempts between recovery retries would otherwise
+    // log the same removal once per draw interval.
+    if (dev_ptr.removed()) {
+        if (!self.device_lost) self.handleDeviceRemoved();
+        return;
+    }
     dev_ptr.retirement.collect(dev_ptr.fence.GetCompletedValue());
 }
 

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -763,10 +763,24 @@ pub fn maxTextureSize(self: *const DirectX12) u32 {
 }
 
 pub fn drawFrameStart(self: *DirectX12) void {
-    _ = self;
     // RTV heap slots are per-frame and stable. No reset needed; each frame's
     // CustomShaderState reuses its own dedicated RTV descriptors during
     // resize via the rtv_slot option in Texture.Options.
+
+    // Free what the GPU has finished with. `beginFrame` collects too, but
+    // it only runs on a wakeup the renderer decided was worth drawing, and
+    // this runs on every wakeup. Whatever the last drawn frame retired
+    // would otherwise stay resident for as long as the terminal stays
+    // quiet, and an atlas grown on that frame retires a texture up to the
+    // size of the atlas ceiling.
+    //
+    // Nothing here waits: `collect` frees only what the fence says is
+    // already done, so a wakeup that draws nothing costs one fence read.
+    const dev_ptr = &(self.dev orelse return);
+    // A removed device's fence reports a value that means nothing; the
+    // recovery path tears the whole queue down instead.
+    if (dev_ptr.removed()) return;
+    dev_ptr.retirement.collect(dev_ptr.fence.GetCompletedValue());
 }
 
 pub fn drawFrameEnd(self: *DirectX12) void {

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -1158,6 +1158,13 @@ pub inline fn beginFrame(
 ///
 /// Nothing needs the repeat anyway: the frame we last presented stays
 /// composited by DWM until we present another one.
+///
+/// What is lost with it: that Present was the only thing checking for
+/// DXGI_ERROR_DEVICE_REMOVED on a surface with nothing to draw, so a TDR
+/// while the terminal sits idle is now noticed on the first frame after
+/// it rather than within a draw interval of the reset. Every path that
+/// touches the GPU still checks, so nothing is drawn against a lost
+/// device; the loss is only in how early we hear about it.
 pub fn presentLastTarget(self: *DirectX12) !void {
     _ = self;
 }

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -380,6 +380,14 @@ pub inline fn imageTextureOptions(
     };
 }
 
+/// The largest atlas texture this device can hold, in either dimension.
+///
+/// The atlas is an ordinary 2D texture here, so this is the device's 2D
+/// texture limit, already queried at init (see `queryMaxTextureSize`).
+pub fn maxTextureSize(self: *const Metal) u32 {
+    return self.max_texture_size;
+}
+
 /// Initializes a Texture suitable for the provided font atlas.
 pub fn initAtlasTexture(
     self: *const Metal,

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -269,7 +269,7 @@ pub inline fn present(self: *Metal, target: Target, sync: bool) !void {
 }
 
 /// Present the last presented target again. (noop for Metal)
-pub inline fn presentLastTarget(self: *Metal) !void {
+pub fn presentLastTarget(self: *Metal) !void {
     _ = self;
 }
 

--- a/src/renderer/directx12/Texture.zig
+++ b/src/renderer/directx12/Texture.zig
@@ -310,9 +310,15 @@ pub fn setCommandList(self: *Texture, cl: ?*d3d12.ID3D12GraphicsCommandList) voi
 /// soon-released resource (harmless). For replaceRegion the destination
 /// survives, so a multi-band atlas update could leave the texture with
 /// the leading bands of the new content and the trailing rows of the
-/// previous content. Acceptable for atlases (next replaceRegion fixes
-/// it) but worth knowing if anyone calls replaceRegion on a multi-band
-/// region of a user-visible texture.
+/// previous content.
+///
+/// A later call does NOT necessarily repair that. The renderer uploads the
+/// atlas region that went dirty since this texture's last sync, so once
+/// this swallow reports success for bytes that were never copied, the
+/// dropped rows stay stale until something dirties them again or the atlas
+/// is grown or reset. Anything that needs a guaranteed-correct texture has
+/// to notice the failure some other way, which today means not going
+/// through this function.
 pub fn replaceRegion(self: *Texture, x: usize, y: usize, width: usize, height: usize, data: []const u8) error{}!void {
     // Retire the staging buffers from the previous upload. They are the
     // source of CopyTextureRegion calls that may still be executing, so

--- a/src/renderer/directx12/Texture.zig
+++ b/src/renderer/directx12/Texture.zig
@@ -332,8 +332,12 @@ pub fn setCommandList(self: *Texture, cl: ?*d3d12.ID3D12GraphicsCommandList) voi
 /// sync, so bytes this swallow reported success for would otherwise stay
 /// stale until something dirtied them again. `upload_dropped` is how a
 /// caller hears about it: the atlas sync reads it through
-/// `takeUploadDropped`, leaves its own upload counter where it was, and
-/// ships the whole atlas on the next frame.
+/// `takeUploadDropped` and leaves its own upload counter where it was.
+/// That is the whole repair -- the atlas keeps reporting those rows as
+/// dirty to a consumer that has not caught up, so the next sync is handed
+/// them again. It does not escalate to a full-atlas upload, which would
+/// ask for the largest upload there is at exactly the moment a small
+/// staging allocation has just failed.
 pub fn replaceRegion(self: *Texture, x: usize, y: usize, width: usize, height: usize, data: []const u8) error{}!void {
     // Retire the staging buffers from the previous upload. They are the
     // source of CopyTextureRegion calls that may still be executing, so

--- a/src/renderer/directx12/Texture.zig
+++ b/src/renderer/directx12/Texture.zig
@@ -128,6 +128,21 @@ pending_staging: std.ArrayListUnmanaged(*d3d12.ID3D12Resource) = .empty,
 /// COM-querying each ID3D12Resource's size. Incremented in uploadRegion
 /// per band; reset in replaceRegion's release loop.
 pending_staging_bytes: u64 = 0,
+/// Set when `replaceRegion` swallowed an upload failure, so the texture
+/// holds less than the caller handed it. Read and cleared through
+/// `takeUploadDropped` by callers that have to make the loss good; the
+/// rest keep the old behaviour of never hearing about it.
+upload_dropped: bool = false,
+
+/// Whether an upload has been dropped since this was last asked, clearing
+/// the record. `replaceRegion` cannot report a failure through its return
+/// type -- it shares a signature with Metal's, which cannot fail -- so
+/// this is how a caller that needs the texture to hold what it handed
+/// over finds out that it does not.
+pub fn takeUploadDropped(self: *Texture) bool {
+    defer self.upload_dropped = false;
+    return self.upload_dropped;
+}
 
 /// Row-pitch alignment that DX12's CopyTextureRegion requires for staging
 /// buffers (D3D12_TEXTURE_DATA_PITCH_ALIGNMENT). `pub` so image.zig can
@@ -312,13 +327,13 @@ pub fn setCommandList(self: *Texture, cl: ?*d3d12.ID3D12GraphicsCommandList) voi
 /// the leading bands of the new content and the trailing rows of the
 /// previous content.
 ///
-/// A later call does NOT necessarily repair that. The renderer uploads the
-/// atlas region that went dirty since this texture's last sync, so once
-/// this swallow reports success for bytes that were never copied, the
-/// dropped rows stay stale until something dirties them again or the atlas
-/// is grown or reset. Anything that needs a guaranteed-correct texture has
-/// to notice the failure some other way, which today means not going
-/// through this function.
+/// A later call does NOT necessarily repair that on its own. The renderer
+/// uploads the atlas region that went dirty since this texture's last
+/// sync, so bytes this swallow reported success for would otherwise stay
+/// stale until something dirtied them again. `upload_dropped` is how a
+/// caller hears about it: the atlas sync reads it through
+/// `takeUploadDropped`, leaves its own upload counter where it was, and
+/// ships the whole atlas on the next frame.
 pub fn replaceRegion(self: *Texture, x: usize, y: usize, width: usize, height: usize, data: []const u8) error{}!void {
     // Retire the staging buffers from the previous upload. They are the
     // source of CopyTextureRegion calls that may still be executing, so
@@ -336,6 +351,7 @@ pub fn replaceRegion(self: *Texture, x: usize, y: usize, width: usize, height: u
 
     self.uploadRegion(@intCast(x), @intCast(y), @intCast(width), @intCast(height), data) catch |err| {
         log.warn("replaceRegion upload dropped: {t}", .{err});
+        self.upload_dropped = true;
     };
 
     // Transition back to shader-readable.

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -194,6 +194,16 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         custom_shader_failure: ?renderer.CustomShaderFailure = null,
 
         /// The current GPU uniform values.
+        ///
+        /// `updateFrame` snapshots these around its critical section and
+        /// asks for a draw if anything moved, so a write from inside there
+        /// takes care of itself. A write from anywhere else must be paired
+        /// with `markDirty()` (or happen on a frame that resizes, which
+        /// draws regardless), or the new value will sit in this struct with
+        /// nothing on screen to show for it. The current outside writers are
+        /// `changeConfig` and `setFontGrid` (both call `markDirty`) and
+        /// `setScreenSize` plus `drawFrame`'s own resize branch (both only
+        /// run for a geometry change, which draws anyway).
         uniforms: shaderpkg.Uniforms,
 
         /// Custom shader uniform values.

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -2393,12 +2393,13 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // If our font atlas changed, sync the texture data.
             // Placed after beginFrame so the DX12 command list is available.
             //
-            // The counter is advanced only once the upload has returned. We
-            // now ship the dirty region rather than the whole atlas, so a
-            // sync that never happened is not made good by the next one: it
-            // would carry only what went dirty after it, leaving the dropped
-            // rows stale for as long as the frame state lives. Leaving the
-            // counter where it was is what makes the next frame try again.
+            // The counter is advanced only once the upload has returned and
+            // said it landed. We now ship the dirty region rather than the
+            // whole atlas, so a sync that never happened is not made good by
+            // the next one: it would carry only what went dirty after it,
+            // leaving the dropped rows stale for as long as the frame state
+            // lives. Leaving the counter where it was is what makes the next
+            // frame try again.
             texture: {
                 const atlas = &self.font_grid.atlas_grayscale;
                 const modified = atlas.modified.load(.monotonic);
@@ -2407,8 +2408,9 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 defer self.font_grid.lock.unlockShared(global.io());
                 const dirty = atlas.dirtySince(frame.grayscale_modified);
                 const synced = atlas.modified.load(.monotonic);
-                try self.syncAtlasTexture(atlas, &frame.grayscale, dirty);
-                frame.grayscale_modified = synced;
+                if (try syncAtlasTexture(&self.api, atlas, &frame.grayscale, dirty)) {
+                    frame.grayscale_modified = synced;
+                }
             }
             texture: {
                 const atlas = &self.font_grid.atlas_color;
@@ -2418,8 +2420,9 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 defer self.font_grid.lock.unlockShared(global.io());
                 const dirty = atlas.dirtySince(frame.color_modified);
                 const synced = atlas.modified.load(.monotonic);
-                try self.syncAtlasTexture(atlas, &frame.color, dirty);
-                frame.color_modified = synced;
+                if (try syncAtlasTexture(&self.api, atlas, &frame.color, dirty)) {
+                    frame.color_modified = synced;
+                }
             }
 
             // Determine if we can use the custom shader path.  All post-process
@@ -4516,58 +4519,92 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 try self.addUnderline(@intCast(coord.x + 1), @intCast(coord.y), .single, screen_fg, 255);
             }
         }
-
-        /// Sync the atlas data to the given texture. If the atlas no longer
-        /// fits into the texture, the texture is reallocated and the whole
-        /// atlas copied into it; otherwise only `dirty` is copied.
-        ///
-        /// `dirty` is what this texture is missing, from
-        /// `font.Atlas.dirtySince`; null means it is missing nothing.
-        ///
-        /// Caller must hold the font grid's read lock.
-        fn syncAtlasTexture(
-            self: *const Self,
-            atlas: *const font.Atlas,
-            texture: *Texture,
-            dirty: ?font.Atlas.Region,
-        ) !void {
-            // DX12 rotates command lists across triple-buffered frames.
-            // Update the texture to use the current frame's command list
-            // before any upload or resize operation. Metal and OpenGL use
-            // immediate uploads so they don't need this.
-            if (@hasDecl(GraphicsAPI, "updateTextureCommandList")) {
-                self.api.updateTextureCommandList(texture);
-            }
-
-            if (atlas.size > texture.width) {
-                try replaceAtlasTexture(&self.api, atlas, texture);
-
-                // The new texture is empty, so it needs the whole atlas
-                // no matter how little the caller asked for.
-                try texture.replaceRegion(0, 0, atlas.size, atlas.size, atlas.data);
-                return;
-            }
-
-            const region = dirty orelse return;
-
-            // `replaceRegion` takes tightly packed rows and has no source
-            // stride, so the narrowest thing we can hand it without copying
-            // the region out first is the full-width band of rows the dirty
-            // box spans, which is already a slice of the atlas data. The
-            // columns outside the box come along for the ride; they hold
-            // what the texture holds, so re-uploading them changes nothing.
-            const stride: usize = @as(usize, atlas.size) * atlas.format.depth();
-            const start: usize = @as(usize, region.y) * stride;
-            const len: usize = @as(usize, region.height) * stride;
-            try texture.replaceRegion(
-                0,
-                region.y,
-                atlas.size,
-                region.height,
-                atlas.data[start..][0..len],
-            );
-        }
     };
+}
+
+/// Whether `texture` has a dropped upload on record.
+///
+/// DX12's `replaceRegion` cannot fail -- it shares a signature with
+/// Metal's, which cannot either -- so it swallows staging-buffer failures
+/// and marks the texture instead. Backends that have no way to drop an
+/// upload never report one.
+fn atlasUploadDropped(texture: anytype) bool {
+    if (!@hasField(@TypeOf(texture.*), "upload_dropped")) return false;
+    return texture.upload_dropped;
+}
+
+/// `atlasUploadDropped`, clearing the record. The record has to outlive
+/// the sync that set it -- it is what tells the next sync to ship the
+/// whole atlas -- so only the sync that acts on it clears it.
+fn takeAtlasUploadDropped(texture: anytype) bool {
+    if (!@hasField(@TypeOf(texture.*), "upload_dropped")) return false;
+    return texture.takeUploadDropped();
+}
+
+/// Sync the atlas data to the given texture. If the atlas no longer fits
+/// into the texture, the texture is reallocated and the whole atlas copied
+/// into it; otherwise only `dirty` is copied.
+///
+/// `dirty` is what this texture is missing, from `font.Atlas.dirtySince`;
+/// null means it is missing nothing.
+///
+/// Returns whether the texture now holds everything it was given. A false
+/// return means the caller must not advance its upload counter: the atlas
+/// stops reporting a region as dirty once it has been handed over, so a
+/// counter advanced over bytes that never arrived leaves them stale for as
+/// long as this texture lives.
+///
+/// A texture that dropped an upload gets the whole atlas next time rather
+/// than the band it lost, because the dirty box is a moving bound: by the
+/// time we come back it may have restarted somewhere past the rows that
+/// went missing.
+///
+/// Caller must hold the font grid's read lock.
+fn syncAtlasTexture(
+    api: anytype,
+    atlas: *const font.Atlas,
+    texture: anytype,
+    dirty: ?font.Atlas.Region,
+) !bool {
+    // DX12 rotates command lists across triple-buffered frames.
+    // Update the texture to use the current frame's command list
+    // before any upload or resize operation. Metal and OpenGL use
+    // immediate uploads so they don't need this.
+    if (@hasDecl(@TypeOf(api.*), "updateTextureCommandList")) {
+        api.updateTextureCommandList(texture);
+    }
+
+    const dropped = takeAtlasUploadDropped(texture);
+    const grew = atlas.size > texture.width;
+    if (grew) try replaceAtlasTexture(api, atlas, texture);
+
+    if (grew or dropped) {
+        // A grown texture is empty and a texture that lost rows has no
+        // record of which, so either way it needs the whole atlas no
+        // matter how little the caller asked for.
+        try texture.replaceRegion(0, 0, atlas.size, atlas.size, atlas.data);
+        return !atlasUploadDropped(texture);
+    }
+
+    const region = dirty orelse return true;
+
+    // `replaceRegion` takes tightly packed rows and has no source
+    // stride, so the narrowest thing we can hand it without copying
+    // the region out first is the full-width band of rows the dirty
+    // box spans, which is already a slice of the atlas data. The
+    // columns outside the box come along for the ride; they hold
+    // what the texture holds, so re-uploading them changes nothing.
+    const stride: usize = @as(usize, atlas.size) * atlas.format.depth();
+    const start: usize = @as(usize, region.y) * stride;
+    const len: usize = @as(usize, region.height) * stride;
+    try texture.replaceRegion(
+        0,
+        region.y,
+        atlas.size,
+        region.height,
+        atlas.data[start..][0..len],
+    );
+    return !atlasUploadDropped(texture);
 }
 
 /// Point `texture` at a freshly allocated texture sized for `atlas`,
@@ -4916,13 +4953,27 @@ const TestAtlasTextures = struct {
     next_id: usize = 0,
     released: [8]bool = @splat(false),
     double_release: bool = false,
+
+    /// Makes the next `replaceRegion` behave the way DX12's does when a
+    /// staging buffer cannot be allocated: it copies nothing and says
+    /// nothing, leaving the record behind on the texture.
+    drop_next_upload: bool = false,
+
+    /// The last region handed to `replaceRegion`, and how many times it
+    /// has been called at all.
+    uploads: usize = 0,
+    last_y: usize = 0,
+    last_height: usize = 0,
 };
 
-/// Stands in for a backend `Texture`. Only `deinit` matters here; the
-/// grow path's `replaceRegion` is the caller's business.
+/// Stands in for a backend `Texture`, modelling the two things
+/// `syncAtlasTexture` needs from one: a size to compare the atlas
+/// against, and an upload that can quietly drop what it was given.
 const TestAtlasTexture = struct {
     store: *TestAtlasTextures,
     id: usize,
+    width: usize,
+    upload_dropped: bool = false,
 
     fn deinit(self: TestAtlasTexture) void {
         if (self.store.released[self.id]) {
@@ -4930,6 +4981,32 @@ const TestAtlasTexture = struct {
             return;
         }
         self.store.released[self.id] = true;
+    }
+
+    fn replaceRegion(
+        self: *TestAtlasTexture,
+        x: usize,
+        y: usize,
+        width: usize,
+        height: usize,
+        data: []const u8,
+    ) error{}!void {
+        _ = x;
+        _ = width;
+        _ = data;
+        self.store.uploads += 1;
+        if (self.store.drop_next_upload) {
+            self.store.drop_next_upload = false;
+            self.upload_dropped = true;
+            return;
+        }
+        self.store.last_y = y;
+        self.store.last_height = height;
+    }
+
+    fn takeUploadDropped(self: *TestAtlasTexture) bool {
+        defer self.upload_dropped = false;
+        return self.upload_dropped;
     }
 };
 
@@ -4942,12 +5019,21 @@ const TestAtlasApi = struct {
         self: *const TestAtlasApi,
         atlas: *const font.Atlas,
     ) !TestAtlasTexture {
-        _ = atlas;
         if (self.store.fail_next) return error.TextureCreateFailed;
         defer self.store.next_id += 1;
-        return .{ .store = self.store, .id = self.store.next_id };
+        return .{
+            .store = self.store,
+            .id = self.store.next_id,
+            .width = atlas.size,
+        };
     }
 };
+
+/// A 4x4 grayscale atlas with real backing bytes, for the sync tests
+/// below (the `replaceAtlasTexture` tests never touch the data).
+fn testSyncAtlas(data: []u8, size: u32) font.Atlas {
+    return .{ .data = data, .size = size, .format = .grayscale };
+}
 
 const test_atlas: font.Atlas = .{
     .data = undefined,
@@ -5013,6 +5099,117 @@ test "replaceAtlasTexture: repeated failed grows never double release" {
     }
     try std.testing.expect(!store.double_release);
     try std.testing.expect(!store.released[texture.id]);
+}
+
+test "syncAtlasTexture: a clean band upload ships only the band and reports synced" {
+    var store: TestAtlasTextures = .{};
+    const api: TestAtlasApi = .{ .store = &store };
+    var data: [16]u8 = @splat(0);
+    const atlas = testSyncAtlas(&data, 4);
+    var texture = try api.initAtlasTexture(&atlas);
+
+    try std.testing.expect(try syncAtlasTexture(&api, &atlas, &texture, .{
+        .x = 0,
+        .y = 1,
+        .width = 4,
+        .height = 2,
+    }));
+    try std.testing.expectEqual(@as(usize, 1), store.last_y);
+    try std.testing.expectEqual(@as(usize, 2), store.last_height);
+}
+
+test "syncAtlasTexture: a dropped upload is not reported as synced" {
+    // Regression: DX12's replaceRegion swallows staging-buffer failures to
+    // keep a signature Metal can implement, so a sync that copied nothing
+    // still returned cleanly. The caller advanced its upload counter over
+    // rows the texture never received, and since only the region that goes
+    // dirty afterwards is ever shipped, they stayed stale for the life of
+    // that frame state.
+    var store: TestAtlasTextures = .{};
+    const api: TestAtlasApi = .{ .store = &store };
+    var data: [16]u8 = @splat(0);
+    const atlas = testSyncAtlas(&data, 4);
+    var texture = try api.initAtlasTexture(&atlas);
+
+    store.drop_next_upload = true;
+    try std.testing.expect(!try syncAtlasTexture(&api, &atlas, &texture, .{
+        .x = 0,
+        .y = 1,
+        .width = 4,
+        .height = 2,
+    }));
+}
+
+test "syncAtlasTexture: the sync after a dropped upload ships the whole atlas" {
+    // The dirty box is a moving bound, so by the time we come back it may
+    // describe rows that have nothing to do with the ones that went
+    // missing. Only a full upload is guaranteed to cover them.
+    var store: TestAtlasTextures = .{};
+    const api: TestAtlasApi = .{ .store = &store };
+    var data: [16]u8 = @splat(0);
+    const atlas = testSyncAtlas(&data, 4);
+    var texture = try api.initAtlasTexture(&atlas);
+
+    store.drop_next_upload = true;
+    _ = try syncAtlasTexture(&api, &atlas, &texture, .{
+        .x = 0,
+        .y = 0,
+        .width = 4,
+        .height = 1,
+    });
+
+    try std.testing.expect(try syncAtlasTexture(&api, &atlas, &texture, .{
+        .x = 0,
+        .y = 3,
+        .width = 4,
+        .height = 1,
+    }));
+    try std.testing.expectEqual(@as(usize, 0), store.last_y);
+    try std.testing.expectEqual(@as(usize, 4), store.last_height);
+}
+
+test "syncAtlasTexture: nothing dirty means no upload at all" {
+    var store: TestAtlasTextures = .{};
+    const api: TestAtlasApi = .{ .store = &store };
+    var data: [16]u8 = @splat(0);
+    const atlas = testSyncAtlas(&data, 4);
+    var texture = try api.initAtlasTexture(&atlas);
+
+    try std.testing.expect(try syncAtlasTexture(&api, &atlas, &texture, null));
+    try std.testing.expectEqual(@as(usize, 0), store.uploads);
+}
+
+test "syncAtlasTexture: a grow ships the whole atlas into the new texture" {
+    var store: TestAtlasTextures = .{};
+    const api: TestAtlasApi = .{ .store = &store };
+    var small: [4]u8 = @splat(0);
+    const before = testSyncAtlas(&small, 2);
+    var texture = try api.initAtlasTexture(&before);
+
+    var data: [16]u8 = @splat(0);
+    const after = testSyncAtlas(&data, 4);
+    try std.testing.expect(try syncAtlasTexture(&api, &after, &texture, .{
+        .x = 0,
+        .y = 3,
+        .width = 4,
+        .height = 1,
+    }));
+    try std.testing.expectEqual(@as(usize, 4), texture.width);
+    try std.testing.expectEqual(@as(usize, 0), store.last_y);
+    try std.testing.expectEqual(@as(usize, 4), store.last_height);
+}
+
+test "syncAtlasTexture: a grow whose upload is dropped is not reported as synced" {
+    var store: TestAtlasTextures = .{};
+    const api: TestAtlasApi = .{ .store = &store };
+    var small: [4]u8 = @splat(0);
+    const before = testSyncAtlas(&small, 2);
+    var texture = try api.initAtlasTexture(&before);
+
+    var data: [16]u8 = @splat(0);
+    const after = testSyncAtlas(&data, 4);
+    store.drop_next_upload = true;
+    try std.testing.expect(!try syncAtlasTexture(&api, &after, &texture, null));
 }
 
 test "customShaderUsable: no custom shader state means no custom shader path" {

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1801,6 +1801,25 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 // kitty state on every frame because any cell change can move
                 // an image.
                 if (self.images_lost or self.images.kittyRequiresUpdate(state.terminal)) {
+                    // The image state is a channel to the renderer of its
+                    // own: it is not part of grid or screen dirtiness, and
+                    // the placements are only drawn on a frame we decide to
+                    // draw. A client that replaces an image in place with
+                    // the cursor hidden dirties no row and moves no uniform,
+                    // so if we don't ask for the frame here nobody will and
+                    // the new image never appears. `kittyUpdate` clears the
+                    // flag, so read it first.
+                    //
+                    // A lost device counts as a change for the same reason:
+                    // the rebuild below is the only thing that puts the
+                    // images back, and nothing else dirties a row to say so.
+                    //
+                    // Virtual references alone are not a change: they only
+                    // move when a cell moves, and that dirties the rows that
+                    // carry them.
+                    const changed = self.images_lost or
+                        state.terminal.screens.active.kitty_images.dirty;
+
                     // We need to grab the draw mutex since this updates
                     // our image state that drawFrame uses.
                     self.draw_mutex.lockUncancelable(global.io());
@@ -1814,6 +1833,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                             .height = self.grid_metrics.cell_height,
                         },
                     );
+                    if (changed) self.cells_rebuilt = true;
                 }
 
                 // Determine which OSC 8 hyperlink cells should be
@@ -2049,12 +2069,19 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 // Prepare our overlay image for upload (or unload). This
                 // has to use our general allocator since it modifies
                 // state that survives frames.
-                self.images.overlayUpdate(
+                //
+                // Like the kitty state above, the overlay reaches the frame
+                // through the image path rather than through any row, so it
+                // has to ask for the draw itself. On an error nothing was
+                // changed and the overlay is rebuilt next frame anyway.
+                const overlay_changed = self.images.overlayUpdate(
                     self.alloc,
                     self.overlay,
-                ) catch |err| {
+                ) catch |err| overlay: {
                     log.warn("error updating overlay images err={}", .{err});
+                    break :overlay false;
                 };
+                if (overlay_changed) self.cells_rebuilt = true;
 
                 // Update custom shader uniforms that depend on terminal state.
                 self.updateCustomShaderUniformsFromState();

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -152,9 +152,11 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         /// cells goes into a separate shader.
         cells: cellpkg.Contents,
 
-        /// Set to true after rebuildCells is called. This can be used
-        /// to determine if any possible changes have been made to the
-        /// cells for the draw call.
+        /// Set when an update produced something the last drawn frame does
+        /// not already show: a rebuilt row, a different cursor glyph, or a
+        /// changed uniform. Cleared by the draw that consumes it. An update
+        /// that finds none of that leaves it alone, which is what lets a
+        /// wakeup with no work skip its frame.
         cells_rebuilt: bool = false,
 
         /// The atlas generations we last built cells against. A generation
@@ -1958,6 +1960,16 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 self.draw_mutex.lockUncancelable(global.io());
                 defer self.draw_mutex.unlock(global.io());
 
+                // The uniforms are as much of the frame as the cells are,
+                // and some of them change without any row going dirty: OSC
+                // 11 moves the background color, the cursor moves within an
+                // otherwise unchanged screen. Whatever this block leaves
+                // different has to be drawn, so hold on to what we had.
+                const uniforms_before = self.uniforms;
+                defer if (!std.meta.eql(uniforms_before, self.uniforms)) {
+                    self.cells_rebuilt = true;
+                };
+
                 // If an atlas was emptied between frames because it hit its
                 // maximum size, the rows we still hold point into the old
                 // layout and would draw garbage. Rebuild everything, the
@@ -3392,6 +3404,13 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         ) Allocator.Error!void {
             const state: *terminal.RenderState = &self.terminal_state;
 
+            // The cursor glyph coming in. Taken before anything below can
+            // disturb the cell contents, and compared at the end: a blink
+            // or a style change replaces this glyph without dirtying any
+            // row, and it is not covered by the uniforms our caller
+            // watches. Where the cursor is and what color it is are.
+            const cursor_glyph_before = self.cells.getCursorGlyph();
+
             const grid_size_diff =
                 self.cells.size.rows != state.rows or
                 self.cells.size.columns != state.cols;
@@ -3408,6 +3427,11 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             }
 
             const rebuild = state.dirty == .full or grid_size_diff;
+
+            // Whether anything about the cells themselves changed. The
+            // cursor is handled separately, at the end.
+            var cells_changed = rebuild;
+
             if (rebuild) {
                 // If we are doing a full rebuild, then we clear the entire cell buffer.
                 self.cells.reset();
@@ -3495,6 +3519,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
                 // Unmark the dirty state in our render state.
                 dirty.* = false;
+                cells_changed = true;
 
                 self.rebuildRow(
                     y,
@@ -3670,8 +3695,18 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 }
             }
 
-            // Update that our cells rebuilt
-            self.cells_rebuilt = true;
+            // Report the rebuild only if it produced something new. A
+            // wakeup that finds no dirty row and leaves the cursor alone
+            // would otherwise draw and present a frame identical to the one
+            // already on screen, and keep the display link running for it.
+            // The flag is only ever raised, never cleared, because a second
+            // rebuild in the same frame must not take back what the first
+            // one found, and because our caller raises it too.
+            if (cells_changed or
+                !std.meta.eql(cursor_glyph_before, self.cells.getCursorGlyph()))
+            {
+                self.cells_rebuilt = true;
+            }
 
             // Log some things
             // log.debug("rebuildCells complete cached_runs={}", .{

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -4546,8 +4546,10 @@ fn takeAtlasUploadDropped(texture: anytype) bool {
 /// into the texture, the texture is reallocated and the whole atlas copied
 /// into it; otherwise only `dirty` is copied.
 ///
-/// `dirty` is what this texture is missing, from `font.Atlas.dirtySince`;
-/// null means it is missing nothing.
+/// `dirty` is what the atlas says this texture is missing, from
+/// `font.Atlas.dirtySince`; null means the atlas has nothing to offer it.
+/// That is not the same as the texture holding everything -- a sync that
+/// dropped an upload lost rows the atlas has already handed over.
 ///
 /// Returns whether the texture now holds everything it was given. A false
 /// return means the caller must not advance its upload counter: the atlas
@@ -4581,8 +4583,9 @@ fn syncAtlasTexture(
     }
 
     // Clear whatever the last sync left behind, so that what this one
-    // reports describes this one.
-    _ = takeAtlasUploadDropped(texture);
+    // reports describes this one. The record is still worth keeping: it
+    // says this texture is missing rows nobody has re-offered yet.
+    const dropped_before = takeAtlasUploadDropped(texture);
 
     if (atlas.size > texture.width) {
         // A grown texture is empty, so it needs the whole atlas no matter
@@ -4592,7 +4595,20 @@ fn syncAtlasTexture(
         return !atlasUploadDropped(texture);
     }
 
-    const region = dirty orelse return true;
+    // Nothing dirty means the atlas has nothing this texture is missing --
+    // unless the last sync dropped an upload, in which case it is missing
+    // exactly what that one lost and the atlas has not been asked for it
+    // again. Reporting synced would advance the caller's counter over
+    // those rows, which is the one thing this function exists to prevent.
+    // Reporting not-synced keeps the counter back, so the next change to
+    // the atlas hands `dirtySince` a consumer that is behind and it
+    // re-offers them.
+    //
+    // Today's callers never reach this with a standing record: they only
+    // call in when `atlas.modified` is ahead of their counter, and
+    // `dirtySince` is null only when it is not. That is their invariant,
+    // not one this function can see, so it does not lean on it.
+    const region = dirty orelse return !dropped_before;
 
     // `replaceRegion` takes tightly packed rows and has no source
     // stride, so the narrowest thing we can hand it without copying
@@ -5216,6 +5232,31 @@ test "syncAtlasTexture: nothing dirty means no upload at all" {
 
     try std.testing.expect(try syncAtlasTexture(&api, &atlas, &texture, null));
     try std.testing.expectEqual(@as(usize, 0), store.uploads);
+}
+
+test "syncAtlasTexture: nothing dirty after a dropped upload is not synced" {
+    // The early return for a null `dirty` used to answer "synced" without
+    // looking at what the previous sync left on the texture, so a standing
+    // drop record was taken, thrown away, and reported as success -- the
+    // caller would then advance its counter over rows that never arrived.
+    var store: TestAtlasTextures = .{};
+    const api: TestAtlasApi = .{ .store = &store };
+    var data: [16]u8 = @splat(0);
+    const atlas = testSyncAtlas(&data, 4);
+    var texture = try api.initAtlasTexture(&atlas);
+
+    store.drop_next_upload = true;
+    try std.testing.expect(!try syncAtlasTexture(&api, &atlas, &texture, .{
+        .x = 0,
+        .y = 0,
+        .width = 4,
+        .height = 1,
+    }));
+
+    // The record from that sync is still standing, and the atlas is now
+    // offering nothing. The texture is still short those rows.
+    try std.testing.expect(!try syncAtlasTexture(&api, &atlas, &texture, null));
+    try std.testing.expectEqual(@as(usize, 1), store.uploads);
 }
 
 test "syncAtlasTexture: a grow ships the whole atlas into the new texture" {

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -2083,8 +2083,12 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 };
                 if (overlay_changed) self.cells_rebuilt = true;
 
-                // Update custom shader uniforms that depend on terminal state.
-                self.updateCustomShaderUniformsFromState();
+                // Update custom shader uniforms that depend on terminal
+                // state. These live in their own struct, outside the
+                // comparison above, so they report their own changes.
+                if (self.updateCustomShaderUniformsFromState()) {
+                    self.cells_rebuilt = true;
+                }
             }
 
             // Start the display link now that the rebuilt frame is ready.
@@ -3145,13 +3149,19 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         /// Update custom shader uniforms that depend on terminal state.
         ///
         /// This should be called in `updateFrame` when terminal state changes.
-        fn updateCustomShaderUniformsFromState(self: *Self) void {
+        ///
+        /// Returns true if any of them moved. A shader with
+        /// `custom-shader-animation = false` has no animation wake to fall
+        /// back on, so a shader that draws from these would otherwise sit on
+        /// a stale frame until something else asked for a draw.
+        fn updateCustomShaderUniformsFromState(self: *Self) bool {
             // We only need to do this if we have custom shaders.
-            if (!self.has_custom_shaders) return;
+            if (!self.has_custom_shaders) return false;
 
             // Only update when terminal state is dirty.
-            if (self.terminal_state.dirty == .false) return;
+            if (self.terminal_state.dirty == .false) return false;
 
+            const before = self.custom_shader_uniforms;
             const uniforms: *shadertoy.Uniforms = &self.custom_shader_uniforms;
             const colors: *const terminal.RenderState.Colors = &self.terminal_state.colors;
 
@@ -3232,6 +3242,8 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             const cursor_style: renderer.CursorStyle = .fromTerminal(self.terminal_state.cursor.visual_style);
             uniforms.previous_cursor_style = uniforms.current_cursor_style;
             uniforms.current_cursor_style = @as(i32, @intFromEnum(cursor_style));
+
+            return !std.meta.eql(before, uniforms.*);
         }
 
         /// Update per-frame custom shader uniforms.

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -2340,20 +2340,24 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // If our font atlas changed, sync the texture data.
             // Placed after beginFrame so the DX12 command list is available.
             texture: {
-                const modified = self.font_grid.atlas_grayscale.modified.load(.monotonic);
+                const atlas = &self.font_grid.atlas_grayscale;
+                const modified = atlas.modified.load(.monotonic);
                 if (modified <= frame.grayscale_modified) break :texture;
                 self.font_grid.lock.lockSharedUncancelable(global.io());
                 defer self.font_grid.lock.unlockShared(global.io());
-                frame.grayscale_modified = self.font_grid.atlas_grayscale.modified.load(.monotonic);
-                try self.syncAtlasTexture(&self.font_grid.atlas_grayscale, &frame.grayscale);
+                const dirty = atlas.dirtySince(frame.grayscale_modified);
+                frame.grayscale_modified = atlas.modified.load(.monotonic);
+                try self.syncAtlasTexture(atlas, &frame.grayscale, dirty);
             }
             texture: {
-                const modified = self.font_grid.atlas_color.modified.load(.monotonic);
+                const atlas = &self.font_grid.atlas_color;
+                const modified = atlas.modified.load(.monotonic);
                 if (modified <= frame.color_modified) break :texture;
                 self.font_grid.lock.lockSharedUncancelable(global.io());
                 defer self.font_grid.lock.unlockShared(global.io());
-                frame.color_modified = self.font_grid.atlas_color.modified.load(.monotonic);
-                try self.syncAtlasTexture(&self.font_grid.atlas_color, &frame.color);
+                const dirty = atlas.dirtySince(frame.color_modified);
+                frame.color_modified = atlas.modified.load(.monotonic);
+                try self.syncAtlasTexture(atlas, &frame.color, dirty);
             }
 
             // Determine if we can use the custom shader path.  All post-process
@@ -4420,13 +4424,19 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             }
         }
 
-        /// Sync the atlas data to the given texture. This copies the bytes
-        /// associated with the atlas to the given texture. If the atlas no
-        /// longer fits into the texture, the texture will be resized.
+        /// Sync the atlas data to the given texture. If the atlas no longer
+        /// fits into the texture, the texture is reallocated and the whole
+        /// atlas copied into it; otherwise only `dirty` is copied.
+        ///
+        /// `dirty` is what this texture is missing, from
+        /// `font.Atlas.dirtySince`; null means it is missing nothing.
+        ///
+        /// Caller must hold the font grid's read lock.
         fn syncAtlasTexture(
             self: *const Self,
             atlas: *const font.Atlas,
             texture: *Texture,
+            dirty: ?font.Atlas.Region,
         ) !void {
             // DX12 rotates command lists across triple-buffered frames.
             // Update the texture to use the current frame's command list
@@ -4440,11 +4450,31 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 // Free our old texture
                 texture.*.deinit();
 
-                // Reallocate
+                // Reallocate. The new texture is empty, so it needs the
+                // whole atlas no matter how little the caller asked for.
                 texture.* = try self.api.initAtlasTexture(atlas);
+                try texture.replaceRegion(0, 0, atlas.size, atlas.size, atlas.data);
+                return;
             }
 
-            try texture.replaceRegion(0, 0, atlas.size, atlas.size, atlas.data);
+            const region = dirty orelse return;
+
+            // `replaceRegion` takes tightly packed rows and has no source
+            // stride, so the narrowest thing we can hand it without copying
+            // the region out first is the full-width band of rows the dirty
+            // box spans, which is already a slice of the atlas data. The
+            // columns outside the box come along for the ride; they hold
+            // what the texture holds, so re-uploading them changes nothing.
+            const stride: usize = @as(usize, atlas.size) * atlas.format.depth();
+            const start: usize = @as(usize, region.y) * stride;
+            const len: usize = @as(usize, region.height) * stride;
+            try texture.replaceRegion(
+                0,
+                region.y,
+                atlas.size,
+                region.height,
+                atlas.data[start..][0..len],
+            );
         }
     };
 }

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -4533,9 +4533,10 @@ fn atlasUploadDropped(texture: anytype) bool {
     return texture.upload_dropped;
 }
 
-/// `atlasUploadDropped`, clearing the record. The record has to outlive
-/// the sync that set it -- it is what tells the next sync to ship the
-/// whole atlas -- so only the sync that acts on it clears it.
+/// `atlasUploadDropped`, clearing the record. `replaceRegion` only ever
+/// sets it, so every sync starts by taking what the last one left behind:
+/// a record left standing would make each later sync report a drop it did
+/// not have, and the caller's counter would never advance again.
 fn takeAtlasUploadDropped(texture: anytype) bool {
     if (!@hasField(@TypeOf(texture.*), "upload_dropped")) return false;
     return texture.takeUploadDropped();
@@ -4554,10 +4555,15 @@ fn takeAtlasUploadDropped(texture: anytype) bool {
 /// counter advanced over bytes that never arrived leaves them stale for as
 /// long as this texture lives.
 ///
-/// A texture that dropped an upload gets the whole atlas next time rather
-/// than the band it lost, because the dirty box is a moving bound: by the
-/// time we come back it may have restarted somewhere past the rows that
-/// went missing.
+/// A texture that dropped an upload gets the same dirty band as anyone
+/// else next time: not advancing the counter is enough on its own. Since
+/// the counter stayed put, `dirtySince` either hands back a box that has
+/// only grown by union over the rows that went missing, or -- if the box
+/// restarted, which raises `dirty_base` above a counter we did not
+/// advance -- the whole atlas. Escalating to a full upload instead would
+/// ask for the largest upload the atlas can produce at exactly the moment
+/// a staging buffer allocation has just failed, which is the request most
+/// likely to fail again and to keep re-arming itself.
 ///
 /// Caller must hold the font grid's read lock.
 fn syncAtlasTexture(
@@ -4574,14 +4580,14 @@ fn syncAtlasTexture(
         api.updateTextureCommandList(texture);
     }
 
-    const dropped = takeAtlasUploadDropped(texture);
-    const grew = atlas.size > texture.width;
-    if (grew) try replaceAtlasTexture(api, atlas, texture);
+    // Clear whatever the last sync left behind, so that what this one
+    // reports describes this one.
+    _ = takeAtlasUploadDropped(texture);
 
-    if (grew or dropped) {
-        // A grown texture is empty and a texture that lost rows has no
-        // record of which, so either way it needs the whole atlas no
-        // matter how little the caller asked for.
+    if (atlas.size > texture.width) {
+        // A grown texture is empty, so it needs the whole atlas no matter
+        // how little the caller asked for.
+        try replaceAtlasTexture(api, atlas, texture);
         try texture.replaceRegion(0, 0, atlas.size, atlas.size, atlas.data);
         return !atlasUploadDropped(texture);
     }
@@ -5140,10 +5146,14 @@ test "syncAtlasTexture: a dropped upload is not reported as synced" {
     }));
 }
 
-test "syncAtlasTexture: the sync after a dropped upload ships the whole atlas" {
-    // The dirty box is a moving bound, so by the time we come back it may
-    // describe rows that have nothing to do with the ones that went
-    // missing. Only a full upload is guaranteed to cover them.
+test "syncAtlasTexture: the sync after a dropped upload ships the band, not the whole atlas" {
+    // `replaceRegion` drops an upload when a staging buffer cannot be
+    // allocated. Answering that with the largest upload the atlas can
+    // produce -- 256 MiB grayscale at the 16384 ceiling -- asks the
+    // allocation that just failed to succeed at a hundred times the size,
+    // and each failure sets the record again. The caller not advancing
+    // its counter is what repairs the drop: the box it gets back next
+    // time still covers the rows that went missing.
     var store: TestAtlasTextures = .{};
     const api: TestAtlasApi = .{ .store = &store };
     var data: [16]u8 = @splat(0);
@@ -5158,14 +5168,43 @@ test "syncAtlasTexture: the sync after a dropped upload ships the whole atlas" {
         .height = 1,
     });
 
+    // What the caller comes back with, having left its counter alone.
     try std.testing.expect(try syncAtlasTexture(&api, &atlas, &texture, .{
         .x = 0,
-        .y = 3,
+        .y = 0,
+        .width = 4,
+        .height = 2,
+    }));
+    try std.testing.expectEqual(@as(usize, 0), store.last_y);
+    try std.testing.expectEqual(@as(usize, 2), store.last_height);
+}
+
+test "syncAtlasTexture: a drop does not stick to the texture" {
+    // The record is set by `replaceRegion` and never cleared there. A sync
+    // that did not clear it before uploading would report every later
+    // clean upload as dropped too, and the caller's counter would never
+    // advance again.
+    var store: TestAtlasTextures = .{};
+    const api: TestAtlasApi = .{ .store = &store };
+    var data: [16]u8 = @splat(0);
+    const atlas = testSyncAtlas(&data, 4);
+    var texture = try api.initAtlasTexture(&atlas);
+
+    store.drop_next_upload = true;
+    try std.testing.expect(!try syncAtlasTexture(&api, &atlas, &texture, .{
+        .x = 0,
+        .y = 0,
         .width = 4,
         .height = 1,
     }));
-    try std.testing.expectEqual(@as(usize, 0), store.last_y);
-    try std.testing.expectEqual(@as(usize, 4), store.last_height);
+
+    try std.testing.expect(try syncAtlasTexture(&api, &atlas, &texture, .{
+        .x = 0,
+        .y = 0,
+        .width = 4,
+        .height = 1,
+    }));
+    try std.testing.expect(!texture.upload_dropped);
 }
 
 test "syncAtlasTexture: nothing dirty means no upload at all" {

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -2378,6 +2378,13 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
             // If our font atlas changed, sync the texture data.
             // Placed after beginFrame so the DX12 command list is available.
+            //
+            // The counter is advanced only once the upload has returned. We
+            // now ship the dirty region rather than the whole atlas, so a
+            // sync that never happened is not made good by the next one: it
+            // would carry only what went dirty after it, leaving the dropped
+            // rows stale for as long as the frame state lives. Leaving the
+            // counter where it was is what makes the next frame try again.
             texture: {
                 const atlas = &self.font_grid.atlas_grayscale;
                 const modified = atlas.modified.load(.monotonic);
@@ -2385,8 +2392,9 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 self.font_grid.lock.lockSharedUncancelable(global.io());
                 defer self.font_grid.lock.unlockShared(global.io());
                 const dirty = atlas.dirtySince(frame.grayscale_modified);
-                frame.grayscale_modified = atlas.modified.load(.monotonic);
+                const synced = atlas.modified.load(.monotonic);
                 try self.syncAtlasTexture(atlas, &frame.grayscale, dirty);
+                frame.grayscale_modified = synced;
             }
             texture: {
                 const atlas = &self.font_grid.atlas_color;
@@ -2395,8 +2403,9 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 self.font_grid.lock.lockSharedUncancelable(global.io());
                 defer self.font_grid.lock.unlockShared(global.io());
                 const dirty = atlas.dirtySince(frame.color_modified);
-                frame.color_modified = atlas.modified.load(.monotonic);
+                const synced = atlas.modified.load(.monotonic);
                 try self.syncAtlasTexture(atlas, &frame.color, dirty);
+                frame.color_modified = synced;
             }
 
             // Determine if we can use the custom shader path.  All post-process

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -4540,12 +4540,10 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             }
 
             if (atlas.size > texture.width) {
-                // Free our old texture
-                texture.*.deinit();
+                try replaceAtlasTexture(&self.api, atlas, texture);
 
-                // Reallocate. The new texture is empty, so it needs the
-                // whole atlas no matter how little the caller asked for.
-                texture.* = try self.api.initAtlasTexture(atlas);
+                // The new texture is empty, so it needs the whole atlas
+                // no matter how little the caller asked for.
                 try texture.replaceRegion(0, 0, atlas.size, atlas.size, atlas.data);
                 return;
             }
@@ -4570,6 +4568,31 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             );
         }
     };
+}
+
+/// Point `texture` at a freshly allocated texture sized for `atlas`,
+/// giving up the one it held.
+///
+/// The new texture is created before the old one is released, so that a
+/// creation failure leaves `texture.*` holding a texture that still owns
+/// its resource. Releasing first would leave it holding a released one,
+/// and since a failed grow does not advance the atlas modified counter,
+/// the next frame syncs the same texture again and releases it a second
+/// time -- on DX12 that double-releases the GPU resource and returns its
+/// descriptor slots to the heap twice.
+///
+/// This ordering is also what keeps the backends interchangeable: DX12's
+/// Texture has an all-defaults zero value that deinits to nothing, but
+/// Metal's and OpenGL's wrap a bare handle with no such value, so there is
+/// no "invalid texture" to park in `texture.*` on the error path.
+fn replaceAtlasTexture(
+    api: anytype,
+    atlas: *const font.Atlas,
+    texture: anytype,
+) !void {
+    const new_texture = try api.initAtlasTexture(atlas);
+    texture.deinit();
+    texture.* = new_texture;
 }
 
 /// Whether the post-process custom shader path can be used for a frame.
@@ -4883,6 +4906,113 @@ test "AbandonReason: every reason completes the log sentence" {
     for (std.enums.values(AbandonReason)) |reason| {
         try std.testing.expect(reason.text().len > 0);
     }
+}
+
+/// Backing store for the fake API and textures below. Release is tracked
+/// per texture id so a second release of the same texture is observable
+/// instead of being the silent GPU corruption it is in production.
+const TestAtlasTextures = struct {
+    fail_next: bool = false,
+    next_id: usize = 0,
+    released: [8]bool = @splat(false),
+    double_release: bool = false,
+};
+
+/// Stands in for a backend `Texture`. Only `deinit` matters here; the
+/// grow path's `replaceRegion` is the caller's business.
+const TestAtlasTexture = struct {
+    store: *TestAtlasTextures,
+    id: usize,
+
+    fn deinit(self: TestAtlasTexture) void {
+        if (self.store.released[self.id]) {
+            self.store.double_release = true;
+            return;
+        }
+        self.store.released[self.id] = true;
+    }
+};
+
+/// Stands in for a `GraphicsAPI`, with a const self like all three real
+/// ones so the call in `replaceAtlasTexture` binds the same way.
+const TestAtlasApi = struct {
+    store: *TestAtlasTextures,
+
+    fn initAtlasTexture(
+        self: *const TestAtlasApi,
+        atlas: *const font.Atlas,
+    ) !TestAtlasTexture {
+        _ = atlas;
+        if (self.store.fail_next) return error.TextureCreateFailed;
+        defer self.store.next_id += 1;
+        return .{ .store = self.store, .id = self.store.next_id };
+    }
+};
+
+const test_atlas: font.Atlas = .{
+    .data = undefined,
+    .size = 1,
+    .format = .grayscale,
+};
+
+test "replaceAtlasTexture: a failed grow keeps the texture it had" {
+    // Regression: the grow path used to release the old texture before
+    // asking for the new one. On the error path `texture.*` was left
+    // holding the released value, so the next sync -- the very next frame,
+    // since a failed grow does not advance the atlas modified counter --
+    // released it a second time. On DX12 that double-releases the GPU
+    // resource and hands the same SRV descriptor slots back twice.
+    var store: TestAtlasTextures = .{};
+    const api: TestAtlasApi = .{ .store = &store };
+    var texture = try api.initAtlasTexture(&test_atlas);
+
+    store.fail_next = true;
+    try std.testing.expectError(
+        error.TextureCreateFailed,
+        replaceAtlasTexture(&api, &test_atlas, &texture),
+    );
+
+    // The texture we still hold must still own its resource: it is what
+    // the renderer keeps drawing from until a later grow succeeds.
+    try std.testing.expect(!store.released[texture.id]);
+
+    // And tearing the frame state down now must be that texture's first
+    // release, not its second.
+    texture.deinit();
+    try std.testing.expect(!store.double_release);
+}
+
+test "replaceAtlasTexture: a successful grow releases the old texture once" {
+    var store: TestAtlasTextures = .{};
+    const api: TestAtlasApi = .{ .store = &store };
+    var texture = try api.initAtlasTexture(&test_atlas);
+    const old_id = texture.id;
+
+    try replaceAtlasTexture(&api, &test_atlas, &texture);
+
+    try std.testing.expect(texture.id != old_id);
+    try std.testing.expect(store.released[old_id]);
+    try std.testing.expect(!store.released[texture.id]);
+    try std.testing.expect(!store.double_release);
+}
+
+test "replaceAtlasTexture: repeated failed grows never double release" {
+    // The failure is not one-shot: a device that cannot create the bigger
+    // texture usually cannot create it on the next frame either, and the
+    // renderer retries every frame for as long as that lasts.
+    var store: TestAtlasTextures = .{};
+    const api: TestAtlasApi = .{ .store = &store };
+    var texture = try api.initAtlasTexture(&test_atlas);
+
+    store.fail_next = true;
+    for (0..5) |_| {
+        try std.testing.expectError(
+            error.TextureCreateFailed,
+            replaceAtlasTexture(&api, &test_atlas, &texture),
+        );
+    }
+    try std.testing.expect(!store.double_release);
+    try std.testing.expect(!store.released[texture.id]);
 }
 
 test "customShaderUsable: no custom shader state means no custom shader path" {

--- a/src/renderer/image.zig
+++ b/src/renderer/image.zig
@@ -317,17 +317,22 @@ pub const State = struct {
     }
 
     /// Update our overlay state. Null value deletes any existing overlay.
+    ///
+    /// Returns true if what the overlay contributes to the frame changed.
+    /// Image state reaches the renderer on its own channel, not through
+    /// grid dirtiness, so this is the only thing that can tell the caller
+    /// it owes a draw.
     pub fn overlayUpdate(
         self: *State,
         alloc: Allocator,
         overlay_: ?Overlay,
-    ) !void {
+    ) !bool {
         const overlay = overlay_ orelse {
             // If we don't have an overlay, remove any existing one.
-            if (self.images.getPtr(.overlay)) |data| {
-                data.image.markForUnload();
-            }
-            return;
+            const data = self.images.getPtr(.overlay) orelse return false;
+            if (data.image.isUnloading()) return false;
+            data.image.markForUnload();
+            return true;
         };
 
         // Overlays are always considered new content, so we take a
@@ -365,6 +370,11 @@ pub const State = struct {
             .source_width = pending.width,
             .source_height = pending.height,
         });
+
+        // An overlay is redrawn from scratch every frame it exists and is
+        // stamped with a fresh generation above, so there is always
+        // something new here for the GPU.
+        return true;
     }
 
     /// Returns true if the Kitty graphics state requires an update based
@@ -1697,6 +1707,35 @@ test "kitty renderer uploads the current animation frame" {
         &.{ 0, 0, 255, 255 },
         entry.image.pending.dataSlice(),
     );
+}
+
+test "renderer overlay update reports whether it changed the frame" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var state: State = .empty;
+    defer state.deinit(alloc);
+
+    // Nothing to remove, so nothing changed.
+    try testing.expect(!try state.overlayUpdate(alloc, null));
+
+    const size: @import("size.zig").Size = .{
+        .screen = .{ .width = 20, .height = 20 },
+        .cell = .{ .width = 10, .height = 10 },
+        .padding = .{},
+    };
+    var overlay: Overlay = try .init(alloc, size);
+    defer overlay.deinit(alloc);
+
+    // An overlay is redrawn from scratch every frame, so every update of
+    // one is new content for the GPU.
+    try testing.expect(try state.overlayUpdate(alloc, overlay));
+    try testing.expect(try state.overlayUpdate(alloc, overlay));
+
+    // Taking it away changes the frame once, and then there is nothing
+    // left to take away.
+    try testing.expect(try state.overlayUpdate(alloc, null));
+    try testing.expect(!try state.overlayUpdate(alloc, null));
 }
 
 test "Image.markForUnload pending -> unload_pending" {


### PR DESCRIPTION
Second half of the renderer audit stack, on top of PR 1024. Thirteen commits, all in the atlas-upload and redraw-gate area that PR 1024 opened up.

The thread running through them: once a font atlas sync ships only the region that went dirty since the last one, every place that used to be forgiving stops being forgiving. A sync that silently dropped bytes used to be repaired by the next whole-atlas upload; now it is not. A frame the renderer decides to skip used to still run the code that collects retired GPU resources; now it does not.

What lands:

- **Partial atlas uploads** (`24f522c795`, `7d470ad158`). `Atlas.dirtySince` hands a consumer the region it is missing rather than the whole atlas, and the Metal device's real texture limit reaches the atlas ceiling.
- **The upload counter no longer advances over bytes that never arrived** (`8da5a48f6f`, `418f80144a`). DX12's `replaceRegion` cannot report a failure through its return type -- it shares a signature with Metal's, which cannot fail -- so it records the drop on the texture and the atlas sync reads it.
- **...and does not answer it by escalating** (`f45288539e`). Re-uploading the whole atlas asks the staging allocation that has just failed to succeed at up to 256 MiB grayscale / 1 GiB BGRA, and each failure records another drop. Leaving the counter where it was is sufficient on its own: the dirty box has only grown by union since, and a box that restarted put `dirty_base` above the counter we did not advance, which takes the whole-atlas branch anyway.
- **...and does not report a drop as a success on the way out** (`4fa6e992e1`). The sync cleared the previous sync's drop record before the "nothing dirty" early return could see it. Unreachable from either production call site today, but only because of an invariant those callers hold and this function neither documented nor asserted.
- **A failed atlas grow keeps the texture it had** (`87cc758193`), instead of leaving a released one in the frame state for the next frame to release again.
- **The redraw gate sees what it is supposed to see** (`26358cd32f`, `3f19564c7e`, `6ad8cd19fb`, `e8caea66a1`): image-state-only changes, custom shader uniforms, and a stale frame on a wakeup with no work.
- **Retired GPU resources are collected on every wakeup** (`8439f9f476`), not only on frames the renderer decided to draw. An atlas that grows on the last frame before the terminal goes idle otherwise keeps the replaced texture resident for as long as the quiet lasts.
- **A device removed while the terminal is idle is noticed** (`52540c079d`). `presentLastTarget` is a no-op on DX12, so `drawFrameStart` is the only thing that touches the device on a wakeup that draws nothing, and it was discarding the answer.

### Dropped from this PR

Three commits that were here in an earlier revision are gone: the image-upload-budget retry (`fc20f8ae13`, `d3cf9ee2f5`, `c9bee846e4`). Review found the mechanism is a guaranteed no-op in the scenario it was written for, on every backend -- not merely one that "cannot yet succeed on DX12".

`retryDeferredUpload` asked for a retry only on a **strictly falling** in-flight staging total. During a burst that total rises monotonically: images that succeed in one pass move `.pending` (which reports 0 bytes) to `.ready` (which reports the texture's staging bytes), so each pass reads a larger number than the last. The single free attempt every run gets is therefore spent on the first deferring pass, mid-burst, where the terminal is about to wake the renderer anyway; and by the time the terminal goes quiet -- the one moment the mechanism exists for -- the predicate is false and stays false. The blocked image never leaves `.pending`, so the arm is never reset either.

That leaves the real fix where it was: releasing a texture's staging buffers once the copy has been submitted. Until that lands there is nothing for a retry to find, so this PR ships no retry rather than a well-tested one that cannot fire.

### What the test runs are and are not evidence for

`zig build test -Dapp-runtime=none` does not compile the redraw gate, the `updateFrame` clear, `rebuildCells`, or `DirectX12.drawFrameStart` -- filtered or unfiltered. Compile probes at each site reached none of them in that config; only `zig build -Dapp-runtime=none` does. So a green test suite is evidence about the free functions, `State.upload`, and `syncAtlasTexture` **as instantiated over the test double** -- and nothing else in this stack. The real `directx12.Texture` instantiation of `syncAtlasTexture`, and everything in `drawFrame`, are compile-covered by the app build only, and `drawFrameStart`'s change has no test at all (`removed()` needs a live `ID3D12Device`).

That is stated here rather than buried because the same gap is what let an earlier revision of this branch ship a fix whose production call site no green run ever saw.

Test plan:
- [x] `zig build test -Dapp-runtime=none` with the atlas/upload filters: 87/87 steps, 98/98 tests, `ghostty-test 97 pass (97 total)`, no skips
- [x] Mutation at the production site (the drop record discarded again, tests untouched): 97/98, failing by name on `syncAtlasTexture: nothing dirty after a dropped upload is not synced`
- [x] Restored by content hash, same filters green again (98/98)
- [x] `zig build -Dapp-runtime=none`: 106/106 steps
- [x] `@compileLog` probe at the changed site in the app build: reached, instantiated with `renderer.directx12.Texture`
- [x] `zig fmt --check` on both touched files, exit 0

This PR targets the parent branch, not `windows`; it will retarget automatically when the parent merges. Squash on merge -- `f45288539e` reverses part of `418f80144a`'s behaviour (and the tests that described it), so a commit-by-commit read shows a flip that the net diff does not have.
