### PR TITLE
windows: tell the user when the renderer stops painting

### DIFF
--- a/windows/Ghostty.Core/Interop/GhosttyActions.cs
+++ b/windows/Ghostty.Core/Interop/GhosttyActions.cs
@@ -62,6 +62,9 @@ internal enum GhosttyActionTag
     MouseShape = 38,
     MouseVisibility = 39,
     MouseOverLink = 40,
+    // The renderer started or stopped painting this surface. On Windows the
+    // only thing that raises it is a lost GPU device and the rebuild after it.
+    RendererHealth = 41,
     OpenConfig = 42,
     FloatWindow = 44,
     ReloadConfig = 49,

--- a/windows/Ghostty.Core/Renderer/RendererHealth.cs
+++ b/windows/Ghostty.Core/Renderer/RendererHealth.cs
@@ -1,0 +1,22 @@
+namespace Ghostty.Core.Renderer;
+
+/// <summary>
+/// Whether a surface's renderer is drawing. Mirrors
+/// <c>ghostty_action_renderer_health_e</c> in include/ghostty.h
+/// (renderer.Health in src/renderer.zig).
+/// </summary>
+/// <remarks>
+/// Unhealthy means the surface is not painting: on Windows that is a lost
+/// GPU device (a TDR, a driver upgrade, an adapter pulled out) and the
+/// renderer is rebuilding everything it owned. Healthy again means the
+/// rebuild landed. A surface the renderer has given up on stays unhealthy.
+///
+/// The ordinals are ABI, not an implementation detail: they arrive as a raw
+/// int in the action payload. GhosttyActionTagHeaderParityTests reads them
+/// out of include/ghostty.h and checks both directions.
+/// </remarks>
+public enum RendererHealth
+{
+    Healthy = 0,
+    Unhealthy = 1,
+}

