### PR TITLE
footprint: deep-idle trims - cut-off sequences, image copies, shaped runs

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1287,6 +1287,7 @@ GHOSTTY_API void ghostty_surface_draw(ghostty_surface_t);
 GHOSTTY_API void ghostty_surface_set_content_scale(ghostty_surface_t, double, double);
 GHOSTTY_API void ghostty_surface_set_focus(ghostty_surface_t, bool);
 GHOSTTY_API void ghostty_surface_set_occlusion(ghostty_surface_t, bool);
+GHOSTTY_API void ghostty_surface_set_idle(ghostty_surface_t, bool);
 // Scrollback compression statistics for the surface's primary screen:
 // total pages, how many are compressed, the raw/encoded byte split, and
 // the compression activity serial (the scheduler's arming input: it

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -159,6 +159,12 @@ focused: bool = true,
 /// visible so reporting remains conservative.
 visible: bool = true,
 
+/// Deep-idle state as last reported by the embedder's tracker. Purely the
+/// dedupe latch for `idleCallback`; the trims themselves are one-shot
+/// messages, so a surface that cycles idle -> awake -> idle trims twice
+/// and that is correct (new output may have allocated new captures).
+idle: bool = false,
+
 /// Used to determine whether to continuously scroll.
 selection_scroll_active: bool = false,
 
@@ -3440,6 +3446,35 @@ pub fn occlusionCallback(self: *Surface, visible: bool) !void {
 
     _ = self.pushRendererMailbox(.{
         .visible = visible,
+    });
+
+    try self.queueRender();
+}
+
+/// Update the deep-idle state of the surface. Idle is the embedder's
+/// call (its tracker knows about interaction and bells; a timer here
+/// would duplicate those rules and the two would drift). Going idle
+/// sends two one-shot trims: the parse-side buffers a sequence cut
+/// mid-flight is pinning go to the IO thread that owns the stream, and
+/// the renderer's image copies and shaper cache go to the render thread.
+///
+/// Waking sends nothing and that is the whole design: nothing the trims
+/// removed is required to serve input, keystrokes never touch the
+/// trimmed state, and the first frame after data arrives rebuilds what
+/// it needs lazily.
+pub fn idleCallback(self: *Surface, idle: bool) !void {
+    // Crash metadata in case we crash in here
+    crash.sentry.thread_state = self.crashThreadState();
+    defer crash.sentry.thread_state = null;
+
+    if (self.idle == idle) return;
+    self.idle = idle;
+    if (!idle) return;
+
+    self.queueIo(.{ .deep_idle = {} }, .unlocked);
+
+    _ = self.pushRendererMailbox(.{
+        .deep_idle = {},
     });
 
     try self.queueRender();

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1350,6 +1350,13 @@ pub const Surface = struct {
         };
     }
 
