### PR TITLE
diagnostics: dump triage default, next-launch hang notice, dll pdb emission (#1044-1046)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,117 @@
+name: Bug report
+description: Report a crash, hang, or anything behaving wrong
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Attach the diagnostic files the app already wrote on your
+        machine; what each one is and where it lives is documented in
+        [windows/docs/diagnostics.md](https://github.com/deblasis/wintty/blob/windows/windows/docs/diagnostics.md).
+
+        Sensitivity rules, short version:
+        - full hang dumps and unredacted `native-stderr.log` can hold
+          secrets (tokens, echoed passwords, command history). Never
+          attach them here; send them to the maintainer over a private
+          channel.
+        - redacted text logs and triage hang dumps are fine to attach.
+        - the redaction prompt at the bottom of this form scrubs text
+          logs before you post them.
+
+  - type: dropdown
+    id: edition
+    attributes:
+      label: Edition
+      options:
+        - OSS build
+        - Sponsor
+        - Pro
+        - Pro Enterprise
+        - Pro Legacy
+        - Not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: channel
+    attributes:
+      label: Channel
+      options:
+        - stable
+        - tip
+        - "-debug install"
+        - Not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: architecture
+    attributes:
+      label: Architecture
+      options:
+        - x64
+        - arm64
+        - Not sure
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Wintty version
+      description: Paste the Version dialog Copy button output, or `wintty +version`.
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What you saw, what you expected instead, and the steps that reproduce it.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: artifacts
+    attributes:
+      label: Attached artifacts
+      description: Check only what you are attaching and are comfortable making public.
+      options:
+        - label: crash.log
+        - label: ghostty-crash.log
+        - label: 'newest two logs\ghostty-*.log'
+        - label: redacted native-stderr.log
+        - label: 'hang dump from hangs\ (triage only, and only if comfortable; full dumps never go in a public issue, see the sensitivity note above)'
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Redaction prompt
+
+        Text logs only. Copy the prompt, give it to any LLM agent
+        together with your log text, and attach the redacted output it
+        returns. Binary `.dmp` files cannot be redacted this way and
+        never go in a public issue.
+
+        ```text
+        You are redacting a log file before I post it in public.
+
+        Replace every secret or identifying value with a same-shaped
+        placeholder, and change nothing else. Redact:
+        - tokens, passwords, API keys, cookies, and anything that looks like a
+          credential, including long random strings in URLs and headers
+        - usernames and account names
+        - hostnames and machine names
+        - file paths that identify me or my organization, keeping the path
+          shape (C:\Users\alice\... becomes C:\Users\<user>\...)
+
+        Preserve exactly:
+        - line order, line structure, and the pipe-separated field layout
+        - timestamps, log levels, event ids, thread ids, error codes, and hex
+          addresses
+        - the wording of error messages, exception types, and function names
+
+        Ambiguous values are redacted, not kept. Output the full redacted log
+        verbatim and nothing else: no commentary, no summary, no surrounding
+        markup.
+        ```

--- a/src/build/GhosttyLib.zig
+++ b/src/build/GhosttyLib.zig
@@ -16,6 +16,9 @@ step: *std.Build.Step,
 output: std.Build.LazyPath,
 /// The import library for DLL builds on Windows (.lib), null otherwise.
 implib: ?std.Build.LazyPath = null,
+/// The MSVC PDB for DLL builds on Windows, null otherwise. User minidumps
+/// captured by the app are only symbolizable against this file.
+pdb: ?std.Build.LazyPath = null,
 dsym: ?std.Build.LazyPath,
 pkg_config: ?std.Build.LazyPath,
 pkg_config_static: ?std.Build.LazyPath,
@@ -94,6 +97,14 @@ pub fn initShared(
         .search_strategy = .mode_first,
     };
 
+    // Stripping a Windows MSVC DLL saves no bytes: the debug info lives in
+    // the .pdb beside the PE, not inside it. Honoring -Dstrip here would
+    // ship releases whose user minidumps can never be symbolized, so the
+    // strip default keeps applying to every other artifact and target.
+    const strip = deps.config.strip and
+        !(deps.config.target.result.os.tag == .windows and
+            deps.config.target.result.abi == .msvc);
+
     const lib = b.addLibrary(.{
         .name = "ghostty",
         .linkage = .dynamic,
@@ -101,9 +112,9 @@ pub fn initShared(
             .root_source_file = b.path("src/main_c.zig"),
             .target = deps.config.target,
             .optimize = deps.config.optimize,
-            .strip = deps.config.strip,
+            .strip = strip,
             .omit_frame_pointer = deps.config.omitFramePointer(),
-            .unwind_tables = if (deps.config.strip) .none else .sync,
+            .unwind_tables = if (strip) .none else .sync,
         }),
 
         // Fails on self-hosted x86_64
@@ -186,6 +197,11 @@ pub fn initShared(
             lib.getEmittedImplib()
         else
             null,
+        .pdb = if (deps.config.target.result.os.tag == .windows and
+            deps.config.target.result.abi == .msvc)
+            lib.getEmittedPdb()
+        else
+            null,
         .dsym = dsymutil,
         .pkg_config = pcs.shared,
         .pkg_config_static = pcs.static,
@@ -229,6 +245,11 @@ pub fn install(self: *const GhosttyLib, name: []const u8) void {
     const step = b.getInstallStep();
     const lib_install = b.addInstallLibFile(self.output, name);
     step.dependOn(&lib_install.step);
+
+    if (self.pdb) |pdb| {
+        const pdb_install = b.addInstallLibFile(pdb, "ghostty.pdb");
+        step.dependOn(&pdb_install.step);
+    }
 
     if (self.pkg_config) |pc| {
         step.dependOn(&b.addInstallFileWithDir(

--- a/src/build/GhosttyLib.zig
+++ b/src/build/GhosttyLib.zig
@@ -97,13 +97,22 @@ pub fn initShared(
         .search_strategy = .mode_first,
     };
 
+    // The one Windows dll target this fork ships; the CRT block below
+    // already assumes it. One const because three decisions hang on it
+    // (strip, CRT libs, pdb install), and drifting apart is exactly how
+    // an unsymbolizable dll ships quietly.
+    const win_msvc = deps.config.target.result.os.tag == .windows and
+        deps.config.target.result.abi == .msvc;
+
     // Stripping a Windows MSVC DLL saves no bytes: the debug info lives in
     // the .pdb beside the PE, not inside it. Honoring -Dstrip here would
     // ship releases whose user minidumps can never be symbolized, so the
     // strip default keeps applying to every other artifact and target.
-    const strip = deps.config.strip and
-        !(deps.config.target.result.os.tag == .windows and
-            deps.config.target.result.abi == .msvc);
+    // Scope note: this forces only the root module; zig's default
+    // additionally strips dependencies under ReleaseSmall, so a
+    // ReleaseSmall dll pdb would carry zig frames but not C dependency
+    // frames. ReleaseSmall is not a shipped dll mode.
+    const strip = deps.config.strip and !win_msvc;
 
     const lib = b.addLibrary(.{
         .name = "ghostty",
@@ -127,8 +136,7 @@ pub fn initShared(
     // that references symbols in vcruntime.lib and ucrt.lib. Zig's library
     // search paths include the MSVC lib dir and the Windows SDK 'um' dir,
     // but not the SDK 'ucrt' dir where ucrt.lib lives.
-    if (deps.config.target.result.os.tag == .windows and
-        deps.config.target.result.abi == .msvc)
+    if (win_msvc)
     {
         // The CRT initialization code in msvcrt.lib calls __vcrt_initialize
         // and __acrt_initialize, which are in the static CRT libraries.
@@ -197,11 +205,7 @@ pub fn initShared(
             lib.getEmittedImplib()
         else
             null,
-        .pdb = if (deps.config.target.result.os.tag == .windows and
-            deps.config.target.result.abi == .msvc)
-            lib.getEmittedPdb()
-        else
-            null,
+        .pdb = if (win_msvc) lib.getEmittedPdb() else null,
         .dsym = dsymutil,
         .pkg_config = pcs.shared,
         .pkg_config_static = pcs.static,

--- a/windows/Ghostty.Core/Config/WindowsOnlyKeys.cs
+++ b/windows/Ghostty.Core/Config/WindowsOnlyKeys.cs
@@ -75,6 +75,8 @@ public static class WindowsOnlyKeys
             "Minimum severity written to the app log: trace, debug, info (default), warn, error, or off. An unrecognized value falls back to info silently."),
         new("log-filter",
             "Comma-separated CATEGORY=LEVEL pairs overriding log-level per component (longest matching category prefix wins). Malformed pairs and unknown levels are skipped silently."),
+        new("hang-dump",
+            "Capture scope of the hang watchdog's dump when the UI thread stalls: triage (default, stacks and locks only) or full (all process memory, which can include terminal output and secrets)."),
     ];
 
     public static readonly FrozenSet<string> Set =

--- a/windows/Ghostty.Core/Config/WindowsOnlyKeys.cs
+++ b/windows/Ghostty.Core/Config/WindowsOnlyKeys.cs
@@ -76,7 +76,7 @@ public static class WindowsOnlyKeys
         new("log-filter",
             "Comma-separated CATEGORY=LEVEL pairs overriding log-level per component (longest matching category prefix wins). Malformed pairs and unknown levels are skipped silently."),
         new("hang-dump",
-            "Capture scope of the hang watchdog's dump when the UI thread stalls: triage (default, stacks and locks only) or full (all process memory, which can include terminal output and secrets)."),
+            "Capture scope of the hang watchdog's dump when the UI thread stalls: triage (default, stacks and locks only) or full (all process memory, which can include terminal output and secrets). Read live: a config reload re-applies it without a restart."),
     ];
 
     public static readonly FrozenSet<string> Set =

--- a/windows/Ghostty.Core/Diagnostics/HangDump.cs
+++ b/windows/Ghostty.Core/Diagnostics/HangDump.cs
@@ -1,0 +1,54 @@
+using System;
+using Ghostty.Core.Config;
+
+namespace Ghostty.Core.Diagnostics;
+
+/// <summary>
+/// Capture scope of the hang watchdog's minidump, selected by the
+/// <c>hang-dump</c> config key.
+/// </summary>
+public enum HangDumpMode
+{
+    /// <summary>
+    /// Stacks, handles and lock words without the heap sweep: small
+    /// enough to attach to a bug report and free of terminal content
+    /// and secrets. The default.
+    /// </summary>
+    Triage,
+
+    /// <summary>
+    /// All process memory. Opt-in only: a full dump carries everything
+    /// the terminals held, secrets included, and is correspondingly
+    /// large.
+    /// </summary>
+    Full,
+}
+
+/// <summary>
+/// Values and parsing for the <c>hang-dump</c> config key, shaped after
+/// <c>NoColorPolicy</c> so every allowed-string key resolves the same
+/// way: unset and invalid values both land on the default, silently,
+/// which is <see cref="WindowsOnlyKeyParsers.ParseStringAllowed"/>'s
+/// convention.
+/// </summary>
+public static class HangDump
+{
+    public const string Triage = "triage";
+
+    public const string Full = "full";
+
+    /// <summary>Allowed values for the <c>hang-dump</c> config key.</summary>
+    public static readonly string[] Allowed = { Triage, Full };
+
+    /// <summary>Default when the key is unset or invalid.</summary>
+    public const string Default = Triage;
+
+    public static HangDumpMode Parse(string? raw) =>
+        WindowsOnlyKeyParsers.ParseStringAllowed(raw, Allowed, Default) == Full
+            ? HangDumpMode.Full
+            : HangDumpMode.Triage;
+
+    /// <summary>Config spelling of a mode, for crash.log lines.</summary>
+    public static string ConfigValue(HangDumpMode mode) =>
+        mode == HangDumpMode.Full ? Full : Triage;
+}

--- a/windows/Ghostty.Core/Diagnostics/HangEvidenceStartup.cs
+++ b/windows/Ghostty.Core/Diagnostics/HangEvidenceStartup.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Globalization;
+
+namespace Ghostty.Core.Diagnostics;
+
+/// <summary>
+/// Outcome of looking for hang evidence the user has not been told
+/// about: whether a notice is warranted, and when the newest stall was
+/// logged.
+/// </summary>
+public readonly record struct HangEvidenceOutcome(bool Notify, DateTimeOffset NewestStall);
+
+/// <summary>
+/// Decides whether a previous session left an unreported UI-thread
+/// stall in crash.log (#1046). The watchdog records the stall while the
+/// UI thread is hung, and a hung UI thread cannot show anything, so the
+/// next launch is the first moment the user can be told. This resolver
+/// is that decision and nothing else: pure and I/O-free so it
+/// unit-tests without a filesystem, and allocation-light because it
+/// runs on the launch path. The app layer supplies the tail of
+/// crash.log and the persisted last-launch instant, and owns every
+/// byte of the I/O.
+/// </summary>
+public static class HangEvidenceStartup
+{
+    /// <summary>
+    /// The marker the hang watchdog writes into crash.log, held here so
+    /// the writer and the reader share one spelling.
+    /// </summary>
+    public const string StallMarker = "[UI-THREAD STALL]";
+
+    /// <summary>
+    /// Newest stall entry in <paramref name="crashLogTail"/> that is
+    /// newer than <paramref name="lastLaunch"/>, or
+    /// <c>Notify = false</c> when there is none. Entries are appended
+    /// chronologically, so the scan walks from the end and the first
+    /// line that parses is the newest; a partial trailing line (a crash
+    /// mid-write can leave one) is skipped rather than fatal.
+    /// </summary>
+    public static HangEvidenceOutcome Resolve(string? crashLogTail, DateTimeOffset lastLaunch)
+    {
+        if (string.IsNullOrEmpty(crashLogTail)) return default;
+
+        var rest = crashLogTail.AsSpan();
+        while (!rest.IsEmpty)
+        {
+            var lastNewline = rest.LastIndexOf('\n');
+            // After the last newline is the final line; before it is
+            // everything older.
+            var line = lastNewline < 0 ? rest : rest[(lastNewline + 1)..];
+            rest = lastNewline < 0 ? default : rest[..lastNewline];
+
+            if (TryReadStallTimestamp(line, out var stall) && stall > lastLaunch)
+                return new HangEvidenceOutcome(Notify: true, NewestStall: stall);
+        }
+
+        return default;
+    }
+
+    /// <summary>
+    /// A stall entry starts with its O-format timestamp (which never
+    /// contains a space) and carries the marker somewhere in the line.
+    /// The unhandled-exception tags match the timestamp shape but not
+    /// the marker; the free-text detail lines match neither.
+    /// </summary>
+    private static bool TryReadStallTimestamp(ReadOnlySpan<char> line, out DateTimeOffset stall)
+    {
+        stall = default;
+        var space = line.IndexOf(' ');
+        if (space <= 0 || !line.Contains(StallMarker, StringComparison.Ordinal)) return false;
+        return DateTimeOffset.TryParse(
+            line[..space],
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.RoundtripKind,
+            out stall);
+    }
+}

--- a/windows/Ghostty.Core/Diagnostics/HangEvidenceStartup.cs
+++ b/windows/Ghostty.Core/Diagnostics/HangEvidenceStartup.cs
@@ -30,18 +30,19 @@ public static class HangEvidenceStartup
     public const string StallMarker = "[UI-THREAD STALL]";
 
     /// <summary>
-    /// Newest stall entry in <paramref name="crashLogTail"/> strictly
+    /// The newest stall entry in <paramref name="crashLogTail"/> strictly
     /// between <paramref name="lastLaunch"/> (the previous session's
-    /// marker) and <paramref name="currentLaunch"/> (this launch's
-    /// instant), or <c>Notify = false</c> when there is none. Entries
-    /// are appended chronologically, so the scan walks from the end and
-    /// the first line that parses is the newest; nothing older can
-    /// change the verdict, so the scan stops there. A partial trailing
-    /// line (a crash mid-write can leave one), or a partial leading
-    /// line (the tail read can cut one), is skipped rather than fatal.
-    /// <paramref name="currentLaunch"/> excludes stalls logged during
-    /// this session's own launch (a slow start can trip the watchdog):
-    /// those notify on the NEXT launch instead.
+    /// marker) and <paramref name="currentLaunch"/> (this launch's arm
+    /// instant), or <c>Notify = false</c> when there is none. The scan
+    /// walks from the end and stops at the first entry inside the
+    /// window; entries outside it do not stop the scan, because append
+    /// order does not guarantee timestamp order (several instances
+    /// append concurrently, and the clock can step back). A partial
+    /// trailing line (a crash mid-write can leave one), or a partial
+    /// leading line (the tail read can cut one), is skipped rather than
+    /// fatal. <paramref name="currentLaunch"/> excludes stalls logged
+    /// during this session's own launch (a slow start can trip the
+    /// watchdog): those notify on the NEXT launch instead.
     /// </summary>
     public static HangEvidenceOutcome Resolve(
         string? crashLogTail,
@@ -62,12 +63,9 @@ public static class HangEvidenceStartup
             var line = lastNewline < 0 ? rest : rest[(lastNewline + 1)..];
             rest = lastNewline < 0 ? default : rest[..lastNewline];
 
-            // First parseable stall line from the end is the newest;
-            // older entries cannot beat it, so one comparison decides.
-            if (TryReadStallTimestamp(line, out var stall))
-                return stall > lastLaunch && stall <= currentLaunch
-                    ? new HangEvidenceOutcome(Notify: true, NewestStall: stall)
-                    : default;
+            if (TryReadStallTimestamp(line, out var stall) &&
+                stall > lastLaunch && stall <= currentLaunch)
+                return new HangEvidenceOutcome(Notify: true, NewestStall: stall);
         }
 
         return default;

--- a/windows/Ghostty.Core/Diagnostics/HangEvidenceStartup.cs
+++ b/windows/Ghostty.Core/Diagnostics/HangEvidenceStartup.cs
@@ -30,16 +30,28 @@ public static class HangEvidenceStartup
     public const string StallMarker = "[UI-THREAD STALL]";
 
     /// <summary>
-    /// Newest stall entry in <paramref name="crashLogTail"/> that is
-    /// newer than <paramref name="lastLaunch"/>, or
-    /// <c>Notify = false</c> when there is none. Entries are appended
-    /// chronologically, so the scan walks from the end and the first
-    /// line that parses is the newest; a partial trailing line (a crash
-    /// mid-write can leave one) is skipped rather than fatal.
+    /// Newest stall entry in <paramref name="crashLogTail"/> strictly
+    /// between <paramref name="lastLaunch"/> (the previous session's
+    /// marker) and <paramref name="currentLaunch"/> (this launch's
+    /// instant), or <c>Notify = false</c> when there is none. Entries
+    /// are appended chronologically, so the scan walks from the end and
+    /// the first line that parses is the newest; nothing older can
+    /// change the verdict, so the scan stops there. A partial trailing
+    /// line (a crash mid-write can leave one), or a partial leading
+    /// line (the tail read can cut one), is skipped rather than fatal.
+    /// <paramref name="currentLaunch"/> excludes stalls logged during
+    /// this session's own launch (a slow start can trip the watchdog):
+    /// those notify on the NEXT launch instead.
     /// </summary>
-    public static HangEvidenceOutcome Resolve(string? crashLogTail, DateTimeOffset lastLaunch)
+    public static HangEvidenceOutcome Resolve(
+        string? crashLogTail,
+        DateTimeOffset lastLaunch,
+        DateTimeOffset currentLaunch)
     {
         if (string.IsNullOrEmpty(crashLogTail)) return default;
+        // The common case is a log with no stall at all; one ordinal
+        // search over the tail beats walking it line by line.
+        if (!crashLogTail.AsSpan().Contains(StallMarker, StringComparison.Ordinal)) return default;
 
         var rest = crashLogTail.AsSpan();
         while (!rest.IsEmpty)
@@ -50,8 +62,12 @@ public static class HangEvidenceStartup
             var line = lastNewline < 0 ? rest : rest[(lastNewline + 1)..];
             rest = lastNewline < 0 ? default : rest[..lastNewline];
 
-            if (TryReadStallTimestamp(line, out var stall) && stall > lastLaunch)
-                return new HangEvidenceOutcome(Notify: true, NewestStall: stall);
+            // First parseable stall line from the end is the newest;
+            // older entries cannot beat it, so one comparison decides.
+            if (TryReadStallTimestamp(line, out var stall))
+                return stall > lastLaunch && stall <= currentLaunch
+                    ? new HangEvidenceOutcome(Notify: true, NewestStall: stall)
+                    : default;
         }
 
         return default;

--- a/windows/Ghostty.Tests/Config/WindowsOnlyKeysTests.cs
+++ b/windows/Ghostty.Tests/Config/WindowsOnlyKeysTests.cs
@@ -32,6 +32,7 @@ public class WindowsOnlyKeysTests
     [InlineData("quick-terminal-key")]
     [InlineData("log-level")]
     [InlineData("log-filter")]
+    [InlineData("hang-dump")]
     public void Contains_KnownKey(string key)
     {
         Assert.True(WindowsOnlyKeys.Contains(key));
@@ -190,6 +191,7 @@ public class WindowsOnlyKeysTests
     [InlineData("quick-terminal-key")]
     [InlineData("log-level")]
     [InlineData("log-filter")]
+    [InlineData("hang-dump")]
     public void FileReadKeyDiagnostic_ExtractsKey_AndClassifiesAsWindowsOnly(string configKey)
     {
         // Shape of the precomputed diagnostic message (src/cli/diagnostics.zig

--- a/windows/Ghostty.Tests/Diagnostics/HangDumpTests.cs
+++ b/windows/Ghostty.Tests/Diagnostics/HangDumpTests.cs
@@ -1,0 +1,44 @@
+using Ghostty.Core.Diagnostics;
+using Xunit;
+
+namespace Ghostty.Tests.Diagnostics;
+
+public class HangDumpTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("triage")]
+    [InlineData("TRIAGE")]
+    [InlineData("bogus")]
+    public void UnsetOrInvalidLandsOnTriage(string? raw)
+    {
+        // Allowed-string keys fall back silently; a typo that quietly
+        // captured full memory would be the surprising direction.
+        Assert.Equal(HangDumpMode.Triage, HangDump.Parse(raw));
+    }
+
+    [Theory]
+    [InlineData("full")]
+    [InlineData("Full")]
+    [InlineData("  FULL  ")]
+    public void FullIsOptIn(string raw)
+    {
+        Assert.Equal(HangDumpMode.Full, HangDump.Parse(raw));
+    }
+
+    [Fact]
+    public void AllowedAndDefaultStayAnchored()
+    {
+        Assert.Equal(new[] { "triage", "full" }, HangDump.Allowed);
+        Assert.Equal("triage", HangDump.Default);
+    }
+
+    [Fact]
+    public void ConfigValueRoundTripsTheConfigSpellings()
+    {
+        Assert.Equal("triage", HangDump.ConfigValue(HangDumpMode.Triage));
+        Assert.Equal("full", HangDump.ConfigValue(HangDumpMode.Full));
+    }
+}

--- a/windows/Ghostty.Tests/Diagnostics/HangEvidenceStartupTests.cs
+++ b/windows/Ghostty.Tests/Diagnostics/HangEvidenceStartupTests.cs
@@ -125,10 +125,24 @@ public class HangEvidenceStartupTests
     }
 
     [Fact]
-    public void MarkerMatchesWhatTheWatchdogWrites()
+    public void OutOfWindowNewestEntryDoesNotHideAnOlderInWindowEntry()
     {
-        // The watchdog writes the constant into crash.log and this test
-        // pins the constant's spelling to the literal, so rewording the
+        // Append order does not guarantee timestamp order: several
+        // instances append concurrently and the clock can step back. A
+        // newest-by-position entry outside the window must not stop the
+        // scan and swallow an older entry that IS unreported news.
+        var log = Entry(T1) + Entry(T2);
+        var outcome = HangEvidenceStartup.Resolve(
+            log, lastLaunch: T1, currentLaunch: T2.AddSeconds(-1));
+        Assert.True(outcome.Notify);
+        Assert.Equal(T1.AddSeconds(2), outcome.NewestStall);
+    }
+
+    [Fact]
+    public void MarkerSpellingIsPinnedToTheLiteral()
+    {
+        // The watchdog and the resolver share the constant; this pins
+        // the constant's spelling to the literal, so rewording the
         // marker is a deliberate, visible act rather than a silent
         // reader-writer split.
         Assert.Equal("[UI-THREAD STALL]", HangEvidenceStartup.StallMarker);

--- a/windows/Ghostty.Tests/Diagnostics/HangEvidenceStartupTests.cs
+++ b/windows/Ghostty.Tests/Diagnostics/HangEvidenceStartupTests.cs
@@ -11,6 +11,11 @@ public class HangEvidenceStartupTests
     private static readonly DateTimeOffset T1 = T0.AddMinutes(5);
     private static readonly DateTimeOffset T2 = T0.AddMinutes(10);
 
+    // The "current launch" instant: comfortably after every entry the
+    // fixtures write, so entries land inside the (lastLaunch, now]
+    // window the resolver notifies on.
+    private static readonly DateTimeOffset Now = T0.AddHours(1);
+
     private const string DumpPath =
         @"C:\Users\alex\AppData\Local\Wintty\hangs\hang-4242-20260901-120000.dmp";
 
@@ -23,7 +28,7 @@ public class HangEvidenceStartupTests
     [Fact]
     public void MissingLogStaysQuiet()
     {
-        var outcome = HangEvidenceStartup.Resolve(null, T0);
+        var outcome = HangEvidenceStartup.Resolve(null, T0, Now);
         Assert.False(outcome.Notify);
         Assert.Equal(default(DateTimeOffset), outcome.NewestStall);
     }
@@ -31,7 +36,7 @@ public class HangEvidenceStartupTests
     [Fact]
     public void EmptyLogStaysQuiet()
     {
-        var outcome = HangEvidenceStartup.Resolve("", T0);
+        var outcome = HangEvidenceStartup.Resolve("", T0, Now);
         Assert.False(outcome.Notify);
     }
 
@@ -41,7 +46,7 @@ public class HangEvidenceStartupTests
         var log = Entry(T0) + Entry(T1);
         // The newest parseable marker line is the post-dump line of the
         // newest entry, two seconds after its stall start.
-        var outcome = HangEvidenceStartup.Resolve(log, lastLaunch: T1.AddSeconds(1));
+        var outcome = HangEvidenceStartup.Resolve(log, lastLaunch: T1.AddSeconds(1), Now);
         Assert.True(outcome.Notify);
         Assert.Equal(T1.AddSeconds(2), outcome.NewestStall);
     }
@@ -50,9 +55,22 @@ public class HangEvidenceStartupTests
     public void StallOlderThanLastLaunchStaysQuiet()
     {
         var log = Entry(T0) + Entry(T1);
-        var outcome = HangEvidenceStartup.Resolve(log, lastLaunch: T1.AddMinutes(1));
+        var outcome = HangEvidenceStartup.Resolve(log, lastLaunch: T1.AddMinutes(1), Now);
         Assert.False(outcome.Notify);
         Assert.Equal(default(DateTimeOffset), outcome.NewestStall);
+    }
+
+    [Fact]
+    public void StallDuringThisLaunchIsDeferredToTheNextLaunch()
+    {
+        // A launch slow enough to trip the watchdog logs a stall during
+        // OnLaunched itself; that stall belongs to THIS session and must
+        // not raise a "previous session froze" notice about the launch
+        // the user is watching. It is still newer than this launch's
+        // marker, so the next launch reports it.
+        var log = Entry(T2);
+        Assert.False(HangEvidenceStartup.Resolve(log, lastLaunch: T1, currentLaunch: T2.AddSeconds(-1)).Notify);
+        Assert.True(HangEvidenceStartup.Resolve(log, lastLaunch: T1, Now).Notify);
     }
 
     [Fact]
@@ -63,7 +81,7 @@ public class HangEvidenceStartupTests
         var log =
             $"{T1:O} [UI-THREAD UNHANDLED]\nSystem.Exception: boom\n\n" +
             $"{T1.AddSeconds(1):O} [APPDOMAIN UNHANDLED]\nSystem.Exception: boom\n\n";
-        var outcome = HangEvidenceStartup.Resolve(log, T0);
+        var outcome = HangEvidenceStartup.Resolve(log, T0, Now);
         Assert.False(outcome.Notify);
     }
 
@@ -73,9 +91,27 @@ public class HangEvidenceStartupTests
         // A crash mid-write can leave the newest line cut short; the
         // scan must pass over it and still see the newest whole entry.
         var log = Entry(T0) + $"{T2:O} [UI-THREAD ST";
-        var outcome = HangEvidenceStartup.Resolve(log, lastLaunch: T0.AddSeconds(-1));
+        var outcome = HangEvidenceStartup.Resolve(log, lastLaunch: T0.AddSeconds(-1), Now);
         Assert.True(outcome.Notify);
         Assert.Equal(T0.AddSeconds(2), outcome.NewestStall);
+    }
+
+    [Fact]
+    public void PartialLeadingLineFromTheTailCutIsSkippedNotFatal()
+    {
+        // The 1 MiB tail read can cut a line at the START of the input
+        // instead of the end: an entry's first line arrives with its
+        // timestamp half gone. It must fail to parse and fall through
+        // to the older whole entry rather than misparse or misnotify.
+        var cut =
+            ($"{T2:O} {HangEvidenceStartup.StallMarker} minidump written (1,024 bytes, triage)\n\n")[10..];
+        var log = cut + Entry(T1);
+        var outcome = HangEvidenceStartup.Resolve(log, lastLaunch: T0, Now);
+        Assert.True(outcome.Notify);
+        Assert.Equal(T1.AddSeconds(2), outcome.NewestStall);
+
+        // And a cut line alone is nothing to report.
+        Assert.False(HangEvidenceStartup.Resolve(cut, T0, Now).Notify);
     }
 
     [Fact]
@@ -84,15 +120,17 @@ public class HangEvidenceStartupTests
         // A detail line cut off mid-word is newer than the last launch
         // but is not an entry, so there is nothing to report.
         var log = Entry(T0) + "The UI thread has not pumped for 2222";
-        var outcome = HangEvidenceStartup.Resolve(log, lastLaunch: T0.AddMinutes(1));
+        var outcome = HangEvidenceStartup.Resolve(log, lastLaunch: T0.AddMinutes(1), Now);
         Assert.False(outcome.Notify);
     }
 
     [Fact]
     public void MarkerMatchesWhatTheWatchdogWrites()
     {
-        // The watchdog writes this literal into crash.log; the resolver
-        // reads the constant. One test line keeps the two from drifting.
+        // The watchdog writes the constant into crash.log and this test
+        // pins the constant's spelling to the literal, so rewording the
+        // marker is a deliberate, visible act rather than a silent
+        // reader-writer split.
         Assert.Equal("[UI-THREAD STALL]", HangEvidenceStartup.StallMarker);
     }
 }

--- a/windows/Ghostty.Tests/Diagnostics/HangEvidenceStartupTests.cs
+++ b/windows/Ghostty.Tests/Diagnostics/HangEvidenceStartupTests.cs
@@ -1,0 +1,98 @@
+using System;
+using Ghostty.Core.Diagnostics;
+using Xunit;
+
+namespace Ghostty.Tests.Diagnostics;
+
+public class HangEvidenceStartupTests
+{
+    private static readonly DateTimeOffset T0 =
+        new(2026, 9, 1, 12, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset T1 = T0.AddMinutes(5);
+    private static readonly DateTimeOffset T2 = T0.AddMinutes(10);
+
+    private const string DumpPath =
+        @"C:\Users\alex\AppData\Local\Wintty\hangs\hang-4242-20260901-120000.dmp";
+
+    /// <summary>An entry pair the way the watchdog writes one.</summary>
+    private static string Entry(DateTimeOffset at) =>
+        $"{at:O} {HangEvidenceStartup.StallMarker}\n" +
+        $"The UI thread has not pumped for 21s; capturing {DumpPath} (triage dump)\n\n" +
+        $"{at.AddSeconds(2):O} {HangEvidenceStartup.StallMarker} minidump written (1,024 bytes, triage)\n\n";
+
+    [Fact]
+    public void MissingLogStaysQuiet()
+    {
+        var outcome = HangEvidenceStartup.Resolve(null, T0);
+        Assert.False(outcome.Notify);
+        Assert.Equal(default(DateTimeOffset), outcome.NewestStall);
+    }
+
+    [Fact]
+    public void EmptyLogStaysQuiet()
+    {
+        var outcome = HangEvidenceStartup.Resolve("", T0);
+        Assert.False(outcome.Notify);
+    }
+
+    [Fact]
+    public void NewestStallAfterLastLaunchNotifies()
+    {
+        var log = Entry(T0) + Entry(T1);
+        // The newest parseable marker line is the post-dump line of the
+        // newest entry, two seconds after its stall start.
+        var outcome = HangEvidenceStartup.Resolve(log, lastLaunch: T1.AddSeconds(1));
+        Assert.True(outcome.Notify);
+        Assert.Equal(T1.AddSeconds(2), outcome.NewestStall);
+    }
+
+    [Fact]
+    public void StallOlderThanLastLaunchStaysQuiet()
+    {
+        var log = Entry(T0) + Entry(T1);
+        var outcome = HangEvidenceStartup.Resolve(log, lastLaunch: T1.AddMinutes(1));
+        Assert.False(outcome.Notify);
+        Assert.Equal(default(DateTimeOffset), outcome.NewestStall);
+    }
+
+    [Fact]
+    public void UnhandledEntriesDoNotCount()
+    {
+        // Same timestamp shape, different tag: an unhandled exception is
+        // already surfaced by its own paths, not this notice.
+        var log =
+            $"{T1:O} [UI-THREAD UNHANDLED]\nSystem.Exception: boom\n\n" +
+            $"{T1.AddSeconds(1):O} [APPDOMAIN UNHANDLED]\nSystem.Exception: boom\n\n";
+        var outcome = HangEvidenceStartup.Resolve(log, T0);
+        Assert.False(outcome.Notify);
+    }
+
+    [Fact]
+    public void PartialTrailingFragmentIsSkippedNotFatal()
+    {
+        // A crash mid-write can leave the newest line cut short; the
+        // scan must pass over it and still see the newest whole entry.
+        var log = Entry(T0) + $"{T2:O} [UI-THREAD ST";
+        var outcome = HangEvidenceStartup.Resolve(log, lastLaunch: T0.AddSeconds(-1));
+        Assert.True(outcome.Notify);
+        Assert.Equal(T0.AddSeconds(2), outcome.NewestStall);
+    }
+
+    [Fact]
+    public void PartialFragmentAloneNeverNotifies()
+    {
+        // A detail line cut off mid-word is newer than the last launch
+        // but is not an entry, so there is nothing to report.
+        var log = Entry(T0) + "The UI thread has not pumped for 2222";
+        var outcome = HangEvidenceStartup.Resolve(log, lastLaunch: T0.AddMinutes(1));
+        Assert.False(outcome.Notify);
+    }
+
+    [Fact]
+    public void MarkerMatchesWhatTheWatchdogWrites()
+    {
+        // The watchdog writes this literal into crash.log; the resolver
+        // reads the constant. One test line keeps the two from drifting.
+        Assert.Equal("[UI-THREAD STALL]", HangEvidenceStartup.StallMarker);
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/DiagnosticsWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/DiagnosticsWiringTests.cs
@@ -151,6 +151,24 @@ public class DiagnosticsWiringTests
         Assert.Equal("0x800", src.Field("MiniDumpWithFullMemoryInfo").Variable.Initializer!.Value.ToString());
         Assert.Equal("0x1000", src.Field("MiniDumpWithThreadInfo").Variable.Initializer!.Value.ToString());
         Assert.Equal("0x40", src.Field("MiniDumpWithIndirectlyReferencedMemory").Variable.Initializer!.Value.ToString());
+
+        // The masks' compositions too: the whole secrets posture of the
+        // default hangs on TriageDumpFlags not containing
+        // MiniDumpWithFullMemory, and no behavioral test can see a flag
+        // quietly dropped or added.
+        var triage = src.Field("TriageDumpFlags").Variable.Initializer!.Value.ToString();
+        Assert.Contains("MiniDumpWithHandleData", triage);
+        Assert.Contains("MiniDumpScanMemory", triage);
+        Assert.Contains("MiniDumpWithUnloadedModules", triage);
+        Assert.Contains("MiniDumpWithThreadInfo", triage);
+        Assert.Contains("MiniDumpWithIndirectlyReferencedMemory", triage);
+        Assert.DoesNotContain("MiniDumpWithFullMemory", triage);
+
+        var full = src.Field("FullDumpFlags").Variable.Initializer!.Value.ToString();
+        Assert.Contains("MiniDumpWithFullMemory", full);
+        Assert.Contains("MiniDumpWithHandleData", full);
+        Assert.Contains("MiniDumpWithFullMemoryInfo", full);
+        Assert.Contains("MiniDumpWithThreadInfo", full);
     }
 }
 

--- a/windows/Ghostty.Tests/Wiring/DiagnosticsWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/DiagnosticsWiringTests.cs
@@ -60,6 +60,53 @@ public class DiagnosticsWiringTests
         // early step would not have started at all.
         Assert.Equal(0, arm.Index);
     }
+
+    [Fact]
+    public void OnLaunchedSeedsTheHangWatchdogDumpModeOnceConfigExists()
+    {
+        var method = App().Method("OnLaunched");
+        var config = method.Body!.Statements
+            .Select((s, i) => (Statement: s, Index: i))
+            .Single(t => t.Statement is ExpressionStatementSyntax e &&
+                         e.Expression is AssignmentExpressionSyntax a &&
+                         a.Right is ObjectCreationExpressionSyntax c &&
+                         c.Type.ToString() == "ConfigService");
+        var seed = method.Body.Statements
+            .Select((s, i) => (Statement: s, Index: i))
+            .Single(t => t.Statement is ExpressionStatementSyntax e &&
+                         e.Expression is InvocationExpressionSyntax i &&
+                         i.CalleeText() == "Diagnostics.HangWatchdog.ConfigureDumpMode");
+
+        // The watchdog arms before the config service can exist, so the
+        // hang-dump scope reaches it only through this seed. It has to
+        // follow the construction, and a stall in the window before it
+        // captures the triage default, which is the safe direction.
+        Assert.True(config.Index < seed.Index,
+            "the hang dump mode must be seeded after the config service is constructed");
+    }
+
+    [Fact]
+    public void OnLaunchedShowsTheHangNoticeAfterTheNotificationServiceExists()
+    {
+        var method = App().Method("OnLaunched");
+        var service = method.Body!.Statements
+            .Select((s, i) => (Statement: s, Index: i))
+            .Single(t => t.Statement is ExpressionStatementSyntax e &&
+                         e.Expression is AssignmentExpressionSyntax a &&
+                         a.Right is ObjectCreationExpressionSyntax c &&
+                         c.Type.ToString() == "Ghostty.Core.Notifications.NotificationService");
+        var evaluate = method.Body.Statements
+            .Select((s, i) => (Statement: s, Index: i))
+            .Single(t => t.Statement is ExpressionStatementSyntax e &&
+                         e.Expression is InvocationExpressionSyntax i &&
+                         i.CalleeText() == "ShowPreviousSessionHangNotice");
+
+        // The evaluation's only output is a notice on the service; run
+        // before it exists, the evidence would be read and the marker
+        // written while the notice itself is dropped on the floor.
+        Assert.True(service.Index < evaluate.Index,
+            "the hang-evidence evaluation must run after the notification service is constructed");
+    }
 }
 
 file static class DiagnosticsSyntaxQueries

--- a/windows/Ghostty.Tests/Wiring/DiagnosticsWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/DiagnosticsWiringTests.cs
@@ -107,6 +107,51 @@ public class DiagnosticsWiringTests
         Assert.True(service.Index < evaluate.Index,
             "the hang-evidence evaluation must run after the notification service is constructed");
     }
+
+    [Fact]
+    public void OnLaunchedShowsTheHangNoticeAfterTheSingleInstanceGate()
+    {
+        var method = App().Method("OnLaunched");
+        var gate = method.Body!.Statements
+            .Select((s, i) => (Statement: s, Index: i))
+            .Single(t => t.Statement is ExpressionStatementSyntax e &&
+                         e.Expression is InvocationExpressionSyntax i &&
+                         i.CalleeText() == "HandleSingleInstanceGate");
+        var evaluate = method.Body.Statements
+            .Select((s, i) => (Statement: s, Index: i))
+            .Single(t => t.Statement is ExpressionStatementSyntax e &&
+                         e.Expression is InvocationExpressionSyntax i &&
+                         i.CalleeText() == "ShowPreviousSessionHangNotice");
+
+        // A secondary instance forwards and exits inside the gate. With
+        // the evaluation before it, the secondary would advance the
+        // last-launch marker and queue the notice into a service no
+        // host ever binds: exactly when the user re-launched because
+        // the primary hung, the one-per-stall notice is consumed
+        // unseen.
+        Assert.True(gate.Index < evaluate.Index,
+            "the hang-evidence evaluation must run after the single-instance gate");
+    }
+
+    [Fact]
+    public void HangWatchdogMinidumpFlagValuesMatchTheSdk()
+    {
+        // The dump masks are composed from raw MINIDUMP_TYPE literals,
+        // and no behavioral test can see a wrong value: 0x40000 is
+        // MiniDumpWithTokenInformation, not indirectly-referenced
+        // memory (0x40), and a dump captured with that mask passes every
+        // test while containing the wrong evidence, token data
+        // included. Pin the literals to minidumpapiset.h so a typo is a
+        // red test, not a shipped mask.
+        var src = ShellSource.Load("Ghostty.Diagnostics.HangWatchdog.cs");
+        Assert.Equal("0x2", src.Field("MiniDumpWithFullMemory").Variable.Initializer!.Value.ToString());
+        Assert.Equal("0x4", src.Field("MiniDumpWithHandleData").Variable.Initializer!.Value.ToString());
+        Assert.Equal("0x10", src.Field("MiniDumpScanMemory").Variable.Initializer!.Value.ToString());
+        Assert.Equal("0x20", src.Field("MiniDumpWithUnloadedModules").Variable.Initializer!.Value.ToString());
+        Assert.Equal("0x800", src.Field("MiniDumpWithFullMemoryInfo").Variable.Initializer!.Value.ToString());
+        Assert.Equal("0x1000", src.Field("MiniDumpWithThreadInfo").Variable.Initializer!.Value.ToString());
+        Assert.Equal("0x40", src.Field("MiniDumpWithIndirectlyReferencedMemory").Variable.Initializer!.Value.ToString());
+    }
 }
 
 file static class DiagnosticsSyntaxQueries

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -463,13 +463,136 @@ public partial class App : Application
 
     private static readonly object _crashLogLock = new();
 
+    // Enough of crash.log to hold every entry that could postdate the
+    // previous launch; the file itself is unbounded.
+    private const long CrashLogTailBytes = 64 * 1024;
+
+    /// <summary>
+    /// Show the one-per-stall notice for hang evidence a previous
+    /// session left in crash.log (#1046). Best-effort by contract: any
+    /// I/O failure gives up on the notice, never on the launch.
+    /// </summary>
+    private void ShowPreviousSessionHangNotice()
+    {
+        // The launch instant, captured before any evaluation I/O: a
+        // stall in the moments between the two must still count as new
+        // next launch, so the marker cannot say "now at write time".
+        var launchedAt = DateTimeOffset.UtcNow;
+        try
+        {
+            var root = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                Ghostty.Core.AppIdentity.StateDirName);
+            var markerPath = Path.Combine(root, "last-launch");
+
+            // A missing or unparseable marker means "nothing has been
+            // reported yet", so any stall entry in the log is news.
+            var lastLaunch = DateTimeOffset.MinValue;
+            if (File.Exists(markerPath))
+            {
+                if (!DateTimeOffset.TryParseExact(
+                        File.ReadAllText(markerPath).Trim(),
+                        "O",
+                        System.Globalization.CultureInfo.InvariantCulture,
+                        System.Globalization.DateTimeStyles.RoundtripKind,
+                        out lastLaunch))
+                {
+                    lastLaunch = DateTimeOffset.MinValue;
+                }
+            }
+
+            var outcome = Ghostty.Core.Diagnostics.HangEvidenceStartup.Resolve(
+                ReadCrashLogTail(Path.Combine(root, "crash.log")),
+                lastLaunch);
+
+            // Written after the evaluation and whether or not a notice
+            // follows: the next launch compares against THIS one, so a
+            // stall logged later in this session still reads as new
+            // then. A failed write means the notice may repeat next
+            // launch; losing it entirely would be worse.
+            File.WriteAllText(markerPath, $"{launchedAt:O}");
+
+            if (!outcome.Notify) return;
+
+            var hangsDir = Path.Combine(root, "hangs");
+            // Null-conditional out of parity with the field's declared
+            // nullability, not out of doubt: the wiring pin holds this
+            // call after the service's construction.
+            _notificationService?.Show(new Ghostty.Core.Notifications.Notice
+            {
+                Title = "Wintty froze and captured evidence",
+                Message = "Wintty froze in a previous session and captured a hang dump in "
+                    + hangsDir + ", which may contain sensitive terminal content.",
+                Severity = Ghostty.Core.Notifications.NoticeSeverity.Informational,
+                IsClosable = true,
+                DedupKey = "hang-evidence",
+                Actions = new Ghostty.Core.Notifications.NoticeAction[]
+                {
+                    // Shell-executing a directory opens it in Explorer,
+                    // the same open pattern the config file uses.
+                    new(
+                        "Open folder",
+                        () =>
+                        {
+                            try
+                            {
+                                System.Diagnostics.Process.Start(
+                                    new System.Diagnostics.ProcessStartInfo
+                                    {
+                                        FileName = hangsDir,
+                                        UseShellExecute = true,
+                                    });
+                            }
+                            catch { /* a folder that will not open must not take the app down */ }
+                        },
+                        IsPrimary: true),
+                    // SetContent races the clipboard broker and can throw
+                    // COMException; the path is in the message either way.
+                    new(
+                        "Copy path",
+                        () =>
+                        {
+                            try
+                            {
+                                var data = new Windows.ApplicationModel.DataTransfer.DataPackage();
+                                data.SetText(hangsDir);
+                                Windows.ApplicationModel.DataTransfer.Clipboard.SetContent(data);
+                            }
+                            catch { /* clipboard busy; the path is one glance away */ }
+                        }),
+                },
+            });
+        }
+        catch
+        {
+            // Deliberately bare: a notice about evidence is the
+            // definition of not worth blocking the launch for.
+        }
+    }
+
+    private static string? ReadCrashLogTail(string path)
+    {
+        if (!File.Exists(path)) return null;
+
+        // ReadWrite sharing like ConfigIniFile: another instance of the
+        // app may hold the log open for appending.
+        using var stream = new FileStream(
+            path, FileMode.Open, FileAccess.Read,
+            FileShare.ReadWrite | FileShare.Delete);
+        if (stream.Length > CrashLogTailBytes)
+            stream.Seek(-CrashLogTailBytes, SeekOrigin.End);
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+
     protected override void OnLaunched(LaunchActivatedEventArgs args)
     {
         // UI-thread stall watchdog (#1033): a hang writes no exception
-        // anywhere, so this records it -- a crash.log entry plus a full
-        // minidump of the still-hung process under
-        // %LOCALAPPDATA%\Wintty\hangs\. First thing in the launch: the
-        // #1036 class of hang existed from the first frame.
+        // anywhere, so this records it -- a crash.log entry plus a
+        // minidump of the still-hung process (triage scope by default,
+        // full via hang-dump) under %LOCALAPPDATA%\Wintty\hangs\. First
+        // thing in the launch: the #1036 class of hang existed from the
+        // first frame.
         Diagnostics.HangWatchdog.Start(DispatcherQueue.GetForCurrentThread());
 
         // Set the explicit AppUserModelID. This MUST happen before
@@ -561,6 +684,12 @@ public partial class App : Application
         _configService = new ConfigService(DispatcherQueue.GetForCurrentThread());
         ConfigService = _configService;
 
+        // The watchdog armed above, before the config service could
+        // exist; hand it the hang-dump scope now, still well inside the
+        // first stall window. Until this line a stall captures the
+        // triage default.
+        Diagnostics.HangWatchdog.ConfigureDumpMode(_configService.HangDump);
+
         // build the factory from Ghostty config before any other service constructs an
         // ILogger<T>. Log directory under the same %LOCALAPPDATA%\Wintty root that
         // App.LogUnhandled already uses for crash.log, so a user reporting a bug only has
@@ -645,6 +774,14 @@ public partial class App : Application
                 persistMode: PersistNoColorMode);
             if (noColorNotice is not null) _notificationService.Show(noColorNotice);
         }