--- a/windows/Ghostty.Core/Renderer/RendererHealthNoticeSource.cs
+++ b/windows/Ghostty.Core/Renderer/RendererHealthNoticeSource.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using Ghostty.Core.Notifications;
+
+namespace Ghostty.Core.Renderer;
+
+/// <summary>
+/// Turns the renderer's per-surface <see cref="RendererHealth"/> reports into
+/// one banner that is up for exactly as long as some pane is not painting.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Without this the signal is invisible. A lost GPU device leaves the pane
+/// showing whatever was on it when the device died, so a frozen terminal looks
+/// identical to a terminal with nothing to say, and the only trace is a Zig
+/// <c>log.warn</c> in a file nobody opens.
+/// </para>
+/// <para>
+/// Membership rather than a last-one-wins flag, because a device loss is an
+/// adapter-wide event: every pane reports unhealthy at once and each reports
+/// healthy again as its own rebuild lands. Taking the banner down on the first
+/// healthy report would clear it while other panes are still dark. Callers
+/// must <see cref="Forget"/> a surface that goes away, or a pane closed while
+/// broken leaves the banner up with nothing left to fix it.
+/// </para>
+/// <para>
+/// Unlike <see cref="CustomShaderNoticeSource"/> there is no once-per-session
+/// gate. That one describes a static config mistake, where the second telling
+/// adds nothing; this describes the live state of the GPU, and a device that
+/// dies again an hour later is news again.
+/// </para>
+/// <para>
+/// UI-free and dependency-free so the bookkeeping and the copy unit-test
+/// without a WinUI runtime. Not thread-safe: call it on the UI thread like
+/// everything else touching <see cref="INotificationService"/>.
+/// </para>
+/// </remarks>
+public sealed class RendererHealthNoticeSource
+{
+    /// <summary>
+    /// One key for every pane, so an adapter-wide loss shows a single banner
+    /// rather than one per pane.
+    /// </summary>
+    public const string DedupKey = "renderer-health";
+
+    // The surfaces that last reported unhealthy. A set rather than a count so
+    // a surface repeating itself -- which it does, health is reported per
+    // frame-completion, not per change, on some paths -- cannot inflate it.
+    private readonly HashSet<nint> _unhealthy = new();
+
+    // The banner currently on screen, kept because Dismiss takes the instance.
+    private Notice? _active;
+
+    // Set when the viewer closed the banner themselves. Distinct from _active
+    // being null, because the two mean opposite things for what to do next:
+    // no banner because the outage ended, versus no banner because they have
+    // already read this one and put it away.
+    private bool _dismissedByViewer;
+
+    /// <summary>
+    /// Record what one surface reported.
+    /// </summary>
+    /// <returns>
+    /// What to do about the banner. Both halves are null when nothing changed,
+    /// which is the common case.
+    /// </returns>
+    public RendererHealthNoticeChange Update(nint surface, RendererHealth health)
+    {
+        var changed = health == RendererHealth.Unhealthy
+            ? _unhealthy.Add(surface)
+            : _unhealthy.Remove(surface);
+
+        return changed ? Reconcile() : default;
+    }
+
+    /// <summary>
+    /// Drop a surface that is going away. Call this when the surface is torn
+    /// down, not when it moves between windows.
+    /// </summary>
+    /// <returns>What to do about the banner.</returns>
+    public RendererHealthNoticeChange Forget(nint surface) =>
+        _unhealthy.Remove(surface) ? Reconcile() : default;
+
+    private RendererHealthNoticeChange Reconcile()
+    {
+        if (_unhealthy.Count > 0)
+        {
+            // One banner per outage. A viewer who closed it is not shown it
+            // again while the same panes are still down; the flag clears when
+            // they all recover, so the next outage speaks up.
+            if (_active is not null || _dismissedByViewer) return default;
+
+            // OnDismiss fires for our own Dismiss as well as for the close X,
+            // and only the second one should latch. Comparing against _active
+            // tells them apart: the recovery path below always clears _active
+            // before handing the notice back, so by the time that dismissal
+            // lands this no longer matches.
+            Notice? raised = null;
+            raised = Build(() =>
+            {
+                if (ReferenceEquals(_active, raised)) _dismissedByViewer = true;
+            });
+            _active = raised;
+            return new RendererHealthNoticeChange(Show: raised, Dismiss: null);
+        }
+
+        _dismissedByViewer = false;
+        if (_active is null) return default;
+        var stale = _active;
+        _active = null;
+        return new RendererHealthNoticeChange(Show: null, Dismiss: stale);
+    }
+
+    private static Notice Build(Action onDismiss) => new()
+    {
+        Title = "Graphics device lost",
+        Message =
+            "The GPU stopped responding and Wintty is trying to rebuild the "
+            + "renderer. Affected panes stay frozen until it succeeds, and some "
+            + "may not come back at all. This usually follows a graphics driver "
+            + "update or crash; if it keeps happening, check for a driver update "
+            + "and try clearing custom-shader.",
+        // Warning, not Error: the terminal session itself is untouched -- the
+        // shell keeps running and the scrollback is intact -- so nothing the
+        // user typed is at risk even when a pane never repaints.
+        Severity = NoticeSeverity.Warning,
+        DedupKey = DedupKey,
+        // Fires for the close X as well as our own Dismiss, which is why the
+        // flag it sets is checked rather than assumed: without it this source
+        // would go on believing a banner the viewer closed is still up, and
+        // never raise another one.
+        OnDismiss = onDismiss,
+        // No actions. Nothing here can hurry a driver along, and the one thing
+        // the user might change (custom-shader) is named in the copy rather
+        // than given a button that would edit their config for them.
+    };
+}
+
+/// <summary>
+/// What <see cref="RendererHealthNoticeSource"/> wants done about the banner.
+/// At most one half is set; both are null when nothing changed.
+/// </summary>
+public readonly record struct RendererHealthNoticeChange(Notice? Show, Notice? Dismiss);

--- a/windows/Ghostty.Tests/Interop/GhosttyActionTagHeaderParityTests.cs
+++ b/windows/Ghostty.Tests/Interop/GhosttyActionTagHeaderParityTests.cs
@@ -114,6 +114,11 @@ public class GhosttyActionTagHeaderParityTests
         AssertMatchesHeader<CustomShaderFailure>(
             "ghostty_action_custom_shader_failure_e", "GHOSTTY_CUSTOM_SHADER_FAILURE_");
 
