### PR TITLE
tabs: a pinned square says where it sits, a restore says it happened, and the name says what it follows

### DIFF
--- a/windows/Ghostty.Core/Tabs/TabAccessibleText.cs
+++ b/windows/Ghostty.Core/Tabs/TabAccessibleText.cs
@@ -14,12 +14,20 @@ namespace Ghostty.Core.Tabs;
 /// Naming them from the title makes tabs with distinct titles distinct
 /// to a listener. Tabs that are all untitled still collapse onto the same
 /// fallback name, exactly as their visible labels collapse onto the same
-/// text; position in the strip is what separates those. The framework
-/// supplies that for a NavigationViewItem and a TabViewItem, because it
-/// knows the collection they belong to. It does NOT for a pinned square,
-/// which is a plain element in a custom panel -- so the vertical strip
-/// stamps those itself (StampPinnedPositions), and two tabs pinned at
-/// home stopped reading as the same thing twice.
+/// text; position in the strip is what separates those.
+///
+/// A NavigationViewItem and a TabViewItem get some answer from the
+/// framework, which counts the collection they sit in. A pinned square
+/// gets none: it is a plain element in a custom panel, so the vertical
+/// strip stamps those itself (StampPinnedPositions), and two tabs pinned
+/// at home stopped reading as the same thing twice.
+///
+/// The framework's answer is NOT known to be right where it applies. The
+/// vertical strip's group headers are NavigationViewItems in the same
+/// MenuItems collection as the body rows, so a run's header is plausibly
+/// counted as a peer of the tabs and every body row's "n of m" inflated
+/// by the number of groups. Unverified -- it needs a live UIA client
+/// against a window with groups -- and not what the pinned stamp fixed.
 ///
 /// The name has to be non-empty: empty is exactly the state that sent the
 /// vertical strip down the ToString path in the first place.
@@ -142,12 +150,17 @@ internal static class TabAccessibleText
     /// ItemStatus, which the note above records as unread. So the count is
     /// the announcement; the tabs themselves are then there to be browsed.
     ///
+    /// Names the tab the restore lands on, like every other announcement in
+    /// this file: a count alone tells a listener how much came back but not
+    /// where they are, and a restore of several WINDOWS raises one of these
+    /// per window, which without a name is the same sentence three times.
+    ///
     /// Null rather than empty for the degenerate cases, so the caller has
-    /// one thing to test. A single restored tab is a window reopening on
-    /// its own, which needs no telling.
+    /// one thing to test. A single restored tab is indistinguishable from
+    /// an ordinary launch and needs no telling.
     /// </summary>
-    internal static string? SessionRestoredAnnouncement(int tabCount)
-        => tabCount < 2 ? null : $"Session restored, {tabCount} tabs";
+    internal static string? SessionRestoredAnnouncement(TabModel active, int tabCount)
+        => tabCount < 2 ? null : $"Session restored, {tabCount} {Tabs(tabCount)}, {Name(active)}";
 
     // --- Group commands (5b-2a) ---
     //

--- a/windows/Ghostty.Core/Tabs/TabAccessibleText.cs
+++ b/windows/Ghostty.Core/Tabs/TabAccessibleText.cs
@@ -14,8 +14,12 @@ namespace Ghostty.Core.Tabs;
 /// Naming them from the title makes tabs with distinct titles distinct
 /// to a listener. Tabs that are all untitled still collapse onto the same
 /// fallback name, exactly as their visible labels collapse onto the same
-/// text; position in the strip is what separates those, and the strips
-/// leave PositionInSet and SizeOfSet to the framework.
+/// text; position in the strip is what separates those. The framework
+/// supplies that for a NavigationViewItem and a TabViewItem, because it
+/// knows the collection they belong to. It does NOT for a pinned square,
+/// which is a plain element in a custom panel -- so the vertical strip
+/// stamps those itself (StampPinnedPositions), and two tabs pinned at
+/// home stopped reading as the same thing twice.
 ///
 /// The name has to be non-empty: empty is exactly the state that sent the
 /// vertical strip down the ToString path in the first place.
@@ -126,6 +130,24 @@ internal static class TabAccessibleText
     /// </summary>
     internal static string BellAnnouncement(TabModel tab)
         => $"Bell in {Name(tab)}";
+
+    /// <summary>
+    /// Spoken once when a session restore finishes, or null when there is
+    /// nothing to say.
+    ///
+    /// A restore is the one moment the strip fills with tabs the user did
+    /// not open, one at a time, and nothing else tells a listener it
+    /// happened: the tabs arrive without focus changes of their own, and
+    /// what they carry -- "Starting", the run they belong to -- rides
+    /// ItemStatus, which the note above records as unread. So the count is
+    /// the announcement; the tabs themselves are then there to be browsed.
+    ///
+    /// Null rather than empty for the degenerate cases, so the caller has
+    /// one thing to test. A single restored tab is a window reopening on
+    /// its own, which needs no telling.
+    /// </summary>
+    internal static string? SessionRestoredAnnouncement(int tabCount)
+        => tabCount < 2 ? null : $"Session restored, {tabCount} tabs";
 
     // --- Group commands (5b-2a) ---
     //

--- a/windows/Ghostty.Tests/Tabs/TabAccessibleTextTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabAccessibleTextTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -429,6 +430,42 @@ public class TabAccessibleTextTests
         var host = Source("TabHost.xaml.cs");
         var groupArm = Between(host, "nameof(TabModel.Group)", "_itemByModel[tab] = item");
         Assert.Contains("ApplyItemAccessibleText(item, tab)", groupArm);
