### PR TITLE
tabs: a home tab says Home, and the directory menu greys instead of vanishing

### DIFF
--- a/windows/Ghostty.Core/Tabs/TabAccessibleText.cs
+++ b/windows/Ghostty.Core/Tabs/TabAccessibleText.cs
@@ -92,8 +92,13 @@ internal static class TabAccessibleText
         if (!string.IsNullOrEmpty(groupTitle)) segments.Add($"Group {groupTitle}");
         if (isCollapsed) segments.Add("Collapsed");
         if (bellRinging) segments.Add("Bell");
-        // A tab that has not started yet says so: sighted users get the
-        // app's icon in the slot, and this is the same fact for a listener.
+        // A tab that has not started yet says so. For a listener this is
+        // very likely inert: the note below records that NVDA does not
+        // surface ItemStatus on a tab or list item, and a start is over
+        // before anyone could arrow onto it -- so unlike the bell, which
+        // earned an announcement, this is the correct UIA property and
+        // nothing more. Written because it is the honest place for the
+        // state, not because it is known to be heard.
         if (isSettling) segments.Add("Starting");
         return string.Join(", ", segments);
     }

--- a/windows/Ghostty.Core/Tabs/TabAccessibleText.cs
+++ b/windows/Ghostty.Core/Tabs/TabAccessibleText.cs
@@ -38,9 +38,20 @@ internal static class TabAccessibleText
             ? AppIdentity.ProductName
             : effectiveTitle;
 
-    /// <summary>Transient state for <paramref name="tab"/>.</summary>
+    /// <summary>
+    /// Transient state for <paramref name="tab"/>, membership included.
+    ///
+    /// The model knows its own group, so this reads it rather than leaving
+    /// each strip to remember. Passing the parts by hand is how the two
+    /// strips came to disagree: the vertical one named the run but dropped
+    /// "Starting" on a grouped member, and the horizontal one never named a
+    /// run at all, so switching layout silently lost the segment.
+    /// </summary>
     internal static string Status(TabModel tab)
-        => Status(tab.IsPinned, tab.BellRinging, groupTitle: null, isCollapsed: false, isSettling: tab.IsSettling);
+        => Status(tab.IsPinned, tab.BellRinging,
+            groupTitle: tab.Group?.Title,
+            isCollapsed: tab.Group?.IsCollapsed ?? false,
+            isSettling: tab.IsSettling);
 
     /// <summary>
     /// Transient state for the tab, for AutomationProperties.ItemStatus.

--- a/windows/Ghostty.Core/Tabs/TabGroup.cs
+++ b/windows/Ghostty.Core/Tabs/TabGroup.cs
@@ -1,6 +1,5 @@
 using System;
 using System.ComponentModel;
-using System.Runtime.CompilerServices;
 
 namespace Ghostty.Core.Tabs;
 
@@ -36,7 +35,7 @@ internal sealed class TabGroup : INotifyPropertyChanged
     public string Title
     {
         get => field;
-        set { if (field != value) { field = value; Raise(); } }
+        set { if (field != value) { field = value; Raise(Args.Title); } }
     } = "New group";
 
     /// <summary>
@@ -59,7 +58,7 @@ internal sealed class TabGroup : INotifyPropertyChanged
         set
         {
             var resolved = TabColorPalette.EnsureGroupColor(value);
-            if (field != resolved) { field = resolved; Raise(); }
+            if (field != resolved) { field = resolved; Raise(Args.Color); }
         }
     } = TabColorPalette.DefaultGroupColor;
 
@@ -71,11 +70,21 @@ internal sealed class TabGroup : INotifyPropertyChanged
     public bool IsCollapsed
     {
         get => field;
-        set { if (field != value) { field = value; Raise(); } }
+        set { if (field != value) { field = value; Raise(Args.IsCollapsed); } }
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
-    private void Raise([CallerMemberName] string? name = null) =>
-        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    /// <summary>
+    /// One args object per name for the life of the process; see the note on
+    /// <c>TabModel</c>'s.
+    /// </summary>
+    private static class Args
+    {
+        internal static readonly PropertyChangedEventArgs Title = new(nameof(TabGroup.Title));
+        internal static readonly PropertyChangedEventArgs Color = new(nameof(TabGroup.Color));
+        internal static readonly PropertyChangedEventArgs IsCollapsed = new(nameof(TabGroup.IsCollapsed));
+    }
+
+    private void Raise(PropertyChangedEventArgs args) => PropertyChanged?.Invoke(this, args);
 }

--- a/windows/Ghostty.Core/Tabs/TabIconViewModel.cs
+++ b/windows/Ghostty.Core/Tabs/TabIconViewModel.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.Runtime.CompilerServices;
 using Ghostty.Core.Profiles;
 
 namespace Ghostty.Core.Tabs;
@@ -114,17 +113,29 @@ public sealed class TabIconViewModel : INotifyPropertyChanged
     {
         if (!Equals(oldIcon, Icon))
         {
-            Raise(nameof(Icon));
-            Raise(nameof(IsMdl2Glyph));
-            Raise(nameof(Mdl2CodePoint));
+            Raise(Args.Icon);
+            Raise(Args.IsMdl2Glyph);
+            Raise(Args.Mdl2CodePoint);
         }
         if (!string.Equals(oldTooltip, TooltipText))
         {
-            Raise(nameof(TooltipText));
+            Raise(Args.TooltipText);
         }
     }
 
+    /// <summary>
+    /// One args object per name for the life of the process; see the note on
+    /// <c>TabModel</c>'s. The foreground-process tracker drives all four of
+    /// these on a timer, per tab.
+    /// </summary>
+    private static class Args
+    {
+        internal static readonly PropertyChangedEventArgs Icon = new(nameof(TabIconViewModel.Icon));
+        internal static readonly PropertyChangedEventArgs IsMdl2Glyph = new(nameof(TabIconViewModel.IsMdl2Glyph));
+        internal static readonly PropertyChangedEventArgs Mdl2CodePoint = new(nameof(TabIconViewModel.Mdl2CodePoint));
+        internal static readonly PropertyChangedEventArgs TooltipText = new(nameof(TabIconViewModel.TooltipText));
+    }
+
     public event PropertyChangedEventHandler? PropertyChanged;
-    private void Raise([CallerMemberName] string? name = null) =>
-        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    private void Raise(PropertyChangedEventArgs args) => PropertyChanged?.Invoke(this, args);
 }

--- a/windows/Ghostty.Core/Tabs/TabLabel.cs
+++ b/windows/Ghostty.Core/Tabs/TabLabel.cs
@@ -62,9 +62,18 @@ internal static class TabLabel
     /// otherwise tilde the whole disk. A share (<c>\\server\profiles\alex</c>)
     /// is a home like any other. Redirected profiles, 8.3 spellings and
     /// junctions can miss the textual match; the cost is the full path
-    /// showing, which is what it did before. A WSL tab's own home is
-    /// <c>\\wsl.localhost\&lt;distro&gt;\home\&lt;user&gt;</c>, which this does not
-    /// know, so there the tilde still means the Windows profile.
+    /// showing, which is what it did before.
+    ///
+    /// A WSL tab reports a Windows path: the native side translates OSC 7
+    /// before it crosses, so that tab's own home arrives as
+    /// <c>\\wsl.localhost\&lt;distro&gt;\home\&lt;user&gt;</c> and its label is the
+    /// leaf, <c>alex</c> -- no tilde, and no risk of one, since a Windows
+    /// profile path can prefix neither that nor a raw POSIX path. Collapsing
+    /// it would need the distro's Linux <c>$HOME</c>, which nothing here
+    /// knows; guessing the shape is wrong for a root shell and for any
+    /// custom home, and a <c>~</c> naming the wrong directory is worse than
+    /// a full path. The shell integration reporting <c>$HOME</c> once at
+    /// startup is the seam if it is ever wanted.
     ///
     /// A directory that is not <see cref="IsPlain"/> -- control characters,
     /// a line break, a bidi override -- is null out, and the label falls to

--- a/windows/Ghostty.Core/Tabs/TabModel.cs
+++ b/windows/Ghostty.Core/Tabs/TabModel.cs
@@ -1,6 +1,5 @@
 using System;
 using System.ComponentModel;
-using System.Runtime.CompilerServices;
 using Ghostty.Core.Panes;
 using Ghostty.Core.Profiles;
 using Ghostty.Core.Session;
@@ -93,7 +92,7 @@ internal sealed class TabModel : INotifyPropertyChanged
         {
             if (field == value) return;
             field = value;
-            Raise();
+            Raise(Args.UserOverrideTitle);
             // EffectiveTitle and the tooltips are computed; classic bindings
             // listen for the exact property name, so raise them explicitly.
             RaiseTitleDerived();
@@ -107,7 +106,7 @@ internal sealed class TabModel : INotifyPropertyChanged
         {
             if (field == value) return;
             field = value;
-            Raise();
+            Raise(Args.ShellReportedTitle);
             RaiseTitleDerived();
             if (value is not null) Settle();
         }
@@ -115,11 +114,11 @@ internal sealed class TabModel : INotifyPropertyChanged
 
     private void RaiseTitleDerived()
     {
-        Raise(nameof(EffectiveTitle));
-        Raise(nameof(IsHome));
-        Raise(nameof(WordTitle));
-        Raise(nameof(TooltipText));
-        Raise(nameof(HoverText));
+        Raise(Args.EffectiveTitle);
+        Raise(Args.IsHome);
+        Raise(Args.WordTitle);
+        Raise(Args.TooltipText);
+        Raise(Args.HoverText);
     }
 
     /// <summary>
@@ -135,7 +134,7 @@ internal sealed class TabModel : INotifyPropertyChanged
         {
             if (field == value) return;
             field = value;
-            Raise();
+            Raise(Args.ShellReportedCwd);
             RaiseTitleDerived();
             if (value is not null) Settle();
         }
@@ -155,7 +154,7 @@ internal sealed class TabModel : INotifyPropertyChanged
         {
             if (field == value) return;
             field = value;
-            Raise();
+            Raise(Args.HomeDirectory);
             RaiseTitleDerived();
         }
     }
@@ -163,7 +162,7 @@ internal sealed class TabModel : INotifyPropertyChanged
     public TabProgressState Progress
     {
         get;
-        set { if (!field.Equals(value)) { field = value; Raise(); } }
+        set { if (!field.Equals(value)) { field = value; Raise(Args.Progress); } }
     } = TabProgressState.None;
 
     /// <summary>
@@ -175,7 +174,7 @@ internal sealed class TabModel : INotifyPropertyChanged
     public TabColor Color
     {
         get;
-        set { if (field != value) { field = value; Raise(); } }
+        set { if (field != value) { field = value; Raise(Args.Color); } }
     } = TabColor.None;
 
     /// <summary>
@@ -187,7 +186,7 @@ internal sealed class TabModel : INotifyPropertyChanged
     public bool BellRinging
     {
         get;
-        set { if (field != value) { field = value; Raise(); } }
+        set { if (field != value) { field = value; Raise(Args.BellRinging); } }
     }
 
     /// <summary>
@@ -201,7 +200,7 @@ internal sealed class TabModel : INotifyPropertyChanged
     public bool IsIdle
     {
         get;
-        set { if (field != value) { field = value; Raise(); } }
+        set { if (field != value) { field = value; Raise(Args.IsIdle); } }
     }
 
     /// <summary>
@@ -225,7 +224,7 @@ internal sealed class TabModel : INotifyPropertyChanged
     public bool IsPinned
     {
         get;
-        set { if (field != value) { field = value; Raise(); } }
+        set { if (field != value) { field = value; Raise(Args.IsPinned); } }
     }
 
     /// <summary>
@@ -242,7 +241,7 @@ internal sealed class TabModel : INotifyPropertyChanged
         {
             if (ReferenceEquals(field, value)) return;
             field = value;
-            Raise();
+            Raise(Args.Group);
         }
     }
 
@@ -321,7 +320,7 @@ internal sealed class TabModel : INotifyPropertyChanged
     public bool IsSettling
     {
         get;
-        private set { if (field != value) { field = value; _tabIcon?.SetSettling(value); Raise(); } }
+        private set { if (field != value) { field = value; _tabIcon?.SetSettling(value); Raise(Args.IsSettling); } }
     }
 
     /// <summary>Marks the tab as starting; the manager calls it on every tab it opens.</summary>
@@ -458,7 +457,40 @@ internal sealed class TabModel : INotifyPropertyChanged
     /// </summary>
     public event Action<TabModel, int?>? ShellPidChanged;
 