+    [Fact]
+    public void RendererHealth_Ordinals_Match_Header() =>
+        AssertMatchesHeader<RendererHealth>(
+            "ghostty_action_renderer_health_e", "GHOSTTY_RENDERER_HEALTH_");
+
     // GhosttyGotoTab is the one enum here whose header entries carry explicit
     // values, and they are negative sentinels rather than positions. Read with
     // `explicitValues`, which parses `= N` instead of counting: refusing it

--- a/windows/Ghostty.Tests/Renderer/RendererHealthNoticeSourceTests.cs
+++ b/windows/Ghostty.Tests/Renderer/RendererHealthNoticeSourceTests.cs
@@ -1,0 +1,216 @@
+using Ghostty.Core.Notifications;
+using Ghostty.Core.Renderer;
+using Xunit;
+
+namespace Ghostty.Tests.Renderer;
+
+public class RendererHealthNoticeSourceTests
+{
+    // Stand-in surface handles. Only their distinctness matters.
+    private static readonly nint PaneA = 1;
+    private static readonly nint PaneB = 2;
+
+    [Fact]
+    public void First_unhealthy_pane_raises_a_closable_warning_with_no_actions()
+    {
+        var change = new RendererHealthNoticeSource().Update(PaneA, RendererHealth.Unhealthy);
+
+        Assert.NotNull(change.Show);
+        Assert.Null(change.Dismiss);
+        Assert.Equal("Graphics device lost", change.Show!.Title);
+        Assert.Equal(NoticeSeverity.Warning, change.Show.Severity);
+        Assert.Equal(RendererHealthNoticeSource.DedupKey, change.Show.DedupKey);
+        Assert.Empty(change.Show.Actions);
+        Assert.True(change.Show.IsClosable);
+        Assert.NotEqual(string.Empty, change.Show.Message);
+    }
+
+    [Fact]
+    public void A_healthy_report_from_a_pane_that_was_never_broken_says_nothing()
+    {
+        var change = new RendererHealthNoticeSource().Update(PaneA, RendererHealth.Healthy);
+
+        Assert.Null(change.Show);
+        Assert.Null(change.Dismiss);
+    }
+
+    [Fact]
+    public void Recovery_dismisses_the_banner_that_was_raised()
+    {
+        var source = new RendererHealthNoticeSource();
+        var raised = source.Update(PaneA, RendererHealth.Unhealthy).Show;
+
+        var change = source.Update(PaneA, RendererHealth.Healthy);
+
+        Assert.Same(raised, change.Dismiss);
+        Assert.Null(change.Show);
+    }
+
+    [Fact]
+    public void A_repeated_unhealthy_report_does_not_raise_a_second_banner()
+    {
+        var source = new RendererHealthNoticeSource();
+        Assert.NotNull(source.Update(PaneA, RendererHealth.Unhealthy).Show);
+
+        var again = source.Update(PaneA, RendererHealth.Unhealthy);
+
+        Assert.Null(again.Show);
+        Assert.Null(again.Dismiss);
+    }
+
+    [Fact]
+    public void The_banner_stays_up_until_the_last_broken_pane_recovers()
+    {
+        // The case a last-one-wins flag gets wrong. A device loss is
+        // adapter-wide, so both panes report unhealthy and then recover
+        // independently; clearing on the first recovery would take the banner
+        // down while the other pane is still frozen.
+        var source = new RendererHealthNoticeSource();
+        var raised = source.Update(PaneA, RendererHealth.Unhealthy).Show;
+        Assert.NotNull(raised);
+        Assert.Null(source.Update(PaneB, RendererHealth.Unhealthy).Show);
+
+        Assert.Null(source.Update(PaneA, RendererHealth.Healthy).Dismiss);
+
+        Assert.Same(raised, source.Update(PaneB, RendererHealth.Healthy).Dismiss);
+    }
+
+    [Fact]
+    public void Forgetting_the_last_broken_pane_takes_the_banner_down()
+    {
+        // A pane closed while its renderer is down never reports healthy
+        // again, so the banner would otherwise outlive everything it refers to.
+        var source = new RendererHealthNoticeSource();
+        var raised = source.Update(PaneA, RendererHealth.Unhealthy).Show;
+
+        Assert.Same(raised, source.Forget(PaneA).Dismiss);
+    }
+
+    [Fact]
+    public void Forgetting_a_pane_that_was_fine_says_nothing()
+    {
+        var source = new RendererHealthNoticeSource();
+        var raised = source.Update(PaneA, RendererHealth.Unhealthy).Show;
+
+        var change = source.Forget(PaneB);
+
+        Assert.Null(change.Show);
+        Assert.Null(change.Dismiss);
+
+        // And the banner PaneA raised is still the live one.
+        Assert.Same(raised, source.Update(PaneA, RendererHealth.Healthy).Dismiss);
+    }
+
+    [Fact]
+    public void A_later_loss_raises_the_banner_again()
+    {
+        // Unlike the custom-shader notice there is no once-per-session gate:
+        // a device that dies again is a new fact about the machine, not a
+        // repeat of a config mistake the user has already been told about.
+        var source = new RendererHealthNoticeSource();
+        var first = source.Update(PaneA, RendererHealth.Unhealthy).Show;
+        source.Update(PaneA, RendererHealth.Healthy);
+
+        var second = source.Update(PaneA, RendererHealth.Unhealthy).Show;
+
+        Assert.NotNull(second);
+        Assert.NotSame(first, second);
+    }
+
+    [Fact]
+    public void Forgetting_one_of_several_broken_panes_leaves_the_banner_up()
+    {
+        var source = new RendererHealthNoticeSource();
+        var raised = source.Update(PaneA, RendererHealth.Unhealthy).Show;
+        source.Update(PaneB, RendererHealth.Unhealthy);
+
+        // Closing one broken pane does not mean the others came back.
+        var change = source.Forget(PaneA);
+        Assert.Null(change.Show);
+        Assert.Null(change.Dismiss);
+
+        Assert.Same(raised, source.Forget(PaneB).Dismiss);
+    }
+
+    [Fact]
+    public void A_banner_the_viewer_closed_does_not_come_back_during_the_same_outage()
+    {
+        var source = new RendererHealthNoticeSource();
+        var raised = source.Update(PaneA, RendererHealth.Unhealthy).Show;
+        Assert.NotNull(raised);
+
+        // The close X, which the service reports through OnDismiss.
+        raised!.OnDismiss!();
+
+        // Another pane goes dark. They have already been told.
+        var change = source.Update(PaneB, RendererHealth.Unhealthy);
+        Assert.Null(change.Show);
+        Assert.Null(change.Dismiss);
+    }
+
+    [Fact]
+    public void A_banner_the_viewer_closed_comes_back_for_the_next_outage()
+    {
+        var source = new RendererHealthNoticeSource();
+        var first = source.Update(PaneA, RendererHealth.Unhealthy).Show;
+        first!.OnDismiss!();
+
+        // Everything recovers, so the next loss is a new event rather than
+        // a repeat of the one they put away.
+        source.Update(PaneA, RendererHealth.Healthy);
+        var second = source.Update(PaneA, RendererHealth.Unhealthy).Show;
+
+        Assert.NotNull(second);
+        Assert.NotSame(first, second);
+    }
+
+    [Fact]
+    public void Our_own_dismissal_is_not_mistaken_for_the_viewer_closing_it()
+    {
+        // OnDismiss fires for both. If the source could not tell them apart it
+        // would think the viewer had put the banner away, and stay silent for
+        // the whole of the next outage.
+        var source = new RendererHealthNoticeSource();
+        var first = source.Update(PaneA, RendererHealth.Unhealthy).Show;
+
+        var dismiss = source.Update(PaneA, RendererHealth.Healthy).Dismiss;
+        Assert.Same(first, dismiss);
+        dismiss!.OnDismiss!();
+
+        Assert.NotNull(source.Update(PaneA, RendererHealth.Unhealthy).Show);
+    }
+
+    [Fact]
+    public void The_copy_never_claims_the_session_was_lost()
+    {
+        // The shell keeps running and the scrollback is intact through a
+        // device loss; copy that implied otherwise would send the user
+        // rebuilding a session that never went away.
+        var notice = new RendererHealthNoticeSource().Update(PaneA, RendererHealth.Unhealthy).Show;
+
+        Assert.NotNull(notice);
+        var text = notice!.Title + " " + notice.Message;
+        foreach (var word in new[] { "closed", "lost your", "restart", "reopen" })
+        {
+            Assert.DoesNotContain(word, text, System.StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
+    public void The_copy_never_promises_the_renderer_comes_back()
+    {
+        // A surface the renderer has given up on stays dark for the life of
+        // the tab. Copy saying the rebuild finishes would leave that user
+        // waiting on something that is never going to happen.
+        var notice = new RendererHealthNoticeSource().Update(PaneA, RendererHealth.Unhealthy).Show;
+
+        Assert.NotNull(notice);
+        foreach (var phrase in new[] { "until it finishes", "will be back", "shortly" })
+        {
+            Assert.DoesNotContain(phrase, notice!.Message, System.StringComparison.OrdinalIgnoreCase);
+        }
+
+        // And says so positively, rather than only avoiding the promise.
+        Assert.Contains("may not come back", notice!.Message, System.StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/RendererHealthNoticeWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/RendererHealthNoticeWiringTests.cs
@@ -1,0 +1,100 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// The banner's bookkeeping is unit-tested in RendererHealthNoticeSourceTests.
+/// What that cannot reach is whether the WinUI host actually asks it anything,
+/// which lives in the action switch and in surface teardown.
+///
+/// Both halves are load-bearing in a way a compiler cannot see. A handler that
+/// shows and never dismisses leaves a "graphics device lost" banner on screen
+/// after the device came back; a teardown that never forgets leaves the same
+/// banner up after the only broken pane has been closed, with nothing left
+/// that could ever clear it.
+/// </summary>
+public class RendererHealthNoticeWiringTests
+{
+    private static ShellSource Host() => ShellSource.Load("Hosting.GhosttyHost.cs");
+
+    [Fact]
+    public void TheHealthCase_AppliesBothHalvesOfTheChange()
+    {
+        var section = Host().Case("OnAction", "RendererHealth");
+
+        Assert.Single(section.Calls("_rendererHealthNotices.Update"));
+        Assert.Equal("show", section.Call("notifications.Show").Arg(0));
+        Assert.Equal("dismiss", section.Call("notifications.Dismiss").Arg(0));
+    }
+
+    [Fact]
+    public void PreviewSurfaces_LeaveTheHealthCaseImmediately()
+    {
+        var section = Host().Case("OnAction", "RendererHealth");
+
+        // A gallery preview owns a separate device. Its loss says nothing about
+        // the terminal the user is working in, and the copy would send them
+        // looking in the wrong place. Handled, not unhandled: returning 0 would
+        // let libghostty treat the action as unconsumed.
+        var guard = Assert.Single(
+            section.DescendantNodes().OfType<IfStatementSyntax>(),
+            s => s.Condition.ToString() == "control.IsPreviewSurface");
+        Assert.Equal("return 1;", guard.Statement.ToString());
+        Assert.True(
+            guard.SpanStart < section.Call("_rendererHealthNotices.Update").SpanStart,
+            "the preview guard must precede _rendererHealthNotices.Update");
+    }
+
+    [Fact]
+    public void ClosingASurface_ForgetsItsHealth_AndAppliesTheDismissal()
+    {
+        var unregister = Host().Method("Unregister");
+
+        Assert.Single(unregister.Calls("_rendererHealthNotices.Forget"));
+
+        // The dismissal half matters as much as the Forget: without it the
+        // banner survives the close of the only pane that was ever broken,
+        // and nothing left alive can clear it.
+        Assert.Single(unregister.Calls("notifications.Dismiss"));
+        Assert.Equal("dismiss", unregister.Call("notifications.Dismiss").Arg(0));
+    }
+
+    [Fact]
+    public void BothHealthPaths_GoThroughTheDispatcher()
+    {
+        // Two reasons, and the second is the one that bites. The source is
+        // documented UI-thread-only and shared statically across windows, so
+        // hoisting either call out of a lambda is a silent data race. And they
+        // must share the queue: OnAction decodes off-thread and enqueues its
+        // Update, so a synchronous Forget racing a device loss runs first,
+        // finds nothing, and lets the Update strand a dead surface in the set.
+        var host = Host();
+
+        foreach (var (method, call) in new[]
+                 {
+                     ("OnAction", "_rendererHealthNotices.Update"),
+                     ("Unregister", "_rendererHealthNotices.Forget"),
+                 })
+        {
+            var enqueued = host.Method(method)
+                .Calls("_dispatcher.TryEnqueue")
+                .Any(e => e.Calls(call).Count == 1);
+
+            Assert.True(enqueued, $"{call} must sit inside a _dispatcher.TryEnqueue in {method}");
+        }
+    }
+
+    [Fact]
+    public void MovingASurfaceBetweenWindows_KeepsItsHealth()
+    {
+        // Detach is the other half of a cross-window pane move, not a teardown:
+        // the surface and its renderer live on under a different host. Forgetting
+        // there would clear the banner for a pane that is still dark, and no
+        // later report would bring it back -- the renderer only raises the
+        // action on a change, and from its side nothing changed.
+        Assert.Empty(Host().Method("Detach").Calls("_rendererHealthNotices.Forget"));
+    }
+}

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -168,6 +168,12 @@ internal sealed partial class GhosttyHost : IDisposable
     // lambda below, and every window in this app shares that thread.
     private static readonly Ghostty.Core.Renderer.CustomShaderNoticeSource _customShaderNotices = new();
 
+    // Which surfaces the renderer has stopped painting, and the banner that
+    // says so. Static for the same reason as the gate above: a host is
+    // per-window, but a GPU device is lost adapter-wide, so the panes reporting
+    // in are spread across every window and only one banner should result.
+    private static readonly Ghostty.Core.Renderer.RendererHealthNoticeSource _rendererHealthNotices = new();
+
     public GhosttyApp App => _app;
 
     /// <summary>
@@ -309,6 +315,34 @@ internal sealed partial class GhosttyHost : IDisposable
         if (surface.Handle == IntPtr.Zero) return;
         _surfaces.TryRemove(surface.Handle, out _);
         Ghostty.App.UnregisterSurfaceRoute(surface.Handle, this);
+
+        // A pane closed while its renderer was down will never report itself
+        // healthy again, so without this the banner outlives the problem.
+        // Deliberately not in Detach: that moves a surface between windows and
+        // the renderer's state travels with it.
+        //
+        // Enqueued, not called here, even though this already runs on the UI
+        // thread. OnAction decodes on libghostty's thread and enqueues its
+        // Update, so a close racing a device loss can reach this first: the
+        // synchronous Forget would find an empty set, and the Update behind it
+        // would then add a surface that no longer exists. Nothing would ever
+        // clear it, and because one banner suppresses the next, every later
+        // loss would be silent too. Going through the same queue restores the
+        // order. It also keeps the handle safe to use as a key after
+        // SurfaceFree below: a reused address can only be added by a later
+        // Update, which is queued behind this.
+        var handle = surface.Handle;
+        _dispatcher.TryEnqueue(() =>
+        {
+            // Forget first, then guard -- the opposite order to the action
+            // case, deliberately. There the guard comes first so the set is
+            // never mutated without the change being applied; here the surface
+            // is gone whether or not there is anywhere to show it, and a
+            // missing service means shutdown, when no banner matters anyway.
+            var change = _rendererHealthNotices.Forget(handle);
+            if (Ghostty.App.NotificationService is not { } notifications) return;
+            if (change.Dismiss is { } dismiss) notifications.Dismiss(dismiss);
+        });
     }
 
     /// <summary>
@@ -1000,6 +1034,33 @@ internal sealed partial class GhosttyHost : IDisposable
                         if (Ghostty.App.NotificationService is not { } notifications) return;
                         if (_customShaderNotices.Resolve(failure) is { } notice)
                             notifications.Show(notice);
+                    });
+                    return 1;
+                }
+
+                case GhosttyActionTag.RendererHealth:
+                {
+                    // The renderer stopped or resumed painting this surface.
+                    // On Windows the only cause is a lost GPU device, and the
+                    // pane keeps showing the last frame it managed to draw --
+                    // so a frozen terminal is indistinguishable from an idle
+                    // one unless we say something.
+                    //
+                    // A preview surface is skipped for the same reason the
+                    // shader notice skips it: a gallery preview owns its own
+                    // device, so its loss says nothing about the terminal the
+                    // user is working in, and the copy would send them looking
+                    // for a problem in the wrong place.
+                    if (control.IsPreviewSurface) return 1;
+
+                    var health = (Ghostty.Core.Renderer.RendererHealth)
+                        Marshal.ReadInt32(actionPtr, 8);
+                    _dispatcher.TryEnqueue(() =>
+                    {
+                        if (Ghostty.App.NotificationService is not { } notifications) return;
+                        var change = _rendererHealthNotices.Update(surfaceHandle, health);
+                        if (change.Show is { } show) notifications.Show(show);
+                        if (change.Dismiss is { } dismiss) notifications.Dismiss(dismiss);
                     });
                     return 1;
                 }


### PR DESCRIPTION
Follow-up from #1014. Sixth item of #1025.

libghostty has raised `GHOSTTY_ACTION_RENDERER_HEALTH` all along and the Windows
shell has never had a `GhosttyActionTag` member for it, so every report fell
through to "return false". Since #1014 that action is the only outward sign of a
lost GPU device: the pane keeps showing whatever frame was on it when the device
died, which looks exactly like a terminal with nothing to say, and the only trace
is a `log.warn` in a file nobody opens.

Adds the tag at ordinal 41, a `RendererHealth` payload enum, and a notice source
that turns the per-surface reports into one banner.

Membership rather than a last-one-wins flag, because a device loss is
adapter-wide: every pane reports unhealthy at once and each reports healthy again
as its own rebuild lands, so clearing on the first healthy report would take the
banner down while other panes are still frozen.

**Both halves go through the dispatcher, and that is load-bearing.** `OnAction`
decodes on libghostty's thread and enqueues its `Update`, so a tab closed during
a device loss could reach a synchronous `Forget` first: it would find an empty
set, and the `Update` behind it would add a surface that no longer exists.
Nothing could ever clear that, and because one banner suppresses the next, every
later loss would be silent too. Sharing the queue restores the order, and keeps
the handle safe as a key after the surface is freed, since a reused address can
only be added by a later `Update` queued behind the `Forget`.

Teardown forgets the pane. `Detach` deliberately does not, because a cross-window
move carries the renderer state with it.

**The banner does not promise the renderer comes back.** A surface the renderer
has given up on stays dark for the life of the tab -- reachable today through
composition mode, and more so with #1048 -- so copy saying the rebuild finishes
would leave that user waiting for something that will never happen.

Viewer dismissal is tracked, or the source would go on believing a closed banner
is still on screen and never raise another. One banner per outage: dismissing it
does not bring it back while the same panes are down, and the flag clears when
they all recover so the next outage speaks up. The callback fires for our own
dismissal too, so it compares against the active notice to tell them apart.

No once-per-session gate, unlike the `CustomShaderNoticeSource` next to it. That
one describes a static config mistake where the second telling adds nothing; this
describes the live state of the GPU, and a device that dies again an hour later
is news again.

Preview surfaces are skipped for the same reason the shader notice skips them: a
gallery preview owns its own device.

## Verification

`dotnet test`: 3677 passed, 0 failed, 1 skipped. 20 renderer-health tests, all
green and confirmed discovered by a filtered run. `dotnet build
windows/Ghostty.sln`: succeeded, 0 errors -- needs `zig build -Dapp-runtime=none`
first or the WinUI project stops before reaching any of this.

The ordinal was re-derived against `include/ghostty.h` after a rebase moved that
header, rather than carried over.

Reviewed by two agents, one on this change and one across all three PRs. The
critical finding was the `Forget`/`Update` ordering above; the rest were the
banner outliving a user dismissal, the copy promising completion, and gaps in the
tests, all fixed here.

## Known limits, not fixed here

A pane hidden mid-outage stops drawing, so it never reports healthy and the
banner stays until the user returns to that tab. And the abandoned state is not
distinguishable on the wire: `reportHealth` dedupes on value, so the shell cannot
tell a rebuild in progress from one that will never come. That one needs a third
`renderer.Health` variant and an ABI change.