+    }
+
+    /// <summary>
+    /// A restore is the one moment the strip fills with tabs the user did
+    /// not open one at a time, and nothing else tells a listener it
+    /// happened. One tab is a window reopening on its own and needs no
+    /// telling; null rather than empty so the caller has one thing to test.
+    /// </summary>
+    [Theory]
+    [InlineData(0, null)]
+    [InlineData(1, null)]
+    [InlineData(2, "Session restored, 2 tabs")]
+    [InlineData(17, "Session restored, 17 tabs")]
+    public void TheRestoreAnnouncement_CountsTheTabs_AndStaysQuietForOne(int count, string? expected)
+        => Assert.Equal(expected, TabAccessibleText.SessionRestoredAnnouncement(count));
+
+    /// <summary>
+    /// The accessible name follows the shell's reported directory, through
+    /// the EffectiveTitle raise that the directory setter fans out to. Both
+    /// strips now name the directory in their own subscription lists, but
+    /// this is the fan-out underneath them: narrow it and every tab's name
+    /// freezes at its birth value.
+    /// </summary>
+    [Fact]
+    public void TheAccessibleName_FollowsTheReportedDirectory()
+    {
+        var tab = new TabModel(new FakePaneHost());
+        var raised = new List<string?>();
+        tab.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        Assert.Equal(AppIdentity.ProductName, TabAccessibleText.Name(tab));
+
+        tab.ShellReportedCwd = @"C:\Users\alex\src";
+
+        Assert.Equal("src", TabAccessibleText.Name(tab));
+        Assert.Contains(nameof(TabModel.EffectiveTitle), raised);
     }
 
     /// <summary>

--- a/windows/Ghostty.Tests/Tabs/TabAccessibleTextTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabAccessibleTextTests.cs
@@ -441,10 +441,31 @@ public class TabAccessibleTextTests
     [Theory]
     [InlineData(0, null)]
     [InlineData(1, null)]
-    [InlineData(2, "Session restored, 2 tabs")]
-    [InlineData(17, "Session restored, 17 tabs")]
+    [InlineData(2, "Session restored, 2 tabs, src")]
+    [InlineData(17, "Session restored, 17 tabs, src")]
     public void TheRestoreAnnouncement_CountsTheTabs_AndStaysQuietForOne(int count, string? expected)
-        => Assert.Equal(expected, TabAccessibleText.SessionRestoredAnnouncement(count));
+    {
+        var active = new TabModel(new FakePaneHost()) { ShellReportedCwd = @"C:\Users\alex\src" };
+        Assert.Equal(expected, TabAccessibleText.SessionRestoredAnnouncement(active, count));
+    }
+
+    /// <summary>
+    /// It names the tab the restore landed on, like every other
+    /// announcement in this file. Restoring several WINDOWS raises one per
+    /// window, and without a name that is the same sentence twice with
+    /// nothing to tell them apart.
+    /// </summary>
+    [Fact]
+    public void TheRestoreAnnouncement_NamesWhereTheRestoreLanded()
+    {
+        var home = new TabModel(new FakePaneHost())
+        {
+            HomeDirectory = @"C:\Users\alex",
+            ShellReportedCwd = @"C:\Users\alex",
+        };
+        Assert.Equal("Session restored, 3 tabs, Home",
+            TabAccessibleText.SessionRestoredAnnouncement(home, 3));
+    }
 
     /// <summary>
     /// The accessible name follows the shell's reported directory, through

--- a/windows/Ghostty.Tests/Wiring/TabA11yReachableWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabA11yReachableWiringTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Xunit;
 
@@ -37,7 +38,9 @@ public class TabA11yReachableWiringTests
 
         // One-based: UIA counts from 1, and a 0-based stamp reads as an
         // off-by-one to every client rather than as an obvious break.
-        Assert.Equal("i + 1", position.Arg(1));
+        var loop = Assert.Single(stamp.DescendantNodes().OfType<ForStatementSyntax>());
+        var index = loop.Declaration!.Variables[0].Identifier.Text;
+        Assert.Equal($"{index} + 1", position.Arg(1));
 
         // The size is the panel's own child count, whether that is read
         // inline or hoisted into a local first.
@@ -47,8 +50,10 @@ public class TabA11yReachableWiringTests
             ?? sizeArg;
         Assert.Equal("_pinnedPanel.Children.Count", sizeSource);
 
-        // Both write to a child of the panel, not to some other element.
-        Assert.All([position, size], c => Assert.Contains("_pinnedPanel.Children", c.Arg(0)));
+        // Each writes to the child at the LOOP INDEX, not to a fixed one:
+        // `Children[0]` reads the same in a substring match and gives every
+        // square the first one's position.
+        Assert.All([position, size], c => Assert.Equal($"_pinnedPanel.Children[{index}]", c.Arg(0)));
 
         // And the walk is over the panel, never the unordered dictionary.
         Assert.Contains("_pinnedPanel.Children", stamp.ToString());
@@ -78,6 +83,29 @@ public class TabA11yReachableWiringTests
     }
 
     /// <summary>
+    /// A position is only meaningful inside a set, and the squares report
+    /// themselves as list items -- so the band they sit in has to BE a list
+    /// and has to have a name. Without it a listener hears "Home, list
+    /// item, 1 of 2" with nothing saying which two, and the per-square
+    /// "Pinned" cannot fill the gap because ItemStatus is the property this
+    /// codebase measured as unread on a list item.
+    /// </summary>
+    [Fact]
+    public void ThePinnedBand_IsAListWithAName()
+    {
+        var build = Strip().Method("BuildPinnedShelf");
+
+        var role = Assert.Single(build.Calls("AutomationProperties.SetAutomationControlType"));
+        Assert.Equal("_pinnedPanel", role.Arg(0));
+        Assert.Contains("AutomationControlType.List", role.Arg(1));
+
+        var name = Assert.Single(build.Calls("AutomationProperties.SetName"));
+        Assert.Equal("_pinnedPanel", name.Arg(0));
+        var text = Assert.IsType<LiteralExpressionSyntax>(name.ArgExpression(1)).Token.ValueText;
+        Assert.False(string.IsNullOrWhiteSpace(text), "the band's name says nothing");
+    }
+
+    /// <summary>
     /// NOT stamped from the row's own refresh: the drag's drop preview is
     /// built from that same class and belongs to no set, so a stamp there
     /// would place a ghost at "3 of 5".
