### PR TITLE
tabs: the motion audit's first rung - one glide curve, the 167 rung, a flip that lands, and fades that ask

### DIFF
--- a/windows/Ghostty.Core/Tabs/TabStripMotion.cs
+++ b/windows/Ghostty.Core/Tabs/TabStripMotion.cs
@@ -49,6 +49,19 @@ internal static class TabStripMotion
     /// <summary>Neighbour gap motion: a short eased glide.</summary>
     public const double GapGlideMs = 250;
 
+    /// <summary>
+    /// The glide's curve: the signature-experiences table's point-to-point
+    /// cubic-bezier(0.55, 0.55, 0, 1), as the two control points a
+    /// Compositor cubic-bezier easing factory takes. Numbers rather than
+    /// an easing object because Core cannot hold composition types; the
+    /// shell passes them verbatim. One token so every gliding reflow
+    /// decelerates the same -- a pin pushed off a row end is the same
+    /// point-to-point move as the neighbour gliding one pane over, and
+    /// anything else reads as two motion systems at once.
+    /// </summary>
+    public static readonly System.Numerics.Vector2 GlideBezierP1 = new(0.55f, 0.55f);
+    public static readonly System.Numerics.Vector2 GlideBezierP2 = new(0f, 1f);
+
     /// <summary>Row lift on grab: a near-critical scale spring to a 3% grow.</summary>
     public const float LiftDampingRatio = 0.70f;
     public const double LiftPeriodMs = 50;
@@ -164,8 +177,9 @@ internal static class TabStripMotion
     /// HighContrastDetector.IsActive() COMPOSED through
     /// HighContrastState.ShouldApply, because raw IsActive diverges from
     /// the chrome whenever the user has opted out of High Contrast
-    /// themes. There is no existing animation-preference read anywhere
-    /// else in the repo to reuse.
+    /// themes. The plain preference read lives beside its callers in the
+    /// shell (the hosts' own readers and Services.SystemAnimations); this
+    /// gate is the one place the two flags compose.
     /// </summary>
     public static bool Enabled(bool animationsEnabled, bool highContrast)
         => animationsEnabled && !highContrast;

--- a/windows/Ghostty.Core/Tabs/TabSwitcherField.cs
+++ b/windows/Ghostty.Core/Tabs/TabSwitcherField.cs
@@ -172,12 +172,17 @@ internal static class TabSwitcherShape
     /// <summary>
     /// The highlight move: the ring, the dim, and the lift all cross on one
     /// clock, so the eye reads one thing moving rather than three things
-    /// changing.
+    /// changing. The table's 167ms rung -- the same one the strips' field
+    /// settle takes, because both are a selection changing hands.
     /// </summary>
-    public const int HighlightMs = 150;
+    public const int HighlightMs = 167;
 
-    /// <summary>The card's entrance, on the same table's Fade token family.</summary>
-    public const int EnterMs = 120;
+    /// <summary>
+    /// The card's entrance, on the table's 167ms rung rather than a bespoke
+    /// value: entrances land on ladder values, or the card reads as a
+    /// different motion system from every surface it arrives over.
+    /// </summary>
+    public const int EnterMs = 167;
 
     /// <summary>The distance the card rises through its entrance.</summary>
     public const double EnterRisePx = 8;