+    /// <summary>
+    /// One <see cref="PropertyChangedEventArgs"/> per property name, minted
+    /// once for the process. The names are a closed set known at compile
+    /// time, and a shell drives the title and directory setters at every
+    /// prompt on every tab -- six raises each -- so a fresh args object per
+    /// raise was garbage with nothing to say for itself.
+    ///
+    /// <c>nameof</c> ties each field to the property it names; what it
+    /// cannot check is a setter reaching for the wrong field, which
+    /// <c>[CallerMemberName]</c> made impossible. TabChangeArgsTests walks
+    /// every settable property and holds that line.
+    /// </summary>
+    private static class Args
+    {
+        internal static readonly PropertyChangedEventArgs UserOverrideTitle = new(nameof(TabModel.UserOverrideTitle));
+        internal static readonly PropertyChangedEventArgs ShellReportedTitle = new(nameof(TabModel.ShellReportedTitle));
+        internal static readonly PropertyChangedEventArgs ShellReportedCwd = new(nameof(TabModel.ShellReportedCwd));
+        internal static readonly PropertyChangedEventArgs HomeDirectory = new(nameof(TabModel.HomeDirectory));
+        internal static readonly PropertyChangedEventArgs Progress = new(nameof(TabModel.Progress));
+        internal static readonly PropertyChangedEventArgs Color = new(nameof(TabModel.Color));
+        internal static readonly PropertyChangedEventArgs BellRinging = new(nameof(TabModel.BellRinging));
+        internal static readonly PropertyChangedEventArgs IsIdle = new(nameof(TabModel.IsIdle));
+        internal static readonly PropertyChangedEventArgs IsPinned = new(nameof(TabModel.IsPinned));
+        internal static readonly PropertyChangedEventArgs Group = new(nameof(TabModel.Group));
+        internal static readonly PropertyChangedEventArgs IsSettling = new(nameof(TabModel.IsSettling));
+
+        // Computed; raised explicitly by RaiseTitleDerived.
+        internal static readonly PropertyChangedEventArgs EffectiveTitle = new(nameof(TabModel.EffectiveTitle));
+        internal static readonly PropertyChangedEventArgs IsHome = new(nameof(TabModel.IsHome));
+        internal static readonly PropertyChangedEventArgs WordTitle = new(nameof(TabModel.WordTitle));
+        internal static readonly PropertyChangedEventArgs TooltipText = new(nameof(TabModel.TooltipText));
+        internal static readonly PropertyChangedEventArgs HoverText = new(nameof(TabModel.HoverText));
+    }
+
     public event PropertyChangedEventHandler? PropertyChanged;
-    private void Raise([CallerMemberName] string? name = null) =>
-        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    private void Raise(PropertyChangedEventArgs args) => PropertyChanged?.Invoke(this, args);
 }

--- a/windows/Ghostty.Tests/Tabs/TabAccessibleTextTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabAccessibleTextTests.cs
@@ -293,11 +293,32 @@ public class TabAccessibleTextTests
 
         Assert.Contains("AutomationProperties.SetName(item, TabAccessibleText.Name(", apply);
         Assert.Contains("AutomationProperties.SetItemStatus(item,", apply);
-        // The status is the tab's; a grouped member adds the run it sits in.
-        Assert.Contains(
-            "TabAccessibleText.Status(tab.IsPinned, tab.BellRinging, group.Title, group.IsCollapsed)",
-            apply);
+        // One call, reading the whole tab. Spelling the segments out here is
+        // what let this strip name a member's run while dropping "Starting",
+        // and the horizontal strip drop the run entirely.
         Assert.Contains("TabAccessibleText.Status(tab)", apply);
+        Assert.DoesNotContain("tab.IsPinned, tab.BellRinging", apply);
+    }
+
+    /// <summary>
+    /// The status a strip shows is composed from the whole tab, so a grouped
+    /// member reports its run AND everything else that is true of it. The
+    /// vertical strip used to build this by hand and pass four of the five
+    /// parts, which left a grouped tab that was still starting saying only
+    /// which group it was in.
+    /// </summary>
+    [Fact]
+    public void TheTabsStatus_NamesItsRun_AndStillReportsEverythingElse()
+    {
+        var tab = new TabModel(new FakePaneHost()) { Group = new TabGroup { Title = "build" } };
+        Assert.Equal("Group build", TabAccessibleText.Status(tab));
+
+        tab.IsPinned = true;
+        tab.BellRinging = true;
+        Assert.Equal("Pinned, Group build, Bell", TabAccessibleText.Status(tab));
+
+        tab.Group!.IsCollapsed = true;
+        Assert.Equal("Pinned, Group build, Collapsed, Bell", TabAccessibleText.Status(tab));
     }
 
     /// <summary>
@@ -353,7 +374,7 @@ public class TabAccessibleTextTests
         var build = Between(host, "var item = new TabViewItem", "tab.PropertyChanged +=");
         Assert.Contains(call, build);
 
-        var titleArm = Between(host, "headerText.Text = tab.EffectiveTitle", "else if");
+        var titleArm = Between(host, "headerText.Text = tab.WordTitle", "else if");
         Assert.Contains(call, titleArm);
 
         var bellArm = Between(host, "bellGlyph.Visibility = tab.BellRinging", "_itemByModel[tab] = item");

--- a/windows/Ghostty.Tests/Tabs/TabAccessibleTextTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabAccessibleTextTests.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using Ghostty.Core;
 using Ghostty.Core.Tabs;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Xunit;
 
 namespace Ghostty.Tests.Tabs;
@@ -293,11 +294,18 @@ public class TabAccessibleTextTests
 
         Assert.Contains("AutomationProperties.SetName(item, TabAccessibleText.Name(", apply);
         Assert.Contains("AutomationProperties.SetItemStatus(item,", apply);
+
         // One call, reading the whole tab. Spelling the segments out here is
         // what let this strip name a member's run while dropping "Starting",
-        // and the horizontal strip drop the run entirely.
-        Assert.Contains("TabAccessibleText.Status(tab)", apply);
-        Assert.DoesNotContain("tab.IsPinned, tab.BellRinging", apply);
+        // and the horizontal strip drop the run entirely. Asserted on the
+        // syntax tree: a negative substring match is defeated by a line
+        // break, and the hand-spelled form is exactly what someone would
+        // reintroduce wrapped.
+        var chrome = Wiring.ShellSource.Load("Tabs.VerticalTabStrip.xaml.cs")
+            .Method("ApplyItemTitleChrome");
+        var status = Assert.Single(chrome.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(i => i.Expression.ToString() == "TabAccessibleText.Status"));
+        Assert.Equal("tab", Assert.Single(status.ArgumentList.Arguments).ToString());
     }
 
     /// <summary>
@@ -319,6 +327,12 @@ public class TabAccessibleTextTests
 
         tab.Group!.IsCollapsed = true;
         Assert.Equal("Pinned, Group build, Collapsed, Bell", TabAccessibleText.Status(tab));
+
+        // The combination the old two-branch call site actually lost: a
+        // grouped tab that is still starting. Reported ungrouped, and
+        // reported grouped, "Starting" has to survive both.
+        tab.BeginSettling();
+        Assert.Equal("Pinned, Group build, Collapsed, Bell, Starting", TabAccessibleText.Status(tab));
     }
 
     /// <summary>
@@ -379,6 +393,42 @@ public class TabAccessibleTextTests
 
         var bellArm = Between(host, "bellGlyph.Visibility = tab.BellRinging", "_itemByModel[tab] = item");
         Assert.Contains(call, bellArm);