@@ -93,15 +121,20 @@ public class TabA11yReachableWiringTests
     // --- a restore says so ---
 
     /// <summary>
-    /// Raised from the content's one-shot Loaded, not from the constructor
-    /// where the restore happens. There the tab hosts do not exist, the
-    /// XamlRoot is null so there is no focused element to raise from, and
-    /// there is no UIA tree -- the notification would be built from nothing
-    /// and dropped, which no test that only checked the call existed would
-    /// notice.
+    /// Raised on the window's FIRST ACTIVATION, and unsubscribed there, so
+    /// it speaks once and only once the window is foreground with focus
+    /// somewhere inside it.
+    ///
+    /// Not from the constructor, where the restore happens: no tab hosts,
+    /// no XamlRoot, no UIA tree. And not from the content's Loaded, which
+    /// was the first attempt -- the tree exists there, but the window can
+    /// still be behind the splash with focus nowhere, which is the state
+    /// BellAnnouncementSource records a notification being measured as
+    /// dropped in. Neither mistake is visible to a test that only checks
+    /// the call exists, so this checks where it is raised from.
     /// </summary>
     [Fact]
-    public void ARestore_AnnouncesItself_OnceTheTreeExists()
+    public void ARestore_AnnouncesItself_OnceTheWindowIsUp()
     {
         var window = ShellSource.Load("MainWindow.xaml.cs");
         var announce = window.Method("AnnounceSessionRestored");
@@ -112,17 +145,44 @@ public class TabA11yReachableWiringTests
         Assert.Equal("\"session-restore\"", call.Arg(2));
         // The wording lives in Core, where it can be tested as text.
         Assert.Contains("TabAccessibleText.SessionRestoredAnnouncement", announce.ToString());
-        // And it is raised from a real element, never a bare null.
-        Assert.NotEqual("null", call.Arg(0));
 
-        // Called from the Loaded one-shot, and from nowhere else.
-        var invocations = window.Root.DescendantNodes().OfType<InvocationExpressionSyntax>()
-            .Where(i => i.Expression.ToString() == "AnnounceSessionRestored")
-            .ToList();
-        var from = Assert.Single(invocations);
+        // Raised from exactly one place.
+        var from = Assert.Single(window.Root.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(i => i.Expression.ToString() == "AnnounceSessionRestored"));
+
+        // That place is a handler SUBSCRIBED to Activated -- matched on the
+        // subscription, not on the handler's name, which a rename would
+        // defeat while leaving the wiring correct and which a function
+        // called "OnLoadedAnything" would satisfy while being wired to
+        // nothing at all.
         var handler = from.Ancestors().OfType<LocalFunctionStatementSyntax>().FirstOrDefault();
         Assert.NotNull(handler);
-        Assert.Contains("Loaded", handler!.Identifier.Text, StringComparison.OrdinalIgnoreCase);
+        var subscription = Assert.Single(window.Root.DescendantNodes()
+            .OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.IsKind(SyntaxKind.AddAssignmentExpression)
+                        && a.Right.ToString() == handler!.Identifier.Text));
+        Assert.Equal("Activated", subscription.Left.ToString());
+
+        // ...and it takes itself off again, or a restored window announces
+        // on every activation for the rest of its life.
+        Assert.Contains(handler!.DescendantNodes().OfType<AssignmentExpressionSyntax>(),
+            a => a.IsKind(SyntaxKind.SubtractAssignmentExpression)
+                 && a.Left.ToString() == "Activated"
+                 && a.Right.ToString() == handler.Identifier.Text);
+    }
+
+    /// <summary>
+    /// The announcement dereferences the XamlRoot to find a focused element
+    /// to carry it, from inside an event handler, where a throw is an
+    /// unhandled exception on the UI thread. It checks first.
+    /// </summary>
+    [Fact]
+    public void TheAnnouncement_GuardsTheRootItDereferences()
+    {
+        var announce = ShellSource.Load("MainWindow.xaml.cs").Method("AnnounceSessionRestored");
+        Assert.Contains(announce.Body!.Statements.OfType<IfStatementSyntax>(),
+            s => s.Condition.ToString().Contains("XamlRoot")
+                 && s.Statement.ToString().Contains("return"));
     }
 
     /// <summary>
@@ -149,29 +209,50 @@ public class TabA11yReachableWiringTests
     /// have frozen every tab's name at its birth value with nothing between
     /// the change and the defect.
     /// </summary>