+    pub fn idleCallback(self: *Surface, idle: bool) void {
+        self.core_surface.idleCallback(idle) catch |err| {
+            log.err("error in idle callback err={}", .{err});
+            return;
+        };
+    }
+
     fn queueInspectorRender(self: *Surface) void {
         _ = self.app.performAction(
             .{ .surface = &self.core_surface },
@@ -2901,6 +2908,17 @@ pub const CAPI = struct {
     /// Update the occlusion state of a surface.
     export fn ghostty_surface_set_occlusion(surface: *Surface, visible: bool) void {
         surface.occlusionCallback(visible);
+    }
+
+    /// Update the deep-idle state of a surface. The CONTRACT: idle=true
+    /// trims state that exists only to make the next frame cheap (parse
+    /// captures, renderer image copies, shaped-run caches); idle=false
+    /// sends no work at all, because waking is lazy -- it only updates
+    /// the dedupe latch so a later idle transition can trim again. What
+    /// "idle" means is entirely the embedder's determination; the
+    /// embedder's own bindings document its policy.
+    export fn ghostty_surface_set_idle(surface: *Surface, idle: bool) void {
+        surface.idleCallback(idle);
     }
 
     /// Scrollback memory statistics for a surface's primary screen.

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -392,6 +392,26 @@ fn drainMailbox(self: *Thread) !void {
                 // check the visible state themselves to control their behavior.
             },
 
+            .deep_idle => {
+                // Tier B, renderer half: the image copies and the shaped-run
+                // cache exist only to make the next frame cheap, and a
+                // deep-idle surface's next frame may be arbitrarily far
+                // away. The terminal's image storage stays the source of
+                // truth; trimIdleMemory latches images_lost so the first
+                // updateFrame after the surface is shown rebuilds the
+                // copies -- without the latch, live placements would draw
+                // with nothing behind them, because no frame revisits
+                // placements whose terminal state did not change.
+                self.renderer.trimIdleMemory();
+
+                // Idle is the strongest "activity stopped" signal there is,
+                // and it arrives on surfaces that may still be visible (an
+                // untouched foreground tab), where the hide transition never
+                // fires: kick the compression scheduler the same way a hide
+                // does so cold pages shed without waiting on a render.
+                self.compression.wake(self);
+            },
+
             .focus => |v| focus: {
                 // If our state didn't change we do nothing.
                 if (self.flags.focused == v) break :focus;

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1436,6 +1436,48 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             }
         }
 
+        /// Deep-idle trim: release the memory that exists only to make
+        /// the NEXT frame cheap -- every uploaded image copy and the
+        /// shaped-run cache. The terminal's ImageStorage remains the
+        /// source of truth for images, and shaping recomputes per run, so
+        /// both rebuild lazily on the frame that wants them; on a
+        /// deep-idle surface that frame may be arbitrarily far away.
+        ///
+        /// The swap chain is NOT touched: visibility already owns it
+        /// (see `releaseGpuResources`), and this trim deliberately also
+        /// serves visible-but-untouched surfaces, whose swap chain must
+        /// stay ready for the next draw.
+        pub fn trimIdleMemory(self: *Self) void {
+            self.draw_mutex.lockUncancelable(global.io());
+            defer self.draw_mutex.unlock(global.io());
+
+            // Virtual placements re-prep on EVERY frame the surface
+            // draws (kittyRequiresUpdate), so trimming their copies only
+            // buys the gap until the next frame and costs a full
+            // re-upload to end it. Surfaces with plain placements are
+            // where the copies genuinely idle.
+            if (!self.images.kitty_virtual) {
+                self.images.trimAll(self.alloc);
+
+                // The trim empties the copy map while the terminal's
+                // placements live on, and nothing in the frame path
+                // revisits placements whose terminal state did not
+                // change. Latch the same loss flag device recovery
+                // uses -- WITHOUT the wake-pending half: a deep-idle
+                // surface draws nothing, so the rebuild lands on the
+                // first updateFrame after it is shown again, which is
+                // exactly when the copies are worth having back.
+                self.images_lost = true;
+            }
+
+            // Whole-cache replacement, the font-change pattern: the old
+            // table frees its shaped runs and a cold first frame on wake
+            // re-populates it.
+            const font_shaper_cache = font.ShaperCache.init();
+            self.font_shaper_cache.deinit(self.alloc);
+            self.font_shaper_cache = font_shaper_cache;
+        }
+
         /// Create or update the display link and match it to the current
         /// surface state.
         fn syncDisplayLink(

--- a/src/renderer/image.zig
+++ b/src/renderer/image.zig
@@ -189,6 +189,25 @@ pub const State = struct {
         return success;
     }
 
+    /// Deep-idle trim: free every image copy now, in place. A deep-idle
+    /// surface draws nothing, so the frame-driven unload path never runs
+    /// and the copies (CPU staging and GPU textures both) sit resident
+    /// indefinitely. The terminal's ImageStorage is untouched -- it is
+    /// the source of truth -- but the CALLER must latch whatever its
+    /// rebuild path keys on (wintty's renderer: `images_lost`): the
+    /// frame path itself has no reason to revisit placements whose
+    /// terminal state did not change, so an unlatched trim would leave
+    /// live placements drawing with no images behind them.
+    pub fn trimAll(self: *State, alloc: Allocator) void {
+        var image_it = self.images.iterator();
+        while (image_it.next()) |kv| {
+            // deinit frees every backing kind directly; there is no
+            // unload transition to honour here, this is a teardown.
+            kv.value_ptr.image.deinit(alloc);
+        }
+        self.images.clearRetainingCapacity();
+    }
+
     pub const DrawPlacements = enum {
         kitty_below_bg,
         kitty_below_text,

--- a/src/renderer/message.zig
+++ b/src/renderer/message.zig
@@ -22,6 +22,11 @@ pub const Message = union(enum) {
     /// and still have focus.
     visible: bool,
 
+    /// The surface went deep-idle: trim what exists only to make the next
+    /// frame cheap. One-directional like the termio-side message -- waking
+    /// rebuilds lazily and needs no signal.
+    deep_idle,
+
     /// Reset the cursor blink by immediately showing the cursor then
     /// restarting the timer.
     reset_cursor_blink,

--- a/src/terminal/Parser.zig
+++ b/src/terminal/Parser.zig
@@ -251,6 +251,26 @@ pub fn deinit(self: *Parser) void {
     self.osc_parser.deinit();
 }
 
+/// Return the parser to ground state, dropping any partially collected
+/// sequence state. The OSC capture is the memory that matters: an
+/// unterminated sequence can hold its heap capture until the next byte
+/// of that sequence arrives, which for a tab that has gone idle may be
+/// a very long time. Everything else reset here (intermediates, CSI
+/// params) is fixed-size and cleared for coherence, not footprint.
+///
+/// The bytes of the discarded fragment were never shown, so nothing
+/// visible changes; the next byte parses from ground exactly as a fresh
+/// input would.
+pub fn resetToGround(self: *Parser) void {
+    self.state = .ground;
+    self.intermediates_idx = 0;
+    self.params_idx = 0;
+    self.param_acc = 0;
+    self.param_acc_idx = 0;
+    self.params_sep = .initEmpty();
+    self.osc_parser.reset();
+}
+
 /// Next consumes the next character c and returns the actions to execute.
 /// Up to 3 actions may need to be executed -- in order -- representing
 /// the state exit, transition, and entry actions.
@@ -903,6 +923,45 @@ test "osc: change window title (end in esc)" {
         try testing.expect(cmd == .change_window_title);
         try testing.expectEqualStrings("abc", cmd.change_window_title);
     }
+}
+
+test "resetToGround drops a truncated OSC capture" {
+    var p: Parser = init();
+    defer p.deinit();
+    p.osc_parser.alloc = std.testing.allocator;
+
+    // An OSC 52 cut mid-flight, pushed past the inline buffer so the
+    // heap capture engages: exactly the state a deep-idle tab pins for
+    // as long as it stays silent. OSC 52 is one of the allocating keys;
+    // title-style OSCs cap inline and hold nothing on the heap, so the
+    // command choice here is load-bearing for what the test proves.
+    _ = p.next(0x1B);
+    _ = p.next(']');
+    _ = p.next('5');
+    _ = p.next('2');
+    _ = p.next(';');
+    var i: usize = 0;
+    while (i < 5_000) : (i += 1) _ = p.next('A');
+    try testing.expect(p.state == .osc_string);
+    // Premise made explicit: the heap capture must actually be engaged,
+    // or the reset below proves nothing about the allocating path.
+    try testing.expect(p.osc_parser.capture != null);
+    try testing.expect(p.osc_parser.capture.?.backing == .allocating);
+
+    p.resetToGround();
+    try testing.expect(p.state == .ground);
+    // The capture is gone, not merely closed: the allocation back out is
+    // the entire point of the trim.
+    try testing.expect(p.osc_parser.capture == null);
+
+    // The next byte parses as fresh input from ground -- the discarded
+    // fragment was never shown, and the reset leaves the parser fully
+    // able to consume text. The print rides the transition slot: at
+    // ground, staying at ground means no exit action and no entry
+    // action.
+    const a = p.next('x');
+    try testing.expect(a[1] != null);
+    try testing.expect(a[1].? == .print);
 }
 
 // https://github.com/darrenstarr/VtNetCore/pull/14

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -554,6 +554,24 @@ pub fn Stream(comptime H: type) type {
             };
         }
 
+        /// Force the stream back to ground state, discarding any
+        /// mid-sequence parse state: the VT parser's state machine, its
+        /// OSC capture, and any partially decoded codepoint. The
+        /// handler's own transient state (DCS, APC, protocol
+        /// accumulators) is the handler's to discard; the termio-side
+        /// deep-idle trim does both halves under the renderer state
+        /// mutex, which is also the lock the read path parses under.
+        ///
+        /// Continuation tracking is deliberately NOT reset: the termio
+        /// stream runs without a tracker, and on a tracking stream the
+        /// caller must discard the tracker's suffix alongside this, or
+        /// a later writeContinuation would faithfully resurrect the
+        /// sequence this just threw away.
+        pub fn resetToGround(self: *Self) void {
+            self.parser.resetToGround();
+            self.utf8decoder = .{};
+        }
+
         pub fn deinit(self: *Self) void {
             if (self.continuation) |*tracker| tracker.deinit();
             self.parser.deinit();

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -649,6 +649,42 @@ pub fn clearScreen(self: *Termio, td: *ThreadData, history: bool) !void {
     try self.queueWrite(td, &[_]u8{0x0C}, false);
 }
 
+/// Deep-idle trim: drop the parse state a sequence cut mid-flight is
+/// pinning. A truncated OSC can hold up to its allocating cap until the
+/// sequence's next byte arrives; DCS, APC, an iTerm2 multipart transfer,
+/// and an in-flight kitty clipboard write each pin their own capture.
+/// These buffers self-clear per completed sequence, so a surface at
+/// ground holds nothing to trim -- the reset is simply cheap when it
+/// has nothing to do. Runs on the IO thread (the stream's owner) under
+/// the same lock the read path parses under, so it cannot race a parse.
+///
+/// Kept: kitty clipboard grants (a session permission, not parse state;
+/// dropping one costs the user a re-prompt) and every terminal screen
+/// (user data -- scrollback shedding is the compression scheduler's
+/// job, not this one).
+///
+/// The one visible behavior change: if the writer resumes a sequence
+/// the trim cut (a stalled peer waking after minutes mid-OSC), its tail
+/// parses as plain text from ground rather than completing the
+/// sequence. That takes a minute-plus stall inside a single sequence,
+/// by which point the peer is almost certainly dead or the payload
+/// garbage either way.
+pub fn deepIdleTrim(self: *Termio) void {
+    self.renderer_state.mutex.lockUncancelable(global.io());
+    defer self.renderer_state.mutex.unlock(global.io());
+
+    self.terminal_stream.resetToGround();
+
+    const h = &self.terminal_stream.handler;
+    h.apc.deinit();
+    h.apc = .{};
+    h.dcs.deinit();
+    h.dcs = .{};
+    h.multipart_iterm2.deinit(h.alloc);
+    h.multipart_iterm2 = .{};
+    h.kittyClipboardWriteAbort();
+}
+
 /// Scroll the viewport
 pub fn scrollViewport(
     self: *Termio,

--- a/src/termio/Thread.zig
+++ b/src/termio/Thread.zig
@@ -347,6 +347,7 @@ fn drainMailbox(
             .start_synchronized_output => self.startSynchronizedOutput(cb),
             .linefeed_mode => |v| self.flags.linefeed_mode = v,
             .focused => |v| try io.focusGained(data, v),
+            .deep_idle => io.deepIdleTrim(),
             .write_small => |v| try io.queueWrite(
                 data,
                 v.data[0..v.len],

--- a/src/termio/message.zig
+++ b/src/termio/message.zig
@@ -82,6 +82,12 @@ pub const Message = union(enum) {
     /// The surface gained or lost focus.
     focused: bool,
 
+    /// The surface went deep-idle (the embedder's tracker: no PTY data
+    /// and no interaction for its threshold). One-directional by
+    /// design: waking sends nothing, because nothing the trim removes
+    /// is required to serve input and everything rebuilds lazily.
+    deep_idle: void,
+
     /// Record a Kitty clipboard protocol session grant for a password
     /// so future requests carrying it skip the permission prompt, for
     /// reads and writes respectively.

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -1542,7 +1542,7 @@ pub const StreamHandler = struct {
     }
 
     /// Drop any in-flight write transaction without responding.
-    fn kittyClipboardWriteAbort(self: *StreamHandler) void {
+    pub fn kittyClipboardWriteAbort(self: *StreamHandler) void {
         if (self.kitty_clipboard_write) |state| {
             state.deinit(self.alloc);
             self.alloc.destroy(state);

--- a/windows/Ghostty.Core/Panes/IPaneHost.cs
+++ b/windows/Ghostty.Core/Panes/IPaneHost.cs
@@ -90,6 +90,19 @@ internal interface IPaneHost
     long LastActivityTick { get; }
 
     /// <summary>
+    /// Tell this pane's surfaces whether their tab is deep-idle (the idle
+    /// tracker's flip). The shell implementation forwards per leaf to
+    /// libghostty, which trims what only exists to make the next frame
+    /// cheap -- parse state a sequence cut mid-flight is pinning, image
+    /// copies, the shaped-run cache. Clearing sends only a latch reset:
+    /// waking is lazy, because nothing trimmed is needed to serve input.
+    /// On this interface (unlike the visibility tell, whose call sites
+    /// hold concrete hosts) because the flip originates from the tab
+    /// model side, which only holds this abstraction.
+    /// </summary>
+    void SetSurfaceIdle(bool idle);
+
+    /// <summary>
     /// Split the active leaf with the given orientation. The new leaf
     /// becomes the active leaf. <paramref name="snapshot"/> is recorded
     /// on the freshly-created leaf.

--- a/windows/Ghostty.Core/Tabs/TabIdleTracker.cs
+++ b/windows/Ghostty.Core/Tabs/TabIdleTracker.cs
@@ -48,6 +48,7 @@ internal sealed class TabIdleTracker : IDisposable
     private readonly double _idleAfterMs;
     private readonly Func<long> _clock;
     private readonly Action<Action> _marshal;
+    private readonly Action<TabModel, bool>? _onIdleFlip;
     private readonly TimeProvider _time;
     private readonly object _gate = new();
     private ITimer? _timer;
@@ -66,17 +67,25 @@ internal sealed class TabIdleTracker : IDisposable
     /// Stamps and reads must share one domain; only differences are
     /// used, so any monotonic base works.</param>
     /// <param name="time">Timer provider, for tests.</param>
+    /// <param name="onIdleFlip">Notified exactly when a tab's
+    /// <see cref="TabModel.IsIdle"/> changes, with the new value --
+    /// from the sweep (marshalled) and from the eager activation clear.
+    /// The shell uses this to carry the idle state across the seam
+    /// (native footprint trims); null leaves the tracker badge-only,
+    /// with no seam-side effect at all.</param>
     public TabIdleTracker(
         TabManager manager,
         Action<Action> marshal,
         TimeSpan? idleAfter = null,
         Func<long>? clock = null,
-        TimeProvider? time = null)
+        TimeProvider? time = null,
+        Action<TabModel, bool>? onIdleFlip = null)
     {
         _manager = manager;
         _idleAfterMs = (idleAfter ?? DefaultIdleAfter).TotalMilliseconds;
         _clock = clock ?? DefaultClock;
         _marshal = marshal;
+        _onIdleFlip = onIdleFlip;
         _time = time ?? TimeProvider.System;
     }
 
@@ -112,7 +121,14 @@ internal sealed class TabIdleTracker : IDisposable
         // sweep.
         if (_lastActive is { } previous) previous.LastActivityTick = _clock();
         tab.LastActivityTick = _clock();
-        tab.IsIdle = false;
+        if (tab.IsIdle)
+        {
+            // The eager clear is also an idle flip: activation wakes the
+            // native side the same moment the moon lifts, not one sweep
+            // later.
+            tab.IsIdle = false;
+            _onIdleFlip?.Invoke(tab, false);
+        }
         _lastActive = tab;
     }
 
@@ -133,10 +149,16 @@ internal sealed class TabIdleTracker : IDisposable
             // signal): treat as fresh rather than ancient, so nothing
             // is born asleep.
             var last = Math.Max(tab.LastActivityTick, tab.PaneHost.LastActivityTick);
-            tab.IsIdle = last != 0
+            var idle = last != 0
                 && !ReferenceEquals(tab, active)
                 && !tab.BellRinging
                 && now - last >= _idleAfterMs;
+            if (idle == tab.IsIdle) continue;
+            tab.IsIdle = idle;
+            // On the flip only, so native state and the badge can never
+            // disagree about which tabs are asleep -- the seam-side trim
+            // rides the same edge the strip renders from.
+            _onIdleFlip?.Invoke(tab, idle);
         }
     }
 

--- a/windows/Ghostty.Tests/Tabs/FakePaneHost.cs
+++ b/windows/Ghostty.Tests/Tabs/FakePaneHost.cs
@@ -30,6 +30,15 @@ internal sealed class FakePaneHost : IPaneHost
     /// </summary>
     public long LastActivityTick { get; set; }
 
+    /// <summary>
+    /// The idle tells the tracker's flip delivered, in order. The real
+    /// host forwards them across the seam; the fake records them so
+    /// model-level tests can assert the edges without any native side.
+    /// </summary>
+    public System.Collections.Generic.List<bool> IdleTells { get; } = new();
+
+    public void SetSurfaceIdle(bool idle) => IdleTells.Add(idle);
+
     public PaneOrientation? LastSplitOrientation { get; private set; }
     public ProfileSnapshot? LastSplitSnapshot { get; private set; }
     public int SplitCalls { get; private set; }

--- a/windows/Ghostty.Tests/Tabs/TabIdleTrackerTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabIdleTrackerTests.cs
@@ -39,10 +39,13 @@ public class TabIdleTrackerTests
             // The timer provider never arms a real timer: tests drive
             // Sweep() themselves, and a live TimeProvider.System timer
             // would keep sweeping this rig from a threadpool thread for
-            // the rest of the test-host process.
+            // the rest of the test-host process. The flip hook is wired
+            // exactly as MainWindow wires it, so the IdleTells the fake
+            // records are the tells the product would deliver.
             _tracker = new TabIdleTracker(
                 Manager, a => a(), idleAfter ?? TimeSpan.FromSeconds(10),
-                () => Now, new NoTimerProvider());
+                () => Now, new NoTimerProvider(),
+                onIdleFlip: (tab, idle) => tab.PaneHost.SetSurfaceIdle(idle));
             _tracker.Start();
         }
 
@@ -177,6 +180,48 @@ public class TabIdleTrackerTests
         rig.Sweep();
         Assert.False(rig.Manager.Tabs[0].IsIdle);
         Assert.True(rig.Manager.Tabs[1].IsIdle);
+    }
+
+    [Fact]
+    public void TheIdleFlipCrossesToThePaneHostAsEdges()
+    {
+        var rig = new Rig();
+        rig.Start();
+        rig.Manager.NewTab();
+
+        // Sweeps that do not change the state tell the host nothing: the
+        // native trims ride EDGES, and a per-sweep tell would re-trim
+        // every thirty seconds forever.
+        rig.Now += 9_000;
+        rig.Sweep();
+        rig.Now += 60_000;
+        rig.Sweep();
+        rig.Sweep();
+        Assert.Equal(new[] { true }, rig.Hosts[0].IdleTells);
+
+        // Data wakes it: the second edge, and nothing more on the
+        // sweeps that follow it.
+        rig.Hosts[0].LastActivityTick = rig.Now;
+        rig.Sweep();
+        rig.Sweep();
+        Assert.Equal(new[] { true, false }, rig.Hosts[0].IdleTells);
+    }
+
+    [Fact]
+    public void ActivatingAnIdleTabTellsTheHostEagerly()
+    {
+        var rig = new Rig();
+        rig.Start();
+        rig.Manager.NewTab();
+        rig.Now += 60_000;
+        rig.Sweep();
+        Assert.Equal(new[] { true }, rig.Hosts[0].IdleTells);
+
+        // The eager clear on activation is an edge too: the native side
+        // learns the tab woke the moment the moon lifts, not one sweep
+        // later.
+        rig.Manager.ActivateIndex(0);
+        Assert.Equal(new[] { true, false }, rig.Hosts[0].IdleTells);
     }
 
     [Fact]

--- a/windows/Ghostty.Tests/Wiring/SurfaceIdleWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/SurfaceIdleWiringTests.cs
@@ -1,0 +1,108 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// The deep-idle trim's wiring pins, hop by hop -- the same discipline as
+/// the occlusion set, because the failure mode is the same shape: an
+/// inverted or dropped hand-off compiles and silently trims nothing (or
+/// trims the tab the user is looking at). The native import/export pair
+/// is already enforced by EntryPointParityTests; these hold the managed
+/// side together with the seam's dedupe latch.
+/// </summary>
+public class SurfaceIdleWiringTests
+{
+    private static ShellSource Window() => ShellSource.Load("Ghostty.MainWindow.xaml.cs");
+    private static ShellSource PaneHost() => ShellSource.Load("Panes.PaneHost.cs");
+    private static ShellSource Native() => ShellSource.Load("Interop.Imports.NativeMethods.cs");
+    private static ShellSource Tracker() => ShellSource.Load("Ghostty.Core.Tabs.TabIdleTracker.cs");
+
+    [Fact]
+    public void MainWindow_CarriesTheFlipAcrossTheSeam()
+    {
+        // The tracker's construction hands each flip to the tab's pane
+        // host, un-negated: true must mean idle at every hop, because the
+        // native side treats idle=true as "trim now".
+        var call = Assert.Single(
+            Window().Root.DescendantNodes().OfType<InvocationExpressionSyntax>()
+                .Where(i => i.CalleeText() == "tab.PaneHost.SetSurfaceIdle"));
+        Assert.Equal("idle", call.Arg(0));
+    }
+
+    [Fact]
+    public void PaneHost_GuardsZeroHandles_AndPassesTheFlagThrough()
+    {
+        var method = PaneHost().Method("SetSurfaceIdle");
+        var body = method.Body!;
+
+        // Same guard-before-call shape as visibility: a surface that does
+        // not exist yet (or is disposed) answers IntPtr.Zero, and the
+        // recorded state reaches it at spawn instead.
+        var guard = body.DescendantNodes().OfType<IfStatementSyntax>()
+            .Where(i => i.Condition.ToString().Contains("IntPtr.Zero")).ToList();
+        var call = body.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(i => i.CalleeText() == "Interop.NativeMethods.SurfaceSetIdle").ToList();
+        Assert.Single(guard);
+        Assert.Single(call);
+        Assert.True(guard[0].SpanStart < call[0].SpanStart,
+            "the zero-handle guard must precede the native call");
+        Assert.Equal("idle", call[0].Arg(1));
+    }
+
+    [Fact]
+    public void LateSpawnedSurfacesInheritTheRecordedIdle()
+    {
+        var spawn = PaneHost().Method("OnLeafSurfaceSpawned");
+        var reapply = spawn.DescendantNodes().OfType<IfStatementSyntax>()
+            .Where(i => i.Condition.ToString() == "_surfaceIdle == true").ToList();
+        Assert.Single(reapply);
+        // The argument is the polarity: idle is what a late spawn missed,
+        // and false would both skip the trim and flip the recorded field
+        // so later spawns never apply it.
+        var call = Assert.Single(
+            reapply[0].DescendantNodes().OfType<InvocationExpressionSyntax>()
+                .Where(i => i.CalleeText() == "SetSurfaceIdle"));
+        Assert.Equal("true", call.Arg(0));
+    }
+
+    [Fact]
+    public void Wrapper_MapsIdleTrueToByteOne()
+    {
+        // Exact argument text, not a substring: a negated condition
+        // (`!idle ? (byte)1 : ...`) would survive a Contains and pin an
+        // inverted wrapper.
+        var method = Native().Method("SurfaceSetIdle");
+        var native = Assert.Single(
+            method.DescendantNodes().OfType<InvocationExpressionSyntax>()
+                .Where(i => i.CalleeText() == "SurfaceSetIdleNative"));
+        Assert.Equal("idle ? (byte)1 : (byte)0", native.Arg(1));
+    }
+
+    [Fact]
+    public void TheSweepNotifiesOnlyOnEdges()
+    {
+        var sweep = Tracker().Method("Sweep");
+        // The flip guard: a sweep that changes nothing must not notify,
+        // or the trims re-fire every period.
+        Assert.Contains(
+            sweep.DescendantNodes().OfType<IfStatementSyntax>(),
+            i => i.Condition.ToString() == "idle == tab.IsIdle");
+        // The notify follows the property write, so native state can
+        // never lag the badge it is supposed to share an edge with.
+        var write = Assert.Single(
+            sweep.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+                .Where(a => a.Left.ToString() == "tab.IsIdle"));
+        // Exact callee: CalleeText reconstructs the null-conditional
+        // receiver, so equality is available and a Contains would accept
+        // any similarly-named call.
+        var notify = Assert.Single(
+            sweep.DescendantNodes().OfType<InvocationExpressionSyntax>()
+                .Where(i => i.CalleeText() == "_onIdleFlip?.Invoke"));
+        Assert.True(write.SpanStart < notify.SpanStart,
+            "the property write precedes the flip notification");
+    }
+}

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -593,6 +593,24 @@ internal static partial class NativeMethods
     internal static void SurfaceSetVisible(GhosttySurface surface, bool visible)
         => SurfaceSetOcclusionNative(surface, visible ? (byte)1 : (byte)0);
 
+    [LibraryImport(Dll, EntryPoint = "ghostty_surface_set_idle")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    private static partial void SurfaceSetIdleNative(GhosttySurface surface, byte idle);
+
+    /// <summary>
+    /// Tell libghostty whether this surface is deep-idle (the tab
+    /// tracker's determination: no PTY data and no interaction for the
+    /// threshold, never the active tab, never while a bell rings).
+    /// Setting idle trims what only exists to make the next frame cheap
+    /// -- parse state a sequence cut mid-flight is pinning, the
+    /// renderer's image copies, the shaped-run cache. Clearing it crosses
+    /// the seam only to reset the native dedupe latch: waking does no
+    /// work by design, and the clear exists so a later idle transition
+    /// can trim again.
+    /// </summary>
+    internal static void SurfaceSetIdle(GhosttySurface surface, bool idle)
+        => SurfaceSetIdleNative(surface, idle ? (byte)1 : (byte)0);
+
     /// <summary>Scrollback compression counters for one surface's primary
     /// screen, read from the page list under the renderer state mutex.
     /// Observes the idle shed as a terminal fact rather than a

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -830,8 +830,12 @@ public sealed partial class MainWindow : Window
         // live (the UI thread), so the timer's fire is marshalled.
         // (TryEnqueue wants a DispatcherQueueHandler, not an Action, so
         // the marshal closes over the conversion rather than fighting it.)
+        // The flip hook carries the same edge across the seam, so the
+        // native idle trims land the moment the moon does, never a sweep
+        // before or after it.
         _idleTracker = new TabIdleTracker(
-            _tabManager, a => DispatcherQueue.TryEnqueue(() => a()));
+            _tabManager, a => DispatcherQueue.TryEnqueue(() => a()),
+            onIdleFlip: (tab, idle) => tab.PaneHost.SetSurfaceIdle(idle));
         _idleTracker.Start();
         _windowState = WindowState.Load();
         // Apply the restored window geometry when restoring; otherwise use

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -867,6 +867,14 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     private bool? _surfaceVisibility;
 
     /// <summary>
+    /// The last idle state this host was told to hold, or null before the
+    /// first <see cref="SetSurfaceIdle"/> call. Same spawn-gap story as
+    /// <see cref="_surfaceVisibility"/>: a restored leaf that spawns after
+    /// its tab already went idle picks the state up here.
+    /// </summary>
+    private bool? _surfaceIdle;
+
+    /// <summary>
     /// Tell libghostty, per leaf, whether this tab's pixels reach the
     /// screen. A hidden tab stops presenting and releases its GPU atlas
     /// copies until it is shown again (the renderer rebuilds them lazily
@@ -889,6 +897,33 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
             if (handle == IntPtr.Zero) continue;
             Interop.NativeMethods.SurfaceSetVisible(
                 new Interop.GhosttySurface(handle), visible);
+        }
+    }
+
+    /// <summary>
+    /// Tell libghostty, per leaf, that this tab is deep-idle (the idle
+    /// tracker's determination). Idle trims what only exists to make the
+    /// next frame cheap: parse state a sequence cut mid-flight is pinning
+    /// (an unterminated OSC can hold its capture for as long as the tab
+    /// stays silent), the renderer's image copies, and the shaped-run
+    /// cache. Clearing sends only the latch reset -- nothing trimmed is
+    /// needed to serve input, so waking does no work and the next frame
+    /// rebuilds lazily. Keyed on the tracker's flip rather than on
+    /// visibility: a foreground tab nobody touches also goes idle.
+    /// </summary>
+    public void SetSurfaceIdle(bool idle)
+    {
+        _surfaceIdle = idle;
+        foreach (var leaf in PaneTree.Leaves(_root))
+        {
+            var handle = leaf.Terminal().SurfaceHandle;
+            // Same zero-handle guard as visibility: before the surface
+            // exists or after disposal, the native call would dereference
+            // a null surface, and the recorded state above is what the
+            // spawn hook applies instead.
+            if (handle == IntPtr.Zero) continue;
+            Interop.NativeMethods.SurfaceSetIdle(
+                new Interop.GhosttySurface(handle), idle);
         }
     }
 
@@ -1153,6 +1188,10 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         // Re-calling SetSurfaceVisibility is idempotent for leaves that
         // already hold the state (libghostty dedups a no-change write).
         if (_surfaceVisibility == false) SetSurfaceVisibility(false);
+
+        // Same spawn-gap as visibility: a tab that went idle before this
+        // leaf existed must not leave the new surface untrimmed.
+        if (_surfaceIdle == true) SetSurfaceIdle(true);
 
         if (!_startupGlowEnabled) return;
         // One glow per control. SurfaceSpawned fires once per control, so


### PR DESCRIPTION
Tier B of the idle-footprint work (#1050), on top of #989 (idle tracker) and #1039 (scrollback shedding). What stays resident per surface while a tab is deep-idle, and what this trims when the tracker's state flips:

## The seam

`ghostty_surface_set_idle(surface, idle)` (mirrors `set_occlusion`; declared in ghostty.h, bound as `SurfaceSetIdle`). The contract: idle=true trims state that exists only to make the NEXT frame cheap; idle=false sends nothing at all -- waking is lazy, and exists only to reset the native dedupe latch so a later idle can trim again. The C# side rides the tracker's new `onIdleFlip` callback (fired exactly on `IsIdle` edges, sweep and eager activation clear), fanned out per leaf through `PaneHost.SetSurfaceIdle` (a new `IPaneHost` member, because the flip originates from the model side), with the recorded-state spawn re-apply the visibility tell already uses.

## What gets trimmed

- **Parse state a cut-off sequence pins** (termio thread, under the lock the read path parses under): `Parser.resetToGround` + `Stream.resetToGround` (OSC heap capture -- an unterminated OSC 52-class sequence can hold up to 8 MiB until its next byte, which on an idle tab may be never), plus the handler's DCS/APC/iTerm2-multipart captures and an in-flight kitty-clipboard write. Kept: clipboard grants (a session permission; dropping one costs a re-prompt) and all terminal screens (user data).
- **Renderer image copies + shaper cache** (renderer thread, draw_mutex): the frame-driven unload path never runs on a surface that draws nothing. `trimAll` empties the copy map and the trim latches `images_lost` (the device-recovery flag, WITHOUT the wake-pending half) so the first `updateFrame` after the surface is shown rebuilds the copies -- without the latch, live placements would draw with nothing behind them, because no frame revisits placements whose terminal state did not change. Virtual-placement surfaces are skipped: they re-prep every drawn frame, so trimming them is pure churn. The shaper cache drops via the whole-cache replacement the font-change path already proved.
- The idle transition also kicks the compression scheduler (the strongest "activity stopped" signal, and it arrives on surfaces that may still be visible, where the hide transition never fires).

## Known behavior change (documented in the trim)

A writer that resumes a sequence the trim cut (a peer stalled mid-OSC for minutes, then waking) has its tail parsed as plain text from ground. That takes a minute-plus stall inside a single sequence; the accepted call is that such a payload is garbage either way.

## Tests

- Zig: `Parser.resetToGround` round-trip with an OSC 52 heap capture engaged (premise asserted: `.allocating` backing, capture freed, next byte parses as print) -- OSC 52 specifically, because title-style OSCs cap inline and would prove nothing about the heap path.
- C#: tracker edge-only flip facts (FakePaneHost records `IdleTells`; rig wires the callback exactly as MainWindow does), and `SurfaceIdleWiringTests` pinning every hop (polarity of each hand-off, zero-handle guard before the native call, spawn re-apply, byte mapping, flip-only notify).

Reviewed by two personas (Zig concurrency/lifetime; C# wiring/conventions). The Zig review's correctness bug -- trimmed images never rebuilding -- is fixed in-tree via the `images_lost` latch; its test-premise finding is fixed by the OSC 52 vehicle. Closes #1050.
