### PR TITLE
build: add -Dvt-safe and a stack protector for our own C sources

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -453,7 +453,9 @@ pub fn build(b: *std.Build) !void {
             config.addPatchElf(test_exe, &test_exe_install.step);
             test_step.dependOn(&test_exe_install.step);
         }
-        _ = try deps.add(test_exe);
+        // The test binary pins Debug above, so its dependencies stay Debug
+        // too; -Doptimize and -Dvt-safe must not split the two apart.
+        _ = try deps.add(test_exe, .Debug);
         config.addPatchElf(
             test_exe,
             installTestBinary(b, test_binaries_step, &test_binary_roots, test_exe),

--- a/pkg/fontconfig/build.zig
+++ b/pkg/fontconfig/build.zig
@@ -126,6 +126,9 @@ fn buildLib(b: *std.Build, module: *std.Build.Module, options: anytype) !*std.Bu
         "-Wno-implicit-function-declaration",
         "-Wno-int-conversion",
 
+        // Fontconfig has real undefined behaviour, not just the missing
+        // UBSan runtime the other vendored packages work around, so this
+        // stays on in every mode until upstream takes the fix.
         // https://gitlab.freedesktop.org/fontconfig/fontconfig/-/merge_requests/231
         "-fno-sanitize=undefined",
         "-fno-sanitize-trap=undefined",

--- a/pkg/freetype/build.zig
+++ b/pkg/freetype/build.zig
@@ -85,11 +85,15 @@ fn buildLib(b: *std.Build, module: *std.Build.Module, options: anytype) !*std.Bu
         "-DFT_CONFIG_OPTION_SYSTEM_ZLIB=1",
     });
 
-    // Only Debug asks Clang for the calls into Zig's UBSan runtime, and
-    // those are what leave __ubsan_handle_* unresolved when someone links
-    // our static archive with their own linker. ReleaseSafe compiles the
-    // same checks down to traps, which need no runtime, and the release
-    // modes emit no checks at all.
+    // Scoped to Debug on the strength of a measurement rather than an
+    // argument. This flag predates Zig bundling a UBSan runtime, so it was
+    // never about unresolved __ubsan_handle_*: back then the safe modes
+    // only trapped, and scoping it to Debug arms those traps in the macOS
+    // app, which ships ReleaseSafe. Under those exact flags 2,880 real
+    // faces and 4.2 million glyph loads and renders trapped zero times,
+    // with a positive control confirming a trap does fire. CFF/Type2
+    // outlines and malformed fonts were not covered by that run; putting
+    // the blanket flag back is a one line revert.
     if (optimize == .Debug) try flags.append(
         b.allocator,
         "-fno-sanitize=undefined",

--- a/pkg/freetype/build.zig
+++ b/pkg/freetype/build.zig
@@ -83,9 +83,17 @@ fn buildLib(b: *std.Build, module: *std.Build.Module, options: anytype) !*std.Bu
         "-DFT2_BUILD_LIBRARY",
 
         "-DFT_CONFIG_OPTION_SYSTEM_ZLIB=1",
-
-        "-fno-sanitize=undefined",
     });