+    }
+
+    /// <summary>
+    /// The run a tab sits in is a segment of its ItemStatus, so a group
+    /// change has to rewrite it — in BOTH strips. The status is not a
+    /// per-tab event when a group is renamed or collapsed, so nothing else
+    /// would: the horizontal strip left a tab that had just left a group
+    /// still claiming membership, and both strips left a renamed run's
+    /// members naming the old title, until some unrelated prompt or bell
+    /// happened to rewrite the status.
+    /// </summary>
+    [Theory]
+    [InlineData("Tabs.TabHost.xaml.cs", "OnGroupPropertyChanged", "ApplyItemAccessibleText")]
+    [InlineData("Tabs.VerticalTabStrip.xaml.cs", "OnGroupStateChanged", "ApplyItemTitleChrome")]
+    public void AGroupChange_RewritesEveryMembersStatus(string source, string method, string apply)
+    {
+        var handler = Wiring.ShellSource.Load(source).Method(method);
+
+        // Over the members, because one group change is many tabs' status.
+        // CommonForEachStatementSyntax, so a deconstructing foreach -- its
+        // own node type -- counts.
+        var loop = Assert.Single(handler.DescendantNodes().OfType<CommonForEachStatementSyntax>());
+        Assert.Contains(loop.DescendantNodes().OfType<InvocationExpressionSyntax>(),
+            i => i.Expression.ToString().EndsWith(apply, StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// And a tab joining or leaving a group rewrites its own, which is the
+    /// per-tab half of the same fact.
+    /// </summary>
+    [Fact]
+    public void ATabLeavingAGroup_RewritesItsOwnStatus()
+    {
+        var host = Source("TabHost.xaml.cs");
+        var groupArm = Between(host, "nameof(TabModel.Group)", "_itemByModel[tab] = item");
+        Assert.Contains("ApplyItemAccessibleText(item, tab)", groupArm);
     }
 
     /// <summary>

--- a/windows/Ghostty.Tests/Tabs/TabChangeArgsTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabChangeArgsTests.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using Ghostty.Core.Profiles;
+using Ghostty.Core.Tabs;
+using Xunit;
+
+namespace Ghostty.Tests.Tabs;
+
+/// <summary>
+/// The change notification itself. A shell drives the title and directory
+/// setters at every prompt, on every tab, and each raise used to mint a
+/// fresh <see cref="PropertyChangedEventArgs"/>; the names are a closed set
+/// known at compile time, so one instance per name is enough forever.
+///
+/// Caching them trades an allocation for a hazard: a hand-written constant
+/// can name the wrong property, which <c>[CallerMemberName]</c> made
+/// impossible. The second test here is the guard against that.
+/// </summary>
+public class TabChangeArgsTests
+{
+    private static List<PropertyChangedEventArgs> Record(INotifyPropertyChanged source)
+    {
+        var seen = new List<PropertyChangedEventArgs>();
+        source.PropertyChanged += (_, e) => seen.Add(e);
+        return seen;
+    }
+
+    // --- one instance per name, not one per raise ---
+
+    [Fact]
+    public void RaisingTheSameProperty_ReusesOneArgsObject()
+    {
+        var tab = new TabModel(new FakePaneHost());
+        var seen = Record(tab);
+
+        tab.IsPinned = true;
+        tab.IsPinned = false;
+
+        var pinned = seen.Where(e => e.PropertyName == nameof(TabModel.IsPinned)).ToList();
+        Assert.Equal(2, pinned.Count);
+        Assert.Same(pinned[0], pinned[1]);
+    }
+
+    [Fact]
+    public void TheDerivedRaises_ReuseOneArgsObjectEach()
+    {
+        var tab = new TabModel(new FakePaneHost());
+        var seen = Record(tab);
+
+        tab.ShellReportedCwd = @"C:\one";
+        tab.ShellReportedCwd = @"C:\two";
+
+        // Every name the directory setter fans out to, not just its own.
+        foreach (var name in new[]
+        {
+            nameof(TabModel.ShellReportedCwd),
+            nameof(TabModel.EffectiveTitle),
+            nameof(TabModel.IsHome),
+            nameof(TabModel.WordTitle),
+            nameof(TabModel.TooltipText),
+            nameof(TabModel.HoverText),
+        })
+        {
+            var raises = seen.Where(e => e.PropertyName == name).ToList();
+            Assert.Equal(2, raises.Count);
+            Assert.Same(raises[0], raises[1]);
+        }
+    }
+
+    [Fact]
+    public void TheIconViewModel_ReusesOneArgsObject()
+    {
+        var vm = new TabIconViewModel(new IconSpec.BundledKey("pwsh"), "pwsh");
+        var seen = Record(vm);
+
+        vm.SetOverride(new IconSpec.Mdl2Token(0xE700), "one");
+        vm.RevertToProfile();
+        vm.SetOverride(new IconSpec.Mdl2Token(0xE700), "two");
+
+        var icon = seen.Where(e => e.PropertyName == nameof(TabIconViewModel.Icon)).ToList();
+        Assert.True(icon.Count >= 2);
+        Assert.Same(icon[0], icon[1]);
+    }
+
+    [Fact]
+    public void TheGroup_ReusesOneArgsObject()
+    {
+        var group = new TabGroup();
+        var seen = Record(group);
+
+        group.Title = "one";
+        group.Title = "two";
+
+        var title = seen.Where(e => e.PropertyName == nameof(TabGroup.Title)).ToList();
+        Assert.Equal(2, title.Count);
+        Assert.Same(title[0], title[1]);
+    }
+
+    // --- a cached constant must still name its own property ---
+
+    /// <summary>
+    /// Every settable property that notifies at all must name itself. This
+    /// is what <c>[CallerMemberName]</c> used to guarantee for free: a
+    /// hand-written <c>Args.IsPinned</c> in the <c>IsIdle</c> setter would
+    /// notify the wrong listeners and nothing else would catch it.
+    /// </summary>
+    [Fact]
+    public void EverySettableProperty_RaisesItsOwnName()
+    {
+        var properties = typeof(TabModel)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.GetSetMethod() is not null)
+            .ToList();
+
+        // A guard on the guard: if the reflection filter ever silently
+        // matches nothing, the test would pass while proving nothing.
+        Assert.True(properties.Count >= 10, $"expected the model's settable properties, found {properties.Count}");
+
+        var checkedAtLeastOne = false;
+        foreach (var property in properties)
+        {
+            if (ValueFor(property.PropertyType) is not { } value) continue;
+
+            var tab = new TabModel(new FakePaneHost());
+            var seen = Record(tab);
+            property.SetValue(tab, value);
+
+            // A property that notifies nothing (a plain auto-property) is
+            // fine; one that notifies must include its own name.
+            if (seen.Count == 0) continue;
+            checkedAtLeastOne = true;
+            Assert.Contains(property.Name, seen.Select(e => e.PropertyName));
+        }
+
+        Assert.True(checkedAtLeastOne, "no settable property notified; the reflection walk proved nothing");
+    }
+
+    private static object? ValueFor(Type type)
+    {
+        if (type == typeof(string)) return "changed";
+        if (type == typeof(bool)) return true;
+        if (type == typeof(TabProgressState)) return TabProgressState.Indeterminate;
+        if (type == typeof(TabGroup)) return new TabGroup();
+        // Any non-default member will do: the point is that the setter runs
+        // and notifies, not which value it lands on.
+        if (type.IsEnum) return Enum.ToObject(type, 1);
+        return null;
+    }
+}

--- a/windows/Ghostty.Tests/Tabs/TabChangeArgsTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabChangeArgsTests.cs
@@ -30,18 +30,29 @@ public class TabChangeArgsTests
 
     // --- one instance per name, not one per raise ---
 
+    /// <summary>
+    /// Across two MODELS, not two raises on one. A per-instance cache would
+    /// satisfy the same-instance check while still allocating a set per tab,
+    /// which is the cost the change exists to remove -- a window holds as
+    /// many tabs as the user opens.
+    /// </summary>
     [Fact]
-    public void RaisingTheSameProperty_ReusesOneArgsObject()
+    public void RaisingTheSameProperty_ReusesOneArgsObject_AcrossEveryTab()
     {
-        var tab = new TabModel(new FakePaneHost());
-        var seen = Record(tab);
+        var one = new TabModel(new FakePaneHost());
+        var other = new TabModel(new FakePaneHost());
+        var seenOne = Record(one);
+        var seenOther = Record(other);
 
-        tab.IsPinned = true;
-        tab.IsPinned = false;
+        one.IsPinned = true;
+        one.IsPinned = false;
+        other.IsPinned = true;
 
-        var pinned = seen.Where(e => e.PropertyName == nameof(TabModel.IsPinned)).ToList();
+        var pinned = seenOne.Where(e => e.PropertyName == nameof(TabModel.IsPinned)).ToList();
         Assert.Equal(2, pinned.Count);
         Assert.Same(pinned[0], pinned[1]);
+        Assert.Same(pinned[0], Assert.Single(seenOther,
+            e => e.PropertyName == nameof(TabModel.IsPinned)));
     }
 
     [Fact]
@@ -107,6 +118,14 @@ public class TabChangeArgsTests
     /// hand-written <c>Args.IsPinned</c> in the <c>IsIdle</c> setter would
     /// notify the wrong listeners and nothing else would catch it.
     /// </summary>
+    /// <summary>
+    /// The properties that deliberately notify nothing. Named rather than
+    /// inferred: a walk that simply skipped whatever stayed silent could not
+    /// tell a plain auto-property from one whose <c>Raise</c> was deleted,
+    /// and would pass on both.
+    /// </summary>
+    private static readonly string[] SilentProperties = [nameof(TabModel.ProfileId)];
+
     [Fact]
     public void EverySettableProperty_RaisesItsOwnName()
     {
@@ -119,23 +138,110 @@ public class TabChangeArgsTests
         // matches nothing, the test would pass while proving nothing.
         Assert.True(properties.Count >= 10, $"expected the model's settable properties, found {properties.Count}");
 
-        var checkedAtLeastOne = false;
         foreach (var property in properties)
         {
-            if (ValueFor(property.PropertyType) is not { } value) continue;
+            var value = ValueFor(property.PropertyType);
+            Assert.True(value is not null,
+                $"{property.Name} is settable but this walk cannot build a value for "
+                + $"{property.PropertyType.Name}, so it is silently uncovered");
 
             var tab = new TabModel(new FakePaneHost());
             var seen = Record(tab);
             property.SetValue(tab, value);
 
-            // A property that notifies nothing (a plain auto-property) is
-            // fine; one that notifies must include its own name.
-            if (seen.Count == 0) continue;
-            checkedAtLeastOne = true;
+            if (SilentProperties.Contains(property.Name))
+            {
+                Assert.Empty(seen);
+                continue;
+            }
             Assert.Contains(property.Name, seen.Select(e => e.PropertyName));
         }
+    }
 
-        Assert.True(checkedAtLeastOne, "no settable property notified; the reflection walk proved nothing");
+    /// <summary>
+    /// The one notifying property the public-setter walk cannot reach: its
+    /// setter is private, and it is the property carrying the strip's
+    /// starting state.
+    /// </summary>
+    [Fact]
+    public void TheStartingFlag_RaisesItsOwnName()
+    {
+        var tab = new TabModel(new FakePaneHost());
+        var seen = Record(tab);
+
+        tab.BeginSettling();
+
+        Assert.Contains(nameof(TabModel.IsSettling), seen.Select(e => e.PropertyName));
+    }
+
+    /// <summary>
+    /// The derived fan-out raises five names, and every one of them is a
+    /// hand-written constant. A swap inside it -- WordTitle where
+    /// EffectiveTitle belongs -- leaves both names present, so a test that
+    /// only asked "are they all there" would pass. Each is raised exactly
+    /// once per change.
+    /// </summary>
+    [Fact]
+    public void TheDerivedFanOut_RaisesEachNameExactlyOnce()
+    {
+        var tab = new TabModel(new FakePaneHost());
+        var seen = Record(tab);
+
+        tab.ShellReportedCwd = @"C:\one";
+
+        foreach (var name in new[]
+        {
+            nameof(TabModel.ShellReportedCwd),
+            nameof(TabModel.EffectiveTitle),
+            nameof(TabModel.IsHome),
+            nameof(TabModel.WordTitle),
+            nameof(TabModel.TooltipText),
+            nameof(TabModel.HoverText),
+        })
+        {
+            Assert.Single(seen, e => e.PropertyName == name);
+        }
+        Assert.Equal(6, seen.Count);
+    }
+
+    /// <summary>
+    /// The other two classes that took the same treatment. Their setters
+    /// name their constants by hand exactly as the model's do, and nothing
+    /// else walks them.
+    /// </summary>
+    [Fact]
+    public void TheGroupsProperties_EachRaiseTheirOwnName()
+    {
+        var group = new TabGroup();
+        var seen = Record(group);
+
+        group.Title = "build";
+        group.Color = TabColor.Green;
+        group.IsCollapsed = true;
+
+        Assert.Equal(
+            [nameof(TabGroup.Title), nameof(TabGroup.Color), nameof(TabGroup.IsCollapsed)],
+            seen.Select(e => e.PropertyName));
+    }
+
+    [Fact]
+    public void TheIconViewModels_Properties_EachRaiseTheirOwnName()
+    {
+        var vm = new TabIconViewModel(new IconSpec.BundledKey("pwsh"), "pwsh");
+        var seen = Record(vm);
+
+        vm.SetOverride(new IconSpec.Mdl2Token(0xE700), "vim");
+
+        // The icon change carries its two derived readings with it, and the
+        // tooltip moved on its own.
+        Assert.Equal(
+            [
+                nameof(TabIconViewModel.Icon),
+                nameof(TabIconViewModel.IsMdl2Glyph),
+                nameof(TabIconViewModel.Mdl2CodePoint),
+                nameof(TabIconViewModel.TooltipText),
+            ],
+            seen.Select(e => e.PropertyName));
     }
 
     private static object? ValueFor(Type type)

--- a/windows/Ghostty.Tests/Tabs/TabContextMenuCwdTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabContextMenuCwdTests.cs
@@ -17,6 +17,13 @@ namespace Ghostty.Tests.Tabs;
 /// file path runs the file's handler, so the menu goes through the
 /// folder-only launcher, and only after a directory check that runs off
 /// the UI thread.
+///
+/// The pair is GREYED, never hidden. The horizontal strip builds one
+/// flyout per tab and reuses it, and a shell reports its directory a
+/// moment after the tab opens -- hiding made the same menu change shape
+/// between two openings. Greying also leaves something to learn from: a
+/// shell with no integration never reports a directory at all, and an
+/// absent item cannot say why.
 /// </summary>
 public class TabContextMenuCwdTests
 {
@@ -33,16 +40,14 @@ public class TabContextMenuCwdTests
 
         Assert.Contains(build.Calls("flyout.Items.Add"), c => c.Arg(0) == local);
 
-        // Hidden, not greyed, unless the tab has a directory to act on --
-        // decided from the same property at build and on every Opening.
+        // Greyed, never hidden: nothing in the method may write this item's
+        // Visibility, at build time or on any later pass.
         var declared = build.DescendantNodes().OfType<VariableDeclaratorSyntax>()
             .Single(v => v.Identifier.Text == local);
-        Assert.Contains(declared.DescendantNodes().OfType<AssignmentExpressionSyntax>(),
-            a => a.Left.ToString() == "Visibility" && a.Right.ToString() == "CwdVisibility(tab)");
-        Assert.Contains(build.DescendantNodes().OfType<AssignmentExpressionSyntax>(),
-            a => a.Left.ToString() == $"{local}.Visibility" && a.Right.ToString() == "CwdVisibility(tab)");
+        Assert.DoesNotContain(declared.DescendantNodes().OfType<AssignmentExpressionSyntax>(),
+            a => a.Left.ToString() == "Visibility");
         Assert.DoesNotContain(build.DescendantNodes().OfType<AssignmentExpressionSyntax>(),
-            a => a.Left.ToString() == $"{local}.IsEnabled");
+            a => a.Left.ToString() == $"{local}.Visibility");
 
         // The click reads ActionableCwd, and nothing else off the tab.
         var click = ClickHandler(build, local);
@@ -54,21 +59,84 @@ public class TabContextMenuCwdTests
     }
 
     [Fact]
-    public void TheDirectoryGroup_HidesWithItsItems()
+    public void TheDirectoryGroup_KeepsItsShape()
     {
-        // The separator that introduces the group follows the same
-        // visibility, or a bare rule is left behind when the items hide.
-        var menu = ShellSource.Load("Tabs.TabContextMenuBuilder.cs");
-        var build = menu.Method("Build");
-        Assert.Contains(build.DescendantNodes().OfType<AssignmentExpressionSyntax>(),
-            a => a.Left.ToString() == "cwdRule.Visibility" && a.Right.ToString() == "CwdVisibility(tab)");
-        // Pinned as parsed: inverted, the rule reads the same in substrings
-        // while showing the group exactly when there is nothing to act on.
-        var rule = menu.Method("CwdVisibility");
-        var choice = Assert.IsType<ConditionalExpressionSyntax>(rule.ExpressionBody!.Expression);
-        Assert.Equal("tab.ActionableCwd is not null", choice.Condition.ToString());
-        Assert.Equal("Visibility.Visible", choice.WhenTrue.ToString());
-        Assert.Equal("Visibility.Collapsed", choice.WhenFalse.ToString());
+        // The separator that introduces the group is a plain rule now. A
+        // rule that hid with the items is what made the menu change height.
+        var build = Build();
+        Assert.DoesNotContain(build.DescendantNodes().OfType<AssignmentExpressionSyntax>(),
+            a => a.Left.ToString().StartsWith("cwdRule.", System.StringComparison.Ordinal));
+
+        // And the hiding rule itself is gone, not merely unused.
+        Assert.DoesNotContain(
+            ShellSource.Load("Tabs.TabContextMenuBuilder.cs").Root.DescendantNodes()
+                .OfType<MethodDeclarationSyntax>(),
+            m => m.Identifier.Text == "CwdVisibility");
+    }
+
+    [Fact]
+    public void Availability_IsDecidedFromTheActionableDirectory()
+    {
+        var rule = ShellSource.Load("Tabs.TabContextMenuBuilder.cs").Method("CwdIsActionable");
+        Assert.Equal("tab.ActionableCwd is not null", rule.ExpressionBody!.Expression.ToString());
+    }
+
+    /// <summary>
+    /// The horizontal strip builds this flyout once per tab and reuses it,
+    /// so a decision taken only at build time freezes at the value the tab
+    /// had before its shell said anything. Both passes, or the item is
+    /// permanently grey on every tab that was right-clicked early.
+    /// </summary>
+    [Fact]
+    public void Availability_IsAppliedAtBuild_AndAgainOnEveryOpening()
+    {
+        var build = Build();
+        var applications = build.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(i => i.Expression.ToString() == "ApplyCwdAvailability")
+            .ToList();
+        Assert.Equal(2, applications.Count);
+
+        var opening = build.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Single(a => a.IsKind(SyntaxKind.AddAssignmentExpression)
+                         && a.Left.ToString() == "flyout.Opening")
+            .Right;
+        Assert.Single(applications, a => a.Ancestors().Any(n => n == opening));
+        Assert.Single(applications, a => !a.Ancestors().Any(n => n == opening));
+
+        // Both items go through it, not just one.
+        foreach (var text in new[] { "Copy Working Directory", "Open in File Explorer" })
+        {
+            var local = ItemNamed(build, text);
+            Assert.All(applications, a =>
+                Assert.Contains(a.ArgumentList.Arguments, arg => arg.Expression.ToString() == local));
+        }
+    }
+
+    /// <summary>
+    /// A disabled MenuFlyoutItem raises none of the pointer events
+    /// ToolTipService needs, so the reason it is unavailable rides
+    /// AutomationProperties.HelpText, which Narrator reads as the item's
+    /// description. Cleared again when the item is live, or a usable item
+    /// carries an explanation for a state it is not in.
+    /// </summary>
+    [Fact]
+    public void TheUnavailableReason_RidesHelpText_AndClearsWhenLive()
+    {
+        var apply = ShellSource.Load("Tabs.TabContextMenuBuilder.cs").Method("ApplyCwdAvailability");
+
+        var enabled = apply.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Single(a => a.Left.ToString().EndsWith(".IsEnabled", System.StringComparison.Ordinal));
+
+        var help = apply.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Single(i => i.Expression.ToString() == "AutomationProperties.SetHelpText");
+
+        // The same decision drives both, and the help text is null exactly
+        // when the item is enabled.
+        var choice = Assert.IsType<ConditionalExpressionSyntax>(
+            help.ArgumentList.Arguments[1].Expression);
+        Assert.Equal(enabled.Right.ToString(), choice.Condition.ToString());
+        Assert.Equal("null", choice.WhenTrue.ToString());
+        Assert.NotEqual("null", choice.WhenFalse.ToString());
     }
 
     [Fact]

--- a/windows/Ghostty.Tests/Tabs/TabContextMenuCwdTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabContextMenuCwdTests.cs
@@ -67,11 +67,21 @@ public class TabContextMenuCwdTests
         Assert.DoesNotContain(build.DescendantNodes().OfType<AssignmentExpressionSyntax>(),
             a => a.Left.ToString().StartsWith("cwdRule.", System.StringComparison.Ordinal));
 
-        // And the hiding rule itself is gone, not merely unused.
+        // ...including through its own initializer, where the assignment
+        // reads `Visibility = ...` and the receiver never appears. That is
+        // exactly the shape this replaced.
+        var rule = build.DescendantNodes().OfType<VariableDeclaratorSyntax>()
+            .Single(v => v.Identifier.Text == "cwdRule");
+        Assert.DoesNotContain(rule.DescendantNodes().OfType<AssignmentExpressionSyntax>(),
+            a => a.Left.ToString() == "Visibility");
+
+        // And nothing in the file decides a Visibility from the directory,
+        // whatever it is called -- naming the old method alone would only
+        // detect a rename.
         Assert.DoesNotContain(
             ShellSource.Load("Tabs.TabContextMenuBuilder.cs").Root.DescendantNodes()
                 .OfType<MethodDeclarationSyntax>(),
-            m => m.Identifier.Text == "CwdVisibility");
+            m => m.ReturnType.ToString() == "Visibility");
     }
 
     [Fact]