--- a/windows/Ghostty.Tests/Tabs/TabMotionFluentRungsTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabMotionFluentRungsTests.cs
@@ -1,0 +1,44 @@
+using System.Numerics;
+using Ghostty.Core.Tabs;
+using Xunit;
+
+namespace Ghostty.Tests.Tabs;
+
+/// <summary>
+/// The Fluent ladder pins: the strip and switcher motion tokens must sit
+/// on the signature-experiences rungs (83 / 167 / 250ms), and every glide
+/// must share the table's point-to-point curve. A duration that drifts off
+/// a rung -- the switcher's old 150 and 120, or a neighbour of 340's --
+/// reads as a second motion system next to every surface that stayed on
+/// the ladder; these pins turn that drift into a test failure rather than
+/// a slow discovery.
+/// </summary>
+public class TabMotionFluentRungsTests
+{
+    [Fact]
+    public void FadesAreOnThe83Rung()
+        => Assert.Equal(83, TabStripMotion.FadeMs);
+
+    [Fact]
+    public void FieldSettleIsOnThe167Rung()
+        => Assert.Equal(167, TabStripMotion.FieldSettleMs);
+
+    [Fact]
+    public void GapGlideIsOnThe250Rung()
+        => Assert.Equal(250, TabStripMotion.GapGlideMs);
+
+    [Fact]
+    public void SwitcherHighlightIsOnThe167Rung()
+        => Assert.Equal(167, TabSwitcherShape.HighlightMs);
+
+    [Fact]
+    public void SwitcherEntranceIsOnThe167Rung()
+        => Assert.Equal(167, TabSwitcherShape.EnterMs);
+
+    [Fact]
+    public void GlidesShareThePointToPointCurve()
+    {
+        Assert.Equal(new Vector2(0.55f, 0.55f), TabStripMotion.GlideBezierP1);
+        Assert.Equal(new Vector2(0f, 1f), TabStripMotion.GlideBezierP2);
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/AnimationsEnabledWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/AnimationsEnabledWiringTests.cs
@@ -1,0 +1,130 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// The reduce-motion contract's wiring guards. Two halves: the system
+/// animation-effects flip must be LISTENED for and must land the long
+/// in-flight clocks (every gate reads the flag fresh per gesture, so
+/// without a listener a clock armed before the flip plays on), and every
+/// custom animation path outside the strips must read the preference at
+/// all -- the audit found bell, glow and quake paths that never asked.
+/// </summary>
+public class AnimationsEnabledWiringTests
+{
+    private static ShellSource MainWindow() => ShellSource.Load("Ghostty.MainWindow.xaml.cs");
+
+    [Fact]
+    public void MainWindowSubscribesAndDetachesTheFlip()
+    {
+        var source = MainWindow();
+        var assignments = source.Root.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.Left.ToString() == "_systemUiSettings.AnimationsEnabledChanged")
+            .ToList();
+
+        // Exactly one subscribe and one detach, and the detach is the
+        // teardown's: UISettings is an OS object that outlives the window,
+        // so a subscription left attached points an OS callback at a
+        // closed window's strip.
+        var detach = Assert.Single(
+            assignments, a => a.IsKind(SyntaxKind.SubtractAssignmentExpression));
+        Assert.Contains(assignments, a => a.IsKind(SyntaxKind.AddAssignmentExpression));
+        Assert.Contains(source.Method("OnClosedAsync")
+            .DescendantNodes().OfType<AssignmentExpressionSyntax>(), a => ReferenceEquals(a, detach));
+
+        // The event is 19041+ and the project reaches older machines: the
+        // subscribe must be behind an ApiInformation probe, which is also
+        // what keeps the platform analyzer quiet.
+        Assert.Contains(source.Root.DescendantNodes().OfType<InvocationExpressionSyntax>(),
+            i => i.CalleeText().EndsWith(".IsEventPresent"));
+    }
+
+    [Fact]
+    public void FlipHandlerLandsStripMotionThroughTheDispatcher()
+    {
+        var handler = MainWindow().Method("OnSystemAnimationsEnabledChanged");
+
+        // The land call exists, and it sits inside a lambda: the event
+        // fires on a thread-pool thread, and the strip's clocks are UI
+        // tree state. LambdaExpressionSyntax, not one of its shapes --
+        // `() => {}` parses as the parenthesized form.
+        var land = handler.Call("_verticalTabHost.Strip.LandAllMotion");
+        Assert.True(
+            land.Ancestors().OfType<LambdaExpressionSyntax>().Any(),
+            "LandAllMotion must run inside the dispatcher hop, not on the callback thread");
+
+        // The handler reads the event's own sender rather than activating
+        // a second UISettings that could answer for a later moment.
+        var read = handler.DescendantNodes().OfType<MemberAccessExpressionSyntax>()
+            .Where(m => m.Name.Identifier.ValueText == "AnimationsEnabled").ToList();
+        Assert.Contains(read, m => m.Expression is IdentifierNameSyntax id
+            && id.Identifier.ValueText == "sender");
+    }
+
+    [Fact]
+    public void BellFadeCutsUnderReduceMotion()
+    {
+        var dismiss = ShellSource.Load("Ghostty.Controls.TerminalControl.xaml.cs")
+            .Method("DismissBellBorder");
+        Assert.Single(dismiss.Calls("Ghostty.Services.SystemAnimations.Enabled"));
+    }
+
+    [Fact]
+    public void GlowOrbitIsGated()
+    {
+        var start = ShellSource.Load("Ghostty.Panes.PaneStartupGlow.cs")
+            .Method("StartGlow");
+        Assert.Single(start.Calls("Ghostty.Services.SystemAnimations.Enabled"));
+    }
+
+    [Fact]
+    public void QuakeSlideIsGated()
+    {
+        var run = ShellSource.Load("Ghostty.Hosting.QuickTerminalSlideAnimator.cs")
+            .Method("Run");
+        Assert.Single(run.Calls("Ghostty.Services.SystemAnimations.Enabled"));
+    }
+
+    [Fact]
+    public void EveryStripGlideNamesTheSharedCurve()
+    {
+        // The pin band's reflow and every strip glide must name the same
+        // token: a square pushed off a row end is the same point-to-point
+        // move as the neighbour gliding one pane over. The rule is "every
+        // bezier factory names the token", not a usage count -- a count
+        // would punish the next glide that gets tokenized.
+        var reflow = ShellSource.Load("Ghostty.Tabs.TabPinBandPanel.cs")
+            .Method("Reflow");
+        Assert.Single(reflow.DescendantNodes().OfType<IdentifierNameSyntax>()
+            .Where(id => id.Identifier.ValueText == "GlideBezierP1"));
+
+        var strip = ShellSource.Load("Ghostty.Tabs.VerticalTabStrip.xaml.cs");
+        var beziers = strip.Root.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(i => i.CalleeText().EndsWith(".CreateCubicBezierEasingFunction"))
+            .ToList();
+        // Load-bearing floor: the drag-neighbour glide and the pin flight
+        // are two distinct call sites today.
+        Assert.True(beziers.Count >= 2,
+            $"expected at least the drag glide and pin flight bezier factories, found {beziers.Count}");
+        foreach (var call in beziers)
+        {
+            Assert.Contains(call.ArgumentList.Arguments,
+                a => a.ToString().Contains("GlideBezierP1", StringComparison.Ordinal));
+        }
+    }
+
+    [Fact]
+    public void SwitcherTracksStayIndependent()
+    {
+        // Opacity and RenderTransform scale/offset are independent
+        // properties; marking them dependent pins to the UI thread
+        // animations the compositor could carry.
+        var popup = ShellSource.Load("Ghostty.Tabs.TabSwitcherPopup.xaml.cs");
+        Assert.DoesNotContain(popup.Root.DescendantTokens(),
+            t => t.IsKind(SyntaxKind.IdentifierToken) && t.ValueText == "EnableDependentAnimation");
+    }
+}

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -503,7 +503,9 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     private BellAudioPlayer? _bellAudio;
 
     // Fade-out duration for the visual bell border once acknowledged.
-    // Matches the macOS easeInOut(duration: 0.3) bell border animation.
+    // Duration matches the macOS easeInOut(duration: 0.3) bell border
+    // animation; the curve is the exit-fade ease-out below, because a
+    // linear decay at this length reads as the border glitching away.
     private const int BellBorderFadeMs = 300;
 
     /// <summary>
@@ -546,10 +548,24 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         if (!_bellBorderActive) return;
         _bellBorderActive = false;
 
+        if (!Ghostty.Services.SystemAnimations.Enabled())
+        {
+            // Reduce-motion cut: the border leaves in the same frame the
+            // dismissal lands, rather than riding a fade under a user who
+            // told the system to stop moving things.
+            BellOverlay.Opacity = 0.0;
+            BellOverlay.Visibility = Visibility.Collapsed;
+            return;
+        }
+
         var fade = new Microsoft.UI.Xaml.Media.Animation.DoubleAnimation
         {
             To = 0.0,
             Duration = new Duration(TimeSpan.FromMilliseconds(BellBorderFadeMs)),
+            EasingFunction = new Microsoft.UI.Xaml.Media.Animation.CubicEase
+            {
+                EasingMode = Microsoft.UI.Xaml.Media.Animation.EasingMode.EaseOut,
+            },
         };
         Microsoft.UI.Xaml.Media.Animation.Storyboard.SetTarget(fade, BellOverlay);
         Microsoft.UI.Xaml.Media.Animation.Storyboard.SetTargetProperty(fade, "Opacity");

--- a/windows/Ghostty/Hosting/QuickTerminalSlideAnimator.cs
+++ b/windows/Ghostty/Hosting/QuickTerminalSlideAnimator.cs
@@ -88,6 +88,19 @@ internal sealed partial class QuickTerminalSlideAnimator : IDisposable
 
     private void Run(QuickTerminalPosition position, double width, double height, TimeSpan duration, bool appearing, Action? onCompleted)
     {
+        if (!Ghostty.Services.SystemAnimations.Enabled())
+        {
+            // Reduce-motion cut: the reveal IS the animation, so without
+            // it the run is its end state and its completion. SnapToShown
+            // owns the shown state (and the token bump that retires any
+            // in-flight tick); a hide completes straight to the Hide() it
+            // promised its caller.
+            if (appearing) SnapToShown();
+            else { _token++; StopLoop(); }
+            onCompleted?.Invoke();
+            return;
+        }
+
         var token = ++_token;
         _runToken = token;
         _position = position;

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -310,6 +310,14 @@ public sealed partial class MainWindow : Window
     private readonly WindowState _windowState;
     // Kept as a field so the ColorValuesChanged subscription is not GC'd.
     private readonly Windows.UI.ViewManagement.UISettings _systemUiSettings;
+    // The animation-effects flip event arrived in 19041 and the project
+    // still reaches down to 17763: on an older machine the only correct
+    // behavior is not to subscribe at all. ApiInformation is also the
+    // guard CA1416 recognizes, so the event use stays warning-free.
+    private static readonly bool AnimationsFlipObservable =
+        Windows.Foundation.Metadata.ApiInformation.IsEventPresent(
+            typeof(Windows.UI.ViewManagement.UISettings).FullName,
+            "AnimationsEnabledChanged");
     // Mirrors the current tab-strip orientation so we can detect when
     // a config reload or settings-toggle callback actually changed the
     // visible state (vs. echoing the same value we already apply).
@@ -695,6 +703,15 @@ public sealed partial class MainWindow : Window
         // outlives the window, and a live subscription both keeps the closed
         // window alive and points an OS callback at a freed libghostty app.
         _systemUiSettings.ColorValuesChanged += OnSystemColorValuesChanged;
+
+        // The other system motion preference, on the same lifetime terms.
+        // High Contrast arrives through ColorValuesChanged above, but the
+        // animation-effects toggle is its own event and nobody listened:
+        // every gate reads the flag fresh per gesture, so a flip applies
+        // from the NEXT gesture, and any clock armed before the flip
+        // played on under a user who had just turned motion off.
+        if (AnimationsFlipObservable)
+            _systemUiSettings.AnimationsEnabledChanged += OnSystemAnimationsEnabledChanged;
 
         // Apply initial backdrop (Mica when opaque, transparent when
         // background-opacity < 1). Also sets the Win32 class brush
@@ -2029,6 +2046,8 @@ public sealed partial class MainWindow : Window
         // toggle during teardown puts AppSetColorScheme through the app
         // pointer _host.Dispose is about to free at the end of this method.
         _systemUiSettings.ColorValuesChanged -= OnSystemColorValuesChanged;
+        if (AnimationsFlipObservable)
+            _systemUiSettings.AnimationsEnabledChanged -= OnSystemAnimationsEnabledChanged;
 
         // CompositionTarget.Rendering is static, so a window closed before
         // its first composed frame would otherwise stay subscribed.
@@ -3970,6 +3989,48 @@ public sealed partial class MainWindow : Window
             // but the backdrop still re-tints off the new desktop, so
             // everything scored against it is stale until this runs.
             RefreshBackdropChrome();
+        });
+    }
+
+    /// <summary>
+    /// UISettings.AnimationsEnabledChanged handler: the user flipped the
+    /// system's animation effects while this window lives. Fires on a
+    /// thread-pool thread like ColorValuesChanged, so the work hops to the
+    /// dispatcher before touching the strip.
+    ///
+    /// Only the OFF direction does work. Every motion gate reads the
+    /// preference fresh per gesture, so the gesture after an on-flip is
+    /// already animated; but an off-flip mid-flight left a pin flight or a
+    /// field glide armed before the flip playing out its half-second under
+    /// a user who had just told the system to stop moving things. The long
+    /// clocks land; one-shot entrances and the switch timeline are left to
+    /// finish on their own (each is well under half a second, and stopping
+    /// a switch mid-flight would cost more than it saves). The horizontal
+    /// host's clocks are likewise left -- per-gesture one-shots, all under
+    /// half a second -- and a drag live at the flip keeps its clocks until
+    /// release in both strips, because the follow is the pointer, which is
+    /// intent rather than decoration.
+    /// </summary>
+    private void OnSystemAnimationsEnabledChanged(
+        Windows.UI.ViewManagement.UISettings sender, object args)
+    {
+        if (_isClosed) return;
+        // The event's own sender, for the same reason the color handler
+        // reads it: a fresh instance could answer for a later moment.
+        bool enabled;
+        try { enabled = sender.AnimationsEnabled; }
+        catch (Exception ex) when (ex is InvalidOperationException
+            or System.Runtime.InteropServices.COMException or NullReferenceException)
+        {
+            // Unreadable is not "off": fail open, as every gate does.
+            return;
+        }
+        if (enabled) return;
+
+        DispatcherQueue.TryEnqueue(() =>
+        {
+            if (_isClosed) return;
+            _verticalTabHost.Strip.LandAllMotion();
         });
     }
 

