### PR TITLE
footprint: dormant surfaces - the terminal torn down into compressed snapshot bytes

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1288,6 +1288,8 @@ GHOSTTY_API void ghostty_surface_set_content_scale(ghostty_surface_t, double, do
 GHOSTTY_API void ghostty_surface_set_focus(ghostty_surface_t, bool);
 GHOSTTY_API void ghostty_surface_set_occlusion(ghostty_surface_t, bool);
 GHOSTTY_API void ghostty_surface_set_idle(ghostty_surface_t, bool);
+GHOSTTY_API bool ghostty_surface_go_dormant(ghostty_surface_t);
+GHOSTTY_API bool ghostty_surface_is_dormant(ghostty_surface_t);
 // Scrollback compression statistics for the surface's primary screen:
 // total pages, how many are compressed, the raw/encoded byte split, and
 // the compression activity serial (the scheduler's arming input: it

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -863,7 +863,11 @@ pub fn deinit(self: *Surface) void {
     self.renderer_thread.deinit();
     self.renderer.deinit();
     self.io_thread.deinit();
-    self.mouse.selection_gesture.deinit(&self.io.terminal);
+    // A dormant terminal is already torn down; the gesture's deinit
+    // untracks pins from pages that no longer exist, and Termio.deinit
+    // below owns the dormant teardown instead.
+    if (!self.renderer_state.dormant.load(.acquire))
+        self.mouse.selection_gesture.deinit(&self.io.terminal);
     self.io.deinit();
 
     if (self.inspector) |v| {
@@ -3432,10 +3436,19 @@ pub fn occlusionCallback(self: *Surface, visible: bool) !void {
     self.visible = visible;
 
     // Update the terminal state for synchronous queries, then notify the IO
-    // thread so it can emit a mode 2033 report when enabled.
+    // thread so it can emit a mode 2033 report when enabled. A dormant
+    // surface wakes FIRST: everything below reads and writes the
+    // terminal, which is undefined until the wake rebuilds it -- and the
+    // flag write would otherwise be clobbered wholesale by the rebuild.
+    _ = self.io.wakeIfDormant();
     self.renderer_state.mutex.lockUncancelable(global.io());
-    self.io.terminal.flags.visible = visible;
-    const report_visibility = self.io.terminal.modes.get(.report_visibility);
+    // A failed wake leaves the terminal undefined; skip the writes (an
+    // `if`, not an early return -- the unlock below must run).
+    const report_visibility: bool = dormant: {
+        if (self.renderer_state.dormant.load(.monotonic)) break :dormant false;
+        self.io.terminal.flags.visible = visible;
+        break :dormant self.io.terminal.modes.get(.report_visibility);
+    };
     self.renderer_state.mutex.unlock(global.io());
     if (report_visibility) {
         self.queueIo(.{ .visibility_report = .{
@@ -3478,6 +3491,39 @@ pub fn idleCallback(self: *Surface, idle: bool) !void {
     });
 
     try self.queueRender();
+}
+
+/// Publish search activity into the shared render state, under the same
+/// mutex the search thread walks under. The dormancy eligibility check
+/// reads this flag, which is what makes the check race-free against a
+/// search starting on this (UI) thread.
+fn setSearchActive(self: *Surface, active: bool) void {
+    self.renderer_state.mutex.lockUncancelable(global.io());
+    defer self.renderer_state.mutex.unlock(global.io());
+    self.renderer_state.search_active = active;
+}
+
+/// Freeze this surface's terminal into a dormant snapshot (Tier C): the
+/// live structures are torn down on the IO thread and the state exists
+/// only as bytes until the next input wakes it. This side checks only
+/// the gates the IO thread cannot see (an active search holds pins into
+/// the page storage the snapshot would tear down); the terminal-side
+/// gates are re-checked against the thing being snapshotted. Fire and
+/// forget: poll `isDormant` for the outcome.
+pub fn goDormantCallback(self: *Surface) void {
+    // The search thread walks the terminal under the renderer state
+    // mutex, but its pins point INTO the pages -- the wake rebuilds
+    // every page, and a pin across that boundary is exactly the class
+    // of stale pointer the search teardown exists to prevent.
+    if (self.search != null) return;
+    self.queueIo(.{ .go_dormant = {} }, .unlocked);
+}
+
+/// Whether this surface's terminal is currently torn down into its
+/// dormant snapshot. Lock-free: the flag is the shared atomic on the
+/// renderer state, published at the dormancy transition.
+pub fn isDormant(self: *const Surface) bool {
+    return self.renderer_state.dormant.load(.acquire);
 }
 
 pub fn focusCallback(self: *Surface, focused: bool) !void {
@@ -3559,10 +3605,15 @@ pub fn focusCallback(self: *Surface, focused: bool) !void {
     // again when tabbing between programs (see #2525).
     self.showMouse();
 
-    // Update the focus state and notify the terminal
+    // Update the focus state and notify the terminal. Wake-first for the
+    // same reason as occlusion: the flag write lands in the terminal,
+    // undefined while dormant, and a failed wake must skip it rather
+    // than write poison.
     {
+        _ = self.io.wakeIfDormant();
         self.renderer_state.mutex.lockUncancelable(global.io());
-        self.io.terminal.flags.focused = focused;
+        if (!self.renderer_state.dormant.load(.monotonic))
+            self.io.terminal.flags.focused = focused;
         self.renderer_state.mutex.unlock(global.io());
         self.queueIo(.{ .focused = focused }, .unlocked);
     }
@@ -5101,6 +5152,7 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             if (self.search) |*s| {
                 s.deinit();
                 self.search = null;
+                self.setSearchActive(false);
             }
 
             _ = try self.rt_app.performAction(
@@ -5132,6 +5184,14 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
                 const s: *Search = &self.search.?;
                 errdefer s.state.deinit();
 
+                // Publish search activity under the same mutex the search
+                // thread walks under, BEFORE the thread exists: the
+                // dormancy eligibility check reads this flag under the
+                // mutex, so a dormant transition can never interleave a
+                // live search's page walks or straddle its pins.
+                self.setSearchActive(true);
+                errdefer self.setSearchActive(false);
+
                 s.thread = try .spawn(
                     .{},
                     terminal.search.Thread.threadMain,
@@ -5146,6 +5206,7 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             if (text.len == 0) {
                 s.deinit();
                 self.search = null;
+                self.setSearchActive(false);
                 break :search;
             }
 

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2444,6 +2444,11 @@ pub const CAPI = struct {
         result: *Text,
     ) bool {
         const core_surface = &surface.core_surface;
+        // A dormant terminal is undefined until woken; these pull reads
+        // serve background tabs (tab overview previews, UIA queries),
+        // which are exactly the dormancy candidates. A failed wake
+        // answers "nothing to read" rather than walking undefined memory.
+        if (!core_surface.io.wakeIfDormant()) return false;
         core_surface.renderer_state.mutex.lockUncancelable(global.io());
         defer core_surface.renderer_state.mutex.unlock(global.io());
 
@@ -2464,6 +2469,9 @@ pub const CAPI = struct {
         sel: Selection,
         result: *Text,
     ) bool {
+        // Wake-first: same dormancy rule as read_selection -- a failed
+        // wake answers "nothing to read".
+        if (!surface.core_surface.io.wakeIfDormant()) return false;
         surface.core_surface.renderer_state.mutex.lockUncancelable(global.io());
         defer surface.core_surface.renderer_state.mutex.unlock(global.io());
 
@@ -2520,6 +2528,9 @@ pub const CAPI = struct {
         result: *Cells,
     ) bool {
         const core_surface = &surface.core_surface;
+        // Wake-first: the tab overview reads background tabs, the exact
+        // surfaces dormancy targets; the read below walks their pages.
+        if (!core_surface.io.wakeIfDormant()) return false;
         core_surface.renderer_state.mutex.lockUncancelable(global.io());
         defer core_surface.renderer_state.mutex.unlock(global.io());
         return readCellsLocked(core_surface, result) catch |err| {
@@ -2921,6 +2932,28 @@ pub const CAPI = struct {
         surface.idleCallback(idle);
     }
 
+    /// Freeze a surface's terminal into a dormant snapshot: the live
+    /// structures are torn down on the IO thread and the state exists
+    /// only as (compressed) bytes until the next input wakes it. Returns
+    /// false when the request was refused outright (an active search);
+    /// other eligibility is re-checked against the terminal on the IO
+    /// thread, so poll `ghostty_surface_is_dormant` for the outcome.
+    /// Wintty drives this only from its test seam today -- the product
+    /// trigger (a long idle threshold and a config knob) is deliberately
+    /// not wired yet.
+    export fn ghostty_surface_go_dormant(surface: *Surface) bool {
+        const core_surface = &surface.core_surface;
+        if (core_surface.search != null) return false;
+        core_surface.goDormantCallback();
+        return true;
+    }
+
+    /// Whether the surface's terminal is currently torn down into its
+    /// dormant snapshot. Lock-free read of the shared flag.
+    export fn ghostty_surface_is_dormant(surface: *Surface) bool {
+        return surface.core_surface.isDormant();
+    }
+
     /// Scrollback memory statistics for a surface's primary screen.
     ///
     /// This exists for embedders and harnesses that need to observe the
@@ -2941,6 +2974,20 @@ pub const CAPI = struct {
         const core_surface = &surface.core_surface;
         core_surface.renderer_state.mutex.lockUncancelable(global.io());
         defer core_surface.renderer_state.mutex.unlock(global.io());
+
+        // A dormant terminal is torn down; its pages exist only as the
+        // IO thread's snapshot bytes, and reading the field here would
+        // walk freed memory. Zeroes say "nothing resident", which is
+        // true in the only sense a memory census reports.
+        if (core_surface.renderer_state.dormant.load(.monotonic)) {
+            out_total_pages.* = 0;
+            out_compressed_pages.* = 0;
+            out_resident_raw_bytes.* = 0;
+            out_decommitted_raw_bytes.* = 0;
+            out_encoded_bytes.* = 0;
+            out_activity_serial.* = 0;
+            return;
+        }
 
         const term = core_surface.renderer_state.terminal;
         const pages = &term.screens.get(.primary).?.pages;
@@ -2988,6 +3035,12 @@ pub const CAPI = struct {
         event: KeyEvent,
     ) bool {
         const key_event = event.keyEvent();
+        // Input is a wake: handling reads and writes the terminal
+        // directly on this thread, and a dormant surface's terminal is
+        // undefined until rebuilt. A FAILED wake drops the event: the
+        // callbacks below would walk undefined memory, and the surface
+        // stays dormant for the next input to retry.
+        if (!surface.core_surface.io.wakeIfDormant()) return false;
 
         if (comptime builtin.os.tag == .windows) {
             // Theme picker etc. intercepts before keybinding resolution.
@@ -3043,6 +3096,12 @@ pub const CAPI = struct {
         ptr: [*]const u8,
         len: usize,
     ) void {
+        // Input is a wake: handling reads and writes the terminal
+        // directly on this thread, and a dormant surface's terminal is
+        // undefined until rebuilt. A FAILED wake drops the event: the
+        // callbacks below would walk undefined memory, and the surface
+        // stays dormant for the next input to retry.
+        if (!surface.core_surface.io.wakeIfDormant()) return;
         if (comptime builtin.os.tag == .windows) {
             if (surface.pending_key) |*pending| {
                 const text = ptr[0..len];
@@ -3098,6 +3157,12 @@ pub const CAPI = struct {
         button: input.MouseButton,
         mods: c_int,
     ) bool {
+        // Input is a wake: handling reads and writes the terminal
+        // directly on this thread, and a dormant surface's terminal is
+        // undefined until rebuilt. A FAILED wake drops the event: the
+        // callbacks below would walk undefined memory, and the surface
+        // stays dormant for the next input to retry.
+        if (!surface.core_surface.io.wakeIfDormant()) return false;
         return surface.mouseButtonCallback(
             action,
             button,
@@ -3115,6 +3180,12 @@ pub const CAPI = struct {
         y: f64,
         mods: c_int,
     ) void {
+        // Input is a wake: handling reads and writes the terminal
+        // directly on this thread, and a dormant surface's terminal is
+        // undefined until rebuilt. A FAILED wake drops the event: the
+        // callbacks below would walk undefined memory, and the surface
+        // stays dormant for the next input to retry.
+        if (!surface.core_surface.io.wakeIfDormant()) return;
         surface.cursorPosCallback(
             x,
             y,
@@ -3131,6 +3202,12 @@ pub const CAPI = struct {
         y: f64,
         scroll_mods: c_int,
     ) void {
+        // Input is a wake: handling reads and writes the terminal
+        // directly on this thread, and a dormant surface's terminal is
+        // undefined until rebuilt. A FAILED wake drops the event: the
+        // callbacks below would walk undefined memory, and the surface
+        // stays dormant for the next input to retry.
+        if (!surface.core_surface.io.wakeIfDormant()) return;
         surface.scrollCallback(
             x,
             y,
@@ -3144,6 +3221,12 @@ pub const CAPI = struct {
         pressure: f64,
     ) void {
         const stage = std.enums.fromInt(input.MousePressureStage, stage_raw) orelse return;
+        // Input is a wake: handling reads and writes the terminal
+        // directly on this thread, and a dormant surface's terminal is
+        // undefined until rebuilt. A FAILED wake drops the event: the
+        // callbacks below would walk undefined memory, and the surface
+        // stays dormant for the next input to retry.
+        if (!surface.core_surface.io.wakeIfDormant()) return;
         surface.mousePressureCallback(stage, pressure);
     }
 
@@ -3460,6 +3543,8 @@ pub const CAPI = struct {
             result: *Text,
         ) bool {
             const surface = &ptr.core_surface;
+            // Wake-first: same dormancy rule as the other pull reads.
+            if (!surface.io.wakeIfDormant()) return false;
             surface.renderer_state.mutex.lockUncancelable(global.io());
             defer surface.renderer_state.mutex.unlock(global.io());
 

--- a/src/renderer/State.zig
+++ b/src/renderer/State.zig
@@ -41,6 +41,24 @@ mouse: Mouse = .{},
 /// first saw a printable byte. Set once and never reset.
 first_content: bool = false,
 
+/// Tier C dormancy: true while this surface's terminal has been torn
+/// down and its state exists only as the IO thread's snapshot bytes. Set
+/// under `mutex` by the IO thread at the dormancy transition; read
+/// WITHOUT the mutex by readers that must not touch a torn-down terminal
+/// (the compression scheduler's tryLock path, the memory-stats export,
+/// the C API's readback). Any reader that takes `mutex` and needs the
+/// terminal itself must first funnel through the IO-side wake, which is
+/// the only thing that can make the terminal valid again.
+dormant: std.atomic.Value(bool) = .init(false),
+
+/// Whether a search thread is walking this terminal's pages. Held under
+/// `mutex` (set before the thread spawns, cleared after it is joined)
+/// so the dormancy eligibility check can refuse race-free: a search
+/// holds pins into the page storage dormancy would tear down, and the
+/// surface-side `search != null` check runs on the wrong thread to be
+/// the gate.
+search_active: bool = false,
+
 /// The number of threads currently waiting to acquire `mutex` via
 /// `lockDemand`. This is not protected by the mutex; it is read by
 /// hot lock/unlock loops (the IO parse thread) in `yieldToDemand` to

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -939,6 +939,11 @@ const Compression = struct {
         // timer indefinitely.
         if (thread.state.mutex.tryLock()) {
             defer thread.state.mutex.unlock(global.io());
+            // A dormant terminal is torn down; the activity read below
+            // would walk freed pages, so treat it as nothing-to-do (the
+            // step path reaches the same conclusion through its own
+            // guard).
+            if (thread.state.dormant.load(.acquire)) return;
             const activity = thread.state.terminal.compressionActivity();
             if (self.activity == activity) return;
             self.activity = activity;
@@ -998,6 +1003,11 @@ const Compression = struct {
         const state = thread.state;
         if (!state.mutex.tryLock()) return idle_interval;
         defer state.mutex.unlock(global.io());
+
+        // A dormant terminal is torn down; its pages exist only as the
+        // IO thread's snapshot bytes. Nothing to compress, and the
+        // terminal must not be read.
+        if (state.dormant.load(.acquire)) return null;
 
         const activity = state.terminal.compressionActivity();
         if (self.activity != activity) {

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1601,6 +1601,15 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // when rebuilding the frame fails due to memory pressure.
             defer self.font_shaper.endFrame();
 
+            // A dormant terminal is torn down; its pages exist only as the
+            // IO thread's snapshot bytes. This is the BACKSTOP -- the show
+            // path wakes the surface before the renderer ever gets a
+            // visible transition for it -- because a frame built against
+            // freed pages is exactly the corruption dormancy must never
+            // cause. Nothing is drawn for a dormant surface anyway: it is
+            // hidden by eligibility.
+            if (state.dormant.load(.acquire)) return;
+
             // This is the pass a device recovery asked for; whether it
             // gets as far as the images is up to the terminal state.
             self.images_wake_pending = false;

--- a/src/terminal/snapshot/snapshot.zig
+++ b/src/terminal/snapshot/snapshot.zig
@@ -919,6 +919,49 @@ test "complete snapshot round trip with history and alternate screen" {
     );
 }
 
+test "complete snapshot survives the dormant LZ4 container" {
+    const testing = std.testing;
+    const lz4 = @import("../compress/lz4.zig");
+
+    // Dormancy stores the snapshot as one raw LZ4 block (the v1 stream
+    // is an uncompressed logical encoding, and unwrapped it can outweigh
+    // the live compressed pages it replaces). This pins the container's
+    // round trip against the checked-in reference bytes: a wrap that
+    // lost, grew, or reordered anything fails the exact decode.
+    const bound = try lz4.compressBound(test_complete_fixture.len);
+    const compressed = try testing.allocator.alloc(u8, bound);
+    defer testing.allocator.free(compressed);
+    var table: lz4.HashTable = undefined;
+    const compressed_len = try lz4.compress(
+        &test_complete_fixture,
+        compressed,
+        &table,
+    );
+
+    const plain = try testing.allocator.alloc(u8, test_complete_fixture.len);
+    defer testing.allocator.free(plain);
+    const plain_len = try lz4.decompress(compressed[0..compressed_len], plain);
+    try testing.expectEqual(test_complete_fixture.len, plain_len);
+    try testing.expectEqualSlices(u8, &test_complete_fixture, plain);
+
+    var source: std.Io.Reader = .fixed(plain);
+    var restored = try decodeExact(
+        testing.allocator,
+        testing.io,
+        &source,
+        test_decode_options,
+    );
+    defer restored.deinit(testing.allocator);
+    try testing.expectEqualStrings(
+        "file:///tmp/snapshot",
+        restored.terminal.?.getPwd().?,
+    );
+    try testing.expectEqualStrings(
+        "complete snapshot",
+        restored.terminal.?.getTitle().?,
+    );
+}
+
 test "complete snapshot restores a canonical Stream continuation" {
     const testing = std.testing;
 

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -447,6 +447,13 @@ fn termiosTimer(
         {
             td.renderer_state.mutex.lockUncancelable(global.io());
             defer td.renderer_state.mutex.unlock(global.io());
+            // The poll timer runs regardless of dormancy, and reading
+            // the torn-down terminal's flags would mismatch every tick
+            // (poison in Debug, stale in Release) and spam the surface
+            // with phantom mode changes for the whole dormancy.
+            if (td.renderer_state.dormant.load(.acquire)) {
+                break :mode_change;
+            }
             const t = td.renderer_state.terminal;
             if (t.flags.password_input == password_input) {
                 break :mode_change;

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -13,6 +13,8 @@ const posix = std.posix;
 const termio = @import("../termio.zig");
 const StreamHandler = @import("stream_handler.zig").StreamHandler;
 const terminalpkg = @import("../terminal/main.zig");
+const snapshotpkg = @import("../terminal/snapshot/snapshot.zig");
+const lz4 = @import("../terminal/compress/lz4.zig");
 const global = @import("../global.zig");
 const xev = global.xev;
 const renderer = @import("../renderer.zig");
@@ -27,6 +29,31 @@ const log = std.log.scoped(.io_exec);
 
 /// Mutex state argument for queueMessage.
 pub const MutexState = enum { locked, unlocked };
+
+/// Cap on the replayable parse state the stream's continuation tracker
+/// may retain. Sized to the allocating OSC class's own ceiling class --
+/// a truncated OSC 52-family sequence is the realistic worst case a
+/// dormant tab would otherwise have to drop.
+const continuation_max_bytes = 1024 * 1024;
+
+/// Tier C dormancy: the terminal torn down into snapshot bytes. The
+/// snapshot is the in-tree GHOSTSNP stream wrapped in one raw LZ4 block
+/// (the v1 stream is an uncompressed logical encoding -- unwrapped, a
+/// dormant heavy session would carry more than its live #1039-compressed
+/// pages ever did). plain_len rides along because the LZ4 decoder needs
+/// an exactly-sized destination. Guarded by renderer_state.mutex.
+const DormantSnapshot = struct {
+    compressed: []u8,
+    plain_len: usize,
+
+    /// Presentation flags the v1 snapshot does not carry (they are
+    /// caller-supplied by design). Captured at teardown so the wake can
+    /// put them back: without this, a surface that went dormant hidden
+    /// rebuilds with the default (visible), and every later dormancy is
+    /// refused for "surface visible" by a fact nobody observes.
+    visible: bool,
+    focused: bool,
+};
 
 /// Allocator
 alloc: Allocator,
@@ -68,6 +95,12 @@ mailbox: termio.Mailbox,
 /// The stream parser. This parses the stream of escape codes and so on
 /// from the child process and calls callbacks in the stream handler.
 terminal_stream: StreamHandler.Stream,
+
+/// Non-null while the terminal field is torn down into its dormant
+/// snapshot; see DormantSnapshot. Everything that can reach the
+/// terminal takes renderer_state.mutex first; the shared atomic on
+/// renderer_state is what lock-free readers check instead.
+dormant_snapshot: ?DormantSnapshot = null,
 
 /// Last time the cursor was reset. This is used to prevent message
 /// flooding with cursor resets.
@@ -356,6 +389,12 @@ pub fn init(self: *Termio, alloc: Allocator, opts: termio.Options) !void {
         .terminal_stream = .init(.{
             .allocator = alloc,
             .handler = handler,
+            // Tier C dormancy snapshots mid-sequence parse state as a
+            // replayable continuation suffix; without tracking enabled
+            // here, a tab that goes dormant inside an OSC cannot be
+            // faithfully woken. The cap bounds what a runaway sequence
+            // can pin; an empty tracker at ground costs a fixed 4 KiB.
+            .continuation_max_bytes = continuation_max_bytes,
         }),
         .thread_enter_state = thread_enter_state,
     };
@@ -363,7 +402,17 @@ pub fn init(self: *Termio, alloc: Allocator, opts: termio.Options) !void {
 
 pub fn deinit(self: *Termio) void {
     self.backend.deinit();
-    self.terminal.deinit(self.alloc);
+    // A dormant terminal is already torn down -- deiniting it again
+    // would double-free the screens -- and its snapshot must be scrubbed
+    // and freed rather than leaked with the scrollback it holds.
+    if (self.dormant_snapshot) |snapshot| {
+        @memset(snapshot.compressed, 0);
+        self.alloc.free(snapshot.compressed);
+        self.dormant_snapshot = null;
+        self.renderer_state.dormant.store(false, .release);
+    } else {
+        self.terminal.deinit(self.alloc);
+    }
     self.config.deinit();
     self.mailbox.deinit(self.alloc);
 
@@ -531,6 +580,12 @@ pub fn resize(
         self.renderer_state.mutex.lockUncancelable(global.io());
         defer self.renderer_state.mutex.unlock(global.io());
 
+        // A coalesced resize timer can fire into a surface that went
+        // dormant inside its window; resizing the torn-down terminal
+        // would walk and reallocate freed pages. Wake first -- arriving
+        // after a failed wake, skip: the next resize retries.
+        if (!self.wakeIfDormantLocked()) return error.OutOfMemory;
+
         // Update the size of our terminal state
         try self.terminal.resize(
             self.alloc,
@@ -589,6 +644,12 @@ fn sizeReportLocked(self: *Termio, td: *ThreadData, style: termio.Message.SizeRe
 pub fn resetSynchronizedOutput(self: *Termio) void {
     self.renderer_state.mutex.lockUncancelable(global.io());
     defer self.renderer_state.mutex.unlock(global.io());
+    // The synchronized-output timeout is a timer, so it can land on a
+    // surface that went dormant while the mode was armed. The write is
+    // meaningless against a torn-down terminal (the wake's decode
+    // carries the mode state forward), so skip it rather than write
+    // into the undefined field.
+    if (self.renderer_state.dormant.load(.monotonic)) return;
     self.terminal.modes.set(.synchronized_output, false);
     self.renderer_wakeup.notify() catch {};
 }
@@ -674,6 +735,12 @@ pub fn deepIdleTrim(self: *Termio) void {
     defer self.renderer_state.mutex.unlock(global.io());
 
     self.terminal_stream.resetToGround();
+    // The continuation tracker must go with the state it describes: the
+    // stream runs with tracking enabled (dormancy needs it), and a
+    // tracker left holding the trimmed sequence's suffix would
+    // faithfully resurrect it in the next snapshot -- inverting this
+    // trim exactly when dormancy later consumes it.
+    if (self.terminal_stream.continuation) |*tracker| tracker.reset();
 
     const h = &self.terminal_stream.handler;
     h.apc.deinit();
@@ -683,6 +750,220 @@ pub fn deepIdleTrim(self: *Termio) void {
     h.multipart_iterm2.deinit(h.alloc);
     h.multipart_iterm2 = .{};
     h.kittyClipboardWriteAbort();
+}
+
+/// Tier C dormancy: tear the terminal down into snapshot bytes. The
+/// eligibility gates here are the ones only the terminal in hand can
+/// answer; the surface-side gates (an active search) are checked before
+/// the message is ever queued. Everything runs under the renderer state
+/// mutex on the IO thread, which is the lock every other terminal
+/// reader takes, so no reader can observe the half-torn-down window.
+///
+/// What snapshot v1 cannot carry is refused rather than silently lost:
+/// kitty image state, glyph glossary registrations, and kitty drag and
+/// drop state are all user-visible, and a dormant wake that dropped
+/// them would read as corruption. The viewport's scroll offset is the
+/// one accepted loss (v1 wakes at the active position).
+pub fn goDormant(self: *Termio) void {
+    self.renderer_state.mutex.lockUncancelable(global.io());
+    defer self.renderer_state.mutex.unlock(global.io());
+
+    if (self.dormant_snapshot != null) return;
+    if (self.dormantBlocker()) |reason| {
+        log.info("dormancy refused: {s}", .{reason});
+        return;
+    }
+
+    // The replayable parse state rides inside the snapshot itself.
+    var cont: std.Io.Writer.Allocating = .init(self.alloc);
+    defer cont.deinit();
+    self.terminal_stream.writeContinuation(&cont.writer) catch |err| {
+        log.warn("dormancy refused: continuation unavailable err={}", .{err});
+        return;
+    };
+    const cont_value: snapshotpkg.Continuation = if (cont.written().len == 0)
+        .ground
+    else
+        .{ .bytes = cont.written() };
+
+    // The plain snapshot. One transient allocation the size of the
+    // logical stream; the dormancy this serves only ever runs on a
+    // surface that has been quiet for the embedder's whole patience.
+    // The defer scrubs on EVERY exit -- refusal paths below leave
+    // through it too, and the plain buffer holds the full scrollback,
+    // secrets and all.
+    var plain: std.Io.Writer.Allocating = .init(self.alloc);
+    defer {
+        @memset(plain.written(), 0);
+        plain.deinit();
+    }
+    snapshotpkg.encode(
+        self.alloc,
+        &plain.writer,
+        &self.terminal,
+        .{ .continuation = cont_value },
+    ) catch |err| {
+        log.warn("dormancy refused: encode err={}", .{err});
+        return;
+    };
+
+    // Wrap it in one raw LZ4 block, same codec the page compression
+    // uses. RAM-only and producer/consumer-identical, so there is no
+    // stability requirement to honor -- only the bytes' size.
+    const bound = lz4.compressBound(plain.written().len) catch |err| {
+        log.warn("dormancy refused: input too large for LZ4 err={}", .{err});
+        return;
+    };
+    var compressed = self.alloc.alloc(u8, bound) catch |err| {
+        log.warn("dormancy refused: out of memory err={}", .{err});
+        return;
+    };
+    var table: lz4.HashTable = undefined;
+    const compressed_len = lz4.compress(plain.written(), compressed, &table) catch |err| {
+        self.alloc.free(compressed);
+        log.warn("dormancy refused: compress err={}", .{err});
+        return;
+    };
+    if (self.alloc.realloc(compressed, compressed_len)) |shrunk| {
+        compressed = shrunk;
+    } else |_| {
+        // Shrinking failed; the larger allocation is still correct.
+    }
+
+    // From here the transition is committed. The plain buffer's scrub
+    // rides the defer above; the same hygiene applies to the compressed
+    // block on wake. Capture the presentation flags BEFORE the deinit:
+    // deinit leaves the field undefined (poisoned in safe builds), and
+    // these are facts the snapshot does not carry.
+    const flags_visible = self.terminal.flags.visible;
+    const flags_focused = self.terminal.flags.focused;
+
+    // Tear the terminal down; the field stays undefined until wake
+    // rebuilds it AT THIS ADDRESS, which is the address
+    // renderer_state.terminal and the handler both point at.
+    self.terminal.deinit(self.alloc);
+
+    // The stream's parse state is already inside the snapshot as the
+    // continuation; leaving it live would double-apply on wake, which
+    // resets before replaying.
+    self.terminal_stream.resetToGround();
+
+    self.dormant_snapshot = .{
+        .compressed = compressed,
+        .plain_len = plain.written().len,
+        .visible = flags_visible,
+        .focused = flags_focused,
+    };
+    self.renderer_state.dormant.store(true, .release);
+    log.info("dormant: {d} plain bytes as {d} compressed", .{
+        plain.written().len,
+        compressed_len,
+    });
+}
+
+/// Why this terminal cannot go dormant right now, or null if it can.
+/// Runs under the renderer state mutex.
+fn dormantBlocker(self: *Termio) ?[]const u8 {
+    if (self.renderer_state.inspector != null) return "inspector active";
+    // Visible surfaces are refused: the frames a visible surface draws
+    // read the terminal constantly, and the win is aimed at tabs nobody
+    // is looking at.
+    if (self.terminal.flags.visible) return "surface visible";
+    for ([_]terminalpkg.ScreenSet.Key{ .primary, .alternate }) |key| {
+        const screen = self.terminal.screens.get(key) orelse continue;
+        if (screen.kitty_images.images.count() > 0)
+            return "kitty images present";
+    }
+    if (self.terminal.glyph_glossary.entries.count() > 0)
+        return "glyph glossary registrations present";
+    if (self.terminal.kitty_dnd != null) return "kitty dnd state present";
+    // v1 restores neither selections nor the viewport offset; a tab
+    // whose selection silently evaporated on wake reads as corruption
+    // for the same reason a dropped kitty image would.
+    for ([_]terminalpkg.ScreenSet.Key{ .primary, .alternate }) |key| {
+        const screen = self.terminal.screens.get(key) orelse continue;
+        if (screen.selection != null) return "selection active";
+    }
+    if (self.renderer_state.search_active) return "search active";
+    return null;
+}
+
+/// Wake a dormant terminal if one is present, taking the renderer state
+/// mutex. The funnel for callers that do not already hold it. Returns
+/// whether a live terminal is now in place -- a surface that was never
+/// dormant counts as woken.
+pub fn wakeIfDormant(self: *Termio) bool {
+    if (!self.renderer_state.dormant.load(.acquire)) return true;
+    self.renderer_state.mutex.lockUncancelable(global.io());
+    defer self.renderer_state.mutex.unlock(global.io());
+    return self.wakeIfDormantLocked();
+}
+
+/// Rebuild the terminal from its snapshot. CALLER HOLDS the renderer
+/// state mutex, and the terminal field is undefined until this returns
+/// successfully -- a failed wake leaves the snapshot intact and the
+/// surface dormant, retried by the next input, because a terminal that
+/// can never wake must not be torn down into bytes it can never read
+/// back. The bool return is the contract callers must honor: FALSE
+/// means the terminal is undefined and the caller must not touch it.
+fn wakeIfDormantLocked(self: *Termio) bool {
+    const snapshot = self.dormant_snapshot orelse return true;
+
+    const plain = self.alloc.alloc(u8, snapshot.plain_len) catch |err| {
+        log.warn("wake deferred: out of memory err={}", .{err});
+        return false;
+    };
+    defer self.alloc.free(plain);
+    const plain_len = lz4.decompress(snapshot.compressed, plain) catch |err| {
+        log.err("wake failed: snapshot corrupt err={}", .{err});
+        return false;
+    };
+    if (plain_len != snapshot.plain_len) {
+        log.err("wake failed: snapshot truncated", .{});
+        return false;
+    }
+
+    var source: std.Io.Reader = .fixed(plain);
+    var decoded = snapshotpkg.decodeExact(
+        self.alloc,
+        global.io(),
+        &source,
+        .{ .max_continuation_bytes = continuation_max_bytes },
+    ) catch |err| {
+        log.err("wake failed: decode err={}", .{err});
+        return false;
+    };
+
+    // Store at the terminal's final address -- this address -- before
+    // anything can observe it, then rebuild the stream's parse state by
+    // replaying the continuation exactly once. The stream was reset at
+    // dormancy; replaying without that reset would apply the suffix to
+    // whatever parse state accumulated since, which is not the state
+    // the snapshot describes.
+    self.terminal = decoded.toOwned();
+    // The snapshot does not carry presentation flags (caller-supplied
+    // by design); restore what teardown captured so dormancy is
+    // transparent to visibility and focus bookkeeping.
+    self.terminal.flags.visible = snapshot.visible;
+    self.terminal.flags.focused = snapshot.focused;
+    self.terminal_stream.resetToGround();
+    switch (decoded.continuation) {
+        .ground => {},
+        .bytes => |bytes| for (bytes) |ch| {
+            _ = self.terminal_stream.next(ch);
+        },
+    }
+    decoded.deinit(self.alloc);
+
+    // The snapshot's bytes are the same secrets the live scrollback
+    // holds; scrub both copies on the way out the door.
+    @memset(plain, 0);
+    @memset(snapshot.compressed, 0);
+    self.alloc.free(snapshot.compressed);
+    self.dormant_snapshot = null;
+    self.renderer_state.dormant.store(false, .release);
+    log.info("dormant surface woke: {d} bytes restored", .{snapshot.plain_len});
+    return true;
 }
 
 /// Scroll the viewport
@@ -740,6 +1021,19 @@ pub fn processOutput(self: *Termio, buf: []const u8) void {
 
 /// Process output from readdata but the lock is already held.
 fn processOutputLocked(self: *Termio, buf: []const u8) void {
+    // Arriving data wakes a dormant surface before it is parsed: the
+    // terminal field is undefined until the wake rebuilds it. A FAILED
+    // wake drops this buffer rather than parsing into the undefined
+    // terminal -- the surface stays dormant and the next arrival
+    // retries, which in the OOM regime this is costs one chunk of
+    // output instead of the process.
+    if (self.renderer_state.dormant.load(.monotonic)) {
+        if (!self.wakeIfDormantLocked()) {
+            log.warn("dropping {d} bytes: dormant wake failed", .{buf.len});
+            return;
+        }
+    }
+
     // Schedule a render. We can call this first because we have the lock.
     self.terminal_stream.handler.queueRender() catch unreachable;
 

--- a/src/termio/Thread.zig
+++ b/src/termio/Thread.zig
@@ -307,6 +307,17 @@ fn drainMailbox(
     // ENOUGH to not mess up throughput on producers.
     var redraw: bool = false;
     while (mailbox.pop(global.io())) |message| {
+        // A dormant terminal is undefined until woken, and every handler
+        // below can reach it (input writes, resize, config, reports).
+        // The check runs per MESSAGE, not per drain: a go_dormant that
+        // lands mid-batch must not leave the messages queued behind it
+        // running against the terminal it just tore down. A failed wake
+        // ends the drain with the popped message released -- the surface
+        // stays dormant and coherent, and the next drain retries.
+        if (!io.wakeIfDormant()) {
+            message.deinit();
+            break;
+        }
         // If we have a message we always redraw
         redraw = true;
 
@@ -348,6 +359,7 @@ fn drainMailbox(
             .linefeed_mode => |v| self.flags.linefeed_mode = v,
             .focused => |v| try io.focusGained(data, v),
             .deep_idle => io.deepIdleTrim(),
+            .go_dormant => io.goDormant(),
             .write_small => |v| try io.queueWrite(
                 data,
                 v.data[0..v.len],
@@ -450,6 +462,15 @@ fn coalesceCallback(
     if (cb.self.coalesce_data.resize) |v| {
         cb.self.coalesce_data.resize = null;
         cb.io.resize(&cb.data, v) catch |err| {
+            // A failed wake (the OOM regime) dropped this resize AFTER
+            // the pty side of it already happened, so the terminal --
+            // and any dormant snapshot -- keep the old geometry while
+            // the pty carries the new one, until the next resize. The
+            // alternatives are worse: re-queuing from this thread would
+            // make a second producer on the mailbox's SPSC queue, and
+            // spinning on the wake burns the memory the wake is failing
+            // for. A resize landing on a dormant surface already needs
+            // the rarest coincidence in the design.
             log.warn("error during resize err={}", .{err});
         };
     }

--- a/src/termio/message.zig
+++ b/src/termio/message.zig
@@ -88,6 +88,14 @@ pub const Message = union(enum) {
     /// is required to serve input and everything rebuilds lazily.
     deep_idle: void,
 
+    /// Freeze this surface's terminal into a dormant snapshot (Tier C):
+    /// the live structures are torn down and the state exists only as
+    /// bytes until the next input wakes it. Fire-and-forget --
+    /// eligibility is re-checked by the handler against the terminal it
+    /// is about to snapshot, and the is-dormant readback is how a caller
+    /// learns the outcome.
+    go_dormant: void,
+
     /// Record a Kitty clipboard protocol session grant for a password
     /// so future requests carrying it skip the permission prompt, for
     /// reads and writes respectively.

--- a/windows/Ghostty.Tests/Interop/MarshalComplianceTests.cs
+++ b/windows/Ghostty.Tests/Interop/MarshalComplianceTests.cs
@@ -115,7 +115,14 @@ public class MarshalComplianceTests
     public void NativeMethods_HasNoMarshalAsAttributes()
     {
         var source = ReadEmbeddedSource();
-        var offending = ScanForBannedAttribute(source, BannedAttribute);
+        // "[return: MarshalAs" does not contain the bare "[MarshalAs"
+        // substring, so it is listed separately: the two-BOOL-shape rule
+        // (byte for libghostty _Bool, wrapper converts) holds of return
+        // values too, and a return-position attribute would otherwise be
+        // the one import shape the scan never sees.
+        var offending = ScanForBannedTokens(
+            source,
+            new[] { BannedAttribute, "[return: MarshalAs" });
 
         Assert.True(
             offending.Count == 0,

--- a/windows/Ghostty.Tests/Wiring/SurfaceDormantWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/SurfaceDormantWiringTests.cs
@@ -1,0 +1,63 @@
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// Tier C dormancy's managed wiring. The product trigger is deliberately
+/// unwired (the #1051 first-PR scope: machinery in, trigger later), so
+/// the test seam op is the machinery's only driver -- the corpus-wide
+/// pin holds THAT claim, not just the seam's half of it. The
+/// import/export pairing itself is EntryPointParityTests' ground, as
+/// with every other crossing.
+/// </summary>
+public class SurfaceDormantWiringTests
+{
+    [Fact]
+    public void TheSeamIsTheOnlyDriverOfDormancy()
+    {
+        // Text-level corpus sweep, so disabled conditional regions are
+        // seen too (a parse-only sweep is exactly the blind spot the
+        // corpus scanner's own docs warn about). The fully-qualified
+        // call spells the boundary; the definition side in
+        // NativeMethods.cs does not carry the "Interop." receiver.
+        var corpus = ShellSource.AllUnder("Ghostty.Tests.Interop.Sources.Ghostty.");
+        var drivers = corpus
+            .Where(kv => kv.Text.Contains("Interop.NativeMethods.SurfaceGoDormant("))
+            .ToList();
+        Assert.Single(drivers);
+        Assert.EndsWith("Testing.TestSeam.cs", drivers[0].Tail);
+
+        // And that one driver sends exactly once, with one shared
+        // readback serving both "go"'s report and "check"'s.
+        var seam = ShellSource.Load("Ghostty.Testing.TestSeam.cs");
+        Assert.Single(seam.Root.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(i => i.CalleeText() == "Interop.NativeMethods.SurfaceGoDormant"));
+        Assert.Single(seam.Root.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(i => i.CalleeText() == "Interop.NativeMethods.SurfaceIsDormant"));
+    }
+
+    [Fact]
+    public void TheWrappersConvertNativeByteToTrue()
+    {
+        // The one-bit conversion is the wrapper's whole job; an inverted
+        // comparison would flip the seam's "sent" field (a refused freeze
+        // reporting sent:true) and pass a mere call-count pin. The
+        // wrappers are expression-bodied, so the conversion rides the
+        // expression: the native call sits on one side of a != 0.
+        var native = ShellSource.Load("Interop.Imports.NativeMethods.cs");
+        foreach (var name in new[] { "SurfaceGoDormant", "SurfaceIsDormant" })
+        {
+            var method = native.Method(name);
+            var call = Assert.Single(method.DescendantNodes()
+                .OfType<InvocationExpressionSyntax>()
+                .Where(i => i.CalleeText() == name + "Native"));
+            var comparison = call.Ancestors()
+                .OfType<BinaryExpressionSyntax>().FirstOrDefault();
+            Assert.NotNull(comparison);
+            Assert.Equal("!=", comparison!.OperatorToken.ValueText);
+            Assert.Equal("0", comparison.Right.ToString());
+        }
+    }
+}

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -330,8 +330,12 @@ internal static partial class NativeMethods
     /// </remarks>
     [LibraryImport(Dll, EntryPoint = "ghostty_crash_wait_ready")]
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
-    [return: MarshalAs(UnmanagedType.U1)]
-    internal static partial bool CrashWaitReady(uint timeoutMs);
+    private static partial byte CrashWaitReadyNative(uint timeoutMs);
+
+    /// <summary>Raw P/Invoke returns byte (C99 _Bool), like every other
+    /// bool-returning import here; the wrapper converts.</summary>
+    internal static bool CrashWaitReady(uint timeoutMs)
+        => CrashWaitReadyNative(timeoutMs) != 0;
 
     /// <summary>
     /// Initialize libghostty from this process's own command line.
@@ -610,6 +614,32 @@ internal static partial class NativeMethods
     /// </summary>
     internal static void SurfaceSetIdle(GhosttySurface surface, bool idle)
         => SurfaceSetIdleNative(surface, idle ? (byte)1 : (byte)0);
+
+    [LibraryImport(Dll, EntryPoint = "ghostty_surface_go_dormant")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    private static partial byte SurfaceGoDormantNative(GhosttySurface surface);
+
+    /// <summary>
+    /// Freeze a surface's terminal into a dormant snapshot: the live
+    /// structures are torn down on the IO thread and the state exists
+    /// only as compressed bytes until the next input wakes it. Returns
+    /// false when refused outright (an active search); other eligibility
+    /// is re-checked on the IO thread, so poll
+    /// <see cref="SurfaceIsDormant"/> for the outcome. Driven today only
+    /// by the test seam -- the product trigger is deliberately unwired.
+    /// </summary>
+    internal static bool SurfaceGoDormant(GhosttySurface surface)
+        => SurfaceGoDormantNative(surface) != 0;
+
+    [LibraryImport(Dll, EntryPoint = "ghostty_surface_is_dormant")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    private static partial byte SurfaceIsDormantNative(GhosttySurface surface);
+
+    /// <summary>Whether the surface's terminal is currently torn down
+    /// into its dormant snapshot (lock-free read of the shared
+    /// flag).</summary>
+    internal static bool SurfaceIsDormant(GhosttySurface surface)
+        => SurfaceIsDormantNative(surface) != 0;
 
     /// <summary>Scrollback compression counters for one surface's primary
     /// screen, read from the page list under the renderer state mutex.

--- a/windows/Ghostty/Testing/TestSeam.cs
+++ b/windows/Ghostty/Testing/TestSeam.cs
@@ -999,6 +999,39 @@ internal static class TestSeam
                 });
             }
 
+            case "surface-dormant":
+            {
+                // Tier C dormancy driver: "go" asks the surface's
+                // terminal to freeze into its snapshot (fire-and-forget
+                // across the IO thread; read back with "check", which a
+                // harness polls), "check" only reads the flag. The
+                // product trigger is deliberately unwired, so this op
+                // is the only driver the dormancy machinery has.
+                var index = ArgInt(args, "index", -1);
+                var tab = TabAt(manager, index);
+                if (tab is null) return Error(op, $"no tab at index {index}");
+                var handle = tab.PaneHost.ActiveLeaf.Terminal().SurfaceHandle;
+                if (handle == IntPtr.Zero)
+                    return Error(op, $"tab {index} has no live surface");
+                var mode = ArgString(args, "mode") ?? "go";
+                var sent = false;
+                if (mode == "go")
+                    sent = Interop.NativeMethods.SurfaceGoDormant(
+                        new Interop.GhosttySurface(handle));
+                else if (mode != "check")
+                    return Error(op, $"unknown mode '{mode}' (go or check)");
+                return Json(json =>
+                {
+                    json.WriteStartObject();
+                    json.WriteBoolean("ok", true);
+                    json.WriteString("op", op);
+                    json.WriteBoolean("sent", sent);
+                    json.WriteBoolean("dormant", Interop.NativeMethods.SurfaceIsDormant(
+                        new Interop.GhosttySurface(handle)));
+                    json.WriteEndObject();
+                });
+            }
+
             case "header-rect":
             {
                 var index = ArgInt(args, "index", -1);

--- a/windows/scripts/dormant-check.ps1
+++ b/windows/scripts/dormant-check.ps1
@@ -1,0 +1,201 @@
+#requires -Version 7
+<#
+    Dormant surfaces (Tier C), measured against the running app.
+
+    The dormancy machinery has no product trigger yet (the #1051 first
+    PR scope): this harness drives it through the surface-dormant seam
+    op and asserts the lifecycle the reviewers held it to:
+
+      1. GO: a hidden tab freezes; the is-dormant readback flips and
+         the surface-mem census reads all zeros (a dormant terminal
+         must not be walked, even for a census).
+      2. WAKE BY SHOW (the occlusion transition is a wake): selecting
+         the tab unfreezes it -- the renderer's visible-transition
+         rebuild reads a LIVE terminal, not freed pages.
+      3. WAKE BY DATA: output arriving into a dormant tab rebuilds the
+         terminal before it is parsed, and the tab still executes
+         (the shell answers with a second title marker).
+      4. QUIT DORMANT: stopping the session with a tab still dormant
+         tears down cleanly (a dormant close must not double-deinit
+         the terminal or leak its snapshot).
+
+    Exits 0 clean, 2 finding, 1 could-not-run.
+#>
+param([Parameter(Mandatory)][string]$ExePath)
+. (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
+. (Join-Path $PSScriptRoot 'lib/seam-client.ps1')
+$ErrorActionPreference = 'Stop'
+
+$Config = @"
+windows-single-instance = true
+window-save-state = never
+"@
+
+function Invoke-SeamCommandBounded($Session, [hashtable]$Command, [int]$TimeoutMs) {
+    Send-SeamCommand $Session $Command
+    $readTask = $Session.Reader.ReadLineAsync()
+    if (-not $readTask.Wait($TimeoutMs)) {
+        throw ("HANG: no response to '{0}' within {1}ms" -f $Command['op'], $TimeoutMs)
+    }
+    $line = $readTask.Result
+    if ($null -eq $line) { throw ("closed without response to '{0}'" -f $Command['op']) }
+    $response = $line | ConvertFrom-Json
+    if (-not $response.ok) { throw ("{0} -> {1}" -f $Command['op'], $response.error) }
+    return $response
+}
+
+# Poll the dormant readback until it flips (or fail).
+function Wait-Dormant($Session, [int]$Index, [bool]$Want, [int]$TimeoutMs) {
+    $deadline = [DateTime]::UtcNow.AddMilliseconds($TimeoutMs)
+    while ([DateTime]::UtcNow -lt $deadline) {
+        $r = Invoke-SeamCommandBounded $Session @{ op = 'surface-dormant'; index = $Index; mode = 'check' } 5000
+        if ($r.dormant -eq $Want) { return $true }
+        Start-Sleep -Milliseconds 100
+    }
+    return $false
+}
+
+$script:Findings = [System.Collections.Generic.List[string]]::new()
+$harnessError = ''
+$session = $null
+
+$ownLock = $null
+try {
+    . C:\temp\seam-lock.ps1
+    $ownLock = Enter-SeamLock -Owner 'dormant-check'
+
+    Assert-NoWintty -Context 'the dormant check'
+    $session = Start-SeamSession -ExePath $ExePath -ConfigText $Config -AllowInput
+    if (-not (Wait-SeamReady $session.Proc)) { throw 'SEAM_REFUSED: app never announced the pipe' }
+
+    # Same shell-agnostic seeding as the shed harness: seed-tabs spawns
+    # cmd.exe, so pwsh is spawned inside the tab, and titles are seeded
+    # empty so the OSC markers below are what get-state reads.
+    [void](Invoke-SeamCommand $session @{ op = 'seed-tabs'; count = 2; titles = @('', '') })
+    Start-Sleep -Seconds 3
+    [void](Invoke-SeamCommand $session @{ op = 'send-text'; index = 1; text = 'pwsh -NoProfile' + [char]13 })
+    Start-Sleep -Seconds 3
+    [void](Invoke-SeamCommand $session @{
+        op = 'send-text'
+        index = 1
+        text = '$Host.UI.RawUI.WindowTitle = "AWAKE-1"' + [char]13
+    })
+    # Poll for the marker: pwsh's cold start varies by seconds on a
+    # loaded machine, and a single fixed sleep made this a coin flip.
+    $title = ''
+    $deadline = [DateTime]::UtcNow.AddSeconds(20)
+    while ([DateTime]::UtcNow -lt $deadline -and $title -ne 'AWAKE-1') {
+        Start-Sleep -Seconds 1
+        $st = Invoke-SeamCommand $session @{ op = 'get-state' }
+        $title = $st.state.tabs[1].title
+    }
+    if ($title -ne 'AWAKE-1') {
+        $script:Findings.Add("setup: tab 1 title is '$title', expected AWAKE-1 -- the shell marker never landed; everything below would be blind")
+    }
+
+    # Hide the tab under test: dormancy refuses visible surfaces.
+    [void](Invoke-SeamCommand $session @{ op = 'select'; index = 0 })
+    Start-Sleep -Seconds 1
+
+    # --- 1. GO ---------------------------------------------------------
+    $go = Invoke-SeamCommandBounded $session @{ op = 'surface-dormant'; index = 1; mode = 'go' } 5000
+    if (-not $go.sent) { $script:Findings.Add("go: the seam reported the request refused outright (active search?)") }
+    if (-not (Wait-Dormant $session 1 $true 10000)) {
+        $script:Findings.Add("go: is-dormant never flipped true within 10s -- eligibility refused or the freeze died on the IO thread")
+    } else {
+        Write-Host 'go: dormant'
+    }
+
+    # A dormant terminal must read as zero pages in the census: the
+    # guard (not the walk) is what answers.
+    $mem = Invoke-SeamCommandBounded $session @{ op = 'surface-mem'; index = 1 } 5000
+    if ($mem.totalPages -ne 0 -or $mem.activitySerial -ne 0) {
+        $script:Findings.Add("census: dormant surface-mem read totalPages=$($mem.totalPages) serial=$($mem.activitySerial); the dormant guard did not answer the census")
+    } else {
+        Write-Host 'census: dormant reads zero'
+    }
+
+    # --- 2. WAKE BY SHOW (occlusion transition) -------------------------
+    [void](Invoke-SeamCommand $session @{ op = 'select'; index = 1 })
+    if (-not (Wait-Dormant $session 1 $false 10000)) {
+        $script:Findings.Add("show-wake: selecting the dormant tab never woke it within 10s -- the renderer's visible transition ran against freed pages or never ran")
+    } else {
+        Write-Host 'show-wake: awake'
+    }
+
+    # --- 3. WAKE BY DATA -------------------------------------------------
+    # Hide, freeze again, then let output do the waking; the shell's
+    # answer proves the parse landed in a REBUILT terminal. The settle
+    # beat after hiding exists because the activation above flushes the
+    # hidden-title queue, and output arriving in the same instant as the
+    # freeze is a wake racing a dormancy -- the freeze wins on the IO
+    # thread, but the readback below should not have to depend on that.
+    [void](Invoke-SeamCommand $session @{ op = 'select'; index = 0 })
+    Start-Sleep -Seconds 2
+    [void](Invoke-SeamCommandBounded $session @{ op = 'surface-dormant'; index = 1; mode = 'go' } 5000
+    ) | Out-Null
+    Start-Sleep -Seconds 1
+    if (-not (Wait-Dormant $session 1 $true 10000)) {
+        $script:Findings.Add("data-wake setup: the second freeze never landed")
+    } else {
+        [void](Invoke-SeamCommand $session @{
+            op = 'send-text'
+            index = 1
+            text = '$Host.UI.RawUI.WindowTitle = "WOKEN-2"' + [char]13
+        })
+        if (-not (Wait-Dormant $session 1 $false 15000)) {
+            $script:Findings.Add("data-wake: output into the dormant tab never woke it within 15s")
+        } else {
+            # Hidden-tab titles queue until activation (#1035 semantics,
+            # pre-dating dormancy), so the shell's answer is read the way
+            # a user would: look at the tab, then read its title.
+            [void](Invoke-SeamCommand $session @{ op = 'select'; index = 1 })
+            $deadline = [DateTime]::UtcNow.AddSeconds(15)
+            $title = ''
+            while ([DateTime]::UtcNow -lt $deadline -and $title -ne 'WOKEN-2') {
+                Start-Sleep -Seconds 1
+                $st = Invoke-SeamCommand $session @{ op = 'get-state' }
+                $title = $st.state.tabs[1].title
+            }
+            if ($title -ne 'WOKEN-2') {
+                $script:Findings.Add("data-wake: woke, but the shell never answered (title '$title') -- the parse after wake did not land in a working terminal")
+            } else {
+                Write-Host 'data-wake: woke and executing'
+            }
+        }
+    }
+
+    # --- 4. QUIT DORMANT --------------------------------------------------
+    # Leave tab 1 frozen on the way out: the session stop tears the app
+    # down through the dormant Termio deinit. A clean stop (no crash
+    # artifacts) is the assert; the teardown asserts live in the exit.
+    # Re-hide first: dormancy refuses visible surfaces, and the data-wake
+    # check above left the tab selected.
+    [void](Invoke-SeamCommand $session @{ op = 'select'; index = 0 })
+    Start-Sleep -Seconds 1
+    [void](Invoke-SeamCommandBounded $session @{ op = 'surface-dormant'; index = 1; mode = 'go' } 5000)
+    if (-not (Wait-Dormant $session 1 $true 10000)) {
+        $script:Findings.Add("quit-dormant setup: the final freeze never landed")
+    } else {
+        Write-Host 'quit-dormant: frozen; stopping session'
+    }
+}
+catch {
+    $harnessError = $_.Exception.Message
+}
+finally {
+    if ($session) { Stop-SeamSession $session }
+    if ($ownLock) { Exit-SeamLock $ownLock }
+}
+
+if ($harnessError) {
+    Write-Host "HARNESS ERROR: $harnessError"
+    exit 1
+}
+if ($script:Findings.Count -gt 0) {
+    Write-Host 'FINDINGS:'
+    $script:Findings | ForEach-Object { Write-Host "  - $_" }
+    exit 2
+}
+Write-Host 'dormant-check: clean'
+exit 0


### PR DESCRIPTION
Tier C of the idle-footprint work (#1051), on top of #1057. The in-tree GHOSTSNP v1 snapshot serde (src/terminal/snapshot/) gets its first app consumer: a hidden, eligible surface can tear its terminal down into compressed bytes and rebuild it at the same address on the next input.

## The machinery

- **Dormant transition** (IO thread, renderer_state.mutex): eligibility re-checked against the terminal in hand (inspector, visible, kitty images, glyph glossary, kitty_dnd, active selection on either screen, search published under the mutex); encode with the stream's continuation (tracking now enabled on the app stream, 1 MiB cap); wrap in one raw LZ4 block via the in-tree codec (the v1 stream is an uncompressed logical encoding -- unwrapped, a dormant heavy session would outweigh the #1039-compressed pages it replaces); scrub+free the plain buffer; capture presentation flags (v1 does not carry them) and deinit the terminal in place.
- **Wake is the single mandatory gateway**: arriving pty data (buffer dropped, logged, retried next arrival on a failed wake), every termio mailbox message (per-message, message released on the failed-wake break), the occlusion/focus transitions, the four pull reads (read_text/read_selection/read_cells/quicklook -- the tab overview reads exactly the dormant-candidate tabs), and the six input exports -- input IS a wake. Rebuild: decompress -> decodeExact -> store at the terminal's own address (renderer_state.terminal and the handler pointer survive) -> restore presentation flags -> reset the stream -> replay the continuation once -> scrub and free both copies.
- **Reader guards**: the compression scheduler (wake and step paths), updateFrame (backstop), memory_stats (zero census), the Exec termios poll, synchronized-output reset, coalesced resize (drops with the geometry-mismatch tradeoff spelled out -- the SPSC queue forbids re-queuing from the IO thread).
- **Dormant-aware teardown**: closing a dormant surface frees and scrubs the snapshot instead of double-deiniting the terminal; the selection-gesture deinit skips.
- **Seam, deliberately triggerless**: ghostty_surface_go_dormant / _is_dormant, driven only by the new surface-dormant seam op (mode go/check). No product trigger in this PR -- the idle-threshold + config knob is its own follow-up, and so is the wake-at-callback-entries close noted on #1051.

## Security

RAM-only by construction. The plain snapshot and the compressed block are both scrubbed on every exit path; closing dormant scrubs too. The hang-dump overlap (#1045) is inherited, not widened: the full-memory dump already captures the live scrollback, the snapshot is a second copy of the same secrets.

## Verification

- `windows/scripts/dormant-check.ps1`: full lifecycle against the live app -- go -> zero census -> wake-by-show -> re-freeze -> wake-by-data (shell executes; title round-trips per the established #1035 hidden-title activation semantics) -> quit-dormant clean teardown. Three consecutive clean runs; during development it caught two real defects live (the scrollViewport poison write through the input path, and the presentation-flags refusal loop).
- Zig: the dormant LZ4-container round trip against the checked-in snapshot fixture; the full snapshot family green.
- C#: SurfaceDormantWiringTests (corpus-wide only-driver sweep, byte-conversion polarity pins), EntryPointParity/MarshalCompliance green -- including a scanner hardening that closes the `[return: MarshalAs` blind spot (the one pre-existing exception, CrashWaitReady, converted to the file's byte discipline).

Reviewed by two personas (Zig lifecycle -- two adversarial passes whose 15 combined findings are all addressed in-tree or logged on #1051; C# wiring). Known accepted edges: viewport scroll offset does not survive dormancy (v1), one-shot decode means the wake cost is the full history under the mutex (the READY-boundary incremental decoder is the documented follow-up), resize-during-failed-wake drops the resize until the next one. Part of #1051.

Size-override: the bulk is one inseparable concern -- the dormant-wake perimeter the lifecycle review required (wake sites, reader guards, dormant-aware teardown) around a single dormancy core; splitting it would merge a known-crashing core first. The rest is the seam op, its tests, and the harness.