@@ -119,24 +129,72 @@ public class TabContextMenuCwdTests
     /// description. Cleared again when the item is live, or a usable item
     /// carries an explanation for a state it is not in.
     /// </summary>
+    /// <summary>
+    /// BOTH items are greyed, not just the one a Single() would find. The
+    /// helper loops, so one assignment covers two items -- which means the
+    /// guard has to say what it loops over, or a body touching only `copy`
+    /// reads identically and leaves Open in File Explorer live on a tab with
+    /// no directory.
+    /// </summary>
     [Fact]
-    public void TheUnavailableReason_RidesHelpText_AndClearsWhenLive()
+    public void BothItems_AreGreyedTogether()
     {
         var apply = ShellSource.Load("Tabs.TabContextMenuBuilder.cs").Method("ApplyCwdAvailability");
+        var loop = Assert.Single(apply.DescendantNodes().OfType<ForEachStatementSyntax>());
 
-        var enabled = apply.DescendantNodes().OfType<AssignmentExpressionSyntax>()
-            .Single(a => a.Left.ToString().EndsWith(".IsEnabled", System.StringComparison.Ordinal));
+        var collection = loop.Expression.ToString();
+        foreach (var parameter in apply.ParameterList.Parameters
+                     .Where(p => p.Type!.ToString() == "MenuFlyoutItem"))
+        {
+            Assert.Contains(parameter.Identifier.Text, collection);
+        }
 
-        var help = apply.DescendantNodes().OfType<InvocationExpressionSyntax>()
-            .Single(i => i.Expression.ToString() == "AutomationProperties.SetHelpText");
+        // The two items the caller hands over, and no fewer.
+        Assert.Equal(2, apply.ParameterList.Parameters
+            .Count(p => p.Type!.ToString() == "MenuFlyoutItem"));
 
-        // The same decision drives both, and the help text is null exactly
-        // when the item is enabled.
-        var choice = Assert.IsType<ConditionalExpressionSyntax>(
-            help.ArgumentList.Arguments[1].Expression);
-        Assert.Equal(enabled.Right.ToString(), choice.Condition.ToString());
-        Assert.Equal("null", choice.WhenTrue.ToString());
-        Assert.NotEqual("null", choice.WhenFalse.ToString());
+        var enabled = Assert.Single(loop.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.Left.ToString().EndsWith(".IsEnabled", System.StringComparison.Ordinal)));
+        Assert.Equal($"{loop.Identifier.Text}.IsEnabled", enabled.Left.ToString());
+    }
+
+    /// <summary>
+    /// The reason rides HelpText, is CLEARED rather than blanked when the
+    /// item is live (UIA reports an empty string as present-but-blank), and
+    /// distinguishes the two things the model can mean. A directory on
+    /// another machine WAS reported -- the label prints it and the tooltip
+    /// shows it in full -- so telling a listener the shell reported nothing
+    /// contradicts what a pointer user is reading.
+    /// </summary>
+    [Fact]
+    public void TheUnavailableReason_RidesHelpText_ClearsWhenLive_AndNamesTheRightCause()
+    {
+        var menu = ShellSource.Load("Tabs.TabContextMenuBuilder.cs");
+        var apply = menu.Method("ApplyCwdAvailability");
+
+        // Set when there is a reason, cleared when there is not.
+        Assert.Single(apply.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(i => i.Expression.ToString() == "AutomationProperties.SetHelpText"));
+        Assert.Contains(apply.DescendantNodes().OfType<InvocationExpressionSyntax>(),
+            i => i.Expression.ToString().EndsWith("ClearValue", System.StringComparison.Ordinal)
+                 && i.ArgumentList.Arguments[0].ToString() == "AutomationProperties.HelpTextProperty");
+
+        // Two distinct reasons, told apart by whether the shell reported at
+        // all -- not by the spawn policy's verdict alone.
+        var reasons = menu.Root.DescendantNodes().OfType<VariableDeclaratorSyntax>()
+            .Where(v => v.Identifier.Text.StartsWith("Cwd", System.StringComparison.Ordinal)
+                        && v.Identifier.Text.EndsWith("Help", System.StringComparison.Ordinal))
+            .Select(v => Assert.IsType<LiteralExpressionSyntax>(v.Initializer!.Value).Token.ValueText)
+            .ToList();
+        Assert.Equal(2, reasons.Count);
+        Assert.Equal(2, reasons.Distinct().Count());
+        // Each says something; an emptied constant is the silent failure.
+        Assert.All(reasons, r => Assert.True(r.Length > 20, $"the reason '{r}' explains nothing"));
+        // And only one of them claims nothing was reported.
+        Assert.Single(reasons, r => r.Contains("has not reported"));
+
+        Assert.Contains(apply.DescendantNodes().OfType<MemberAccessExpressionSyntax>(),
+            m => m.ToString() == "tab.ShellReportedCwd");
     }
 
     [Fact]

--- a/windows/Ghostty.Tests/Tabs/TabLabelHomeTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabLabelHomeTests.cs
@@ -49,6 +49,31 @@ public class TabLabelHomeTests
     public void Collapse_LeavesEveryOtherDirectoryAlone(string cwd)
         => Assert.Equal(cwd, TabLabel.Collapse(cwd, Home));
 
+    /// <summary>
+    /// A WSL tab's own home is not a home here, and that is a decision
+    /// rather than an oversight. The native side translates OSC 7 before it
+    /// crosses, so such a tab reports a Windows path and labels itself with
+    /// the leaf -- "alex" -- which is what Finder shows for a home folder
+    /// anyway. Collapsing it needs the distro's Linux $HOME, and nothing in
+    /// this layer knows it: guessing the shape gets a root shell and every
+    /// custom home wrong, and a tilde naming the wrong directory is worse
+    /// than a full path.
+    ///
+    /// The Windows profile cannot accidentally match either spelling, which
+    /// is the half that would be a bug rather than a choice.
+    /// </summary>
+    [Theory]
+    [InlineData(@"\\wsl.localhost\Ubuntu-24.04\home\alex", "alex")]
+    [InlineData(@"\\wsl$\Ubuntu-24.04\home\alex", "alex")]
+    [InlineData(@"\\wsl.localhost\Ubuntu-24.04\home\alex\src", "src")]
+    [InlineData("/home/alex", "alex")]
+    public void AWslHome_KeepsItsPath_AndLabelsFromTheLeaf(string cwd, string leaf)
+    {
+        var displayed = TabLabel.Collapse(cwd, Home);
+        Assert.Equal(cwd, displayed);
+        Assert.Equal(leaf, TabLabel.FolderName(displayed));
+    }
+
     [Theory]
     [InlineData("C:\\Users\\alex\ndel *")]
     [InlineData("C:\\Users\\alex\\\u202Esdaolnwod")]

--- a/windows/Ghostty.Tests/Tabs/TabTitleSurfacesTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabTitleSurfacesTests.cs
@@ -74,12 +74,16 @@ public class TabTitleSurfacesTests
         return data;
     }
 
+    /// <summary>
+    /// The glyph surfaces are a SUBSET of the word surfaces, not an
+    /// alternative to them: a strip draws the house and prints the word.
+    /// (That every title surface prints the word is not asserted here --
+    /// it would be <c>X.Except(X)</c> now that the two lists are one. The
+    /// theory below carries it, file by file.)
+    /// </summary>
     [Fact]
-    public void EveryTitleSurface_PrintsTheWord_AndTheStripsAlsoDrawTheHouse()
-    {
-        Assert.Empty(TitleSurfaceNames.Except(WordSurfaceNames));
-        Assert.Empty(GlyphSurfaceNames.Except(WordSurfaceNames));
-    }
+    public void TheStripsThatDrawTheHouse_AlsoPrintTheWord()
+        => Assert.Empty(GlyphSurfaceNames.Except(WordSurfaceNames));
 
 
     [Theory]

--- a/windows/Ghostty.Tests/Tabs/TabTitleSurfacesTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabTitleSurfacesTests.cs
@@ -42,22 +42,19 @@ public class TabTitleSurfacesTests
     ];
 
     /// <summary>
-    /// Surfaces that can only show words, where a home tab's glyph has to
-    /// become "Home": they read the model's WordTitle instead. Every
-    /// surface is on exactly one of these two lists -- a text surface left
-    /// unclassified is one that prints a bare tilde while the strips draw a
-    /// house and the window title says "Home".
+    /// Every surface prints the word form: a home tab reads "Home"
+    /// everywhere, so the strip agrees with the window title, the palette,
+    /// the switcher and the overview instead of being the one place that
+    /// shows a symbol nobody can read aloud. A surface missing from here is
+    /// one that prints a bare tilde while every other surface says "Home".
     /// </summary>
-    private static readonly string[] WordSurfaceNames =
-    [
-        "Shell.TitleBarCoordinator.cs",     // window title (taskbar, Alt+Tab), vertical caption
-        "Commands.JumpCommandSource.cs",    // command palette entries
-        "Tabs.TabSwitcherPopup.xaml.cs",    // Ctrl+Tab tiles
-        "Tabs.TabOverviewControl.xaml.cs",  // overview grid
-        "Shell.TabMorphGhost.cs",           // the layout-switch ghost
-    ];
+    private static readonly string[] WordSurfaceNames = TitleSurfaceNames;
 
-    /// <summary>The two surfaces that draw the glyph rather than print it.</summary>
+    /// <summary>
+    /// The two strips, which draw the house BESIDE the word rather than
+    /// instead of it. A subset of the word surfaces, not an alternative to
+    /// them: the glyph is the ornament, the word is the label.
+    /// </summary>
     private static readonly string[] GlyphSurfaceNames =
     [
         "Tabs.TabHost.xaml.cs",
@@ -78,10 +75,10 @@ public class TabTitleSurfacesTests
     }
 
     [Fact]
-    public void EveryTitleSurface_IsClassifiedExactlyOnce()
+    public void EveryTitleSurface_PrintsTheWord_AndTheStripsAlsoDrawTheHouse()
     {
-        Assert.Empty(WordSurfaceNames.Intersect(GlyphSurfaceNames));
-        Assert.Empty(TitleSurfaceNames.Except(WordSurfaceNames).Except(GlyphSurfaceNames));
+        Assert.Empty(TitleSurfaceNames.Except(WordSurfaceNames));
+        Assert.Empty(GlyphSurfaceNames.Except(WordSurfaceNames));
     }
 
 
@@ -117,13 +114,22 @@ public class TabTitleSurfacesTests
         }
     }
 
+    /// <summary>
+    /// A strip draws the house AND prints the word. The house alone was two
+    /// icons and no text in a strip whose every other tab is scanned by
+    /// reading a folder name -- and on Windows that glyph is the one File
+    /// Explorer uses for its Home *page*, so unlabelled it names the wrong
+    /// thing.
+    /// </summary>
     [Theory]
     [MemberData(nameof(GlyphSurfaces))]
-    public void AGlyphSurface_DrawsTheComposedTitle_NotTheWordForm(string source)
+    public void AGlyphSurface_DrawsTheHouseBesideTheWord(string source)
     {
         var root = ShellSource.Load(source).Root;
-        Assert.True(InstanceReads(root, "EffectiveTitle") > 0, $"{source} never reads EffectiveTitle");
-        Assert.Equal(0, InstanceReads(root, "WordTitle"));
+        Assert.True(InstanceReads(root, "WordTitle") > 0, $"{source} never reads WordTitle");
+        Assert.Contains(
+            root.DescendantNodes().OfType<VariableDeclaratorSyntax>(),
+            v => v.Identifier.Text == "HomeGlyph");
     }
 
     /// <summary>

--- a/windows/Ghostty.Tests/Wiring/PaneCloseFocusWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/PaneCloseFocusWiringTests.cs
@@ -51,4 +51,52 @@ public class PaneCloseFocusWiringTests
             statements.IndexOf(raise!) > statements.IndexOf(lastAssign),
             "LeafFocused is raised before the active leaf's last reassignment, so subscribers rebind to the wrong pane");
     }