--- a/windows/Ghostty/Panes/PaneStartupGlow.cs
+++ b/windows/Ghostty/Panes/PaneStartupGlow.cs
@@ -128,6 +128,11 @@ internal sealed partial class PaneStartupGlow : IDisposable
     public void StartGlow()
     {
         if (_disposed) return;
+        // The orbit is decorative continuous motion, the one class of
+        // animation reduce-motion has no reading for; the static ring
+        // stays, because it is the "pane is starting" signal and it does
+        // not move.
+        if (!Ghostty.Services.SystemAnimations.Enabled()) return;
         _coreBrush.StartAnimation("EllipseCenter", _orbit);
         _haloBrush.StartAnimation("EllipseCenter", _orbit);
     }

--- a/windows/Ghostty/Services/SystemAnimations.cs
+++ b/windows/Ghostty/Services/SystemAnimations.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace Ghostty.Services;
+
+/// <summary>
+/// The OS animation-effects preference, for the custom motion paths that
+/// live outside the tab strips: the bell border fade, the pane startup
+/// glow's orbit, and the quick terminal's slide. The strips read
+/// <c>UISettings.AnimationsEnabled</c> through their own per-gesture
+/// checks (see <c>TabStripMotion</c>); these callers had no read at all,
+/// which is the gap this closes -- reduce-motion is a contract that a
+/// custom animation honours by cutting to its end state.
+/// </summary>
+internal static class SystemAnimations
+{
+    /// <summary>
+    /// Whether system animation effects are on. A new UISettings per read,
+    /// mirroring what each strip does per gesture: the reads are rare
+    /// (bell dismissals, glow starts, quake toggles), and an instance
+    /// cached here would have to be created on a UI thread to be trusted
+    /// anyway.
+    /// </summary>
+    public static bool Enabled()
+    {
+        try { return new Windows.UI.ViewManagement.UISettings().AnimationsEnabled; }
+        catch (Exception ex) when (ex is InvalidOperationException
+            or System.Runtime.InteropServices.COMException or NullReferenceException)
+        {
+            // Unreadable is not "off": fail open, matching the strips'
+            // identical guards in packaged/sandboxed contexts.
+            return true;
+        }
+    }
+}

