### PR TITLE
chore: zig fmt the file that landed unformatted

### DIFF
--- a/src/build/GhosttyLib.zig
+++ b/src/build/GhosttyLib.zig
@@ -136,8 +136,7 @@ pub fn initShared(
     // that references symbols in vcruntime.lib and ucrt.lib. Zig's library
     // search paths include the MSVC lib dir and the Windows SDK 'um' dir,
     // but not the SDK 'ucrt' dir where ucrt.lib lives.
-    if (win_msvc)
-    {
+    if (win_msvc) {
         // The CRT initialization code in msvcrt.lib calls __vcrt_initialize
         // and __acrt_initialize, which are in the static CRT libraries.
         lib.root_module.linkSystemLibrary("libvcruntime", dynamic_link_opts);


### PR DESCRIPTION
`src/build/GhosttyLib.zig` landed with an opening brace on its own line in
#1054, so `zig fmt --check src` is red on `windows`.

That is a signoff leg, and it is scoped by path rather than by file: every PR
touching anything under `src/` runs it and fails on this, whatever the PR
itself changed. #1048 hit it first.

One line, produced by `zig fmt`, nothing hand-edited. Same shape as #715,
which did this for eight files at once.

## Verification

`zig fmt --check src` is clean after it, and red before.