+
+    /// <summary>
+    /// The pane that is TOLD to take focus and the pane CloseLeaf REPORTS as
+    /// focused have to be the same one, so the focus call is enqueued after
+    /// the zoom re-entry that can still move the active leaf.
+    ///
+    /// Enqueued before it, the call named the tree's first leaf; re-entering
+    /// zoom then parked that leaf off-screen, the dispatcher drained the
+    /// stale call afterwards, and OnTerminalGotFocus took it for a real
+    /// focus change -- raising a second, contradicting LeafFocused and
+    /// painting the active border on a pane nobody could see.
+    /// </summary>
+    [Fact]
+    public void CloseLeaf_EnqueuesOneFocus_AfterTheZoomDecision()
+    {
+        var close = ShellSource.Load("Panes.PaneHost.cs").Root.DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .Single(m => m.Identifier.ValueText == "CloseLeaf" && m.ParameterList.Parameters.Count == 2);
+        var statements = close.Body!.DescendantNodes().OfType<StatementSyntax>().ToList();
+
+        // Exactly one enqueued focus call, or two panes race for it.
+        var focusEnqueues = statements.OfType<ExpressionStatementSyntax>()
+            .Where(s => s.ToString().Contains("DispatcherQueue.TryEnqueue")
+                        && s.ToString().Contains(".Focus("))
+            .ToList();
+        Assert.Single(focusEnqueues);
+
+        // It comes after the last thing that can move the active leaf --
+        // which is the zoom re-entry's assignment.
+        var lastAssign = statements.Last(s =>
+            s is ExpressionStatementSyntax { Expression: AssignmentExpressionSyntax { Left: IdentifierNameSyntax { Identifier.Text: "_activeLeaf" } } });
+        Assert.True(
+            statements.IndexOf(focusEnqueues[0]) > statements.IndexOf(lastAssign),
+            "the focus call is enqueued before the zoom re-entry can move the active leaf, so it names the wrong pane");
+
+        // And it focuses the leaf that decision settled on, not a copy taken
+        // before it. The capture is a local so the lambda cannot read a
+        // field that moves again before the dispatcher drains.
+        var captured = statements.OfType<LocalDeclarationStatementSyntax>()
+            .Last(s => s.Declaration.Variables.Count == 1
+                       && s.Declaration.Variables[0].Initializer?.Value.ToString() == "_activeLeaf");
+        Assert.True(
+            statements.IndexOf(captured) > statements.IndexOf(lastAssign),
+            "the focus target is captured before the zoom re-entry, so it is the pre-zoom leaf");
+        Assert.Contains(
+            captured.Declaration.Variables[0].Identifier.Text,
+            focusEnqueues[0].ToString());
+    }
 }

--- a/windows/Ghostty.Tests/Wiring/PaneCloseFocusWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/PaneCloseFocusWiringTests.cs
@@ -71,12 +71,20 @@ public class PaneCloseFocusWiringTests
             .Single(m => m.Identifier.ValueText == "CloseLeaf" && m.ParameterList.Parameters.Count == 2);
         var statements = close.Body!.DescendantNodes().OfType<StatementSyntax>().ToList();
 
-        // Exactly one enqueued focus call, or two panes race for it.
+        // One enqueued focus call in THIS method. The zoom re-entry's own
+        // ToggleSplitZoom enqueues a second, but that one targets the leaf
+        // this method has already made active, so it drains as a no-op on an
+        // already-focused control. Two here would be two different panes.
         var focusEnqueues = statements.OfType<ExpressionStatementSyntax>()
             .Where(s => s.ToString().Contains("DispatcherQueue.TryEnqueue")
                         && s.ToString().Contains(".Focus("))
             .ToList();
         Assert.Single(focusEnqueues);
+        // A top-level statement of the method, not one branch's. Nested
+        // inside the zoom re-entry it would still sort after every
+        // assignment below while leaving the ordinary close -- no zoom in
+        // play at all -- focusing nothing.
+        Assert.Same(close.Body, focusEnqueues[0].Parent);
 
         // It comes after the last thing that can move the active leaf --
         // which is the zoom re-entry's assignment.
@@ -92,6 +100,7 @@ public class PaneCloseFocusWiringTests
         var captured = statements.OfType<LocalDeclarationStatementSyntax>()
             .Last(s => s.Declaration.Variables.Count == 1
                        && s.Declaration.Variables[0].Initializer?.Value.ToString() == "_activeLeaf");
+        Assert.Same(close.Body, captured.Parent);
         Assert.True(
             statements.IndexOf(captured) > statements.IndexOf(lastAssign),
             "the focus target is captured before the zoom re-entry, so it is the pre-zoom leaf");

--- a/windows/Ghostty.Tests/Wiring/RestoredTabSettlingWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/RestoredTabSettlingWiringTests.cs
@@ -23,23 +23,34 @@ public class RestoredTabSettlingWiringTests
 {
     private static SyntaxNode Window() => ShellSource.Load("MainWindow.xaml.cs").Root;
 
+    /// <summary>
+    /// It asks the manager which tab is active rather than indexing the
+    /// restored list. A saved tab whose tree no longer rebuilds shortens
+    /// that list, so the saved index can fall off the end -- and the
+    /// fallback would then flag a collapsed tab that never paints while the
+    /// adopt loop's last tab is the one on screen. Even in range, the saved
+    /// index counts the list as saved and the manager has since normalized
+    /// pins and runs.
+    /// </summary>
     [Fact]
-    public void TheRestore_BeginsSettlingOnlyTheTabItBringsToTheFront()
+    public void TheRestore_BeginsSettlingOnTheTabTheManagerMadeActive()
     {
-        var begins = Window().DescendantNodes().OfType<InvocationExpressionSyntax>()
-            .Where(i => i.Expression is MemberAccessExpressionSyntax
-            {
-                Name.Identifier.Text: "BeginSettling",
-                Expression: ElementAccessExpressionSyntax,
-            })
-            .ToList();
+        // The restore lives in a constructor, so this finds the statement
+        // rather than a named method.
+        var begin = Assert.Single(Window().DescendantNodes().OfType<ExpressionStatementSyntax>()
+            .Where(s => s.ToString().Contains("BeginSettling")
+                        && s.ToString().Contains("_tabManager.ActiveTab")));
 
-        // Exactly one, and it indexes the restored list rather than looping
-        // it -- a foreach here is the flicker this guard exists to stop.
-        var begin = Assert.Single(begins);
-        var target = (ElementAccessExpressionSyntax)
-            ((MemberAccessExpressionSyntax)begin.Expression).Expression;
-        Assert.Equal("restoredTabs", target.Expression.ToString());
+        // On the manager's own answer, not on a subscript of the built list.
+        Assert.DoesNotContain("restoredTabs[", begin.ToString());
+
+        // And after the activation that decides that answer, in the same
+        // block, or it names whichever tab the adopt loop left active.
+        var block = Assert.IsType<BlockSyntax>(begin.Parent);
+        var activate = block.Statements.Last(s => s.ToString().Contains("ActivateIndex"));
+        Assert.True(
+            block.Statements.IndexOf(begin) > block.Statements.IndexOf(activate),
+            "the restore begins settling before it activates, so it flags the wrong tab");
     }
 
     [Theory]
@@ -75,11 +86,23 @@ public class RestoredTabSettlingWiringTests
     [Fact]
     public void NoBeginSettling_SitsInsideALoop()
     {
-        foreach (var begin in Window().DescendantNodes().OfType<InvocationExpressionSyntax>()
-                     .Where(i => i.Expression is MemberAccessExpressionSyntax { Name.Identifier.Text: "BeginSettling" }))
+        // EndsWith, not a MemberAccess pattern: the restore's call is
+        // null-conditional, which parses as a member BINDING and would slip
+        // a pattern match silently.
+        var begins = Window().DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(i => i.Expression.ToString().EndsWith("BeginSettling", System.StringComparison.Ordinal))
+            .ToList();
+
+        // Three sites: the restore, reopen-closed-tab, Duplicate Tab. An
+        // empty query would make the loop below say nothing at all.
+        Assert.Equal(3, begins.Count);
+
+        foreach (var begin in begins)
         {
+            // CommonForEachStatementSyntax covers the deconstructing form
+            // too, which is its own node type.
             Assert.DoesNotContain(begin.Ancestors(),
-                a => a is ForEachStatementSyntax or ForStatementSyntax or WhileStatementSyntax);
+                a => a is CommonForEachStatementSyntax or ForStatementSyntax or WhileStatementSyntax);
         }
     }
 }