--- a/windows/Ghostty/Shell/LayoutCoordinator.cs
+++ b/windows/Ghostty/Shell/LayoutCoordinator.cs
@@ -13,19 +13,24 @@ using Windows.Foundation;
 namespace Ghostty.Shell;
 
 /// <summary>
-/// Owns every piece of state that drives the runtime switch
-/// between the horizontal and vertical tab layouts: the cross-fade
-/// Storyboard, the strip-column width tween, the snap-to-end-state
-/// helper, and the concurrent-tween guard.
+/// Owns every piece of state that drives the runtime switch between
+/// the horizontal and vertical tab layouts: the compositor-driven
+/// switch timeline (<see cref="LayoutSwitchTimeline"/>), the
+/// once-per-switch strip-column move, the pane reveal, the
+/// snap-to-end-state helper, and the concurrent-switch guard.
 ///
 /// Lifted out of MainWindow so the window itself stays a thin
 /// composition root. The two tab hosts and the vertical title bar
 /// are owned by MainWindow's XAML and passed in via the ctor; this
 /// type only animates and toggles them.
 ///
-/// Why the column width tween is code-driven: WinUI 3 has no native
-/// GridLengthAnimation. Star/Auto refactoring is a separate piece
-/// of work tracked in the deferred review items list.
+/// The strip column is MOVED once per switch, never tweened, and no
+/// Storyboard is involved anywhere in the switch: changing the column
+/// resizes the terminal surface, which re-renders synchronously on the
+/// UI thread, so a per-frame width animation starves the very thread
+/// it runs on. The full measured story lives at the SnapStripColumn
+/// call site below; this note exists so a reader does not reinstate a
+/// GridLength tween for want of a native one.
 /// </summary>
 internal sealed class LayoutCoordinator
 {
@@ -231,9 +236,9 @@ internal sealed class LayoutCoordinator
     /// <summary>
     /// Snap both hosts and the vertical title bar to the end state
     /// for <paramref name="verticalTabs"/>. Used at construction
-    /// (no animation needed) and from the Storyboard Completed
-    /// handler to guarantee a consistent end state regardless of
-    /// mid-flight cancellation.
+    /// (no animation needed) and when a switch lands (the timeline's
+    /// scoped batches complete) to guarantee a consistent end state
+    /// regardless of mid-flight cancellation.
     /// </summary>
     public void Snap(bool verticalTabs)
     {
@@ -705,8 +710,8 @@ internal sealed class LayoutCoordinator
     /// Drop an in-flight layout switch on window teardown without running any
     /// of the end-state work it was going to run.
     ///
-    /// A switch lands on its Storyboard's Completed handler roughly 340ms
-    /// after it starts, and the landing goes through Snap, which touches both
+    /// A switch lands roughly 340ms after it starts, when the timeline's
+    /// scoped batches complete and route the landing through Snap, which touches both
     /// tab hosts, the vertical title bar and the pane host. A closing window
     /// is disposing exactly that tree, so the landing has to be dropped rather
     /// than fast-forwarded: calling FinishSwitch here would run the work this
@@ -787,9 +792,9 @@ internal sealed class LayoutCoordinator
         CancelPaneReveal();
 
         if (_morph is not { } morph) return;
-        // The ghost's box rides the compositor, which no Storyboard.Stop
-        // reaches -- the same shape as the pane reveal's sweep, and
-        // released here for the same reason.
+        // The ghost's box rides the compositor, which nothing in the
+        // switch's landing path stops -- the same shape as the pane
+        // reveal's sweep, and released here for the same reason.
         morph.Ghost.StopBoxAnimations();
         if (morph.Waiting is not null)
         {
@@ -1333,9 +1338,9 @@ internal sealed class LayoutCoordinator
     /// the margin shifted.
     ///
     /// The clip is the half that has to go. Its left inset is swept by a
-    /// key-frame animation the compositor owns, so no Storyboard.Stop reaches
-    /// it and it would go on running against the pane host after the window
-    /// is gone. Restoring the margin is the half that must not run: it is
+    /// key-frame animation the compositor owns, so nothing in the teardown
+    /// path stops it and it would go on running against the pane host after
+    /// the window is gone. Restoring the margin is the half that must not run: it is
     /// cosmetic on a window nobody will see again, and writing it invalidates
     /// measure on a tree whose panes are about to be freed, which is the work
     /// CancelSwitch exists to avoid.

--- a/windows/Ghostty/Tabs/TabPinBandPanel.cs
+++ b/windows/Ghostty/Tabs/TabPinBandPanel.cs
@@ -177,7 +177,13 @@ internal sealed partial class TabPinBandPanel : Panel
 
             var glide = visual.Compositor.CreateVector3KeyFrameAnimation();
             glide.Duration = TimeSpan.FromMilliseconds(TabStripMotion.GapGlideMs);
-            glide.InsertKeyFrame(1f, Vector3.Zero);
+            // The strip's own glide curve, not a linear slide: a square
+            // pushed off a row end is the same point-to-point move the
+            // rows make one pane over, and decelerating differently than
+            // they do reads as two motion systems moving at once.
+            glide.InsertKeyFrame(1f, Vector3.Zero,
+                visual.Compositor.CreateCubicBezierEasingFunction(
+                    TabStripMotion.GlideBezierP1, TabStripMotion.GlideBezierP2));
 
             var batch = visual.Compositor.CreateScopedBatch(CompositionBatchTypes.Animation);
             _gliding[child] = batch;

--- a/windows/Ghostty/Tabs/TabSwitcherPopup.xaml.cs
+++ b/windows/Ghostty/Tabs/TabSwitcherPopup.xaml.cs
@@ -1057,7 +1057,13 @@ internal sealed partial class TabSwitcherPopup : UserControl
             To = to,
             Duration = new Duration(duration),
             EasingFunction = easing,
-            EnableDependentAnimation = true,
+            // Deliberately no EnableDependentAnimation: the flag is only
+            // consulted for DEPENDENT (layout-affecting) properties, so on
+            // the independent paths this board serves (Opacity,
+            // RenderTransform scale and offset) it was a no-op. This comment
+            // is the guard for the day a track targets a dependent property
+            // (Width, Margin): those do not run without the flag, and this
+            // helper is generic over the path.
         };
         Storyboard.SetTarget(animation, target);
         Storyboard.SetTargetProperty(animation, path);

--- a/windows/Ghostty/Tabs/VerticalTabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabHost.xaml.cs
@@ -63,6 +63,13 @@ internal sealed partial class VerticalTabHost : UserControl, ITabHost
     /// <summary>The strip, for the test seam's drag driver.</summary>
     internal VerticalTabStrip StripForTestSeam => _strip;
 
+    /// <summary>
+    /// The strip, for the window's motion-life coordination: the
+    /// reduce-motion flip handler lands in-flight strip motion rather
+    /// than letting a clock armed before the flip play on.
+    /// </summary>
+    internal VerticalTabStrip Strip => _strip;
+
     public FrameworkElement? TabElement(TabModel tab) => _strip.TabElement(tab);
 
     public System.Collections.Generic.IReadOnlyList<Testing.TestSeamStripRow>

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -1127,6 +1127,35 @@ internal sealed partial class VerticalTabStrip : UserControl
         _fieldMotion.Clear();
     }
 
+    /// <summary>
+    /// Land every long custom clock the strip can hold, at its end state.
+    /// The window's reduce-motion flip handler calls this when the OS
+    /// animation-effects preference turns off mid-session: the per-gesture
+    /// gates read the flag fresh, so the next gesture is already a cut --
+    /// this closes the window where a clock armed before the flip (a pin
+    /// flight, a field glide, a band reflow) keeps playing under a user
+    /// who just told the system to stop moving things.
+    ///
+    /// What lands: the pin flight gives its row back at full strength
+    /// (the row is already arranged where the flight promised -- only the
+    /// ghost flourish dies), each field flight stops and takes its
+    /// destination, and the band hands every gliding square back.
+    /// Deliberately not landed: a drag live at the flip keeps its clocks
+    /// until release -- the follow is the pointer, which is intent, not
+    /// decoration -- and the band is already still mid-drag, because its
+    /// motion is forced off while a drag is live.
+    /// </summary>
+    internal void LandAllMotion()
+    {
+        FinishPinFlight("animations-off");
+        // Snapshot first: StopFieldMotion removes from the dictionary as
+        // it lands each group, and a landing must not mutate the
+        // enumerator it is being reached through.
+        foreach (var group in _fieldMotion.Keys.ToArray())
+            StopFieldMotion(group);
+        _pinnedPanel.StopMotion();
+    }
+
     private void StopFieldMotion(TabGroup group)
     {
         if (!_fieldMotion.Remove(group, out var flight)) return;
@@ -3371,7 +3400,7 @@ internal sealed partial class VerticalTabStrip : UserControl
                 // which is the slot delta GlideRow just pinned.
                 glide.InsertKeyFrame(1f, Vector3.Zero,
                     drag.Visual.Compositor.CreateCubicBezierEasingFunction(
-                        new Vector2(0.55f, 0.55f), new Vector2(0f, 1f)));
+                        TabStripMotion.GlideBezierP1, TabStripMotion.GlideBezierP2));
                 drag.Glide = glide;
             }
         }