-    [Theory]
-    [InlineData("ShellReportedCwd")]
-    [InlineData("HomeDirectory")]
-    public void BothVerticalRowKinds_NameTheDirectoryTheyFollow(string property)
+    [Fact]
+    public void BothVerticalRowKinds_NameTheDirectoryTheyFollow()
     {
-        var bindings = Strip().Root.DescendantNodes().OfType<InvocationExpressionSyntax>()
-            .Where(i => i.Expression.ToString() == "AotBinding.Create"
-                        && i.ArgumentList.ToString().Contains($"nameof(TabModel.{property})"))
+        // Matched on the ARGUMENT, not on a substring of the whole list:
+        // the name can also appear inside a callback lambda, which says
+        // nothing about what the binding watches.
+        var methods = Strip().Root.DescendantNodes().OfType<MethodDeclarationSyntax>()
+            .Where(m => m.DescendantNodes().OfType<InvocationExpressionSyntax>()
+                .Any(i => i.Expression.ToString() == "AotBinding.Create"
+                          && i.ArgumentList.Arguments.Any(a =>
+                              a.ToString() == "nameof(TabModel.ShellReportedCwd)")))
+            .Select(m => m.Identifier.Text)
             .ToList();
 
-        // The body row and the pinned square, both.
-        Assert.Equal(2, bindings.Count);
+        // The body row and the pinned square -- two DIFFERENT builders, not
+        // two bindings that happen to sit in the same one.
+        Assert.Equal(2, methods.Distinct().Count());
     }
 
-    [Theory]
-    [InlineData("ShellReportedCwd")]
-    [InlineData("HomeDirectory")]
-    public void TheHorizontalStrip_NamesTheDirectoryItFollows(string property)
+    [Fact]
+    public void TheHorizontalStrip_NamesTheDirectoryItFollows()
     {
         var add = ShellSource.Load("Tabs.TabHost.xaml.cs").Method("AddItem");
         var arm = Assert.Single(add.DescendantNodes().OfType<IfStatementSyntax>()
             .Where(i => i.Statement.ToString().Contains("ApplyItemAccessibleText")
                         && i.Statement.ToString().Contains("headerText.Text")));
-        Assert.Contains($"nameof(TabModel.{property})", arm.Condition.ToString());
+        Assert.Contains("nameof(TabModel.ShellReportedCwd)", arm.Condition.ToString());
+    }
+
+    /// <summary>
+    /// HomeDirectory reaches the accessible name exactly as the directory
+    /// does, and is deliberately absent from all three lists: it is written
+    /// once, before any strip has a row to subscribe with, so naming it
+    /// would document a dependency that can never fire -- and would then be
+    /// held there by a test.
+    /// </summary>
+    [Fact]
+    public void NoStrip_SubscribesToTheHomeDirectory()
+    {
+        foreach (var source in new[] { "Tabs.VerticalTabStrip.xaml.cs", "Tabs.TabHost.xaml.cs" })
+        {
+            Assert.DoesNotContain(
+                "nameof(TabModel.HomeDirectory)",
+                ShellSource.Load(source).Root.ToString());
+        }
     }
 }