--- a/windows/Ghostty.Tests/Wiring/RestoredTabSettlingWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/RestoredTabSettlingWiringTests.cs
@@ -1,0 +1,85 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// A tab rebuilt from a snapshot -- session restore, reopen-closed-tab,
+/// Duplicate Tab -- gets fresh shells, so it is genuinely starting and
+/// should say so. It is ADOPTED rather than opened, though, and the
+/// adopter deliberately begins nothing: adoption is also where a tab
+/// dragged in from another window lands, and that host has already
+/// painted and already disposed its cap timer, so a begin there would
+/// strand every moved tab reading "Starting…" for good.
+///
+/// So the begin belongs at the three sites that know the tab is a rebuild
+/// AND is about to be shown. Restore flags only the tab it brings to the
+/// front: the others go in collapsed, never paint, and would sit starting
+/// until their caps expired.
+/// </summary>
+public class RestoredTabSettlingWiringTests
+{
+    private static SyntaxNode Window() => ShellSource.Load("MainWindow.xaml.cs").Root;
+
+    [Fact]
+    public void TheRestore_BeginsSettlingOnlyTheTabItBringsToTheFront()
+    {
+        var begins = Window().DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(i => i.Expression is MemberAccessExpressionSyntax
+            {
+                Name.Identifier.Text: "BeginSettling",
+                Expression: ElementAccessExpressionSyntax,
+            })
+            .ToList();
+
+        // Exactly one, and it indexes the restored list rather than looping
+        // it -- a foreach here is the flicker this guard exists to stop.
+        var begin = Assert.Single(begins);
+        var target = (ElementAccessExpressionSyntax)
+            ((MemberAccessExpressionSyntax)begin.Expression).Expression;
+        Assert.Equal("restoredTabs", target.Expression.ToString());
+    }
+
+    [Theory]
+    [InlineData("ReopenClosedTab", "tab")]
+    [InlineData("DuplicateTab", "clone")]
+    public void ARebuiltTab_StartsBeforeItIsAdopted(string method, string local)
+    {
+        var body = ShellSource.Load("MainWindow.xaml.cs").Method(method);
+        var statements = body.Body!.Statements;
+
+        int IndexOf(string call) => statements.IndexOf(statements.Single(s =>
+            s.DescendantNodesAndSelf().OfType<InvocationExpressionSyntax>()
+                .Any(i => i.Expression.ToString() == call)));
+
+        var begin = IndexOf($"{local}.BeginSettling");
+        var adopt = IndexOf("_tabManager.AdoptTab");
+        Assert.True(begin < adopt,
+            $"{method} adopts before it begins settling, so the strip draws the tab once with the wrong icon");
+    }
+
+    /// <summary>
+    /// No begin sits inside a loop. The whole point of picking one tab is
+    /// that a restore of twenty tabs does not flag twenty of them; a
+    /// foreach over the restored list would read as a reasonable
+    /// generalisation and undo it.
+    ///
+    /// The other half of this -- that the ADOPTER itself begins nothing, so
+    /// a tab dragged in from another window is not stranded starting -- is a
+    /// behaviour, not a shape, and
+    /// <c>TabStripPolishTests.ANewTabFromTheManager_StartsSettling_AndAnAdoptedOneDoesNot</c>
+    /// holds it against the real TabManager.
+    /// </summary>
+    [Fact]
+    public void NoBeginSettling_SitsInsideALoop()
+    {
+        foreach (var begin in Window().DescendantNodes().OfType<InvocationExpressionSyntax>()
+                     .Where(i => i.Expression is MemberAccessExpressionSyntax { Name.Identifier.Text: "BeginSettling" }))
+        {
+            Assert.DoesNotContain(begin.Ancestors(),
+                a => a is ForEachStatementSyntax or ForStatementSyntax or WhileStatementSyntax);
+        }
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/TabStripPolishWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabStripPolishWiringTests.cs
@@ -120,13 +120,26 @@ public class TabStripPolishWiringTests
     public void TheHorizontalTab_DrawsTheGlyphBesideTheWord()
     {
         var anatomy = ShellSource.Load("Tabs.TabHost.xaml.cs").Method("ApplyPinnedTabAnatomy");
-        var writes = anatomy.DescendantNodes().OfType<AssignmentExpressionSyntax>()
-            .Where(a => a.Left.ToString().EndsWith(".Visibility", System.StringComparison.Ordinal))
-            .Select(a => a.Right.ToString())
-            .ToList();
 
-        Assert.Contains("pinned ? Visibility.Collapsed : Visibility.Visible", writes);
-        Assert.Contains("pinned || !tab.IsHome ? Visibility.Collapsed : Visibility.Visible", writes);
+        // Keyed by the switch arm each write sits in, not gathered into one
+        // bag of right-hand sides: swapping the two bodies leaves both
+        // strings present, and a home tab would then wear a permanent house
+        // and no title -- the exact regression this names.
+        static string WriteIn(MethodDeclarationSyntax method, string label)
+        {
+            var section = method.DescendantNodes().OfType<SwitchSectionSyntax>()
+                .Single(s => s.Labels.ToString().Contains(label, System.StringComparison.Ordinal));
+            return section.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+                .Single(a => a.Left.ToString().EndsWith(".Visibility", System.StringComparison.Ordinal))
+                .Right.ToString();
+        }
+
+        Assert.Equal(
+            "pinned ? Visibility.Collapsed : Visibility.Visible",
+            WriteIn(anatomy, "TextBlock title"));
+        Assert.Equal(
+            "pinned || !tab.IsHome ? Visibility.Collapsed : Visibility.Visible",
+            WriteIn(anatomy, "HomeGlyph"));
     }
 
     /// <summary>

--- a/windows/Ghostty.Tests/Wiring/TabStripPolishWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabStripPolishWiringTests.cs
@@ -85,29 +85,39 @@ public class TabStripPolishWiringTests
     }
 
     /// <summary>
-    /// The body row swaps the pair: at home the glyph shows and the title
-    /// does not, both decided by the model's own judgement. Asserting the
-    /// glyph merely exists would survive a row that went on printing the
-    /// tilde beside it.
+    /// The body row draws the glyph BESIDE the word: the house appears at
+    /// home, and the title prints either way -- "Home" there, the folder
+    /// elsewhere. A row that hid its title behind the glyph left two icons
+    /// and no text in a strip that is scanned by reading.
     /// </summary>
     [Fact]
-    public void TheBodyRow_ShowsTheGlyphInsteadOfTheTitle()
+    public void TheBodyRow_DrawsTheGlyphBesideTheWord()
     {
-        var refresh = ShellSource.Load("Tabs.VerticalTabNavRow.cs").Method("Refresh");
+        var row = ShellSource.Load("Tabs.VerticalTabNavRow.cs");
+        var refresh = row.Method("Refresh");
         var writes = refresh.DescendantNodes().OfType<AssignmentExpressionSyntax>()
             .Where(a => a.Left.ToString().EndsWith(".Visibility", System.StringComparison.Ordinal))
             .ToDictionary(a => a.Left.ToString(), a => a.Right.ToString());
 
-        Assert.Equal("tab.IsHome ? Visibility.Collapsed : Visibility.Visible", writes["_title.Visibility"]);
         Assert.Equal("tab.IsHome ? Visibility.Visible : Visibility.Collapsed", writes["_home.Visibility"]);
+
+        // Nothing hides the title -- not in the refresh, not anywhere else
+        // in the row.
+        Assert.DoesNotContain(row.Root.DescendantNodes().OfType<AssignmentExpressionSyntax>(),
+            a => a.Left.ToString() == "_title.Visibility");
+
+        // And the word it prints is the one every other surface prints.
+        Assert.Contains(refresh.DescendantNodes().OfType<AssignmentExpressionSyntax>(),
+            a => a.Left.ToString() == "_title.Text" && a.Right.ToString() == "tab.WordTitle");
     }
 
     /// <summary>
-    /// The horizontal strip does the same swap inside its anatomy pass,
-    /// where a pinned tab hides both.
+    /// The horizontal strip does the same in its anatomy pass. Only the pin
+    /// takes the title away there -- a 48px square has no room for it. The
+    /// house still hides on a pin, because the square is the icon's.
     /// </summary>
     [Fact]
-    public void TheHorizontalTab_ShowsTheGlyphInsteadOfTheTitle()
+    public void TheHorizontalTab_DrawsTheGlyphBesideTheWord()
     {
         var anatomy = ShellSource.Load("Tabs.TabHost.xaml.cs").Method("ApplyPinnedTabAnatomy");
         var writes = anatomy.DescendantNodes().OfType<AssignmentExpressionSyntax>()
@@ -115,7 +125,7 @@ public class TabStripPolishWiringTests
             .Select(a => a.Right.ToString())
             .ToList();
 
-        Assert.Contains("pinned || tab.IsHome ? Visibility.Collapsed : Visibility.Visible", writes);
+        Assert.Contains("pinned ? Visibility.Collapsed : Visibility.Visible", writes);
         Assert.Contains("pinned || !tab.IsHome ? Visibility.Collapsed : Visibility.Visible", writes);
     }
 

--- a/windows/Ghostty.Tests/Wiring/VerticalTabGroupHeaderWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/VerticalTabGroupHeaderWiringTests.cs
@@ -200,7 +200,13 @@ public class VerticalTabGroupHeaderWiringTests
         Assert.Contains("nameof(TabGroup.IsCollapsed)", headerBinding.ArgumentList.ToString());
         Assert.Contains("nameof(TabGroup.Title)", headerBinding.ArgumentList.ToString());
         Assert.Contains("nameof(TabGroup.Color)", headerBinding.ArgumentList.ToString());
-        Assert.Contains("ScheduleReconcile", headerBinding.Arg(1).ToString());
+        // The binding goes through OnGroupStateChanged, which first rewrites
+        // each member's accessible status -- the group's title and collapse
+        // bit are segments of it, and a group change is not a per-tab event
+        // -- then defers the layout answer to the same coalescing reconcile
+        // the binding used to call directly.
+        Assert.Contains("OnGroupStateChanged", headerBinding.Arg(1).ToString());
+        Assert.Single(strip.Method("OnGroupStateChanged").Calls("ScheduleReconcile"));
 
         var remove = strip.Method("RemoveGroupRow");
         var fence = remove.AssignsTo("_syncing").Where(a => a.Right.ToString() == "true").ToList();

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -783,18 +783,24 @@ public sealed partial class MainWindow : Window
             // path.
             restorer.RestoreGroups(_tabManager, restore!);
 
+            if (restore!.ActiveTabIndex >= 0 && restore.ActiveTabIndex < restoredTabs.Count)
+                _tabManager.ActivateIndex(restore.ActiveTabIndex);
+
             // Restored shells really are cold-starting, but only the tab the
             // restore brings to the front says so. The rest go into the tree
             // collapsed and do not paint until they are first visited, so
             // flagging them would put "Starting…" across a strip of tabs
             // that are doing nothing and then release them in a ragged clump
             // as their cap timers expired one by one.
-            var presenting = restore!.ActiveTabIndex >= 0 && restore.ActiveTabIndex < restoredTabs.Count
-                ? restore.ActiveTabIndex
-                : 0;
-            restoredTabs[presenting].BeginSettling();
-            if (restore.ActiveTabIndex >= 0 && restore.ActiveTabIndex < restoredTabs.Count)
-                _tabManager.ActivateIndex(restore.ActiveTabIndex);
+            //
+            // Asked of the manager AFTER activating, not computed from an
+            // index: a saved tab whose tree no longer rebuilds shortens the
+            // list, so the saved index can fall off the end and the adopt
+            // loop's last tab is what stays active -- and even in range, the
+            // saved index counts the list as saved while the manager has
+            // since normalized pins and runs. Whichever tab is actually
+            // active is the one that will paint.
+            _tabManager.ActiveTab?.BeginSettling();
         }
         else
         {

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -782,7 +782,18 @@ public sealed partial class MainWindow : Window
             // bits. Restore never auto-expands; JoinGroup is not on this
             // path.
             restorer.RestoreGroups(_tabManager, restore!);
-            if (restore!.ActiveTabIndex >= 0 && restore.ActiveTabIndex < restoredTabs.Count)
+
+            // Restored shells really are cold-starting, but only the tab the
+            // restore brings to the front says so. The rest go into the tree
+            // collapsed and do not paint until they are first visited, so
+            // flagging them would put "Starting…" across a strip of tabs
+            // that are doing nothing and then release them in a ragged clump
+            // as their cap timers expired one by one.
+            var presenting = restore!.ActiveTabIndex >= 0 && restore.ActiveTabIndex < restoredTabs.Count
+                ? restore.ActiveTabIndex
+                : 0;
+            restoredTabs[presenting].BeginSettling();
+            if (restore.ActiveTabIndex >= 0 && restore.ActiveTabIndex < restoredTabs.Count)
                 _tabManager.ActivateIndex(restore.ActiveTabIndex);
         }
         else
@@ -2491,6 +2502,12 @@ public sealed partial class MainWindow : Window
         var restorer = new Ghostty.Session.SessionRestorer(_factory, App.ProfileRegistry);
         if (restorer.BuildTab(tabSession) is not { } tab) return;
 
+        // Fresh shells, and this one comes straight to the front, so it wears
+        // the starting state the way a new tab does. Before the adopt: the
+        // adopt activates, and the icon should be right the first time the
+        // strip draws it.
+        tab.BeginSettling();
+
         // AdoptTab raises TabAdded -> AddPaneHost + activation, so the rebuilt
         // tab renders and focuses just like the session-restore path.
         _tabManager.AdoptTab(tab);
@@ -2516,6 +2533,9 @@ public sealed partial class MainWindow : Window
             tab.UserOverrideTitle);
         if (new Ghostty.Session.SessionRestorer(_factory, App.ProfileRegistry)
                 .BuildTab(session) is not { } clone) return;
+
+        // Same as reopen: fresh shells, front of the strip, so it starts.
+        clone.BeginSettling();
 
         // Adopt appends and activates. Pin comes before the move: the flag
         // defines the zone Move clamps into, so a pinned source's clone is

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -1082,7 +1082,6 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         // nested visual structure to confuse the framework.
         if (!TryIncrementalCloseRebuild(leafParentGrid)) Rebuild();
         UpdateHighlightPosition();
-        DispatcherQueue.TryEnqueue(() => nextActive.Terminal().Focus(FocusState.Programmatic));
 
         // A close while zoomed always force-unzooms (the structural rebuild
         // clears zoom state). If the pane that closed was NOT the zoomed
@@ -1097,6 +1096,15 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
             _activeLeaf = zoomedBefore;
             ToggleSplitZoom();
         }
+
+        // Focus goes to whichever leaf the zoom decision above settled on,
+        // which is why it is enqueued here rather than beside the rebuild.
+        // Enqueued earlier it named the tree's first leaf, and a re-entered
+        // zoom then parked that leaf off-screen: the dispatcher drained the
+        // stale call afterwards, OnTerminalGotFocus took it as a real focus
+        // change, and the tab spent a beat naming a pane nobody could see.
+        var focusTarget = _activeLeaf;
+        DispatcherQueue.TryEnqueue(() => focusTarget.Terminal().Focus(FocusState.Programmatic));
 
         // The active leaf was reassigned above, before focus lands on it,
         // so OnTerminalGotFocus sees a leaf that is already active and

--- a/windows/Ghostty/Tabs/TabContextMenuBuilder.cs
+++ b/windows/Ghostty/Tabs/TabContextMenuBuilder.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Ghostty.Core.Tabs;
 using Ghostty.Dialogs;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Windows.ApplicationModel.DataTransfer;