@@ -4984,7 +5013,7 @@ internal sealed partial class VerticalTabStrip : UserControl
         fly.Duration = TimeSpan.FromMilliseconds(TabStripMotion.PinFlightMs);
         fly.InsertKeyFrame(1f, Vector3.Zero,
             compositor.CreateCubicBezierEasingFunction(
-                new Vector2(0.55f, 0.55f), new Vector2(0f, 1f)));
+                TabStripMotion.GlideBezierP1, TabStripMotion.GlideBezierP2));
         visual.Properties.InsertVector3("Translation", new Vector3(
             (float)(start.X - dest.X), (float)(start.Y - dest.Y), 0f));
         var flying = compositor.CreateScopedBatch(CompositionBatchTypes.Animation);

--- a/windows/scripts/vtabs-switcher-capture.ps1
+++ b/windows/scripts/vtabs-switcher-capture.ps1
@@ -118,7 +118,7 @@ try {
     # The switcher and the wrap oracle. switcher-cells is the purpose-built
     # instrument (#923): every slot's CARD rect in one synchronous UI-thread
     # read, screen pixels, refusing cleanly when the popup is down. A UIA
-    # walk could straddle the 120ms entrance rise and read same-row tiles
+    # walk could straddle the 167ms entrance rise and read same-row tiles
     # into different row bins - inflated rows is the false-PASS direction of
     # the one-row gate - and it measured the tile ICON, ~14px inside the
     # card the claim is about. One instant, the card itself.


### PR DESCRIPTION
Rung 1 of the tab-strip motion audit against the WinUI 3 motion guide (spec section 2.6 + the owner checklist). The audit itself inventoried 24 motion sites; the two owner-named hot spots (StripColumn width tween, ghost Width/Height tween) were already fixed, so this PR is the ranked residue that is safe to land now. The heavier conversions are filed as #1052.

## What lands

- **One glide curve, everywhere.** The point-to-point bezier (0.55, 0.55, 0, 1) moves to `TabStripMotion.GlideBezierP1/P2` and all three composition glides name it: the drag-neighbour glide, the pin-band reflow (which was linear — a square pushed off a row end decelerated differently than the row one pane over), and the pin flight.
- **Switcher durations onto the ladder.** Highlight 150 -> 167, entrance 120 -> 167 (`TabSwitcherShape`), and the storyboard tracks drop `EnableDependentAnimation` — the flag is only consulted for dependent properties, and Opacity / RenderTransform scale / offset are independent, so it was a no-op.
- **The animation-effects flip is now listened for.** `UISettings.AnimationsEnabledChanged` (HC already had `ColorValuesChanged`; this is the asymmetric sibling). On flip-to-off the window lands the long in-flight clocks via `VerticalTabStrip.LandAllMotion` (pin flight, field glides, band reflow). Deliberately not landed: one-shot entrances, the 340ms switch, the horizontal host's per-gesture clocks, and a drag live at the flip (the follow is the pointer — intent, not decoration); the handler doc states all of this.
- **Three custom paths that never asked, now ask.** Bell border fade, pane startup glow orbit, and the quake slide read `UISettings.AnimationsEnabled` (`Services.SystemAnimations`) and cut to end state when off. The bell fade also gains the exit ease-out (its macOS-parity duration is kept; the comment now says so accurately).
- **Doc truth pass.** LayoutCoordinator's class doc advertised a cross-fade Storyboard and a width tween that no longer exist (four sibling comments agreed with the ghost); all now describe the compositor timeline + once-per-switch column move that is actually there.

## Tests

- `TabMotionFluentRungsTests`: the 83/167/250 rungs and the shared curve, pinned as values.
- `AnimationsEnabledWiringTests`: subscribe/detach + dispatcher-hop shape of the flip handler, the three new gates, and every bezier factory in the strip naming the token (a per-callsite rule, not a usage count, so the next tokenized glide does not trip it).
- Build green; 48/48 then 16/16 on the motion families.

Reviewed by two personas (WinUI/composition correctness; conventions/regressions); every finding addressed in-tree or filed on #1052 (including two pre-existing defects the audit brushed: the field glide's Height track may silently not run as a dependent animation, and a bell re-armed mid-fade can lose its border to DP precedence).
