### PR TITLE
termio: refuse a reported directory carrying control characters, and the device namespace with it

### DIFF
--- a/src/build/GhosttyLib.zig
+++ b/src/build/GhosttyLib.zig
@@ -136,8 +136,7 @@ pub fn initShared(
     // that references symbols in vcruntime.lib and ucrt.lib. Zig's library
     // search paths include the MSVC lib dir and the Windows SDK 'um' dir,
     // but not the SDK 'ucrt' dir where ucrt.lib lives.
-    if (win_msvc)
-    {
+    if (win_msvc) {
         // The CRT initialization code in msvcrt.lib calls __vcrt_initialize
         // and __acrt_initialize, which are in the static CRT libraries.
         lib.root_module.linkSystemLibrary("libvcruntime", dynamic_link_opts);

--- a/src/os/posix_path.zig
+++ b/src/os/posix_path.zig
@@ -168,9 +168,16 @@ pub fn pathHost(path: []const u8) error{InvalidPath}!PathHost {
     if (!std.mem.startsWith(u8, path, "\\\\")) return .local;
     const rest = path[2..];
 
-    // `\\?\` (extended-length) and `\\.\` (device) share a shape and a
-    // meaning: what follows is not a server name.
-    if (rest.len >= 2 and (rest[0] == '?' or rest[0] == '.') and rest[1] == '\\') {
+    // `\\.\` is the device namespace. It shares its shape with `\\?\` --
+    // what follows either is not a server name -- but not its permitted
+    // continuations: `\\?\C:\dir` is the long-path spelling of a real
+    // directory, while `\\.\C:` is a handle to the volume object. No shell
+    // reports a device as its working directory, so the whole namespace is
+    // refused rather than sharing the drive-letter escape below.
+    if (rest.len >= 2 and rest[0] == '.' and rest[1] == '\\') return error.InvalidPath;
+
+    // `\\?\` (extended-length): what follows is not a server name either.
+    if (rest.len >= 2 and rest[0] == '?' and rest[1] == '\\') {
         const tail = rest[2..];
         if (std.ascii.startsWithIgnoreCase(tail, "UNC\\")) return hostOf(tail[4..]);
         // `\\?\C:\dir` is the long-path spelling of a drive root.
@@ -445,6 +452,14 @@ test "posix_path: pathHost recovers the server a raw path names" {
     // The device namespace is not a directory.
     try std.testing.expectError(error.InvalidPath, pathHost("\\\\.\\COM1"));
     try std.testing.expectError(error.InvalidPath, pathHost("\\\\?\\GLOBALROOT\\Device\\X"));
+    // ...including where it borrows a drive letter. `\\?\C:\dir` is the
+    // long-path spelling of a real directory; `\\.\C:` is a handle to the
+    // volume object, and no shell reports one as its working directory. The
+    // two prefixes share a shape, not a permitted continuation.
+    try std.testing.expectError(error.InvalidPath, pathHost("\\\\.\\C:\\dir"));
+    try std.testing.expectError(error.InvalidPath, pathHost("\\\\.\\C:"));
+    try std.testing.expectError(error.InvalidPath, pathHost("\\\\.\\pipe\\x"));
+    try std.testing.expectError(error.InvalidPath, pathHost("\\\\.\\UNC\\evil.example.com\\share"));
 }
 
 test "posix_path: isLocalShareHost admits only hosts that never reach the wire" {

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -123,6 +123,14 @@ pub const StreamHandler = struct {
     /// reporting" edge would never see it.
     pwd_reported: bool = false,
 
+    /// Whether a report has already been refused as implausible. The dedupe
+    /// that keeps a repeated directory quiet cannot help here: a refused
+    /// path never becomes the known one, so it never matches, and a shell
+    /// emitting one does so at every prompt for the life of the session.
+    /// One warning per surface is enough to say the reports are being
+    /// ignored.
+    pwd_refused: bool = false,
+
     pub const Stream = terminal.Stream(StreamHandler);
 
     /// True if we have tmux control mode built in.
@@ -1737,31 +1745,69 @@ pub const StreamHandler = struct {
         };
     }
 
+    /// Whether `path` can be a directory name at all, as opposed to bytes a
+    /// program wrote to the pty hoping we would render them.
+    ///
+    /// Three rules, and they are not the same rule:
+    ///
+    /// NUL is refused everywhere. No filesystem admits it, and it is the one
+    /// byte that makes the two sides of the C ABI disagree: the slice keeps
+    /// its full length while `[*:0]const u8` truncates, so the app runtime
+    /// acts on a prefix of what the terminal believes.
+    ///
+    /// Invalid UTF-8 is refused everywhere. An unpaired surrogate or a stray
+    /// C1 byte survives to the ABI and comes back as U+FFFD on the other
+    /// side -- the same two-readings-of-one-value problem as NUL, arriving
+    /// by a different road. This is the half that makes the claim of parity
+    /// with the OSC 7777 parser true: that parser validates UTF-8 too.
+    ///
+    /// The remaining C0 and DEL are refused ONLY on Windows, where Win32
+    /// cannot create such a directory, so a report containing one is
+    /// necessarily a fabrication. On a POSIX filesystem every byte but NUL
+    /// and `/` is a legal filename character: refusing `/tmp/a<TAB>b` there
+    /// would discard a real directory and -- worse -- leave the terminal
+    /// confidently holding the PREVIOUS one, which then seeds new tabs and
+    /// resolves relative paths. A hostile newline on POSIX is a real but
+    /// lesser problem, and it belongs to whatever renders the value, not to
+    /// the record of where the shell is.
+    fn isPlausiblePwd(path: []const u8) bool {
+        if (!std.unicode.utf8ValidateSlice(path)) return false;
+        for (path) |b| {
+            if (b == 0) return false;
+            if (comptime builtin.os.tag == .windows) {
+                if (b < 0x20 or b == 0x7f) return false;
+            }
+        }
+        return true;
+    }
+
     /// Commit a fully-resolved pwd: the terminal's own state, the surface
     /// notification, and the title when no shell has claimed one. Shared by
     /// every arm of `reportPwd` so a raw Windows path and a translated URL
     /// land identically.
     fn setPwdReported(self: *StreamHandler, reported: []const u8) !void {
-        log.debug("terminal pwd: {s}", .{reported});
-
         // A directory is bytes off the pty, and nothing upstream of here
         // filters them. The VT parser drops raw C0, but an OSC 7 URL is
         // percent-decoded AFTER that, so `%0A`, `%1B` and `%07` arrive as
         // real bytes; the parse table admits DEL and C1 as payload, so an
-        // OSC 9;9 path needs no encoding trick at all; and an interior NUL
-        // is legal in the slice but truncates the moment it crosses the C
-        // ABI as `[*:0]const u8`, leaving the two sides holding different
-        // paths.
+        // OSC 9;9 path needs no encoding trick at all. This is the one
+        // funnel every reporting arm reaches -- the raw Windows path, the
+        // translated URL and OSC 7777 -- so the rule lands on all of them.
         //
-        // Anything that can move a cursor or open an escape sequence has no
-        // business in a directory name. This is the one funnel every
-        // reporting arm reaches -- the raw Windows path, the translated URL
-        // and OSC 7777 -- so the rule lands on all of them at once. Same
-        // rule the OSC 7777 parser already applies to its own fields.
-        for (reported) |b| if (b < 0x20 or b == 0x7f) {
-            log.warn("ignoring reported pwd containing control characters", .{});
+        // Checked BEFORE the debug log, so the bytes this refuses are not
+        // the ones written to a log sink.
+        if (!isPlausiblePwd(reported)) {
+            // Once per surface: the dedupe below cannot suppress this,
+            // because a refused path never becomes the known one, and a
+            // shell that reports one does so at every prompt forever.
+            if (!self.pwd_refused) {
+                self.pwd_refused = true;
+                log.warn("ignoring reported pwd: not a plausible directory name", .{});
+            }
             return;
-        };
+        }
+
+        log.debug("terminal pwd: {s}", .{reported});
 
         // One prompt reports its directory three times: OSC 7 and OSC 9;9
         // both carry it and OSC 7777 carries it again. Only the first is
@@ -2403,6 +2449,42 @@ test "pwd: one prompt's OSC 7, 9;9 and 7777 burst reports once" {
     try testing.expectEqualStrings("C:\\Users\\me\\src", h.handler.terminal.getPwd().?);
 }
 
+test "pwd: what counts as a plausible directory name" {
+    // Runs on every platform, unlike the end-to-end test below, which needs
+    // the Windows raw-path arm. The defect this guards is NOT Windows-only:
+    // an OSC 7 URL is percent-decoded on every platform, so `%00` reached
+    // the pwd everywhere.
+    const testing = std.testing;
+
+    // Always fine, whatever the host.
+    try testing.expect(StreamHandler.isPlausiblePwd("C:\\Users\\me"));
+    try testing.expect(StreamHandler.isPlausiblePwd("/home/me/src"));
+    // High bytes are UTF-8 continuations, not controls.
+    try testing.expect(StreamHandler.isPlausiblePwd("/home/me/\u{00e9}t\u{00e9}"));
+    try testing.expect(StreamHandler.isPlausiblePwd("/home/me/\u{1f600}"));
+
+    // Refused everywhere: NUL truncates at the C ABI, so the two sides of
+    // the boundary would hold different paths...
+    try testing.expect(!StreamHandler.isPlausiblePwd("/home/me\x00evil"));
+    // ...and invalid UTF-8 comes back as U+FFFD on the far side, which is
+    // the same disagreement arriving by another road. An unpaired
+    // surrogate, and a stray C1 byte:
+    try testing.expect(!StreamHandler.isPlausiblePwd("/home/me/\xed\xa0\x80"));
+    try testing.expect(!StreamHandler.isPlausiblePwd("/home/me/\x9b"));
+
+    // The rest of C0 and DEL are a Windows rule, because Win32 cannot
+    // create such a directory -- so a report carrying one is necessarily a
+    // fabrication. On POSIX they are legal filename bytes, and refusing
+    // them would drop a real directory AND leave the previous one standing.
+    const legal_on_posix = [_][]const u8{ "/home/me/a\tb", "/home/me/a\nb", "/home/me/a\x1bb", "/home/me/a\x7fb" };
+    for (legal_on_posix) |path| {
+        try testing.expectEqual(
+            comptime builtin.os.tag != .windows,
+            StreamHandler.isPlausiblePwd(path),
+        );
+    }
+}
+
 test "pwd: a reported directory carrying control characters is refused" {
     // The VT parser drops raw C0 before an OSC string is assembled, which is
     // why this went unnoticed: OSC 7 percent-decodes AFTER that, so `%0A`,
@@ -2422,8 +2504,9 @@ test "pwd: a reported directory carrying control characters is refused" {
     _ = h.drain();
     try testing.expectEqualStrings("C:\\Users\\me", h.handler.terminal.getPwd().?);
 
-    // A newline, an ESC opening a title sequence, and a BEL -- all reached
-    // through percent-decoding, all past the parser's C0 filter.
+    // A newline, an ESC and a BEL -- all reached through percent-decoding,
+    // all past the parser's C0 filter. The decoded ESC never re-enters the
+    // parser; it lands in the pwd, and from there in the title buffer.
     h.feed("\x1b]7;file://MYPC/c:/Users/me%0A%1B]0;X%07evil\x07");
     // A raw DEL, which the parse table hands through as payload.
     h.feed("\x1b]9;9;C:\\Users\\me\x7fevil\x07");

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -1744,6 +1744,25 @@ pub const StreamHandler = struct {
     fn setPwdReported(self: *StreamHandler, reported: []const u8) !void {
         log.debug("terminal pwd: {s}", .{reported});
 
+        // A directory is bytes off the pty, and nothing upstream of here
+        // filters them. The VT parser drops raw C0, but an OSC 7 URL is
+        // percent-decoded AFTER that, so `%0A`, `%1B` and `%07` arrive as
+        // real bytes; the parse table admits DEL and C1 as payload, so an
+        // OSC 9;9 path needs no encoding trick at all; and an interior NUL
+        // is legal in the slice but truncates the moment it crosses the C
+        // ABI as `[*:0]const u8`, leaving the two sides holding different
+        // paths.
+        //
+        // Anything that can move a cursor or open an escape sequence has no
+        // business in a directory name. This is the one funnel every
+        // reporting arm reaches -- the raw Windows path, the translated URL
+        // and OSC 7777 -- so the rule lands on all of them at once. Same
+        // rule the OSC 7777 parser already applies to its own fields.
+        for (reported) |b| if (b < 0x20 or b == 0x7f) {
+            log.warn("ignoring reported pwd containing control characters", .{});
+            return;
+        };
+
         // One prompt reports its directory three times: OSC 7 and OSC 9;9
         // both carry it and OSC 7777 carries it again. Only the first is
         // news. Each of the others otherwise costs a copy, a heap
@@ -2381,6 +2400,45 @@ test "pwd: one prompt's OSC 7, 9;9 and 7777 burst reports once" {
     const moved = h.drain();
     try testing.expectEqual(@as(usize, 1), moved.pwd);
     try testing.expectEqual(@as(usize, 1), moved.title);
+    try testing.expectEqualStrings("C:\\Users\\me\\src", h.handler.terminal.getPwd().?);
+}
+
+test "pwd: a reported directory carrying control characters is refused" {
+    // The VT parser drops raw C0 before an OSC string is assembled, which is
+    // why this went unnoticed: OSC 7 percent-decodes AFTER that, so `%0A`,
+    // `%1B` and `%07` travel as ordinary ASCII and become real control bytes
+    // in the path. OSC 9;9 needs no trick -- the parse table admits DEL as
+    // payload. Either way the surface must keep the directory it had.
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var h: PwdTestHarness = undefined;
+    try h.init(testing.allocator);
+    defer h.deinit(testing.allocator);
+
+    // A good directory first, so a refusal has something it must not replace
+    // -- and so this cannot pass merely because nothing was ever set.
+    h.feed("\x1b]9;9;C:\\Users\\me\x07");
+    _ = h.drain();
+    try testing.expectEqualStrings("C:\\Users\\me", h.handler.terminal.getPwd().?);
+
+    // A newline, an ESC opening a title sequence, and a BEL -- all reached
+    // through percent-decoding, all past the parser's C0 filter.
+    h.feed("\x1b]7;file://MYPC/c:/Users/me%0A%1B]0;X%07evil\x07");
+    // A raw DEL, which the parse table hands through as payload.
+    h.feed("\x1b]9;9;C:\\Users\\me\x7fevil\x07");
+    // And a NUL, which is legal in the slice but truncates at the C ABI, so
+    // the two sides of the boundary would disagree about the path.
+    h.feed("\x1b]7;file://MYPC/c:/Users/me%00evil\x07");
+
+    const refused = h.drain();
+    try testing.expectEqual(@as(usize, 0), refused.pwd);
+    try testing.expectEqual(@as(usize, 0), refused.title);
+    try testing.expectEqualStrings("C:\\Users\\me", h.handler.terminal.getPwd().?);
+
+    // The guard refuses those bytes, not every path after them.
+    h.feed("\x1b]9;9;C:\\Users\\me\\src\x07");
+    try testing.expectEqual(@as(usize, 1), h.drain().pwd);
     try testing.expectEqualStrings("C:\\Users\\me\\src", h.handler.terminal.getPwd().?);
 }
 

--- a/windows/Ghostty.Core/Session/SessionProfileResolver.cs
+++ b/windows/Ghostty.Core/Session/SessionProfileResolver.cs
@@ -63,11 +63,27 @@ internal static class SessionProfileResolver
     /// not replace the profile's value either.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// A reported directory the shell cannot be trusted to have named is
     /// dropped rather than spawned into, and the profile's own directory
     /// stands -- see <see cref="SpawnCwdPolicy"/> for what that means and
     /// why this is the funnel it guards.
+    /// </para>
+    /// <para>
+    /// Both tests, the same pair <see cref="Ghostty.Core.Tabs.TabModel"/>
+    /// requires before it will put a directory on the clipboard: a host the
+    /// spawn policy accepts, AND plain text. The terminal core refuses a
+    /// path carrying control characters at the source now, but this path
+    /// reaches further back than the core can -- a restored session was
+    /// written by whatever build recorded it, including builds with no such
+    /// check -- and it is the funnel that reaches CreateProcess. Checking
+    /// only the host here meant a directory refused for the clipboard, for
+    /// Explorer, for the label and for the tooltip was still handed to a
+    /// spawn.
+    /// </para>
     /// </remarks>
     private static ProfileSnapshot SpawnAtReportedCwd(ProfileSnapshot snap, string? cwd)
-        => SpawnCwdPolicy.MaySpawnAt(cwd) ? snap with { WorkingDirectory = cwd } : snap;
+        => cwd is not null && Ghostty.Core.Tabs.TabLabel.IsPlain(cwd) && SpawnCwdPolicy.MaySpawnAt(cwd)
+            ? snap with { WorkingDirectory = cwd }
+            : snap;
 }

--- a/windows/Ghostty.Core/Session/SpawnCwdPolicy.cs
+++ b/windows/Ghostty.Core/Session/SpawnCwdPolicy.cs
@@ -60,14 +60,27 @@ internal static class SpawnCwdPolicy
 
         var rest = cwd.AsSpan(2);
 
-        // `\\?\` (extended-length) and `\\.\` (device) share a shape and a
-        // meaning: what follows is not a server name. Both prefixes are
-        // matched with literal backslashes because Windows does NOT normalize
-        // separators inside them -- `//?/UNC/host/share` is not an extended
-        // path at all, it is a plain UNC one naming the host `?`, which falls
-        // through below and is refused. Strict here is what makes that true.
-        if (rest.Length >= 2 && (rest[0] == '?' || rest[0] == '.')
-            && cwd[0] == '\\' && cwd[1] == '\\' && rest[1] == '\\')
+        // Both prefixes below are matched with literal backslashes because
+        // Windows does NOT normalize separators inside them --
+        // `//?/UNC/host/share` is not an extended path at all, it is a plain
+        // UNC one naming the host `?`, which falls through below and is
+        // refused. Strict here is what makes that true.
+        var literalPrefix = cwd[0] == '\\' && cwd[1] == '\\' && rest.Length >= 2 && rest[1] == '\\';
+
+        // `\\.\` is the device namespace. It shares its shape with `\\?\` --
+        // what follows either is not a server name -- but not its permitted
+        // continuations: `\\?\C:\dir` is the long-path spelling of a real
+        // directory, while `\\.\C:` is a handle to the volume object. No
+        // shell reports a device as its working directory, and CreateProcess
+        // has no business being handed one, so the whole namespace is refused
+        // rather than sharing the drive-letter escape below. Mirrors
+        // posix_path.pathHost, which decides the same thing for the native
+        // side; the two disagreeing is how a path gets displayed by one layer
+        // and spawned by the other.
+        if (literalPrefix && rest[0] == '.') return false;
+
+        // `\\?\` (extended-length): what follows is not a server name either.
+        if (literalPrefix && rest[0] == '?')
         {
             var tail = rest[2..];
             // `\\?\UNC\server\share` is a second spelling of the same reach,
@@ -76,7 +89,7 @@ internal static class SpawnCwdPolicy
                 return HostIsLocal(tail[4..]);
             // `\\?\C:\dir` is the long-path spelling of a drive root.
             if (tail.Length >= 2 && char.IsAsciiLetter(tail[0]) && tail[1] == ':') return true;
-            // The device namespace names no directory at all.
+            // Anything else under the prefix names no directory at all.
             return false;
         }
 

--- a/windows/Ghostty.Core/Tabs/TabLabel.cs
+++ b/windows/Ghostty.Core/Tabs/TabLabel.cs
@@ -100,9 +100,15 @@ internal static class TabLabel
     /// The VT parser drops C0 bytes, but an OSC 7 URL is percent-decoded
     /// after that, and OSC 9;9 admits any UTF-8, so a program in the pane
     /// can put a newline or a right-to-left override into what it reports.
-    /// NTFS cannot hold a control character in a name, so nothing real is
-    /// lost; only the bidi controls are refused among the format
-    /// characters, since joiners appear in legitimate emoji folder names.
+    /// Only the bidi controls are refused among the format characters,
+    /// since joiners appear in legitimate emoji folder names.
+    ///
+    /// This is not free, and the cost used to be stated here as nothing.
+    /// NTFS refuses C0, but a directory named with a C1 character, U+2028
+    /// or U+2029 can be created and does exist; such a folder loses its
+    /// label and the tab falls to a lower tier. That is the trade taken --
+    /// those characters are far likelier to be an injection than a folder
+    /// name, and something still names the tab.
     /// </summary>
     internal static bool IsPlain(string s)
     {

--- a/windows/Ghostty.Tests/Session/SpawnCwdPolicyTests.cs
+++ b/windows/Ghostty.Tests/Session/SpawnCwdPolicyTests.cs
@@ -86,4 +86,55 @@ public class SpawnCwdPolicyTests
     [InlineData(@"\\\share")]
     public void APathNamingNoHost_MayNotSpawn(string cwd)
         => Assert.False(SpawnCwdPolicy.MaySpawnAt(cwd));
+
+    /// <summary>
+    /// The spawn funnel demands plain text as well as an acceptable host.
+    ///
+    /// The terminal core refuses a path carrying control characters at the
+    /// source now, but this path reaches further back than the core can: a
+    /// restored session was written by whatever build recorded it, and
+    /// builds before that guard had no such check. Testing only the host
+    /// here meant a directory refused for the clipboard, for Explorer, for
+    /// the label and for the tooltip was still handed to CreateProcess.
+    /// </summary>
+    [Theory]
+    [InlineData("C:\\Users\\alex\nevil")]
+    [InlineData("C:\\Users\\alex\u202Eevil")]
+    [InlineData("C:\\Users\\alex\u2028evil")]
+    [InlineData("C:\\Users\\alex\u007Fevil")]
+    public void ADirectoryThatIsNotPlainText_IsNotSpawnedInto(string cwd)
+    {
+        // The host itself is fine -- it is the bytes that are not, which is
+        // why checking the host alone let these through.
+        Assert.True(SpawnCwdPolicy.MaySpawnAt(cwd));
+
+        var resolved = SessionProfileResolver.ResolveLeaf(
+            registry: null,
+            new LeafDto
+            {
+                ProfileId = null,
+                Fallback = new LeafCommand { ResolvedCommand = "pwsh.exe", DisplayName = "p" },
+                Cwd = cwd,
+            });
+
+        Assert.NotNull(resolved);
+        // The profile's own directory stands; the reported one is dropped.
+        Assert.Null(resolved!.WorkingDirectory);
+    }
+
+    /// <summary>The same funnel still honours a directory that IS plain.</summary>
+    [Fact]
+    public void APlainLocalDirectory_IsSpawnedInto()
+    {
+        var resolved = SessionProfileResolver.ResolveLeaf(
+            registry: null,
+            new LeafDto
+            {
+                ProfileId = null,
+                Fallback = new LeafCommand { ResolvedCommand = "pwsh.exe", DisplayName = "p" },
+                Cwd = @"C:\Users\alex\src",
+            });
+
+        Assert.Equal(@"C:\Users\alex\src", resolved!.WorkingDirectory);
+    }
 }

--- a/windows/Ghostty.Tests/Session/SpawnCwdPolicyTests.cs
+++ b/windows/Ghostty.Tests/Session/SpawnCwdPolicyTests.cs
@@ -1,0 +1,89 @@
+using Ghostty.Core.Session;
+using Xunit;
+
+namespace Ghostty.Tests.Session;
+
+/// <summary>
+/// The gate a shell-reported directory passes before it can become a spawn
+/// directory. A reported cwd is bytes off the pty, and Duplicate Tab, Reopen
+/// Closed Tab and session restore all hand it to CreateProcess -- which opens
+/// an SMB connection to whatever server a UNC path names, and authenticates
+/// to it. This layer decides who may receive the user's credentials, and had
+/// no tests of its own.
+///
+/// It mirrors <c>posix_path.pathHost</c> on the native side. The two
+/// disagreeing is how a path comes to be refused by one layer and spawned by
+/// the other, so the cases below are deliberately the same ones.
+/// </summary>
+public class SpawnCwdPolicyTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void NothingReported_IsNotADirectoryToSpawnIn(string? cwd)
+        => Assert.False(SpawnCwdPolicy.MaySpawnAt(cwd));
+
+    [Theory]
+    [InlineData(@"C:\Users\alex")]
+    [InlineData("C:/Users/alex")]
+    [InlineData(@"Z:\work")]
+    // The long-path spelling of a real directory.
+    [InlineData(@"\\?\C:\Users\alex")]
+    public void ALocalDirectory_MaySpawn(string cwd)
+        => Assert.True(SpawnCwdPolicy.MaySpawnAt(cwd));
+
+    [Theory]
+    // Served by the local WSL service rather than by SMB over the wire.
+    [InlineData(@"\\wsl.localhost\Ubuntu-24.04\home\alex")]
+    [InlineData(@"\\wsl$\Ubuntu-24.04\home\alex")]
+    [InlineData(@"\\WSL.LOCALHOST\Ubuntu\home\alex")]
+    [InlineData(@"\\localhost\c$\Users\alex")]
+    [InlineData(@"\\127.0.0.1\share")]
+    public void AShareThatNeverLeavesTheMachine_MaySpawn(string cwd)
+        => Assert.True(SpawnCwdPolicy.MaySpawnAt(cwd));
+
+    [Theory]
+    [InlineData(@"\\evil.example.com\share")]
+    [InlineData(@"\\evil.example.com\share\deep\dir")]
+    // Win32 folds forward slashes before resolving, so the same reach spelled
+    // the other way has to be refused too.
+    [InlineData("//evil.example.com/share")]
+    // The second spelling of the same reach, through the extended prefix.
+    [InlineData(@"\\?\UNC\evil.example.com\share")]
+    [InlineData(@"\\?\unc\evil.example.com\share")]
+    public void AShareOnAnotherMachine_MayNotSpawn(string cwd)
+        => Assert.False(SpawnCwdPolicy.MaySpawnAt(cwd));
+
+    /// <summary>
+    /// The device namespace shares its shape with the extended-length prefix
+    /// but not its permitted continuations. <c>\\?\C:\dir</c> is a real
+    /// directory; <c>\\.\C:</c> is a handle to the volume object. Treating
+    /// the two prefixes as one let a device path borrow the drive-letter
+    /// escape and reach CreateProcess.
+    /// </summary>
+    [Theory]
+    [InlineData(@"\\.\C:\dir")]
+    [InlineData(@"\\.\C:")]
+    [InlineData(@"\\.\COM1")]
+    [InlineData(@"\\.\pipe\x")]
+    [InlineData(@"\\.\UNC\evil.example.com\share")]
+    [InlineData(@"\\?\GLOBALROOT\Device\X")]
+    public void ADevicePath_MayNotSpawn(string cwd)
+        => Assert.False(SpawnCwdPolicy.MaySpawnAt(cwd));
+
+    /// <summary>
+    /// Windows does not normalize separators inside the extended-length
+    /// prefix, so <c>//?/UNC/host/share</c> is not an extended path at all --
+    /// it is a plain UNC path naming the host <c>?</c>, and it is refused as
+    /// one rather than parsed as a prefix.
+    /// </summary>
+    [Fact]
+    public void AForwardSlashPrefix_IsAHostNamedQuestionMark_AndIsRefused()
+        => Assert.False(SpawnCwdPolicy.MaySpawnAt("//?/UNC/evil.example.com/share"));
+
+    [Theory]
+    [InlineData(@"\\")]
+    [InlineData(@"\\\share")]
+    public void APathNamingNoHost_MayNotSpawn(string cwd)
+        => Assert.False(SpawnCwdPolicy.MaySpawnAt(cwd));
+}


### PR DESCRIPTION
The two native-side residuals from #1017, split out of #1055 because they are a different language, a different test runner, and both are upstream candidates.

## Control characters reach the reported directory

A shell's working directory is bytes off the pty, and nothing between the wire and the surface looked at them.

The VT parser drops raw C0 before an OSC string is assembled, which is why this went unnoticed: **OSC 7 percent-decodes after that**, so `%0A`, `%1B` and `%07` travel as ordinary ASCII and land in the path as real control bytes. OSC 9;9 needs no trick at all — the parse table admits DEL and C1 as payload.

The check goes in `setPwdReported`, which is where the raw Windows path, the translated URL and OSC 7777 converge, so one rule covers all three.

It is three rules, not one, and the distinction is the whole of the second commit:

- **NUL, everywhere.** No filesystem admits it, and it is the byte that makes the two sides of the C ABI disagree — the slice keeps its length while `[*:0]const u8` truncates.
- **Invalid UTF-8, everywhere.** An unpaired surrogate or a stray C1 byte survives to the boundary and returns as U+FFFD: the same disagreement by another road. This is also what makes the parity claim with the OSC 7777 parser true — that parser validates UTF-8 as well.
- **The remaining C0 and DEL, on Windows only.** Win32 cannot create such a directory, so a report carrying one is necessarily fabricated. On POSIX they are legal filename bytes, and refusing `/tmp/a<TAB>b` would discard a real directory *and* leave the terminal holding the previous one, which then seeds new tabs and resolves relative paths.

## `\\.\` borrowed the drive-letter escape

`pathHost` treated `\\?\` and `\\.\` as one prefix. They share a shape — what follows is not a server name — but not a permitted continuation: `\\?\C:\dir` is the long-path spelling of a real directory, while `\\.\C:` is a handle to the volume object. The shared branch let a device path take the drive-letter escape.

Impact is narrow, and measured rather than assumed: `CreateProcess` resolves `\\.\C:\Windows` to the same local directory as `C:\Windows`, so there was no remote reach and no credential exposure. What it cost was the two layers disagreeing, plus `\\.\C:` and `\\.\pipe` shapes that simply fail a spawn. `SpawnCwdPolicy` carried the identical defect from the same shared branch and is fixed with it.

## The spawn funnel tested the host and not the text

`SpawnAtReportedCwd` — the funnel that reaches `CreateProcess` on restore, reopen-closed-tab and duplicate — checked `MaySpawnAt` alone, so a directory refused for the clipboard, for Explorer, for the label and for the tooltip was still spawned into. It takes both tests now, the pair `TabModel` already required. This path also reaches further back than the core guard can: a restored session was written by whatever build recorded it, including builds with no such check. That layer had no tests of its own; it has them now.

## Scope, stated honestly

The guard covers **libghostty-app** on all three platforms — the pwd, the pwd-derived title, the surface `pwd_change`, the inherited spawn cwd, and the C boundary. It does **not** cover libghostty-vt: `stream_terminal.zig` stores the raw OSC payload by documented contract, and snapshot restore and the embedder-set pwd bypass it too. Those are a separate surface with a different contract, not a hole this PR leaves open by accident.

Known and not addressed here: the two host-locality checks differ in case sensitivity (Zig `std.mem.eql`, C# `OrdinalIgnoreCase`), which fails safe today because the core refuses first; and `\\?\C:\dir` is allowed by policy while `cmd.exe` refuses it as a working directory, so a cmd tab silently loses cwd inheritance there.

## Verification

Zig tests over the `pwd:` and `posix_path:` filters, and 3728 C# tests. Both defects are demonstrated by tests that fail before the fix — pre-fix, all three bad reports reached the surface, and `pathHost` returned `.local` for `\\.\C:\dir`. Nine mutations, each proving one rule red under its own removal, every anchor verified to have matched.

Reviewed by a Zig/terminal-core persona and a security persona. They independently found the platform-gating defect above; the second commit is their round.