@@ -31,13 +32,42 @@ internal readonly record struct SnapZoneSource(
 internal static class TabContextMenuBuilder
 {
     /// <summary>
-    /// Whether the directory group is on the menu at all: only while the
-    /// tab has a directory it will act on. Hidden rather than greyed, so
-    /// a shell without integration is not offered two items that can
-    /// never do anything.
+    /// Whether the tab has a directory the two directory items will act on.
     /// </summary>
-    private static Visibility CwdVisibility(TabModel tab)
-        => tab.ActionableCwd is not null ? Visibility.Visible : Visibility.Collapsed;
+    private static bool CwdIsActionable(TabModel tab) => tab.ActionableCwd is not null;
+
+    /// <summary>
+    /// Why the directory items are unavailable, for assistive clients. A
+    /// disabled <see cref="MenuFlyoutItem"/> raises none of the pointer
+    /// events <see cref="ToolTipService"/> needs, so a tooltip here would be
+    /// text nobody could reach; Narrator reads HelpText as the item's
+    /// description. One string for all three reasons the model can refuse --
+    /// nothing reported yet, bytes that are not plain text, a host the spawn
+    /// policy will not enter -- because the menu owes "not here", and the
+    /// reasoning belongs in the policy, not the flyout.
+    /// </summary>
+    private const string CwdUnavailableHelp =
+        "Unavailable: this tab's shell has not reported a working directory that can be used.";
+
+    /// <summary>
+    /// Greys the directory pair rather than hiding it. The horizontal strip
+    /// builds one flyout per tab and reuses it, and a shell reports its
+    /// directory a moment after the tab opens -- hiding made the same menu
+    /// three items shorter at one opening and longer at the next. Greying
+    /// also leaves something to learn from: a shell without integration
+    /// never reports a directory at all, and an absent item cannot say so.
+    /// This is what the Move Tab items above already do with state that
+    /// moves just as freely.
+    /// </summary>
+    private static void ApplyCwdAvailability(TabModel tab, MenuFlyoutItem copy, MenuFlyoutItem open)
+    {
+        var actionable = CwdIsActionable(tab);
+        foreach (var item in new[] { copy, open })
+        {
+            item.IsEnabled = actionable;
+            AutomationProperties.SetHelpText(item, actionable ? null : CwdUnavailableHelp);
+        }
+    }
 
     public static MenuFlyout Build(
         TabManager manager,
@@ -158,16 +188,16 @@ internal static class TabContextMenuBuilder
         // The directory the shell reported, in the two forms a person wants
         // it: on the clipboard, and open in File Explorer. Its own group,
         // because these are about the shell's directory rather than the
-        // tab. Hidden, not greyed, until the model has one it will act on:
-        // reported, plain text, and a directory the spawn policy accepts,
-        // since the path is bytes off the pty.
-        var cwdRule = new MenuFlyoutSeparator { Visibility = CwdVisibility(tab) };
+        // tab. Live only while the model has one it will act on: reported,
+        // plain text, and a directory the spawn policy accepts, since the
+        // path is bytes off the pty. Greyed when it has not, so the menu
+        // keeps one shape -- see ApplyCwdAvailability.
+        var cwdRule = new MenuFlyoutSeparator();
         flyout.Items.Add(cwdRule);
 
         var copyCwd = new MenuFlyoutItem
         {
             Text = "Copy Working Directory",
-            Visibility = CwdVisibility(tab),
         };
         copyCwd.Click += (_, _) =>
         {
@@ -185,7 +215,6 @@ internal static class TabContextMenuBuilder
         var openCwd = new MenuFlyoutItem
         {
             Text = "Open in File Explorer",
-            Visibility = CwdVisibility(tab),
         };
         openCwd.Click += async (_, _) =>
         {
@@ -204,6 +233,7 @@ internal static class TabContextMenuBuilder
             catch (Exception) { }
         };
         flyout.Items.Add(openCwd);
+        ApplyCwdAvailability(tab, copyCwd, openCwd);
 
         flyout.Items.Add(new MenuFlyoutSeparator());
 
@@ -258,12 +288,12 @@ internal static class TabContextMenuBuilder
             if (moveToZone is not null)
                 moveToZone.IsEnabled = manager.Tabs.Count > 1;
             pin.Text = tab.IsPinned ? "Unpin Tab" : "Pin Tab";
-            // The directory group is absent until the tab has one it will
-            // act on, and a shell can report one any time after the flyout
-            // was built. The rule that introduces the group follows it.
-            cwdRule.Visibility = CwdVisibility(tab);
-            copyCwd.Visibility = CwdVisibility(tab);
-            openCwd.Visibility = CwdVisibility(tab);
+            // The directory pair is dead until the tab has one it will act
+            // on, and a shell can report one any time after the flyout was
+            // built -- the horizontal strip keeps one flyout per tab and
+            // reuses it, so build-time alone would freeze the pair grey on
+            // any tab right-clicked in its first second.
+            ApplyCwdAvailability(tab, copyCwd, openCwd);
         };
 
         flyout.Items.Add(new MenuFlyoutSeparator());

--- a/windows/Ghostty/Tabs/TabContextMenuBuilder.cs
+++ b/windows/Ghostty/Tabs/TabContextMenuBuilder.cs
@@ -37,17 +37,33 @@ internal static class TabContextMenuBuilder
     private static bool CwdIsActionable(TabModel tab) => tab.ActionableCwd is not null;
 
     /// <summary>
-    /// Why the directory items are unavailable, for assistive clients. A
-    /// disabled <see cref="MenuFlyoutItem"/> raises none of the pointer
-    /// events <see cref="ToolTipService"/> needs, so a tooltip here would be
-    /// text nobody could reach; Narrator reads HelpText as the item's
-    /// description. One string for all three reasons the model can refuse --
-    /// nothing reported yet, bytes that are not plain text, a host the spawn
-    /// policy will not enter -- because the menu owes "not here", and the
-    /// reasoning belongs in the policy, not the flyout.
+    /// Why the directory items are unavailable, for assistive clients.
+    ///
+    /// Two strings, because the model refuses for two different reasons and
+    /// only one of them is "there is no directory". A remote share IS
+    /// reported -- the tab labels itself from it, and the tooltip shows it
+    /// in full -- so telling a listener the shell reported nothing, while a
+    /// pointer user reads the path, is a contradiction rather than a
+    /// simplification. What the spawn policy refuses, it refuses because the
+    /// directory is on another machine.
+    ///
+    /// HelpText rather than a tooltip because a disabled
+    /// <see cref="MenuFlyoutItem"/> raises none of the pointer events
+    /// <see cref="ToolTipService"/> needs, so a tooltip here would be text
+    /// nobody could reach. NOT measured, unlike the NVDA note in
+    /// <c>TabAccessibleText</c>: whether a menu's arrow-key traversal stops
+    /// on a disabled item -- and so whether a screen reader reaches this at
+    /// all -- is unverified on WinAppSDK. Object navigation reaches it;
+    /// directional focus may not. Written on the reasoning that an
+    /// unreachable description costs nothing and a missing one cannot be
+    /// read by anyone.
     /// </summary>
-    private const string CwdUnavailableHelp =
-        "Unavailable: this tab's shell has not reported a working directory that can be used.";
+    private const string CwdNotReportedHelp =
+        "Unavailable: this tab's shell has not reported a working directory.";
+
+    /// <summary>The directory was reported, and names another machine.</summary>
+    private const string CwdRefusedHelp =
+        "Unavailable: this tab's working directory is on another computer.";
 
     /// <summary>
     /// Greys the directory pair rather than hiding it. The horizontal strip
@@ -62,10 +78,20 @@ internal static class TabContextMenuBuilder
     private static void ApplyCwdAvailability(TabModel tab, MenuFlyoutItem copy, MenuFlyoutItem open)
     {
         var actionable = CwdIsActionable(tab);
+        var help = actionable ? null
+            : tab.ShellReportedCwd is not null ? CwdRefusedHelp
+            : CwdNotReportedHelp;
         foreach (var item in new[] { copy, open })
         {
             item.IsEnabled = actionable;
-            AutomationProperties.SetHelpText(item, actionable ? null : CwdUnavailableHelp);
+            // Cleared rather than blanked: UIA reports an empty string as
+            // present-but-blank, so a live item would carry an empty
+            // description instead of none. Same rule as the palette's
+            // SetOrClear, and the same reason.
+            if (help is null)
+                item.ClearValue(AutomationProperties.HelpTextProperty);
+            else
+                AutomationProperties.SetHelpText(item, help);
         }
     }
 

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -435,6 +435,11 @@ internal sealed partial class TabHost : UserControl, ITabHost
         // TabViewItem: the close button and the hover chrome stay
         // full-strength so an idle tab still reads as fully operable.
         ApplyIdleInk(iconHost, headerText, tab);
+        // The house takes the label's ink here too, not only on the later
+        // IsIdle pass: a tab restored past the idle threshold and sitting at
+        // home would otherwise draw a full-strength house beside a dimmed
+        // "Home" until something happened to change IsIdle.
+        homeGlyph.Opacity = headerText.Opacity;
 
         // The group rail: a 2px line in the group's color in the header's
         // TOP slot. The progress bar owns the bottom slot; the two
@@ -565,6 +570,11 @@ internal sealed partial class TabHost : UserControl, ITabHost
                 ReconcileStripOrder();
                 ApplyTabChrome(item, headerPanel, tab,
                     ReferenceEquals(tab, _manager.ActiveTab));
+                // The run the tab sits in rides ItemStatus, so leaving this
+                // out left a tab that had just left a group still telling
+                // assistive clients it was in one -- until some unrelated
+                // prompt or bell happened to rewrite the status.
+                ApplyItemAccessibleText(item, tab);
             }
         };
         _itemByModel[tab] = item;
@@ -977,6 +987,16 @@ internal sealed partial class TabHost : UserControl, ITabHost
             // repaints them, so a recolor never leaves a two-tone run.
             RefreshRunRails(group);
         }
+
+        // A group's title and its collapse bit are both segments of every
+        // member's ItemStatus, and a group change is not a per-tab event, so
+        // nothing else would rewrite them: a renamed run left every member
+        // naming the old title to assistive clients. The members are the
+        // manager's to enumerate; the strip only owns the items.
+        foreach (var member in _manager.Tabs)
+            if (ReferenceEquals(member.Group, group)
+                && _itemByModel.TryGetValue(member, out var memberItem))
+                ApplyItemAccessibleText(memberItem, member);
 
         // Both arms move the field, and neither reaches it on its own.
         //

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -66,8 +66,8 @@ internal sealed partial class TabHost : UserControl, ITabHost
     // "resting", strong enough to notice in a scan of the strip.
     private const double IdleOpacity = 0.45;
 
-    // Segoe Fluent / MDL2 "Home": drawn in the title's place for a tab
-    // sitting in the user's own directory.
+    // Segoe Fluent / MDL2 "Home": drawn ahead of the title on a tab sitting
+    // in the user's own directory, where the title reads "Home".
     private const string HomeGlyph = "\uE80F";
 
     // One chip per group the projection renders as collapsed-without-the-
@@ -323,7 +323,9 @@ internal sealed partial class TabHost : UserControl, ITabHost
         // trimming mode is set.
         var headerText = new TextBlock
         {
-            Text = tab.EffectiveTitle,
+            // WordTitle, not EffectiveTitle: a home tab reads "Home" here,
+            // the same word every other surface prints for it.
+            Text = tab.WordTitle,
             TextTrimming = TextTrimming.CharacterEllipsis,
         };
         // If the shell theme is already active, paint the new tab's
@@ -368,14 +370,16 @@ internal sealed partial class TabHost : UserControl, ITabHost
         };
         iconHost.Attach(tab.TabIcon);
         iconRow.Children.Add(iconHost);
-        iconRow.Children.Add(headerText);
-        // The home glyph, shown instead of the title when the tab sits in
-        // the user's own directory; the anatomy pass toggles the pair.
+        // The home glyph leads the title rather than replacing it: a house
+        // with no word beside it is the one Windows draws for Explorer's
+        // Home *page*, and a header with no text cannot be scanned like its
+        // neighbours. The anatomy pass toggles it.
         var homeGlyph = new FontIcon
         {
             Glyph = HomeGlyph,
             FontSize = 14,
             VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(0, 0, 4, 0),
             Visibility = tab.IsHome ? Visibility.Visible : Visibility.Collapsed,
         };
         if (Application.Current.Resources.TryGetValue("SymbolThemeFontFamily", out var homeFont)
@@ -387,6 +391,7 @@ internal sealed partial class TabHost : UserControl, ITabHost
         AutomationProperties.SetAccessibilityView(
             homeGlyph, Microsoft.UI.Xaml.Automation.Peers.AccessibilityView.Raw);
         iconRow.Children.Add(homeGlyph);
+        iconRow.Children.Add(headerText);
 
         // Bell indicator: a Ringer glyph shown after the title while the
         // tab has an unacknowledged bell (bell-features `title`). Collapsed
@@ -480,7 +485,7 @@ internal sealed partial class TabHost : UserControl, ITabHost
                 e.PropertyName == nameof(TabModel.ShellReportedTitle) ||
                 e.PropertyName == nameof(TabModel.UserOverrideTitle))
             {
-                headerText.Text = tab.EffectiveTitle;
+                headerText.Text = tab.WordTitle;
                 ApplyItemAccessibleText(item, tab);
                 // headerText is COLLAPSED on a pinned tab, so the line above
                 // updates something nobody can see and the tooltip -- the
@@ -2148,7 +2153,7 @@ internal sealed partial class TabHost : UserControl, ITabHost
                     icon.ShowsTooltip = !pinned;
                     break;
                 case TextBlock title:
-                    title.Visibility = pinned || tab.IsHome ? Visibility.Collapsed : Visibility.Visible;
+                    title.Visibility = pinned ? Visibility.Collapsed : Visibility.Visible;
                     break;
                 case FontIcon home when home.Glyph == HomeGlyph:
                     home.Visibility = pinned || !tab.IsHome ? Visibility.Collapsed : Visibility.Visible;

--- a/windows/Ghostty/Tabs/VerticalTabNavRow.cs
+++ b/windows/Ghostty/Tabs/VerticalTabNavRow.cs
@@ -16,8 +16,8 @@ internal sealed partial class VerticalTabNavRow : Grid
     // strip's: sleeping is a rest state, not an alert.
     private const string IdleGlyph = "\uE708";
     private const double IdleOpacity = 0.45;
-    // Segoe Fluent / MDL2 "Home": what a tab sitting in the user's own
-    // directory shows in place of a printed tilde.
+    // Segoe Fluent / MDL2 "Home": drawn ahead of the title on a tab sitting
+    // in the user's own directory, where the title reads "Home".
     private const string HomeGlyph = "\uE80F";
 
     private readonly TextBlock _title;
@@ -39,9 +39,12 @@ internal sealed partial class VerticalTabNavRow : Grid
             VerticalAlignment = VerticalAlignment.Center,
             TextTrimming = TextTrimming.CharacterEllipsis,
             Margin = new Thickness(0, 0, 4, 0),
-            Text = tab.EffectiveTitle,
+            Text = tab.WordTitle,
         };
-        // The home glyph shares the title's column and shows instead of it.
+        // The home glyph leads the title rather than replacing it: a house
+        // with no word beside it is the one Windows draws for Explorer's
+        // Home *page*, and a row with no text cannot be scanned like its
+        // neighbours.
         _home = new FontIcon
         {
             Glyph = HomeGlyph,
@@ -110,6 +113,11 @@ internal sealed partial class VerticalTabNavRow : Grid
         _close.Click += closeClick;
 
         var textRow = new Grid();
+        // House, then title, then badges. The house takes its own auto
+        // column so the title still owns the star column and trims against
+        // the badges the way it always did -- the word gives way first, the
+        // glyph never trims.
+        textRow.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
         textRow.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
         textRow.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
         // Both badges share the one auto column -- moon first, bell
@@ -123,11 +131,11 @@ internal sealed partial class VerticalTabNavRow : Grid
         };
         badges.Children.Add(_idle);
         badges.Children.Add(_bell);
-        Grid.SetColumn(_title, 0);
         Grid.SetColumn(_home, 0);
-        Grid.SetColumn(badges, 1);
-        textRow.Children.Add(_title);
+        Grid.SetColumn(_title, 1);
+        Grid.SetColumn(badges, 2);
         textRow.Children.Add(_home);
+        textRow.Children.Add(_title);
         textRow.Children.Add(badges);
 
         Grid.SetColumn(textRow, 0);