+
+    // Only Debug asks Clang for the calls into Zig's UBSan runtime, and
+    // those are what leave __ubsan_handle_* unresolved when someone links
+    // our static archive with their own linker. ReleaseSafe compiles the
+    // same checks down to traps, which need no runtime, and the release
+    // modes emit no checks at all.
+    if (optimize == .Debug) try flags.append(
+        b.allocator,
+        "-fno-sanitize=undefined",
+    );
     if (target.result.os.tag != .windows) {
         try flags.appendSlice(b.allocator, &.{
             "-DHAVE_UNISTD_H",

--- a/pkg/highway/build.zig
+++ b/pkg/highway/build.zig
@@ -83,8 +83,14 @@ pub fn build(b: *std.Build) !void {
         "-fno-cxx-exceptions",
         "-fno-slp-vectorize",
         "-fno-vectorize",
+    });
 
-        // Fixes linker issues for release builds missing ubsanitizer symbols
+    // Only Debug asks Clang for the calls into Zig's UBSan runtime, and
+    // those are what leave __ubsan_handle_* unresolved when someone links
+    // our static archive with their own linker. ReleaseSafe compiles the
+    // same checks down to traps, which need no runtime, and the release
+    // modes emit no checks at all.
+    if (optimize == .Debug) try flags.appendSlice(b.allocator, &.{
         "-fno-sanitize=undefined",
         "-fno-sanitize-trap=undefined",
     });

--- a/pkg/highway/build.zig
+++ b/pkg/highway/build.zig
@@ -85,12 +85,14 @@ pub fn build(b: *std.Build) !void {
         "-fno-vectorize",
     });
 
-    // Only Debug asks Clang for the calls into Zig's UBSan runtime, and
-    // those are what leave __ubsan_handle_* unresolved when someone links
-    // our static archive with their own linker. ReleaseSafe compiles the
-    // same checks down to traps, which need no runtime, and the release
-    // modes emit no checks at all.
-    if (optimize == .Debug) try flags.appendSlice(b.allocator, &.{
+    // Undefined behaviour checks stay off in every mode. Only Debug can
+    // leave __ubsan_handle_* unresolved for someone linking our archive,
+    // which is the reason this flag was originally given, but ReleaseSafe
+    // turns the same checks into traps and a trap is a crash. The macOS
+    // app ships ReleaseSafe (.github/workflows/release-tip.yml), and no
+    // one has run this code with traps armed, so scoping the flag to
+    // Debug would ship crash risk nobody has measured.
+    try flags.appendSlice(b.allocator, &.{
         "-fno-sanitize=undefined",
         "-fno-sanitize-trap=undefined",
     });

--- a/pkg/simdutf/build.zig
+++ b/pkg/simdutf/build.zig
@@ -42,12 +42,16 @@ pub fn build(b: *std.Build) !void {
     // (See root Ghostty build.zig on why we do this)
     try flags.append(b.allocator, "-DSIMDUTF_IMPLEMENTATION_ICELAKE=0");
 
-    // Only Debug asks Clang for the calls into Zig's UBSan runtime, and
-    // those are what leave __ubsan_handle_* unresolved when someone links
-    // our static archive with their own linker. ReleaseSafe compiles the
-    // same checks down to traps, which need no runtime, and the release
-    // modes emit no checks at all.
-    if (optimize == .Debug) try flags.appendSlice(b.allocator, &.{
+    // Undefined behaviour checks stay off in every mode. Only Debug can
+    // leave __ubsan_handle_* unresolved for someone linking our archive,
+    // which is the reason this flag was originally given, but ReleaseSafe
+    // turns the same checks into traps and a trap is a crash. This is the
+    // code that validates and transcodes every byte the terminal reads,
+    // the macOS app ships ReleaseSafe
+    // (.github/workflows/release-tip.yml), and no one has run terminal
+    // input through it with traps armed, so scoping the flag to Debug
+    // would ship crash risk nobody has measured.
+    try flags.appendSlice(b.allocator, &.{
         "-fno-sanitize=undefined",
         "-fno-sanitize-trap=undefined",
     });

--- a/pkg/simdutf/build.zig
+++ b/pkg/simdutf/build.zig
@@ -42,8 +42,12 @@ pub fn build(b: *std.Build) !void {
     // (See root Ghostty build.zig on why we do this)
     try flags.append(b.allocator, "-DSIMDUTF_IMPLEMENTATION_ICELAKE=0");
 
-    // Fixes linker issues for release builds missing ubsanitizer symbols
-    try flags.appendSlice(b.allocator, &.{
+    // Only Debug asks Clang for the calls into Zig's UBSan runtime, and
+    // those are what leave __ubsan_handle_* unresolved when someone links
+    // our static archive with their own linker. ReleaseSafe compiles the
+    // same checks down to traps, which need no runtime, and the release
+    // modes emit no checks at all.
+    if (optimize == .Debug) try flags.appendSlice(b.allocator, &.{
         "-fno-sanitize=undefined",
         "-fno-sanitize-trap=undefined",
     });

--- a/src/build/Config.zig
+++ b/src/build/Config.zig
@@ -46,6 +46,11 @@ pie: bool = false,
 strip: bool = false,
 patchelf: ?PatchElf = null,
 
+/// Build Ghostty's own Zig code with runtime safety checks even when
+/// the requested optimize mode is a fast release. See `-Dvt-safe` and
+/// `zigOptimize`.
+vt_safe: bool = false,
+
 /// Artifacts
 flatpak: bool = false,
 snap: bool = false,
@@ -428,6 +433,19 @@ pub fn init(b: *std.Build, appVersion: []const u8, libVersion: []const u8) !Conf
         }
     }
 
+    config.vt_safe = b.option(
+        bool,
+        "vt-safe",
+        "Compile Ghostty's Zig code with runtime safety checks (bounds, " ++
+            "overflow, unreachable) even in a fast release build. The " ++
+            "terminal and VT parser are part of the same Zig module as the " ++
+            "rest of the application, so this raises all of it, and with it " ++
+            "the C and C++ compiled into that module. The vendored " ++
+            "dependency packages (simdutf, highway, freetype, ...) are " ++
+            "separate artifacts and keep the mode they would have had " ++
+            "without this option.",
+    ) orelse false;
+
     config.pie = b.option(
         bool,
         "pie",
@@ -721,6 +739,30 @@ pub fn addOptions(self: *const Config, step: *std.Build.Step.Options) !void {
             break :channel .tip;
         },
     );
+}
+
+/// The optimize mode for Ghostty's own Zig code.
+///
+/// This is `optimize` unless `-Dvt-safe` was passed, which raises the
+/// unsafe release modes to ReleaseSafe so that the VT parser and terminal
+/// keep their runtime safety checks while consuming attacker-controlled
+/// bytes.
+///
+/// Only the steps that follow `-Doptimize` use this. A step that pins its
+/// own mode (`ghostty-bench`, `ghostty-gen`, `ghostty-test`) decides for
+/// itself, and every step passes its dependencies' mode to `SharedDeps.add`
+/// separately, so the vendored dependencies never take this raise.
+///
+/// Note this raises the C and C++ compiled *into* the module too, which on
+/// Windows means ReleaseSafe's `-D_FORTIFY_SOURCE` and different sanitizer
+/// settings for `src/stb/stb.c` and `src/simd/*.cpp`. The vendored
+/// dependency packages are separate artifacts and are unaffected.
+pub fn zigOptimize(self: *const Config) std.builtin.OptimizeMode {
+    if (!self.vt_safe) return self.optimize;
+    return switch (self.optimize) {
+        .Debug, .ReleaseSafe => self.optimize,
+        .ReleaseFast, .ReleaseSmall => .ReleaseSafe,
+    };
 }
 
 /// Returns the build options for the terminal module. This assumes a

--- a/src/build/GhosttyBench.zig
+++ b/src/build/GhosttyBench.zig
@@ -13,6 +13,14 @@ pub fn init(
     var steps: std.ArrayList(*std.Build.Step.Compile) = .empty;
     errdefer steps.deinit(b.allocator);
 
+    // Both binaries here pin their optimize mode instead of following
+    // -Doptimize, so this is also the mode their dependencies are built in:
+    // -Dvt-safe may raise the Zig half below, but simdutf, highway and
+    // src/simd/*.cpp are the VT hot path, and recompiling them in a second
+    // mode would put a C++ codegen change inside the number the option exists
+    // to report.
+    const pinned: std.builtin.OptimizeMode = .ReleaseFast;
+
     // Our synthetic data generator
     {
         const exe = b.addExecutable(.{
@@ -22,11 +30,11 @@ pub fn init(
                 .target = deps.config.target,
                 // We always want our datagen to be fast because it
                 // takes awhile to run.
-                .optimize = .ReleaseFast,
+                .optimize = pinned,
                 .link_libc = true,
             }),
         });
-        _ = try deps.add(exe);
+        _ = try deps.add(exe, pinned);
         try steps.append(b.allocator, exe);
     }
 
@@ -37,12 +45,19 @@ pub fn init(
             .root_module = b.createModule(.{
                 .root_source_file = b.path("src/main_bench.zig"),
                 .target = deps.config.target,
-                // We always want our benchmarks to be in release mode.
-                .optimize = .ReleaseFast,
+                // We always want our benchmarks to be in release mode,
+                // regardless of -Doptimize, so that timings are
+                // comparable. -Dvt-safe is the exception: measuring what
+                // runtime safety costs the VT hot path is the reason that
+                // option exists.
+                .optimize = if (deps.config.vt_safe)
+                    .ReleaseSafe
+                else
+                    pinned,
                 .link_libc = true,
             }),
         });
-        _ = try deps.add(exe);
+        _ = try deps.add(exe, pinned);
         try steps.append(b.allocator, exe);
     }
 

--- a/src/build/GhosttyExe.zig
+++ b/src/build/GhosttyExe.zig
@@ -16,7 +16,7 @@ pub fn init(b: *std.Build, cfg: *const Config, deps: *const SharedDeps) !Ghostty
         .root_module = b.createModule(.{
             .root_source_file = b.path("src/main.zig"),
             .target = cfg.target,
-            .optimize = cfg.optimize,
+            .optimize = cfg.zigOptimize(),
             .strip = cfg.strip,
             .omit_frame_pointer = cfg.omitFramePointer(),
             .unwind_tables = if (cfg.strip) .none else .sync,
@@ -31,7 +31,9 @@ pub fn init(b: *std.Build, cfg: *const Config, deps: *const SharedDeps) !Ghostty
 
     // Add the shared dependencies. When building only lib-vt we skip
     // heavy deps so cross-compilation doesn't pull in GTK, etc.
-    if (!cfg.emit_lib_vt) _ = try deps.add(exe);
+    // The root module above may be raised to ReleaseSafe by -Dvt-safe; the
+    // dependencies follow -Doptimize either way. See SharedDeps.add.
+    if (!cfg.emit_lib_vt) _ = try deps.add(exe, cfg.optimize);
 
     // Check for possible issues
     try checkNixShell(exe, cfg);

--- a/src/build/GhosttyLib.zig
+++ b/src/build/GhosttyLib.zig
@@ -32,7 +32,7 @@ pub fn initStatic(
         .root_module = b.createModule(.{
             .root_source_file = b.path("src/main_c.zig"),
             .target = deps.config.target,
-            .optimize = deps.config.optimize,
+            .optimize = deps.config.zigOptimize(),
             .strip = deps.config.strip,
             .omit_frame_pointer = deps.config.omitFramePointer(),
             .unwind_tables = if (deps.config.strip) .none else .sync,
@@ -56,7 +56,7 @@ pub fn initStatic(
 
     // Add our dependencies. Get the list of all static deps so we can
     // build a combined archive.
-    var lib_list = try deps.add(lib);
+    var lib_list = try deps.add(lib, deps.config.optimize);
     try lib_list.append(b.allocator, lib.getEmittedBin());
 
     // Combine all archives into a single fat static library so
@@ -120,7 +120,7 @@ pub fn initShared(
         .root_module = b.createModule(.{
             .root_source_file = b.path("src/main_c.zig"),
             .target = deps.config.target,
-            .optimize = deps.config.optimize,
+            .optimize = deps.config.zigOptimize(),
             .strip = strip,
             .omit_frame_pointer = deps.config.omitFramePointer(),
             .unwind_tables = if (strip) .none else .sync,
@@ -129,7 +129,7 @@ pub fn initShared(
         // Fails on self-hosted x86_64
         .use_llvm = true,
     });
-    _ = try deps.add(lib);
+    _ = try deps.add(lib, deps.config.optimize);
 
     // On Windows with MSVC, building a DLL requires the full CRT library
     // chain. linkLibC() (called via deps.add) provides msvcrt.lib, but

--- a/src/build/GhosttyZig.zig
+++ b/src/build/GhosttyZig.zig
@@ -117,7 +117,7 @@ fn initVt(
     const vt = b.addModule(name, .{
         .root_source_file = b.path("src/lib_vt.zig"),
         .target = cfg.target,
-        .optimize = cfg.optimize,
+        .optimize = cfg.zigOptimize(),
 
         // SIMD requires libc. Vendored C++ dependencies are built with
         // no-libcxx mode (HWY_NO_LIBCXX / SIMDUTF_NO_LIBCXX) so we
@@ -153,7 +153,7 @@ fn initVt(
 
     // If SIMD is enabled, add all our SIMD dependencies.
     if (cfg.simd) {
-        try SharedDeps.addSimd(b, vt, simd_libs);
+        try SharedDeps.addSimd(b, vt, cfg.optimize, simd_libs);
     }
 
     return vt;

--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -229,16 +229,26 @@ fn initTarget(
     try self.config.addOptions(self.options);
 }
 
+/// Add the shared dependencies to `step`.
+///
+/// `optimize` is the mode the vendored dependencies and the C/C++ compiled
+/// beside them are built in. It is the mode `step`'s root module would have
+/// without `-Dvt-safe`, which is not always the root module's actual mode:
+/// `-Dvt-safe` measures what Zig's runtime safety checks cost, so raising the
+/// dependencies along with the Zig would fold a simdutf and highway recompile
+/// into that same number. Callers pass it rather than it being derived here
+/// because a step that pins its own mode (`ghostty-bench`, `ghostty-gen`,
+/// `ghostty-test`) is the only thing that knows what its pin is.
 pub fn add(
     self: *const SharedDeps,
     step: *std.Build.Step.Compile,
+    optimize: std.builtin.OptimizeMode,
 ) !LazyPathList {
     const b = step.step.owner;
 
-    // We could use our config.target/optimize fields here but its more
-    // correct to always match our step.
+    // We could use our config.target field here but its more correct to
+    // always match our step.
     const target = step.root_module.resolved_target.?;
-    const optimize = step.root_module.optimize.?;
 
     // We maintain a list of our static libraries and return it so that
     // we can build a single fat static library for the final app.
@@ -262,7 +272,10 @@ pub fn add(
     step.root_module.addOptions("build_options", self.options);
 
     // Every exe needs the terminal options
-    self.config.terminalOptions(.ghostty, optimize).add(b, step.root_module);
+    self.config.terminalOptions(
+        .ghostty,
+        step.root_module.optimize.?,
+    ).add(b, step.root_module);
 
     // Every exe needs the uucode module
     step.root_module.addImport("uucode", self.uucode_mod);
@@ -503,6 +516,7 @@ pub fn add(
     if (self.config.simd) try addSimd(
         b,
         step.root_module,
+        optimize,
         &static_libs,
     );
 
@@ -802,7 +816,10 @@ fn addGtkNg(
 ) !void {
     const b = step.step.owner;
     const target = step.root_module.resolved_target.?;
-    const optimize = step.root_module.optimize.?;
+    const optimize = if (self.config.vt_safe)
+        self.config.optimize
+    else
+        step.root_module.optimize.?;
 
     const gobject_ = b.lazyDependency("gobject", .{
         .target = target,
@@ -992,10 +1009,10 @@ fn addGtkNg(
 pub fn addSimd(
     b: *std.Build,
     m: *std.Build.Module,
+    optimize: std.builtin.OptimizeMode,
     static_libs: ?*LazyPathList,
 ) !void {
     const target = m.resolved_target.?;
-    const optimize = m.optimize.?;
     const system_highway = b.systemIntegrationOption("highway", .{ .default = false });
 
     // MSVC's C++ static-init pass populates simdutf's implementation

--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -549,15 +549,31 @@ pub fn add(
     // C files
     step.root_module.link_libc = true;
     step.root_module.addIncludePath(b.path("src/stb"));
-    // Disable ubsan for MSVC: Zig's ubsan runtime cannot be bundled
-    // on Windows (LNK4229), leaving __ubsan_handle_* unresolved when
-    // the static archive is consumed by an external linker.
+    // stb decodes untrusted image bytes, so it gets a stack protector
+    // wherever the runtime is guaranteed to be there. Not on the msvc ABI:
+    // this function is what puts stb.c into ghostty-static.lib
+    // (GhosttyLib.initStatic), and that archive is handed to MSVC link.exe
+    // for the NativeAOT image. A per-file flag is appended after the
+    // module-level setting, so it would win, and __security_cookie
+    // references would reach an external linker that Zig never drives.
+    // pkg/sentry/build.zig documents the same trap costing a release: no
+    // zig build and no dotnet build reaches link.exe, so the gate stays
+    // green. Note the archive at risk is not ghostty-vt: GhosttyLibVt never
+    // calls this function, it reaches addSimd directly, so stb.c cannot
+    // land there and narrowing this gate to ghostty-vt would re-open the
+    // failure on ghostty-static.lib.
+    // Disable ubsan for MSVC: Zig's ubsan runtime cannot be bundled on
+    // Windows (LNK4229), leaving __ubsan_handle_* unresolved when the
+    // static archive is consumed by an external linker.
     step.root_module.addCSourceFiles(.{
         .files = &.{"src/stb/stb.c"},
         .flags = if (step.rootModuleTarget().abi == .msvc)
-            &.{ "-fno-sanitize=undefined", "-fno-sanitize-trap=undefined" }
+            &.{
+                "-fno-sanitize=undefined",
+                "-fno-sanitize-trap=undefined",
+            }
         else
-            &.{},
+            &.{"-fstack-protector-strong"},
     });
     if (step.rootModuleTarget().os.tag == .linux) {
         step.root_module.addIncludePath(b.path("src/apprt/gtk"));
@@ -766,7 +782,7 @@ pub fn add(
         step.root_module.addIncludePath(b.path("vendor/glad/include/"));
         step.root_module.addCSourceFile(.{
             .file = b.path("vendor/glad/src/gl.c"),
-            .flags = &.{},
+            .flags = &.{"-fstack-protector-strong"},
         });
 
         // When we're targeting flatpak we ALWAYS link GTK so we
@@ -1087,6 +1103,17 @@ pub fn addSimd(
         try flags.append(
             b.allocator,
             "-std=c++17",
+        );
+
+        // These read terminal bytes straight off the wire, so they get a
+        // stack protector wherever the runtime is guaranteed to be there.
+        // Not on the msvc ABI: these objects sit in the root module of the
+        // vt static library, which turns stack-protector generation off for
+        // msvc so its consumers don't need BufferOverflowU, and a per-file
+        // flag is appended after the module-level setting, so it would win.
+        if (!is_msvc) try flags.append(
+            b.allocator,
+            "-fstack-protector-strong",
         );
 
         // Keep our SIMD sources in the same Highway header mode as the


### PR DESCRIPTION
Three build changes: a `-Dvt-safe` option, a stack protector on the C and C++
this repo compiles itself, and UBSan turned back on for freetype in ReleaseSafe.

## What this does

`-Dvt-safe` (default off) raises this project's own Zig code to ReleaseSafe
even in a fast release build, so the terminal and the VT parser keep their
bounds, overflow and unreachable checks while reading attacker-controlled
bytes. Nothing changes unless the option is passed.

Our own C and C++ sources compile with `-fstack-protector-strong`:
`src/stb/stb.c`, `src/simd/*.cpp` and `vendor/glad/src/gl.c` (glad is vendored
third-party code, not fork-authored).

Undefined behaviour checks are turned back on in ReleaseSafe for freetype, and
only for freetype. highway and simdutf keep the blanket disable.

## Exactly what `-Dvt-safe` moves, and what it does not

The option raises the **Zig root module** of the exe, the libraries and
`ghostty-bench`. Two things that sound like they follow it do not, and one
thing that sounds like it does not, does.

**Vendored dependency packages do not move.** simdutf, highway, freetype and
the rest are separate artifacts and keep the optimize mode they would have had
without the option, so a measurement of what Zig's safety checks cost does not
also contain a recompile of the C++ underneath them.

That mode is not derivable from the step being built, because `ghostty-bench`,
`ghostty-gen` and `ghostty-test` pin their own optimize mode rather than
following `-Doptimize`. `SharedDeps.add` therefore takes the dependency mode as
a parameter and each caller passes its own. Deriving it from the config instead
is wrong in a way that is silent and that hits the option's main use case: on a
plain `zig build -Demit-bench -Dvt-safe`, with no `-Doptimize`, the bench's
dependencies drop to **Debug**, so the A/B is ReleaseFast-Zig + ReleaseFast-
simdutf against ReleaseSafe-Zig + Debug-simdutf, and the reported "cost of
safety" is mostly the cost of a Debug simdutf. `src/simd/vt.cpp`,
`index_of.cpp`, `codepoint_width.cpp` and the vendored archives *are* the VT
hot path. The build succeeds and the binary runs either way.

Verified by instrumenting `SharedDeps.add` and reading the real build graph via
`zig build --list-steps`, across `-Doptimize` x `-Dvt-safe`. Every step's
dependency mode is now identical with and without the option:

| step | root module | dependencies |
|---|---|---|
| `ghostty`, `ghostty-static`, `ghostty` (dll) | `-Doptimize`, raised by `-Dvt-safe` | `-Doptimize`, never raised |
| `ghostty-bench` | ReleaseFast, raised by `-Dvt-safe` | ReleaseFast, never raised |
| `ghostty-gen` | ReleaseFast, never raised | ReleaseFast, never raised |
| `ghostty-test` | Debug, never raised | Debug, never raised |

**C and C++ compiled into the raised module does move.** `src/stb/stb.c` and
`src/simd/*.cpp` go through `addCSourceFiles` on the step's root module, so
they follow that module's mode. On Windows, ReleaseSafe adds
`-D_FORTIFY_SOURCE` and changes the sanitizer settings, on both ABIs. So
`-Dvt-safe` is not a Zig-only change, and the headline size delta below is not
purely Zig codegen.

With the option off, the build graph is unchanged: `Config.addOptions` emits
neither `vt_safe` nor `optimize`, `zigOptimize()` returns `self.optimize`, and
every dependency mode above equals what the base computed.

## Stack protector: measured scope

Measured with an isolated `zig build-lib ... --verbose-cc` on a **cold cache
per row** (`--verbose-cc` prints nothing on a cache hit, which is an easy false
negative). Identical on `x86_64-windows-msvc` and `x86_64-windows-gnu`:

| Mode | What Zig already passes by default |
|---|---|
| Debug | `-fstack-protector-strong`, `-fsanitize=undefined` |
| ReleaseSafe | `-fstack-protector-strong`, `_FORTIFY_SOURCE`, `-fsanitize=undefined`, `-fsanitize-trap=undefined` |
| ReleaseFast | `-fno-stack-protector` |
| ReleaseSmall | `-fno-stack-protector` |

So these sources were **not** unprotected in every mode. The real effect of the
commit is confined to **ReleaseFast and ReleaseSmall**, the two modes where Zig
explicitly turns the protector off. The per-file flag is appended after Zig's
own on the clang command line (measured: index 35 vs index 812) and clang is
last-wins, so it takes.

**On the shipped Windows DLL this is a no-op.** All three sites miss
`x86_64-windows-msvc` for the `.lib` artifact:

| Site | On msvc |
|---|---|
| `src/stb/stb.c` | msvc takes the ubsan branch instead, no protector flag |
| `src/simd/*.cpp` | gated `if (!is_msvc)` |
| `vendor/glad/src/gl.c` | gated `if (step.kind != .lib)`, so it is excluded from the dll and every archive. It has **no** ABI gate, so it does reach msvc executables and test binaries -- harmless, Zig links those itself |

Both gates test the ABI only and never the optimize mode, so this is structural
rather than mode-dependent. Real new coverage is macOS, `x86_64-linux-gnu` and
`x86_64-windows-gnu` in ReleaseFast and ReleaseSmall. Worth stating plainly:
the commit's motivation is stb decoding untrusted image bytes and SIMD reading
terminal bytes, and it does **not** deliver that on the artifact this fork
actually ships.

**Why msvc is excluded.** The archive at risk is `ghostty-static.lib`
(`GhosttyLib.initStatic`), which MSVC `link.exe` consumes for the NativeAOT
image. Per-file cflags are appended after the module-level setting, so an
ungated flag would put `__security_cookie` references into an archive Zig never
links itself, and no `zig build` and no `dotnet build` reaches `link.exe` --
the same trap `pkg/sentry/build.zig` documents, where that gap kept a four-tier
gate green while no release could link.

It is specifically **not** `ghostty-vt`: `GhosttyLibVt` never calls
`SharedDeps.add` (it reaches `addSimd` directly), so `stb.c` cannot land in the
vt library at all. Narrowing the gate to `ghostty-vt` would re-open the real
failure on `ghostty-static.lib`. The comment in the source now says so.

**`ghostty-static.lib` does not set `stack_protector = false`.** The only
module-level disable in the repo is `GhosttyLibVt.zig`, gated on windows +
static + msvc. Whether `ghostty-static.lib` needs the same carve-out is left
open here: it is pre-existing, unchanged by this branch, and `-Dvt-safe` is the
only thing on this branch that could make it reachable (a ReleaseSafe static
lib would take Zig's default `-fstack-protector-strong` on its C). Flagged
rather than fixed, because it is a separate change.

## `windows-gnu` takes the protector fine

This was previously listed as untested. It is now settled: the app cross-builds
`x86_64-windows-gnu` ReleaseFast with the flag on the real compiler
invocations, and an isolated probe -- a static archive built with
`-fstack-protector-strong` and then linked by a separate `zig build-exe` --
resolves `__stack_chk_fail`. That covers CI and everything this fork does. It
does not exercise a non-Zig mingw `ld` consumer, which has no known user.

## Why freetype is narrowed and highway and simdutf are not

The reason originally recorded for all three was a link failure: someone
linking our static archive with their own linker has no Zig UBSan runtime, so
`__ubsan_handle_*` goes unresolved. That is a real Debug-only problem.
ReleaseSafe emits no runtime calls, so the link argument does not apply there,
but it does emit traps, and a trap is a crash -- and the macOS app ships
ReleaseSafe (`.github/workflows/release-tip.yml`), so that crash would be in a
signed, distributed application.

**freetype: narrowed, on a measurement.** The link rationale was never
freetype's rationale. Its flag dates from 2022, when Zig bundled no UBSan
runtime at all and the safe modes only trapped, so the flag could only ever
have been suppressing a trap. The narrowing rests on measurement: freetype
built from the vendored sources with the exact ReleaseSafe sanitizer
configuration, 2,880 real faces and 4,240,962 glyph loads and renders across
three pixel sizes and three hinting targets, **zero traps**, with a positive
control on the same flags exiting `0xC000001D` to prove the traps were armed.
Not covered: CFF/Type2 and Type1 outlines (no CFF-flavoured font on the host),
malformed or adversarial fonts, and freetype's PNG path for `CBDT`/`sbix`.
Exposure on the one shipped ReleaseSafe artifact is small anyway: the macOS
font backend is CoreText, and freetype is linked there only because Dear ImGui
needs it, so its only input is one embedded font the app ships itself. If a
trap appears, restoring the blanket flag is a one-line revert.

**highway and simdutf: not narrowed.** These are SIMD libraries, the class most
likely to lean on deliberate undefined behaviour, and simdutf is the code that
validates and transcodes every byte the terminal reads. Nobody has run either
with traps armed on anything, let alone on terminal input. Arming them in the
mode the macOS app ships would be shipping crash risk with no measurement
behind it, so the blanket disable stays and the comment now says what would
have to happen first.

## Coverage: nothing in this PR is pinned by a test

Stated plainly rather than left implicit. `src/build/test.zig` is the
collection root for build-time code and its header says *"One import per file.
A file that is not listed here has no tests running."* It lists two files, and
neither is touched here. None of the eleven files this PR touches contains a
`test` block. So **zero of this PR's effects are verified by a test that would
fail if a flag stopped being passed** -- `zigOptimize`'s four-arm switch, the
dependency-optimize parameter and its six call sites, all three
`-fstack-protector-strong` sites, and the four `pkg/*/build.zig` UBSan gates
all rest on a build succeeding and on reading the build graph by hand.

The dependency-optimize inversion described above is the concrete cost of that:
a one-line expression, in exactly the untested spot, wrong in a way that
silently corrupts a measurement, which survived a full first-round review. No
test harness for build flags is added here; that is a separate piece of work.

## What was built

- `zig build -Dapp-runtime=none` (native `x86_64-windows-msvc`, Debug):
  106/106 steps succeeded.
- `zig build -Dtarget=x86_64-windows-gnu -Dapp-runtime=none
  -Doptimize=ReleaseFast`: 105/105 steps succeeded. This is the gate that
  matters for the UBSan commits -- the freetype, highway and simdutf changes
  differ from the base only outside Debug, so a Debug build does not exercise
  them at all. It is also the ABI where `-fstack-protector-strong` is actually
  applied.
- `zig fmt --check` on all eleven touched files: clean.
- Build-graph matrix via `zig build --list-steps` across `-Doptimize` x
  `-Dvt-safe` x target, with `SharedDeps.add` instrumented (instrumentation
  reverted afterwards).

## Unverified

**The DLL size number is not verified and no figure is quoted.** Three attempts
in the round-2 review and one more here all died inside the **shared** central
zig cache, not in this branch: `native-native-msvc` ReleaseFast fails on cache
object `e18cbe5c72997b4cf70dd49dec82d5b7`, whose directory contains only a
2-byte `size` file and no `simdutf.lib`. The same object hash failed across two
independent sessions. Clearing it would mean touching a cache other sessions
are actively using, so it was left alone and flagged instead. The number also
has to be re-taken after this rebase regardless: the base now forces
`strip = deps.config.strip and !win_msvc` and installs a PDB for this exact
artifact, so dll size behaviour on the merged result is not what the branch was
originally measured with. And per the `-Dvt-safe` section, any such delta is
not purely Zig codegen.

Throughput numbers are likewise not quoted: the machine runs several agents'
builds concurrently and two measurement passes disagreed by two to three times.
Both numbers need an idle machine.

## Things a reviewer should know

- The asymmetry in the UBSan changes is deliberate. dcimgui, harfbuzz, libpng,
  oniguruma, sentry, wuffs and zlib have their own already-gated
  `-fno-sanitize=undefined` hits that were left alone; freetype is now the only
  vendored dependency with UBSan armed in ReleaseSafe.
- `src/simd/*.cpp`, where Highway's vector headers actually get instantiated,
  disables UBSan only on Windows. So on macOS ReleaseSafe those objects already
  compile with traps armed today, unchanged by this branch. Pre-existing
  exposure this PR neither adds nor removes, and worth its own look.
- `-Dvt-safe` leaves no record in the artifact, the version string or
  `build_options` that it was used. Fine for an investigative flag; a trap if
  the default is ever flipped, or if a support case needs to know which binary
  a user ran.
- `GhosttyZig.zig` still keys `terminalOptions` off `cfg.optimize` while the
  module uses `cfg.zigOptimize()`. Harmless today -- `slow_runtime_safety` is
  `optimize == .Debug`, and `zigOptimize` only maps ReleaseFast/ReleaseSmall to
  ReleaseSafe, so the two expressions cannot disagree. Left alone rather than
  folded into this PR.

## Pre-existing failures, confirmed pre-existing

- `-Dtarget=x86_64-linux-gnu -Doptimize=ReleaseSafe` fails in
  `b.addTranslateC` on `src/pty.c`: `_FORTIFY_SOURCE` reaches translate-c and
  produces a `bool` where a `c_int` is wanted. Nothing under `pkg/` can reach
  it and this branch does not touch `src/pty.zig` or `src/pty.c`. `-Dvt-safe`
  does not trip it: `addTranslateC` receives the dependency mode, which is not
  raised.
- `pkg/highway`'s standalone test step is broken with or without any build:
  `pkg/highway/src/main.zig:11` imports `runtime_detect.zig`, which does not
  exist.
- `pkg/freetype`'s standalone test step passes 7/7 in Debug. It fails only
  under `-Doptimize=ReleaseSafe`, and only in the Zig test module's cimport;
  the library itself compiles fine in that mode.
- A `translate-c` warning about unknown `-fno-sanitize` arguments appears on
  `hb_c.h`. Those flags come from `pkg/harfbuzz/build.zig`, which this branch
  does not touch.