+
+        // Hang evidence from a previous session (#1046): the watchdog
+        // logged a stall while the UI thread was hung, and a hung UI
+        // thread cannot show anything, so this launch is the first
+        // moment the user can be told. One notice per stall event; the
+        // last-launch marker inside keeps later launches quiet unless a
+        // newer stall lands.
+        ShowPreviousSessionHangNotice();
 
         // Single-instance gate. Acted on here -- after the logger factory
         // exists (so failures are visible in Release), but before the

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -479,10 +479,13 @@ public partial class App : Application
     /// </summary>
     private void ShowPreviousSessionHangNotice()
     {
-        // The launch instant, captured before any evaluation I/O: a
-        // stall in the moments between the two must still count as new
-        // next launch, so the marker cannot say "now at write time".
-        var launchedAt = DateTimeOffset.UtcNow;
+        // This session's boundary is the watchdog's arm instant, the
+        // earliest moment a stall could belong to this launch. Capturing
+        // "now" instead would fold a stall from a slow early launch (the
+        // arm is OnLaunched's first statement) into the previous-session
+        // window: the notice would describe a freeze the user just
+        // watched, and the marker write would consume it.
+        var launchedAt = Diagnostics.HangWatchdog.ArmedAtUtc;
         try
         {
             var root = Path.Combine(
@@ -527,8 +530,9 @@ public partial class App : Application
             _notificationService?.Show(new Ghostty.Core.Notifications.Notice
             {
                 Title = "Wintty froze and captured evidence",
-                Message = "Wintty froze in a previous session and wrote hang evidence to "
-                    + hangsDir + ". If a hang dump is there it may contain sensitive content.",
+                Message = "Wintty froze in a previous session. crash.log holds the stall "
+                    + "entries, and any captured hang dump sits in " + hangsDir
+                    + "; a dump may contain sensitive content.",
                 Severity = Ghostty.Core.Notifications.NoticeSeverity.Informational,
                 IsClosable = true,
                 DedupKey = "hang-evidence",

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -464,8 +464,13 @@ public partial class App : Application
     private static readonly object _crashLogLock = new();
 
     // Enough of crash.log to hold every entry that could postdate the
-    // previous launch; the file itself is unbounded.
-    private const long CrashLogTailBytes = 64 * 1024;
+    // previous launch; the file itself is unbounded. A post-stall
+    // cascade (three handlers per exception, one entry per unobserved
+    // task, other instances appending) can add a burst of entries after
+    // the stall line, so this is deliberately generous: the cost is one
+    // 1 MiB read at launch, and a marker advanced past a stall the
+    // window missed is unrecoverable.
+    private const long CrashLogTailBytes = 1024 * 1024;
 
     /// <summary>
     /// Show the one-per-stall notice for hang evidence a previous
@@ -503,7 +508,8 @@ public partial class App : Application
 
             var outcome = Ghostty.Core.Diagnostics.HangEvidenceStartup.Resolve(
                 ReadCrashLogTail(Path.Combine(root, "crash.log")),
-                lastLaunch);
+                lastLaunch,
+                launchedAt);
 
             // Written after the evaluation and whether or not a notice
             // follows: the next launch compares against THIS one, so a
@@ -521,8 +527,8 @@ public partial class App : Application
             _notificationService?.Show(new Ghostty.Core.Notifications.Notice
             {
                 Title = "Wintty froze and captured evidence",
-                Message = "Wintty froze in a previous session and captured a hang dump in "
-                    + hangsDir + ", which may contain sensitive terminal content.",
+                Message = "Wintty froze in a previous session and wrote hang evidence to "
+                    + hangsDir + ". If a hang dump is there it may contain sensitive content.",
                 Severity = Ghostty.Core.Notifications.NoticeSeverity.Informational,
                 IsClosable = true,
                 DedupKey = "hang-evidence",
@@ -570,20 +576,10 @@ public partial class App : Application
         }
     }
 
-    private static string? ReadCrashLogTail(string path)
-    {
-        if (!File.Exists(path)) return null;
-
-        // ReadWrite sharing like ConfigIniFile: another instance of the
-        // app may hold the log open for appending.
-        using var stream = new FileStream(
-            path, FileMode.Open, FileAccess.Read,
-            FileShare.ReadWrite | FileShare.Delete);
-        if (stream.Length > CrashLogTailBytes)
-            stream.Seek(-CrashLogTailBytes, SeekOrigin.End);
-        using var reader = new StreamReader(stream);
-        return reader.ReadToEnd();
-    }
+    private static string? ReadCrashLogTail(string path) =>
+        Diagnostics.FileTail.Read(path, CrashLogTailBytes) is { } tail
+            ? System.Text.Encoding.UTF8.GetString(tail)
+            : null;
 
     protected override void OnLaunched(LaunchActivatedEventArgs args)
     {
@@ -706,6 +702,11 @@ public partial class App : Application
         _logFilters = filters;
         LoggerFactory = factory;
         _configService.ConfigChanged += OnConfigChanged_ApplyLogFilters;
+        // The watchdog's hang-dump scope is a launch-time seed, not a
+        // live read; re-seed on reload so a mid-session switch (support
+        // asking for hang-dump = full before a repro) takes effect
+        // without a restart, in both directions.
+        _configService.ConfigChanged += OnConfigChanged_SeedHangDumpMode;
 
         // Install the libghostty log bridge now that the factory
         // exists. After this point every Zig std.log call is delivered
@@ -780,15 +781,14 @@ public partial class App : Application
         // thread cannot show anything, so this launch is the first
         // moment the user can be told. One notice per stall event; the
         // last-launch marker inside keeps later launches quiet unless a
-        // newer stall lands.
-        ShowPreviousSessionHangNotice();
-
-        // Single-instance gate. Acted on here -- after the logger factory
-        // exists (so failures are visible in Release), but before the
-        // bootstrap host, window, and DX12 renderer are created -- so a
-        // secondary process forwards its launch and exits without ever
-        // creating a window or paying for the renderer.
+        // newer stall lands. AFTER the single-instance gate: a secondary
+        // process forwards and exits below, and if it evaluated first it
+        // would advance the marker and consume the notice into a
+        // NotificationService no host ever binds -- precisely when the
+        // user re-launched because the primary hung.
         HandleSingleInstanceGate(Program.SingleInstance);
+
+        ShowPreviousSessionHangNotice();
 
         // Power-saving monitor. Reads power-saver-mode from config every
         // time it resolves (Func thunk decouples it from ConfigService
@@ -2051,6 +2051,12 @@ public partial class App : Application
         if (_logFilters is null) return;
         Ghostty.Core.Logging.LoggingBootstrap.ApplyFilters(
             _logFilters, cfg.LogLevel, cfg.LogFilter);
+    }
+
+    private void OnConfigChanged_SeedHangDumpMode(Ghostty.Core.Config.IConfigService cfg)
+    {
+        // Fires after the re-read, so the property is the fresh value.
+        Diagnostics.HangWatchdog.ConfigureDumpMode(_configService.HangDump);
     }
 
     private void OnConfigChanged_NotifyPowerMonitor(Ghostty.Core.Config.IConfigService cfg)

--- a/windows/Ghostty/Diagnostics/FileTail.cs
+++ b/windows/Ghostty/Diagnostics/FileTail.cs
@@ -1,0 +1,32 @@
+using System.IO;
+
+namespace Ghostty.Diagnostics;
+
+/// <summary>
+/// The one way to read the newest bytes of a file another process or
+/// instance may hold open: crash.log is appended by every instance, and
+/// native-stderr.log is held for append by its capturing instance. One
+/// helper instead of per-caller copies, because a concurrency fix
+/// applied to one copy silently misses the others.
+/// </summary>
+internal static class FileTail
+{
+    /// <summary>
+    /// The last at most <paramref name="maxBytes"/> of the file, or null
+    /// when it does not exist. A line cut by the window boundary is the
+    /// caller's to tolerate.
+    /// </summary>
+    internal static byte[]? Read(string path, long maxBytes)
+    {
+        if (!File.Exists(path)) return null;
+
+        using var stream = new FileStream(
+            path, FileMode.Open, FileAccess.Read,
+            FileShare.ReadWrite | FileShare.Delete);
+        if (stream.Length > maxBytes)
+            stream.Seek(-maxBytes, SeekOrigin.End);
+        using var tail = new MemoryStream((int)maxBytes);
+        stream.CopyTo(tail);
+        return tail.ToArray();
+    }
+}

--- a/windows/Ghostty/Diagnostics/HangWatchdog.cs
+++ b/windows/Ghostty/Diagnostics/HangWatchdog.cs
@@ -48,10 +48,19 @@ internal static class HangWatchdog
 
     // The watchdog arms before the config service can exist, so the
     // capture scope starts at the triage default and is seeded from
-    // hang-dump once App has a config to read (well inside the first
-    // stall window). volatile: written on the UI thread, read on the
-    // watch thread.
+    // hang-dump once App has a config to read, then re-seeded on every
+    // config reload (well inside the first stall window either way).
+    // volatile: written on the UI thread, read on the watch thread.
     private static volatile HangDumpMode _dumpMode = HangDumpMode.Triage;
+
+    /// <summary>
+    /// When the watchdog armed, i.e. the earliest instant a stall could
+    /// belong to this session. The launch notice uses it as this
+    /// session's boundary: capturing the instant at the notice instead
+    /// would mislabel a stall from a slow early launch as a previous
+    /// session's and consume it.
+    /// </summary>
+    public static DateTimeOffset ArmedAtUtc { get; private set; }
 
     /// <summary>
     /// Seed the capture scope from the <c>hang-dump</c> config key.
@@ -65,6 +74,7 @@ internal static class HangWatchdog
     public static void Start(DispatcherQueue dispatcher)
     {
         if (Interlocked.Exchange(ref _armed, 1) == 1) return;
+        ArmedAtUtc = DateTimeOffset.UtcNow;
 
         // The heartbeat: a lightweight repeating timer on the UI thread.
         // DispatcherQueueTimer runs on the thread that owns the queue,

--- a/windows/Ghostty/Diagnostics/HangWatchdog.cs
+++ b/windows/Ghostty/Diagnostics/HangWatchdog.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
+using Ghostty.Core.Diagnostics;
 using Microsoft.UI.Dispatching;
 
 namespace Ghostty.Diagnostics;
@@ -17,14 +18,15 @@ namespace Ghostty.Diagnostics;
 /// watchdog closes that gap: a UI-thread heartbeat counter is advanced
 /// by a dispatcher timer, and a background thread checks it. If the
 /// counter has not moved for the stall window, the watchdog appends a
-/// crash.log entry and captures a full minidump of the still-hung
-/// process -- the same evidence class that took a three-hour ad-hoc
-/// debug session to collect by hand.
+/// crash.log entry and captures a minidump of the still-hung process
+/// (triage scope by default; full via hang-dump) -- the same evidence
+/// class that took a three-hour ad-hoc debug session to collect by
+/// hand.
 ///
 /// One capture per stall: after firing, the watchdog disarms itself
 /// (the UI thread is not going to un-hang on its own; a second dump of
-/// the same stacks helps nobody) and keeps a marker so the stall is
-/// still visible in the log if the process is later killed.
+/// the same stacks helps nobody). The crash.log entries it wrote are
+/// what the next launch's hang notice reads (#1046).
 /// </summary>
 internal static class HangWatchdog
 {
@@ -43,6 +45,18 @@ internal static class HangWatchdog
     private static int _armed;
     private static DispatcherQueueTimer? _heartbeatTimer;
     private static Thread? _watchThread;
+
+    // The watchdog arms before the config service can exist, so the
+    // capture scope starts at the triage default and is seeded from
+    // hang-dump once App has a config to read (well inside the first
+    // stall window). volatile: written on the UI thread, read on the
+    // watch thread.
+    private static volatile HangDumpMode _dumpMode = HangDumpMode.Triage;
+
+    /// <summary>
+    /// Seed the capture scope from the <c>hang-dump</c> config key.
+    /// </summary>
+    internal static void ConfigureDumpMode(HangDumpMode mode) => _dumpMode = mode;
 
     /// <summary>
     /// Arm the watchdog. Call once, on the UI thread, once the
@@ -94,6 +108,9 @@ internal static class HangWatchdog
     private static void RecordStall(TimeSpan stalledFor)
     {
         var pid = Environment.ProcessId;
+        // Read at capture time: the seed can land while the watch thread
+        // is already running.
+        var mode = _dumpMode;
         var (logPath, dumpPath) = Paths(pid);
         try
         {
@@ -102,18 +119,21 @@ internal static class HangWatchdog
                 logPath,
                 $"{DateTimeOffset.UtcNow:O} [UI-THREAD STALL]\n" +
                 $"The UI thread has not pumped for {stalledFor.TotalSeconds:N0}s; " +
-                $"capturing {dumpPath}\n\n");
+                $"capturing {dumpPath} ({DumpLabel(mode)})\n\n");
         }
         catch { /* diagnostics must not throw */ }
 
-        CaptureMinidump(pid, dumpPath);
+        CaptureMinidump(pid, dumpPath, mode);
 
         try
         {
+            var modeWord = HangDump.ConfigValue(mode);
             File.AppendAllText(
                 logPath,
                 $"{DateTimeOffset.UtcNow:O} [UI-THREAD STALL] minidump " +
-                (File.Exists(dumpPath) ? $"written ({new FileInfo(dumpPath).Length:N0} bytes)" : "FAILED") +
+                (File.Exists(dumpPath)
+                    ? $"written ({new FileInfo(dumpPath).Length:N0} bytes, {modeWord})"
+                    : $"FAILED ({modeWord})") +
                 "\n\n");
         }
         catch { }
@@ -131,10 +151,34 @@ internal static class HangWatchdog
 
     // ---- minidump capture ------------------------------------------------
 
-    private const uint MiniDumpWithFullMemory = 0x2;
-    private const uint MiniDumpWithHandleData = 0x4;
-    private const uint MiniDumpWithFullMemoryInfo = 0x800;
-    private const uint MiniDumpWithThreadInfo = 0x1000;
+    // MINIDUMP_TYPE flag values, each with the reason it earns a place
+    // in a mask below.
+    private const uint MiniDumpWithFullMemory = 0x2;                     // every byte of the process: the secrets-bearing opt-in
+    private const uint MiniDumpWithHandleData = 0x4;                     // the handle table: which thread holds the lock the UI thread is stuck on
+    private const uint MiniDumpScanMemory = 0x10;                        // marks dump ranges so stacks that walk referenced memory still symbolize
+    private const uint MiniDumpWithUnloadedModules = 0x20;               // resolves stale frames pointing into modules that already exited
+    private const uint MiniDumpWithFullMemoryInfo = 0x800;               // the full virtual-memory map: only meaningful alongside full memory
+    private const uint MiniDumpWithThreadInfo = 0x1000;                  // per-thread timings: how long each thread sat where it is
+    private const uint MiniDumpWithIndirectlyReferencedMemory = 0x40000; // memory the stacks point at: locals and lock words without the whole heap
+
+    // Triage mask (the default): walks stacks and lock ownership with no
+    // heap sweep, so the dump stays small and free of terminal content.
+    private const uint TriageDumpFlags =
+        MiniDumpWithHandleData |
+        MiniDumpScanMemory |
+        MiniDumpWithUnloadedModules |
+        MiniDumpWithThreadInfo |
+        MiniDumpWithIndirectlyReferencedMemory;
+
+    // Full mask (hang-dump = full): exactly the pre-#1045 0x1806 capture.
+    private const uint FullDumpFlags =
+        MiniDumpWithFullMemory |
+        MiniDumpWithHandleData |
+        MiniDumpWithFullMemoryInfo |
+        MiniDumpWithThreadInfo;
+
+    private static string DumpLabel(HangDumpMode mode) =>
+        mode == HangDumpMode.Full ? "full memory dump" : "triage dump";
 
     /// <summary>
     /// dbghelp's MiniDumpWriteDump called in-process. In-process on
@@ -142,7 +186,7 @@ internal static class HangWatchdog
     /// DACL nobody can read without elevating (verified while chasing
     /// #1036), and the dump then can't even be copied out for support.
     /// </summary>
-    private static void CaptureMinidump(int pid, string path)
+    private static void CaptureMinidump(int pid, string path, HangDumpMode mode)
     {
         try
         {
@@ -150,10 +194,10 @@ internal static class HangWatchdog
             using var proc = Process.GetProcessById(pid);
             using var fs = new FileStream(
                 path, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
-            // 0x1806: full memory + handle data + full memory info + thread info.
             _ = MiniDumpWriteDump(
                 proc.Handle, (uint)pid, fs.SafeFileHandle.DangerousGetHandle(),
-                0x1806, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+                mode == HangDumpMode.Full ? FullDumpFlags : TriageDumpFlags,
+                IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
         }
         catch { /* diagnostics must not throw */ }
     }

--- a/windows/Ghostty/Diagnostics/HangWatchdog.cs
+++ b/windows/Ghostty/Diagnostics/HangWatchdog.cs
@@ -117,21 +117,21 @@ internal static class HangWatchdog
             Directory.CreateDirectory(Path.GetDirectoryName(logPath)!);
             File.AppendAllText(
                 logPath,
-                $"{DateTimeOffset.UtcNow:O} [UI-THREAD STALL]\n" +
+                $"{DateTimeOffset.UtcNow:O} {HangEvidenceStartup.StallMarker}\n" +
                 $"The UI thread has not pumped for {stalledFor.TotalSeconds:N0}s; " +
                 $"capturing {dumpPath} ({DumpLabel(mode)})\n\n");
         }
         catch { /* diagnostics must not throw */ }
 
-        CaptureMinidump(pid, dumpPath, mode);
+        var written = CaptureMinidump(pid, dumpPath, mode);
 
         try
         {
             var modeWord = HangDump.ConfigValue(mode);
             File.AppendAllText(
                 logPath,
-                $"{DateTimeOffset.UtcNow:O} [UI-THREAD STALL] minidump " +
-                (File.Exists(dumpPath)
+                $"{DateTimeOffset.UtcNow:O} {HangEvidenceStartup.StallMarker} minidump " +
+                (written && File.Exists(dumpPath)
                     ? $"written ({new FileInfo(dumpPath).Length:N0} bytes, {modeWord})"
                     : $"FAILED ({modeWord})") +
                 "\n\n");
@@ -151,15 +151,15 @@ internal static class HangWatchdog
 
     // ---- minidump capture ------------------------------------------------
 
-    // MINIDUMP_TYPE flag values, each with the reason it earns a place
-    // in a mask below.
+    // MINIDUMP_TYPE flag values (minidumpapiset.h), each with the reason
+    // it earns a place in a mask below.
     private const uint MiniDumpWithFullMemory = 0x2;                     // every byte of the process: the secrets-bearing opt-in
     private const uint MiniDumpWithHandleData = 0x4;                     // the handle table: which thread holds the lock the UI thread is stuck on
     private const uint MiniDumpScanMemory = 0x10;                        // marks dump ranges so stacks that walk referenced memory still symbolize
     private const uint MiniDumpWithUnloadedModules = 0x20;               // resolves stale frames pointing into modules that already exited
     private const uint MiniDumpWithFullMemoryInfo = 0x800;               // the full virtual-memory map: only meaningful alongside full memory
     private const uint MiniDumpWithThreadInfo = 0x1000;                  // per-thread timings: how long each thread sat where it is
-    private const uint MiniDumpWithIndirectlyReferencedMemory = 0x40000; // memory the stacks point at: locals and lock words without the whole heap
+    private const uint MiniDumpWithIndirectlyReferencedMemory = 0x40;    // memory the stacks point at: locals and lock words without the whole heap
 
     // Triage mask (the default): walks stacks and lock ownership with no
     // heap sweep, so the dump stays small and free of terminal content.
@@ -185,8 +185,11 @@ internal static class HangWatchdog
     /// purpose: comsvcs' rundll32 dumper writes an Administrators-only
     /// DACL nobody can read without elevating (verified while chasing
     /// #1036), and the dump then can't even be copied out for support.
+    /// Returns whether dbghelp reported success: the file is created
+    /// before the call, so its existence proves nothing (a failed
+    /// capture leaves an empty .dmp).
     /// </summary>
-    private static void CaptureMinidump(int pid, string path, HangDumpMode mode)
+    private static bool CaptureMinidump(int pid, string path, HangDumpMode mode)
     {
         try
         {
@@ -194,12 +197,15 @@ internal static class HangWatchdog
             using var proc = Process.GetProcessById(pid);
             using var fs = new FileStream(
                 path, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
-            _ = MiniDumpWriteDump(
+            return MiniDumpWriteDump(
                 proc.Handle, (uint)pid, fs.SafeFileHandle.DangerousGetHandle(),
                 mode == HangDumpMode.Full ? FullDumpFlags : TriageDumpFlags,
                 IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
         }
-        catch { /* diagnostics must not throw */ }
+        catch
+        {
+            return false;
+        }
     }
 
     [DllImport("dbghelp.dll")]

--- a/windows/Ghostty/Diagnostics/NativeStderrCapture.cs
+++ b/windows/Ghostty/Diagnostics/NativeStderrCapture.cs
@@ -99,7 +99,7 @@ internal static partial class NativeStderrCapture
     private static void KeepTail(string path, long keepBytes)
     {
         var tail = FileTail.Read(path, keepBytes);
-        if (tail is null || tail.Length < keepBytes) return;
+        if (tail is null || tail.Length <= keepBytes) return;
         File.WriteAllBytes(path, tail);
     }
 

--- a/windows/Ghostty/Diagnostics/NativeStderrCapture.cs
+++ b/windows/Ghostty/Diagnostics/NativeStderrCapture.cs
@@ -58,12 +58,18 @@ internal static partial class NativeStderrCapture
             var path = LogPath;
             Directory.CreateDirectory(Path.GetDirectoryName(path)!);
 
-            // Rotate at the cap: truncate rather than rename -- simpler
-            // than rename racing a concurrent writer, and the
-            // interesting content (the panic) is always at the tail,
-            // which truncation preserves.
+            // Rotate at the cap: keep the newest half. A rename would
+            // race any concurrent writer, and emptying would discard
+            // exactly the panic text the file exists to keep -- the
+            // evidence is always at the tail.
             if (File.Exists(path) && new FileInfo(path).Length > MaxBytes)
-                File.WriteAllText(path, string.Empty);
+            {
+                try
+                {
+                    KeepTail(path, MaxBytes / 2);
+                }
+                catch { /* rotation is best-effort; the append below still happens */ }
+            }
 
             // FileShare.ReadWrite so a concurrently-running second
             // window of the same process does not open-exclusively us.
@@ -81,6 +87,25 @@ internal static partial class NativeStderrCapture
         {
             // Best-effort by contract: silent on failure.
         }
+    }
+
+    /// <summary>
+    /// Rewrite <paramref name="path"/> holding only its last
+    /// <paramref name="keepBytes"/> bytes. ReadWrite sharing because a
+    /// concurrently-running second instance may hold the file open for
+    /// appending; if that same instance then blocks the rewrite, the
+    /// caller treats rotation as failed and keeps appending.
+    /// </summary>
+    private static void KeepTail(string path, long keepBytes)
+    {
+        using var src = new FileStream(
+            path, FileMode.Open, FileAccess.Read,
+            FileShare.ReadWrite | FileShare.Delete);
+        if (src.Length <= keepBytes) return;
+        src.Seek(-keepBytes, SeekOrigin.End);
+        using var tail = new MemoryStream((int)keepBytes);
+        src.CopyTo(tail);
+        File.WriteAllBytes(path, tail.ToArray());
     }
 
     private const int StdErrorHandle = -12; // STD_ERROR_HANDLE

--- a/windows/Ghostty/Diagnostics/NativeStderrCapture.cs
+++ b/windows/Ghostty/Diagnostics/NativeStderrCapture.cs
@@ -26,7 +26,8 @@ internal static partial class NativeStderrCapture
     /// <summary>
     /// Cap on the capture file. Panics are a few KB; anything past this
     /// is a chatty native write we do not need to keep across launches,
-    /// so the file truncates at the cap rather than growing forever.
+    /// so at the cap the file is rewritten holding its newest half
+    /// rather than growing forever.
     /// </summary>
     private const long MaxBytes = 8 * 1024 * 1024;
 
@@ -91,21 +92,15 @@ internal static partial class NativeStderrCapture
 
     /// <summary>
     /// Rewrite <paramref name="path"/> holding only its last
-    /// <paramref name="keepBytes"/> bytes. ReadWrite sharing because a
-    /// concurrently-running second instance may hold the file open for
-    /// appending; if that same instance then blocks the rewrite, the
+    /// <paramref name="keepBytes"/> bytes, via the shared tail reader.
+    /// If a concurrently-running second instance blocks the rewrite, the
     /// caller treats rotation as failed and keeps appending.
     /// </summary>
     private static void KeepTail(string path, long keepBytes)
     {
-        using var src = new FileStream(
-            path, FileMode.Open, FileAccess.Read,
-            FileShare.ReadWrite | FileShare.Delete);
-        if (src.Length <= keepBytes) return;
-        src.Seek(-keepBytes, SeekOrigin.End);
-        using var tail = new MemoryStream((int)keepBytes);
-        src.CopyTo(tail);
-        File.WriteAllBytes(path, tail.ToArray());
+        var tail = FileTail.Read(path, keepBytes);
+        if (tail is null || tail.Length < keepBytes) return;
+        File.WriteAllBytes(path, tail);
     }
 
     private const int StdErrorHandle = -12; // STD_ERROR_HANDLE

--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -504,10 +504,18 @@
     Always copy regardless of whether the static lib also exists:
     zig build produces both artifacts, and Debug builds load the DLL
     at runtime even when the static lib is present on disk.
+    The pdb rides along beside it: user minidumps of hangs and crashes
+    are only symbolizable against the pdb matching this exact dll, and
+    release packaging sweeps every *.pdb out of the publish folder into
+    the per-build symbol archive before anything ships.
   -->
   <ItemGroup>
     <None Include="..\..\zig-out\lib\ghostty.dll" Condition="Exists('..\..\zig-out\lib\ghostty.dll')">
       <Link>native\ghostty.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\zig-out\lib\ghostty.pdb" Condition="Exists('..\..\zig-out\lib\ghostty.pdb')">
+      <Link>native\ghostty.pdb</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -567,6 +567,19 @@
   </Target>
 
   <!--
+    Same silent-drop mechanism, pdb edition: a zig-out built before the
+    pdb was installed (or by a target that installs none) drops the pdb
+    copy item with zero signal, and every dump that build ever produces
+    is unsymbolizable. A warning, not an error: the app runs fine
+    without symbols, and release packaging (wintty-release's symbol
+    archive step) is where absence becomes fatal.
+  -->
+  <Target Name="WarnIfNoLibghosttyPdb" BeforeTargets="Build"
+          Condition="Exists('..\..\zig-out\lib\ghostty.dll') and !Exists('..\..\zig-out\lib\ghostty.pdb')">
+    <Warning Text="ghostty.pdb missing at $([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\..\..\zig-out\lib\ghostty.pdb')) while ghostty.dll exists: minidumps from this build cannot be symbolized. Rebuild the dll ('zig build -Dapp-runtime=none') from a tree that installs the pdb." />
+  </Target>
+
+  <!--
     NativeAOT publish omits XAML binary resources (.xbf) and the
     package resource index (.pri) from the publish output. Without
     them Application.LoadComponent() cannot resolve ms-appx:/// URIs

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -74,6 +74,10 @@ internal sealed partial class ConfigService : IConfigService, Ghostty.Core.Profi
     public bool WindowsHighContrast { get; private set; } = true;
     public string CommandPaletteBackground { get; private set; } = "acrylic";
     public string NoColorOverride { get; private set; } = NoColorPolicy.Default;
+    // Read here but consumed by the hang watchdog via the seed App hands
+    // it in OnLaunched: the watchdog arms before this service exists.
+    public Ghostty.Core.Diagnostics.HangDumpMode HangDump { get; private set; }
+        = Ghostty.Core.Diagnostics.HangDumpMode.Triage;
 
     // The High Contrast palette to layer on top of the user's config, or
     // null when HC is inactive/opted-out. Set by HighContrastMonitor;
@@ -989,6 +993,8 @@ internal sealed partial class ConfigService : IConfigService, Ghostty.Core.Profi
             GetFileValue("no-color-override", ""),
             allowed: NoColorPolicy.Allowed,
             defaultValue: NoColorPolicy.Default);
+        HangDump = Ghostty.Core.Diagnostics.HangDump.Parse(
+            GetFileValue("hang-dump", ""));
         // Windows-only logger keys. Parsing into LogLevel/filter rules
         // happens in LoggingBootstrap; here we just surface the raw
         // strings so reloads can re-read them without parser knowledge.

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -75,7 +75,9 @@ internal sealed partial class ConfigService : IConfigService, Ghostty.Core.Profi
     public string CommandPaletteBackground { get; private set; } = "acrylic";
     public string NoColorOverride { get; private set; } = NoColorPolicy.Default;
     // Read here but consumed by the hang watchdog via the seed App hands
-    // it in OnLaunched: the watchdog arms before this service exists.
+    // it in OnLaunched and again on every ConfigChanged: the watchdog
+    // arms before this service exists, and reloads must not leave it on
+    // a stale scope.
     public Ghostty.Core.Diagnostics.HangDumpMode HangDump { get; private set; }
         = Ghostty.Core.Diagnostics.HangDumpMode.Triage;
 

--- a/windows/docs/diagnostics.md
+++ b/windows/docs/diagnostics.md
@@ -31,8 +31,9 @@ reaches one of the handlers (UI thread, `AppDomain`, `TaskScheduler`),
 and it receives `[UI-THREAD STALL]` entries from the hang watchdog
 described below.
 
-Entries carry a round-trip UTC timestamp (`2026-04-17T14:23:17.042Z`)
-and a handler tag, followed by the exception detail.
+Entries carry a round-trip UTC timestamp
+(`2026-04-17T14:23:17.0423168+00:00`) and a handler tag, followed by
+the exception detail.
 
 Never pruned, never truncated: it only grows when something goes wrong.
 Delete it at any time; the next failure recreates it.

--- a/windows/docs/diagnostics.md
+++ b/windows/docs/diagnostics.md
@@ -95,9 +95,10 @@ GUI process has no usable stderr. Panic messages and their backtraces
 land here verbatim; a native abort otherwise disappears with only an
 exit code.
 
-Capped at 8 MB. When a launch finds the file past the cap it is emptied
-before the capture installs, so the interesting content (a panic at the
-tail) survives.
+Capped at 8 MB. When a launch finds the file past the cap it is
+rewritten holding its newest half (4 MB), so the interesting content
+(a panic at the tail) survives while content from older sessions is
+gone. Content below the cap from a previous session is still present.
 
 Sensitivity: whatever the core printed, which can include echoed text
 and tokens. Redact before sharing, or send it privately.

--- a/windows/docs/diagnostics.md
+++ b/windows/docs/diagnostics.md
@@ -1,0 +1,172 @@
+# Windows diagnostics
+
+Wintty captures evidence of failures locally and never sends anything
+anywhere on its own. When something goes wrong, files appear in fixed
+locations under the state directory, `%LOCALAPPDATA%\Wintty`, and a bug
+report is built from those files. This page covers every artifact: what
+it is, when it is written, what it contains, how sensitive it is, and
+how long it stays.
+
+The rolling application log has its own page, [logging.md](logging.md);
+it appears in the tables below for completeness.
+
+> Packaged (MSIX) builds: Windows virtualizes `%LOCALAPPDATA%` into the
+> package's private app-data directory. The artifacts are the same; the
+> literal path is not. The Settings app shows the real location.
+
+## Where things live
+
+| Artifact | Path |
+|---|---|
+| Unhandled exceptions, UI stalls | `%LOCALAPPDATA%\Wintty\crash.log` |
+| Hang dumps | `%LOCALAPPDATA%\Wintty\hangs\hang-<pid>-<timestamp>.dmp` |
+| Native (Zig) stderr capture | `%LOCALAPPDATA%\Wintty\native-stderr.log` |
+| Rolling application log | `%LOCALAPPDATA%\Wintty\logs\ghostty-YYYYMMDD[-N].log` |
+| Startup-fatal errors | `ghostty-crash.log` beside `Wintty.exe`, else `%LOCALAPPDATA%\Wintty\ghostty-crash.log` |
+
+## crash.log
+
+Append-only file. It receives an entry whenever an unhandled exception
+reaches one of the handlers (UI thread, `AppDomain`, `TaskScheduler`),
+and it receives `[UI-THREAD STALL]` entries from the hang watchdog
+described below.
+
+Entries carry a round-trip UTC timestamp (`2026-04-17T14:23:17.042Z`)
+and a handler tag, followed by the exception detail.
+
+Never pruned, never truncated: it only grows when something goes wrong.
+Delete it at any time; the next failure recreates it.
+
+Sensitivity: exception text and stack frames, usually file paths and
+window titles. Redact before sharing.
+
+## Hang dumps
+
+A hang produces no exception: the unhandled-exception handlers never
+run for a frozen UI thread. The hang watchdog closes that gap. A
+heartbeat timer on the UI thread proves it is pumping messages; a
+background thread samples the counter. When the UI thread has not
+pumped for 20 seconds:
+
+1. `crash.log` gains a `[UI-THREAD STALL]` entry with a UTC timestamp
+2. a dump of the still-hung process is written to
+   `%LOCALAPPDATA%\Wintty\hangs\hang-<pid>-<timestamp>.dmp`
+3. a second entry records the dump size, or a capture failure
+
+The watchdog then disarms: one dump per process, because a second dump
+of the same stuck stacks helps nobody. The 20 second window is
+deliberately long so a synchronous dialog pump or a slow layout pass is
+not mistaken for a hang.
+
+### Triage vs full
+
+| Mode | Config | Dump contents |
+|---|---|---|
+| triage (default) | `hang-dump = "triage"` | thread stacks, handles, stack-referenced memory |
+| full | `hang-dump = "full"` | all of the above plus all process memory |
+
+`hang-dump` lives in the regular Ghostty config file. The default,
+`triage`, keeps the useful evidence (what every thread is stuck on)
+without a RAM image.
+
+A full dump is a RAM image: every scrollback line, every token the
+terminal echoed, every pasted and echoed text, including passwords. If
+you run with `hang-dump = "full"`, treat the files in `hangs\` as
+secrets.
+
+Dumps are never pruned automatically. They stay in `hangs\` until you
+delete them.
+
+### Sensitivity rules
+
+- Triage dump: thread stacks and handles only, far less sensitive, but
+  still contains module paths and stack memory. Attaching one to a
+  public issue is acceptable if you are comfortable with that.
+- Full dump: never attach to a public issue. Send it to the maintainer
+  over a private channel, or delete it and reproduce with
+  `hang-dump = "triage"`.
+- Binary dumps cannot be redacted by a prompt; only text artifacts can
+  (see below).
+
+## native-stderr.log
+
+Everything the Zig core writes to stderr, captured to a file because a
+GUI process has no usable stderr. Panic messages and their backtraces
+land here verbatim; a native abort otherwise disappears with only an
+exit code.
+
+Capped at 8 MB. When a launch finds the file past the cap it is emptied
+before the capture installs, so the interesting content (a panic at the
+tail) survives.
+
+Sensitivity: whatever the core printed, which can include echoed text
+and tokens. Redact before sharing, or send it privately.
+
+## logs\ghostty-YYYYMMDD[-N].log
+
+The rolling application log: one file per UTC day, 16 MB per file with
+`-1`, `-2` suffixes on rollover, 14 day retention, pruned at startup
+and at UTC-day boundaries. Format, config keys, and the event id
+taxonomy are on [logging.md](logging.md).
+
+Sensitivity: structured log lines, but they can carry file paths and
+other identifying strings. A redaction pass is cheap; do one.
+
+## ghostty-crash.log
+
+Startup-fatal errors: the launch paths that die before the UI exists.
+Written beside `Wintty.exe`; when that directory is not writable
+(machine-wide installs, protected portable copies) it falls back to
+`%LOCALAPPDATA%\Wintty\ghostty-crash.log`. Entry shape, sensitivity,
+and retention match crash.log.
+
+## What to attach to a bug report
+
+Version first: the Version dialog's Copy button, or `wintty +version`
+on the command line, pasted verbatim.
+
+Then, by symptom:
+
+| Symptom | Attach |
+|---|---|
+| crash | `crash.log`; add `ghostty-crash.log` if the app died at startup |
+| hang or freeze | `crash.log` (the `[UI-THREAD STALL]` entries) and the dump from `hangs\`, triage only |
+| silent exit | redacted `native-stderr.log` |
+| anything else | the newest two `logs\ghostty-*.log` files |
+
+Text artifacts are safe to attach once redacted. Binary dumps follow
+the sensitivity rules above.
+
+## Before you share logs
+
+The four text artifacts (`crash.log`, `native-stderr.log`,
+`logs\ghostty-*.log`, `ghostty-crash.log`) can be scrubbed before they
+are posted. The prompt below is copy-paste ready: give it to any LLM
+agent together with the log text, and attach the redacted output it
+returns.
+
+Binary `.dmp` files cannot be redacted this way and must never be
+posted publicly; they follow the sensitivity rules above.
+
+```
+You are redacting a log file before I post it in public.
+
+Replace every secret or identifying value with a same-shaped
+placeholder, and change nothing else. Redact:
+- tokens, passwords, API keys, cookies, and anything that looks like a
+  credential, including long random strings in URLs and headers
+- usernames and account names
+- hostnames and machine names
+- file paths that identify me or my organization, keeping the path
+  shape (C:\Users\alice\... becomes C:\Users\<user>\...)
+
+Preserve exactly:
+- line order, line structure, and the pipe-separated field layout
+- timestamps, log levels, event ids, thread ids, error codes, and hex
+  addresses
+- the wording of error messages, exception types, and function names
+
+Ambiguous values are redacted, not kept. Output the full redacted log
+verbatim and nothing else: no commentary, no summary, no surrounding
+markup.
+```

--- a/windows/docs/logging.md
+++ b/windows/docs/logging.md
@@ -3,6 +3,10 @@
 Ghostty's Windows shell emits diagnostics through `Microsoft.Extensions.Logging`
 with two sinks wired at startup.
 
+Crash dumps, hang dumps, and the other on-disk diagnostic artifacts
+outside this logging pipeline are covered in
+[diagnostics.md](diagnostics.md).
+
 ## Sinks
 
 ### ETW (EventSource)


### PR DESCRIPTION
Follow-ups to #1041's watchdog: the three ways the first cut fell short.

## #1044, dll half (the archive gate lands in the release build)

`build-dll-release` stripped the dll (`Config.zig` defaults strip on for ReleaseFast/ReleaseSmall), and even unstripped cuts never installed a pdb: `GhosttyLib` installed the binary only, so no release could archive the symbols its user dumps need.

- `GhosttyLib` now keeps the MSVC dll unstripped (the debug info lives in the pdb beside the PE, so stripping saved nothing on the dll) and installs `ghostty.pdb` next to it.
- `Ghostty.csproj` copies that pdb into `native\` so a release cut's symbol sweep archives it.
- Verified both modes: pre-patch, ReleaseSafe and ReleaseFast both left `zig-out/lib` with no pdb; post-patch both install one (61 MB beside the 19 MB ReleaseSafe dll, 66 MB beside the 19.5 MB ReleaseFast dll), and the shell build copies it to `native\ghostty.pdb`.

## #1045, full-memory dumps are RAM images

The watchdog's dump was `0x1806` (full memory): every scrollback, token and echoed password, captured to disk automatically.

- Default mask is now triage (handle data, thread info, unloaded modules, stack scan, indirectly referenced memory): walks every stack and lock word without the heap. Full memory is an opt-in via the `hang-dump` config key (`triage` default, `full` opt-in), seeded from config at capture time.
- LLM redaction of a binary dump is not sound (a prompt cannot scrub a minidump's memory streams while preserving structure), so full dumps are private-channel-only in the template and the copy-paste redaction prompt covers the four text artifacts instead.
- `crash.log` stall lines now name the capture scope.
- `windows/docs/diagnostics.md` documents every artifact (what, where, sensitivity, retention) plus the redaction prompt; linked from `logging.md`.

## #1046, nothing told the user a hang was captured

A hung UI could say nothing, and the next launch stayed silent about the evidence in `hangs\`.

- `HangEvidenceStartup` (pure, in Core) decides from crash.log's tail plus a persisted `last-launch` marker whether a previous session left an unreported stall.
- `OnLaunched` surfaces one informational notice naming the hangs folder, with open-folder and copy-path actions. The launch instant is captured before any IO and written after evaluation, so a stall in this session notifies exactly once on the next launch and quiet launches stay quiet.

## Also

- `NativeStderrCapture`: the 8 MB cap rotation now keeps the newest half. The #1041 comment claimed truncation preserved the tail; the code emptied the file, discarding exactly the panic text the file exists to keep.
- `.github/ISSUE_TEMPLATE/bug_report.yml`: edition, channel and arch dropdowns, version paste, artifact checklist with the sensitivity rules. The upstream vouch auto-close does not run on this fork (its workflows gate on `ghostty-org/ghostty`), so the form is live.

## Tests

`HangEvidenceStartupTests` (8), `HangDumpTests` (11), two new `DiagnosticsWiring` pins (dump-mode seed after ConfigService, notice evaluation after NotificationService), `WindowsOnlyKeysTests` rows; 101/101 in the narrow set. `ghostty.pdb` install verified in both optimize modes plus the csproj copy into `native\`.

Fixes #1045
Fixes #1046
Refs #1044 (dll emission side; the per-build archive gate and the support fetch runbook land in the release build)