@@ -157,14 +165,14 @@ internal sealed partial class VerticalTabNavRow : Grid
     /// <summary>
     /// The text this row is actually showing. Read by the test seam so a
     /// label assertion sees the rendered TextBlock, not the model property
-    /// that was supposed to reach it. Empty when the row draws the home
-    /// glyph instead, which is what a person sees there.
+    /// that was supposed to reach it. A home row reads "Home" here, beside
+    /// the glyph.
     /// </summary>
     internal string TestSeamRenderedTitle
         => _title.Visibility == Visibility.Visible ? _title.Text : "";
 
     /// <summary>
-    /// Whether the row is drawing the home glyph in the title's place.
+    /// Whether the row is drawing the home glyph ahead of the title.
     /// </summary>
     internal bool TestSeamShowsHomeGlyph => _home.Visibility == Visibility.Visible;
 
@@ -176,10 +184,9 @@ internal sealed partial class VerticalTabNavRow : Grid
     internal void Refresh(TabModel tab)
     {
         _tab = tab;
-        _title.Text = tab.EffectiveTitle;
-        // A home tab draws the glyph where the title would print; the
-        // TextBlock keeps the text so the seam can still read it.
-        _title.Visibility = tab.IsHome ? Visibility.Collapsed : Visibility.Visible;
+        // WordTitle, not EffectiveTitle: a home tab reads "Home" here, the
+        // same word the window title, the palette and the switcher use.
+        _title.Text = tab.WordTitle;
         _home.Visibility = tab.IsHome ? Visibility.Visible : Visibility.Collapsed;
         ApplyTooltip(tab);
         _bell.Visibility = tab.BellRinging ? Visibility.Visible : Visibility.Collapsed;
@@ -192,10 +199,10 @@ internal sealed partial class VerticalTabNavRow : Grid
     }
 
     /// <summary>
-    /// The row's hover text, on the row rather than on the title: a home
-    /// row's title is collapsed, and a tooltip on a collapsed element is a
-    /// tooltip nobody can reach. A label the row has had to trim is the one
-    /// case where a hover that repeats the label still earns its place.
+    /// The row's hover text, on the row rather than on the title, so the
+    /// whole row -- glyph included -- is the hover target rather than just
+    /// the words. A label the row has had to trim is the one case where a
+    /// hover that repeats the label still earns its place.
     /// </summary>
     private void ApplyTooltip(TabModel tab)
         => ToolTipService.SetToolTip(

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -2239,7 +2239,7 @@ internal sealed partial class VerticalTabStrip : UserControl
         ApplyGroupChrome(item, group);
         ApplyHeaderAnatomy(item);
 
-        var binding = AotBinding.Create(group, _ => ScheduleReconcile(),
+        var binding = AotBinding.Create(group, _ => OnGroupStateChanged(group),
             nameof(TabGroup.IsCollapsed), nameof(TabGroup.Title), nameof(TabGroup.Color));
         _headers[group] = item;
         _groupHooks[group] = binding;
@@ -2337,6 +2337,22 @@ internal sealed partial class VerticalTabStrip : UserControl
     /// </summary>
     private double ContentInsetRight
         => ShowsTitles ? RowInsetRight - NavItemTemplateRightGutter : 0;
+
+    /// <summary>
+    /// A group's own state changed: its title, its colour, or its collapse
+    /// bit. The layout answer is the deferred reconcile, but the title and
+    /// the collapse bit are also segments of every member's ItemStatus, and
+    /// a group change is not a per-tab event -- so without this pass a
+    /// renamed run left every member naming the old title to assistive
+    /// clients until something unrelated rewrote it.
+    /// </summary>
+    private void OnGroupStateChanged(TabGroup group)
+    {
+        foreach (var (tab, item) in _items)
+            if (ReferenceEquals(tab.Group, group))
+                ApplyItemTitleChrome(item, tab);
+        ScheduleReconcile();
+    }
 
     private void OnTabGroupStateChanged(TabModel tab)
     {

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -2166,9 +2166,11 @@ internal sealed partial class VerticalTabStrip : UserControl
         ToolTipService.SetToolTip(
             item, NavView.IsPaneOpen ? tab.HoverText : tab.TooltipText);
         AutomationProperties.SetName(item, TabAccessibleText.Name(tab));
-        AutomationProperties.SetItemStatus(item, tab.Group is { } group
-            ? TabAccessibleText.Status(tab.IsPinned, tab.BellRinging, group.Title, group.IsCollapsed)
-            : TabAccessibleText.Status(tab));
+        // One call: the status reads the tab's group itself, so this strip
+        // cannot report a segment the horizontal one forgets -- which is
+        // how a grouped member came to lose "Starting" here and its run
+        // there.
+        AutomationProperties.SetItemStatus(item, TabAccessibleText.Status(tab));
     }
 
     private void OnRowCloseClick(object sender, RoutedEventArgs e)

--- a/windows/scripts/seam-cwd-tab-label.ps1
+++ b/windows/scripts/seam-cwd-tab-label.ps1
@@ -145,6 +145,10 @@ function Exit-StagedResources($res) {
 
 $crashPath = Join-Path $env:LOCALAPPDATA 'Wintty\crash.log'
 $script:Scenarios = [System.Collections.Generic.List[object]]::new()
+# Whether any scenario's shell actually started in the profile directory, so
+# the home assertions ran at all. See the 'home-exercised' scenario appended
+# after the run.
+$script:SawHome = $false
 
 
 function New-ProbeDir([string]$Leaf, [string]$Root = $OutDir) {
@@ -270,6 +274,7 @@ $ConfigExtra
                     $Name, ($homeNames -join ', '))
             }
             $entry.homeGlyph = $true
+            $script:SawHome = $true
         } else {
             if ($first.renderedHomeGlyph -or $first.rendered -eq '') {
                 throw ("PRODUCT_FAIL: {0}: away from home the row should print its name; glyph={1} rendered='{2}' cwd='{3}'" -f
@@ -524,6 +529,20 @@ try {
     } -ConfigExtra "profile.probe.name = Probe`nprofile.probe.command = pwsh.exe"
     Invoke-UncRefusedScenario
 } finally { Exit-StagedResources $staged }
+
+# The home leg is the one this harness can silently skip: whether a shell
+# starts in the profile directory is the machine's business, not the
+# product's, so an `else` branch takes over and every scenario still passes.
+# That would report a green run in which the glyph, the word and the
+# accessible name were never looked at once. A run that never reached home
+# proves nothing about home, and says so.
+$script:Scenarios.Add([pscustomobject]@{
+    name = 'home-exercised'; ok = [bool]$script:SawHome
+    class = $(if ($script:SawHome) { '' } else { 'harness' })
+    error = $(if ($script:SawHome) { '' } else {
+        "no scenario's shell started in '$ProfileDir', so the home glyph, the word and the accessible name went unchecked" })
+    cwd = ''; rendered = ''; icon = ''
+})
 
 # The icon has to name the interpreter, which means two shells must not wear
 # the same one.

--- a/windows/scripts/seam-cwd-tab-label.ps1
+++ b/windows/scripts/seam-cwd-tab-label.ps1
@@ -246,20 +246,28 @@ $ConfigExtra
             "$Name never reported a directory at its first prompt (the native OSC 7 / OSC 9;9 arms are dead)"
 
         # A shell that starts in the user's own directory is the one tab that
-        # draws the home glyph instead of printing a name. Both branches
-        # assert: the harness decides for itself whether the reported
-        # directory IS the profile directory, requires the product to agree,
-        # and then requires the drawing to match. A skip would otherwise read
-        # as a pass on a machine whose shells start somewhere else.
+        # draws the home glyph, beside the word "Home". Both branches assert:
+        # the harness decides for itself whether the reported directory IS
+        # the profile directory, requires the product to agree, and then
+        # requires the drawing to match. A skip would otherwise read as a
+        # pass on a machine whose shells start somewhere else.
         $atHome = $first.cwd.TrimEnd('\', '/') -eq $ProfileDir
         if ($first.home -ne $atHome) {
             throw ("PRODUCT_FAIL: {0}: the tab says home={1} for '{2}' while the profile directory is '{3}'" -f
                 $Name, $first.home, $first.cwd, $ProfileDir)
         }
         if ($atHome) {
-            if (-not $first.renderedHomeGlyph -or $first.rendered -ne '') {
-                throw ("PRODUCT_FAIL: {0}: at home the row should draw the glyph and print nothing; glyph={1} rendered='{2}'" -f
+            if (-not $first.renderedHomeGlyph -or $first.rendered -ne 'Home') {
+                throw ("PRODUCT_FAIL: {0}: at home the row should draw the glyph and print 'Home'; glyph={1} rendered='{2}'" -f
                     $Name, $first.renderedHomeGlyph, $first.rendered)
+            }
+            # ... and say so through UIA too, which shares no code with the
+            # readout above. A wiring regression that left a home tab
+            # nameless in the tree used to pass this harness.
+            $homeNames = Get-UiaRowNames
+            if (@($homeNames | Where-Object { $_ -eq 'Home' }).Count -eq 0) {
+                throw ("PRODUCT_FAIL: {0}: at home no row is named 'Home'; rows are [{1}]" -f
+                    $Name, ($homeNames -join ', '))
             }
             $entry.homeGlyph = $true
         } else {


### PR DESCRIPTION
The residuals left over from #1017 and #1030. Two were design calls reversed after a product designer and an interaction/accessibility persona both argued against the earlier choice; the rest are defects.

Size-override: 393 product lines. The remaining 855 are guards and harness — this repo requires every guard to be provably red under the mutation it names, and a review round that found twelve weak guards roughly doubled that half. Splitting further would separate a fix from the guard that holds it.

## The home tab says "Home"

The strip drew a bare house. On Windows that glyph is the one File Explorer uses for its Home *page*, and unlabelled it left two icons and no text in a strip whose every other tab is scanned by reading a folder name. The house now leads the title instead of replacing it, and the title reads "Home" — the word the window title, palette, switcher and overview already printed. Every text surface prints the word form now, so `TabTitleSurfacesTests` collapses to one list plus a subset that also draws the glyph.

## The directory menu greys instead of vanishing

The horizontal strip builds one flyout per tab and reuses it, and a shell reports its directory a moment after the tab opens — so the same menu was three items shorter at one opening and longer at the next. Copy Working Directory and Open in File Explorer are always present now and grey when there is nothing to act on, which is what the Move Tab items in the same `Opening` handler already did.

The reason rides `AutomationProperties.HelpText` in two strings, not one: a directory on another machine *was* reported — the label prints it, the tooltip shows it in full — so telling a listener the shell reported nothing contradicts what a pointer user is reading. It is cleared rather than blanked, since UIA reports an empty string as present-but-blank. Whether a menu's arrow-key traversal stops on a disabled item is **not** measured, and the comment says so.

## A restored tab says it is starting

A tab rebuilt from a snapshot gets fresh shells, so it is genuinely starting — but it is adopted rather than opened, and the adopter deliberately begins nothing, because adoption is also where a tab dragged from another window lands and that host has already painted and disposed its cap timer. Restore begins settling on the tab it brings to the front, asked of the manager after activating rather than computed from an index: a saved tab whose tree no longer rebuilds shortens the list, so the saved index can fall off the end while the adopt loop's last tab stays active. The rest go in collapsed and never paint. Reopen-closed-tab and Duplicate Tab begin too, before the adopt.

## Closing a pane while another is zoomed

`CloseLeaf` enqueued its focus call before the zoom re-entry that can still move the active leaf, so the call named the tree's first leaf while the event reported the zoomed one. Re-entering zoom parked that leaf off-screen, the dispatcher drained the stale call afterwards, and `OnTerminalGotFocus` took it for a real focus change — a second, contradicting `LeafFocused`, and the active border painted on a pane nobody could see. One call now, after the decision, against the leaf the event reports.

## Both strips agree about a run

`TabAccessibleText.Status` reads the tab's group itself; spelling the parts out at the call site is how the vertical strip came to name a member's run while dropping "Starting", and the horizontal strip to drop the run entirely. That widened what the status reports, which then needed the other half: a group change is not a per-tab event, so both strips now rewrite every member's status when a run is renamed, recoloured or collapsed, and the horizontal strip rewrites a tab's own when it joins or leaves. Without it a renamed run left every member naming the old title.

## Smaller

- `PropertyChangedEventArgs` were minted per raise on a path a shell drives at every prompt, on every tab, six at a time. One instance per name now, tied to its property by `nameof`. That costs the guarantee `[CallerMemberName]` gave for free, so `TabChangeArgsTests` walks every settable property — including the private-setter flag and the two other classes that took the same treatment.
- WSL is unchanged and now says so: such a tab reports a translated Windows path, labels from the leaf, and cannot collide with the Windows profile. Collapsing its home needs the distro's Linux `$HOME`, which nothing in this layer knows.
- The harness reads the home tab's accessible name end to end, and a run whose shells never started at home now fails instead of quietly reporting a pass on assertions that never executed.

## Verification

3698 + 47 + 73 + 42 tests green. The seam harness green on this build, exit 0, all six scenarios, with the home branch exercised on all three shells. Thirty-one mutations across four batches, each proving one guard red under the defect it names, every anchor verified to have matched.

Reviewed by three personas (.NET/WinUI, accessibility, adversarial test quality). They found two regressions this change introduced and twelve guards weaker than they looked; all are fixed in the second commit.

The two Zig-side items — rejecting control characters in the reported directory, and `\\.\` device paths in the host check — are a separate branch. Different language, different test runner, and both are upstream candidates.