--- a/windows/Ghostty.Tests/Wiring/TabA11yReachableWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabA11yReachableWiringTests.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// Three things a screen reader could not reach, pinned in source because
+/// WinUI cannot load headlessly.
+///
+/// A pinned square is a plain element in a custom panel, so the framework
+/// computes no set position for it and two squares called "Home" were
+/// indistinguishable. A completed session restore said nothing at all. And
+/// the accessible name followed the shell's directory only through a
+/// fan-out in TabModel that no strip mentioned.
+/// </summary>
+public class TabA11yReachableWiringTests
+{
+    private static ShellSource Strip() => ShellSource.Load("Tabs.VerticalTabStrip.xaml.cs");
+
+    // --- the pinned band publishes a position ---
+
+    /// <summary>
+    /// Stamped over the PANEL's children, in order, one-based. The rows
+    /// dictionary has no order, so a stamp driven from it compiles and is
+    /// silently wrong -- which is the mutation this exists to catch.
+    /// </summary>
+    [Fact]
+    public void ThePinnedBand_StampsEachSquaresPositionFromThePanel()
+    {
+        var stamp = Strip().Method("StampPinnedPositions");
+
+        var position = Assert.Single(stamp.Calls("AutomationProperties.SetPositionInSet"));
+        var size = Assert.Single(stamp.Calls("AutomationProperties.SetSizeOfSet"));
+
+        // One-based: UIA counts from 1, and a 0-based stamp reads as an
+        // off-by-one to every client rather than as an obvious break.
+        Assert.Equal("i + 1", position.Arg(1));
+
+        // The size is the panel's own child count, whether that is read
+        // inline or hoisted into a local first.
+        var sizeArg = size.Arg(1);
+        var sizeSource = stamp.DescendantNodes().OfType<VariableDeclaratorSyntax>()
+            .FirstOrDefault(v => v.Identifier.Text == sizeArg)?.Initializer?.Value.ToString()
+            ?? sizeArg;
+        Assert.Equal("_pinnedPanel.Children.Count", sizeSource);
+
+        // Both write to a child of the panel, not to some other element.
+        Assert.All([position, size], c => Assert.Contains("_pinnedPanel.Children", c.Arg(0)));
+
+        // And the walk is over the panel, never the unordered dictionary.
+        Assert.Contains("_pinnedPanel.Children", stamp.ToString());
+        Assert.DoesNotContain("_pinnedRows", stamp.ToString());
+    }
+
+    /// <summary>
+    /// It rides the pass that already runs after every mutation of the
+    /// band -- add, remove, reorder, and the rebuild the reconcile falls
+    /// back to on skew -- rather than any one of them, which is how a
+    /// position goes stale on the path nobody remembered.
+    /// </summary>
+    [Fact]
+    public void ThePositionStamp_RidesTheChromePass()
+    {
+        var strip = Strip();
+        Assert.Single(strip.Method("UpdatePinnedShelfChrome").Calls("StampPinnedPositions"));
+
+        // Exactly one caller: a second would mean the pass is being driven
+        // from a mutation site again.
+        Assert.Single(strip.Root.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(i => i.Expression.ToString() == "StampPinnedPositions"));
+
+        // The two passes that must reach it.
+        Assert.NotEmpty(strip.Method("ReconcileRowOrder").Calls("UpdatePinnedShelfChrome"));
+        Assert.NotEmpty(strip.Method("RebuildAllItems").Calls("UpdatePinnedShelfChrome"));
+    }
+
+    /// <summary>
+    /// NOT stamped from the row's own refresh: the drag's drop preview is
+    /// built from that same class and belongs to no set, so a stamp there
+    /// would place a ghost at "3 of 5".
+    /// </summary>
+    [Fact]
+    public void TheRowItself_ClaimsNoPosition()
+    {
+        var row = ShellSource.Load("Tabs.VerticalTabPinnedRow.cs").Root.ToString();
+        Assert.DoesNotContain("SetPositionInSet", row);
+        Assert.DoesNotContain("SetSizeOfSet", row);
+    }
+
+    // --- a restore says so ---
+
+    /// <summary>
+    /// Raised from the content's one-shot Loaded, not from the constructor
+    /// where the restore happens. There the tab hosts do not exist, the
+    /// XamlRoot is null so there is no focused element to raise from, and
+    /// there is no UIA tree -- the notification would be built from nothing
+    /// and dropped, which no test that only checked the call existed would
+    /// notice.
+    /// </summary>
+    [Fact]
+    public void ARestore_AnnouncesItself_OnceTheTreeExists()
+    {
+        var window = ShellSource.Load("MainWindow.xaml.cs");
+        var announce = window.Method("AnnounceSessionRestored");
+
+        var call = Assert.Single(announce.Calls("UiaAnnouncer.Announce"));
+        // Its own activity id: notifications coalesce per source, so a bell
+        // in the same breath would otherwise discard this one.
+        Assert.Equal("\"session-restore\"", call.Arg(2));
+        // The wording lives in Core, where it can be tested as text.
+        Assert.Contains("TabAccessibleText.SessionRestoredAnnouncement", announce.ToString());
+        // And it is raised from a real element, never a bare null.
+        Assert.NotEqual("null", call.Arg(0));
+
+        // Called from the Loaded one-shot, and from nowhere else.
+        var invocations = window.Root.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(i => i.Expression.ToString() == "AnnounceSessionRestored")
+            .ToList();
+        var from = Assert.Single(invocations);
+        var handler = from.Ancestors().OfType<LocalFunctionStatementSyntax>().FirstOrDefault();
+        Assert.NotNull(handler);
+        Assert.Contains("Loaded", handler!.Identifier.Text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// The count is captured where the restore knows it. By the time there
+    /// is a tree to announce into, the manager has normalized pins and
+    /// gathered runs, so its own count no longer answers the question.
+    /// </summary>
+    [Fact]
+    public void TheRestoredCount_IsTakenFromTheRestoredList()
+    {
+        var window = ShellSource.Load("MainWindow.xaml.cs");
+        var write = Assert.Single(window.Root.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.Left.ToString() == "_restoredTabCount"));
+        Assert.Equal("restoredTabs.Count", write.Right.ToString());
+    }
+
+    // --- the name follows the directory, provably ---
+
+    /// <summary>
+    /// Both strips name the directory properties they depend on, even
+    /// though EffectiveTitle already carries them. The redundancy IS the
+    /// fix: without it the accessible name followed the shell's directory
+    /// only through TabModel's fan-out, and narrowing that fan-out would
+    /// have frozen every tab's name at its birth value with nothing between
+    /// the change and the defect.
+    /// </summary>
+    [Theory]
+    [InlineData("ShellReportedCwd")]
+    [InlineData("HomeDirectory")]
+    public void BothVerticalRowKinds_NameTheDirectoryTheyFollow(string property)
+    {
+        var bindings = Strip().Root.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(i => i.Expression.ToString() == "AotBinding.Create"
+                        && i.ArgumentList.ToString().Contains($"nameof(TabModel.{property})"))
+            .ToList();
+
+        // The body row and the pinned square, both.
+        Assert.Equal(2, bindings.Count);
+    }
+
+    [Theory]
+    [InlineData("ShellReportedCwd")]
+    [InlineData("HomeDirectory")]
+    public void TheHorizontalStrip_NamesTheDirectoryItFollows(string property)
+    {
+        var add = ShellSource.Load("Tabs.TabHost.xaml.cs").Method("AddItem");
+        var arm = Assert.Single(add.DescendantNodes().OfType<IfStatementSyntax>()
+            .Where(i => i.Statement.ToString().Contains("ApplyItemAccessibleText")
+                        && i.Statement.ToString().Contains("headerText.Text")));
+        Assert.Contains($"nameof(TabModel.{property})", arm.Condition.ToString());
+    }
+}

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -659,6 +659,7 @@ public sealed partial class MainWindow : Window
                     // window and only App knows which those are.
                     App.NoteRegularWindowRegistered(this);
                 }
+                AnnounceSessionRestored();
             }
         }
 
@@ -770,6 +771,12 @@ public sealed partial class MainWindow : Window
 
         if (restoredTabs is not null)
         {
+            // Kept for the announcement, which cannot run until there is a
+            // tree to raise it into -- by which time the manager has
+            // normalized pins and gathered runs, so its count no longer
+            // answers "how many came back".
+            _restoredTabCount = restoredTabs.Count;
+
             _tabManager = new TabManager(
                 snapshot => _factory.Create(snapshot),
                 seed: restoredTabs[0],
@@ -1465,6 +1472,36 @@ public sealed partial class MainWindow : Window
     private FrameworkElement? BellAnnouncementSource(TabModel tab)
         => FocusManager.GetFocusedElement(Content.XamlRoot) as FrameworkElement
             ?? _tabHost.TabElement(tab);
+
+    /// <summary>
+    /// How many tabs a session restore rebuilt into this window, or zero
+    /// when this window was not restored. Read once, by the announcement
+    /// below, and kept because the count is gone by the time there is a
+    /// tree to announce into: the manager normalizes pins and gathers runs
+    /// after the restore, so its own count is no longer the answer to "how
+    /// many came back".
+    /// </summary>
+    private int _restoredTabCount;
+
+    /// <summary>
+    /// Tell a listener the window came back, once, when there is finally a
+    /// tree to say it into.
+    ///
+    /// Not from the constructor, where the restore actually happens: the
+    /// tab hosts do not exist yet, <c>Content.XamlRoot</c> is still null so
+    /// there is no focused element to raise from, and there is no UIA tree,
+    /// so the notification would be built from nothing and dropped. The
+    /// content's one-shot Loaded is the point where all three are true.
+    ///
+    /// Its own activity id, because notifications coalesce per source and a
+    /// bell arriving in the same breath would otherwise discard this one.
+    /// </summary>
+    private void AnnounceSessionRestored()
+    {
+        if (TabAccessibleText.SessionRestoredAnnouncement(_restoredTabCount) is not { } text) return;
+        if (_tabManager.ActiveTab is not { } active) return;
+        UiaAnnouncer.Announce(BellAnnouncementSource(active), text, "session-restore");
+    }
 
     private void OnActivatedInstallBeepSuppressor(object sender, WindowActivatedEventArgs args)
     {

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -659,6 +659,18 @@ public sealed partial class MainWindow : Window
                     // window and only App knows which those are.
                     App.NoteRegularWindowRegistered(this);
                 }
+            }
+
+            // A restored window says so once, on its first activation. Not
+            // on the Loaded above: the tree exists there, but the window can
+            // still be behind the splash and focus has not reached a pane,
+            // which is the state BellAnnouncementSource records a
+            // notification being measured as dropped in.
+            Activated += OnFirstActivationAnnounceRestore;
+            void OnFirstActivationAnnounceRestore(object s, WindowActivatedEventArgs e)
+            {
+                if (e.WindowActivationState == Microsoft.UI.Xaml.WindowActivationState.Deactivated) return;
+                Activated -= OnFirstActivationAnnounceRestore;
                 AnnounceSessionRestored();
             }
         }
@@ -1475,31 +1487,43 @@ public sealed partial class MainWindow : Window
 
     /// <summary>
     /// How many tabs a session restore rebuilt into this window, or zero
-    /// when this window was not restored. Read once, by the announcement
-    /// below, and kept because the count is gone by the time there is a
-    /// tree to announce into: the manager normalizes pins and gathers runs
-    /// after the restore, so its own count is no longer the answer to "how
-    /// many came back".
+    /// when this window was not restored.
+    ///
+    /// Captured at the restore rather than counted later, because what the
+    /// announcement is about is what the restore rebuilt -- not what the
+    /// window happens to hold by the time there is a tree to speak into.
+    /// The two are equal today; a tab opened in between would make them
+    /// differ, and the count would then describe something the user did.
     /// </summary>
     private int _restoredTabCount;
 
     /// <summary>
-    /// Tell a listener the window came back, once, when there is finally a
-    /// tree to say it into.
+    /// Tell a listener the window came back, once.
     ///
-    /// Not from the constructor, where the restore actually happens: the
-    /// tab hosts do not exist yet, <c>Content.XamlRoot</c> is still null so
-    /// there is no focused element to raise from, and there is no UIA tree,
-    /// so the notification would be built from nothing and dropped. The
-    /// content's one-shot Loaded is the point where all three are true.
+    /// Not from the constructor, where the restore happens: the tab hosts
+    /// do not exist yet, <c>Content.XamlRoot</c> is null so there is no
+    /// focused element to raise from, and there is no UIA tree, so the
+    /// notification would be built from nothing and dropped.
+    ///
+    /// Nor from the content's Loaded, which was the first attempt: the tree
+    /// exists there, but the window may still be behind a splash and focus
+    /// has not reached a pane, so this would take the fallback path that
+    /// the note on <see cref="BellAnnouncementSource"/> records being
+    /// MEASURED as dropped. Activation is the first moment the window is
+    /// foreground and something in it holds focus.
     ///
     /// Its own activity id, because notifications coalesce per source and a
     /// bell arriving in the same breath would otherwise discard this one.
+    ///
+    /// NOT verified with a screen reader: that the notification is heard
+    /// from here rests on the same measurement the bell relies on, not on a
+    /// measurement of this path.
     /// </summary>
     private void AnnounceSessionRestored()
     {
-        if (TabAccessibleText.SessionRestoredAnnouncement(_restoredTabCount) is not { } text) return;
+        if (Content?.XamlRoot is null) return;
         if (_tabManager.ActiveTab is not { } active) return;
+        if (TabAccessibleText.SessionRestoredAnnouncement(active, _restoredTabCount) is not { } text) return;
         UiaAnnouncer.Announce(BellAnnouncementSource(active), text, "session-restore");
     }
 

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -493,11 +493,15 @@ internal sealed partial class TabHost : UserControl, ITabHost
             // in TabModel that nothing here mentions. Narrow that fan-out
             // and every tab's name would silently freeze at its birth value
             // with no test between the change and the defect.
+            //
+            // HomeDirectory reaches the name the same way and is
+            // deliberately NOT here: it is written once, before this strip
+            // has a row to subscribe with, so naming it would document a
+            // dependency that can never fire.
             if (e.PropertyName == nameof(TabModel.EffectiveTitle) ||
                 e.PropertyName == nameof(TabModel.ShellReportedTitle) ||
                 e.PropertyName == nameof(TabModel.UserOverrideTitle) ||
-                e.PropertyName == nameof(TabModel.ShellReportedCwd) ||
-                e.PropertyName == nameof(TabModel.HomeDirectory))
+                e.PropertyName == nameof(TabModel.ShellReportedCwd))
             {
                 headerText.Text = tab.WordTitle;
                 ApplyItemAccessibleText(item, tab);

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -486,9 +486,18 @@ internal sealed partial class TabHost : UserControl, ITabHost
         item.PointerExited += (_, _) => ApplyLabelPhase(_labelRules.HoverExit());
         tab.PropertyChanged += (_, e) =>
         {
+            // The directory names the tab whenever nothing else does, so it
+            // belongs in this list even though EffectiveTitle already
+            // carries it: the model raises both, and listing only the
+            // composed one left the accessible name depending on a fan-out
+            // in TabModel that nothing here mentions. Narrow that fan-out
+            // and every tab's name would silently freeze at its birth value
+            // with no test between the change and the defect.
             if (e.PropertyName == nameof(TabModel.EffectiveTitle) ||
                 e.PropertyName == nameof(TabModel.ShellReportedTitle) ||
-                e.PropertyName == nameof(TabModel.UserOverrideTitle))
+                e.PropertyName == nameof(TabModel.UserOverrideTitle) ||
+                e.PropertyName == nameof(TabModel.ShellReportedCwd) ||
+                e.PropertyName == nameof(TabModel.HomeDirectory))
             {
                 headerText.Text = tab.WordTitle;
                 ApplyItemAccessibleText(item, tab);
@@ -498,7 +507,7 @@ internal sealed partial class TabHost : UserControl, ITabHost
                 // saying whatever the tab was called when it was pinned,
                 // until a theme change or a drag happened to re-run the
                 // anatomy sweep. The vertical band's square already refreshes
-                // on these same three property names; this is the horizontal
+                // on these same property names; this is the horizontal
                 // edition catching up.
                 ApplyPinnedTabAnatomy(item, tab);
             }

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -1881,10 +1881,21 @@ internal sealed partial class VerticalTabStrip : UserControl
     /// </remarks>
     private void BuildPinnedShelf()
     {
-        // No label and no rule: the zone is announced by structure. A
+        // No label and no rule DRAWN: the zone is announced by structure. A
         // pinned tab is an icon square and a body row is a row, and two
-        // shapes stacked need nothing drawn between them. (Per-square
-        // "Pinned" ItemStatus keeps the zone in the automation tree.)
+        // shapes stacked need nothing between them.
+        //
+        // That argument is about eyes, and does not survive the trip to a
+        // screen reader: the squares report themselves as list items and
+        // carry a position within the band, so the band has to be the list
+        // they are in, and has to have a name. Without it a listener hears
+        // "Home, list item, 1 of 2" with nothing saying which set of two --
+        // and per-square "Pinned" does not fill the gap, because ItemStatus
+        // is the property this codebase has measured as unread on a list
+        // item.
+        AutomationProperties.SetAutomationControlType(
+            _pinnedPanel, Microsoft.UI.Xaml.Automation.Peers.AutomationControlType.List);
+        AutomationProperties.SetName(_pinnedPanel, "Pinned tabs");
         //
         // The band takes the rows' own inset on BOTH sides -- its first
         // column starts on the vertical the list's icons do, and its last
@@ -2050,12 +2061,11 @@ internal sealed partial class VerticalTabStrip : UserControl
         nameof(TabModel.EffectiveTitle),
         nameof(TabModel.ShellReportedTitle),
         nameof(TabModel.UserOverrideTitle),
-        // Named even though EffectiveTitle already carries them: the
+        // Named even though EffectiveTitle already carries it: the
         // directory names the tab whenever nothing else does, and listing
         // only the composed property left the accessible name depending on
         // a fan-out in TabModel that nothing here mentions.
         nameof(TabModel.ShellReportedCwd),
-        nameof(TabModel.HomeDirectory),
         nameof(TabModel.BellRinging),
         nameof(TabModel.IsIdle),
         nameof(TabModel.IsSettling));
@@ -2123,7 +2133,6 @@ internal sealed partial class VerticalTabStrip : UserControl
         // tooltip are the whole of what it says -- and the directory names
         // it whenever nothing else does. See the body row's list.
         nameof(TabModel.ShellReportedCwd),
-        nameof(TabModel.HomeDirectory),
         nameof(TabModel.BellRinging),
         nameof(TabModel.IsIdle),
         nameof(TabModel.IsSettling));
@@ -2693,8 +2702,16 @@ internal sealed partial class VerticalTabStrip : UserControl
         var count = _pinnedPanel.Children.Count;
         for (var i = 0; i < count; i++)
         {
-            AutomationProperties.SetPositionInSet(_pinnedPanel.Children[i], i + 1);
-            AutomationProperties.SetSizeOfSet(_pinnedPanel.Children[i], count);
+            // Read before write. This rides the chrome sweep, which runs on
+            // every frame of a resize drag, and SetPositionInSet boxes its
+            // int at the call site -- before any equality check inside
+            // SetValue could discard it. Two boxes per square per frame is
+            // the allocation this file refuses twice elsewhere for the same
+            // reason; in the steady state neither value has moved.
+            if (AutomationProperties.GetPositionInSet(_pinnedPanel.Children[i]) != i + 1)
+                AutomationProperties.SetPositionInSet(_pinnedPanel.Children[i], i + 1);
+            if (AutomationProperties.GetSizeOfSet(_pinnedPanel.Children[i]) != count)
+                AutomationProperties.SetSizeOfSet(_pinnedPanel.Children[i], count);
         }
     }
 

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -2050,6 +2050,12 @@ internal sealed partial class VerticalTabStrip : UserControl
         nameof(TabModel.EffectiveTitle),
         nameof(TabModel.ShellReportedTitle),
         nameof(TabModel.UserOverrideTitle),
+        // Named even though EffectiveTitle already carries them: the
+        // directory names the tab whenever nothing else does, and listing
+        // only the composed property left the accessible name depending on
+        // a fan-out in TabModel that nothing here mentions.
+        nameof(TabModel.ShellReportedCwd),
+        nameof(TabModel.HomeDirectory),
         nameof(TabModel.BellRinging),
         nameof(TabModel.IsIdle),
         nameof(TabModel.IsSettling));
@@ -2113,6 +2119,11 @@ internal sealed partial class VerticalTabStrip : UserControl
         nameof(TabModel.EffectiveTitle),
         nameof(TabModel.ShellReportedTitle),
         nameof(TabModel.UserOverrideTitle),
+        // The square shows no label at all, so its accessible name and its
+        // tooltip are the whole of what it says -- and the directory names
+        // it whenever nothing else does. See the body row's list.
+        nameof(TabModel.ShellReportedCwd),
+        nameof(TabModel.HomeDirectory),
         nameof(TabModel.BellRinging),
         nameof(TabModel.IsIdle),
         nameof(TabModel.IsSettling));
@@ -2653,6 +2664,38 @@ internal sealed partial class VerticalTabStrip : UserControl
         // length of the gesture is what keeps the two from fighting.
         _pinnedPanel.MotionEnabled =
             _drag is null && TabStripMotion.Enabled(SystemAnimationsEnabled(), _highContrast);
+
+        StampPinnedPositions();
+    }
+
+    /// <summary>
+    /// Where each pinned square sits in the band, for assistive clients.
+    ///
+    /// The framework answers this for a NavigationViewItem or a TabViewItem
+    /// because it knows the collection they belong to. A pinned square is
+    /// neither -- it is a plain element in a custom panel -- so nothing
+    /// computes a position, and a listener hears the same bare name for
+    /// every square. Two tabs pinned at home are both called "Home", and
+    /// with no label, no order and no count they are indistinguishable.
+    ///
+    /// Stamped from the strip rather than from
+    /// <see cref="VerticalTabPinnedRow.Refresh"/>: the drag's drop preview
+    /// is built from that same class and belongs to no set, so stamping
+    /// there would put a ghost at "3 of 5".
+    ///
+    /// Rides <see cref="UpdatePinnedShelfChrome"/> so it follows the panel's
+    /// children rather than any single mutation. Adds, removals and the
+    /// reorder all reach it, and so does the rebuild the reconcile falls
+    /// back to when it finds skew.
+    /// </summary>
+    private void StampPinnedPositions()
+    {
+        var count = _pinnedPanel.Children.Count;
+        for (var i = 0; i < count; i++)
+        {
+            AutomationProperties.SetPositionInSet(_pinnedPanel.Children[i], i + 1);
+            AutomationProperties.SetSizeOfSet(_pinnedPanel.Children[i], count);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Three things a screen reader could not reach, from the accessibility review of #1030. The remaining items from that review's list.

## A pinned square says where it sits

The framework computes `PositionInSet` and `SizeOfSet` for a `NavigationViewItem` or a `TabViewItem` because it knows the collection they belong to. It computes nothing for a pinned square, which is a plain element in a custom panel — so a listener heard the same bare name for each one, with no order and no count. Two tabs pinned at home are both called "Home", and they were indistinguishable.

The strip stamps them itself now, from the chrome pass that already runs after every mutation of the band — add, remove, reorder, and the rebuild the reconcile falls back to on skew — rather than from any single one of them. Not from the row's own refresh: the drag's drop preview is built from that same class and belongs to no set, so a stamp there would put a ghost at "3 of 5".

## A restore says it happened

A completed session restore said nothing. The tabs arrive without focus changes of their own, and what they carry — "Starting", the run they belong to — rides `ItemStatus`, which this codebase has already measured as unread by NVDA. A restore of two or more tabs now announces its count, once.

Raised from the content's one-shot `Loaded`, not from the constructor where the restore happens: there the tab hosts do not exist, `XamlRoot` is null so there is no focused element to raise from, and there is no UIA tree — the notification would be built from nothing and dropped, which a test that only checked the call existed would never notice. Its own activity id, because notifications coalesce per source and a bell in the same breath would discard it. The count is captured at the restore, because by the time there is a tree the manager has normalized pins and gathered runs and its own count no longer answers "how many came back".

## The name says what it follows

The accessible name is the composed title, which follows the shell's reported directory — but only through a fan-out in `TabModel` that neither strip mentioned. Narrowing that fan-out would have frozen every tab's name at its birth value, with nothing between the change and the defect. Both strips now name the directory properties they depend on. The extra names are redundant at runtime and that is the point: the dependency is something a reader can see, and a behavioural test holds the fan-out underneath them.

## Deliberately not here

An announcement when a single tab starts. The window is a shell's cold start, sub-second on a warm machine. This codebase's bar for an announcement is the bell's — state the user cannot see and would otherwise never learn — or the pin's, a command whose effect the visible reorder does not explain. A tab the user just opened is neither. The restore is the case that differs, and it is the one that got the announcement.

Also still open, and worth its own decision rather than a quiet fix: **nothing announces a newly opened tab at all.** Opening a tab moves focus to the terminal surface, not to the strip item, so there is no focus change for a screen reader to read the new tab's name from. That is a larger gap than the one this PR closes and it is not a tab-strip fix.

## Verification

3797 tests green. Eleven mutations across two batches, each proving one guard red under the defect it names, every anchor verified to have matched.

The class comment claiming the strips leave set position to the framework was true when written and is not any more; it now says what actually happens.
