### PR TITLE
renderer: say when a surface is never coming back

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -868,6 +868,7 @@ typedef struct {
 typedef enum {
   GHOSTTY_RENDERER_HEALTH_HEALTHY,
   GHOSTTY_RENDERER_HEALTH_UNHEALTHY,
+  GHOSTTY_RENDERER_HEALTH_ABANDONED,
 } ghostty_action_renderer_health_e;
 
 // renderer.CustomShaderFailure

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -47,8 +47,21 @@ pub const Renderer = switch (build_config.renderer) {
 /// renderers even if some states aren't reachable so that our API users
 /// can use the same enum for all renderers.
 pub const Health = enum(c_int) {
+    /// Drawing normally.
     healthy,
+
+    /// Not drawing, and expected to recover. On Windows this is a lost
+    /// GPU device with a rebuild under way: the surface keeps showing
+    /// whatever frame was on it when the device died until that lands.
     unhealthy,
+
+    /// Not drawing, and nothing will try again. Separate from
+    /// `unhealthy` because it is the one state where waiting is not the
+    /// answer, and an embedder that cannot tell them apart has to
+    /// either promise a recovery that will never come or withhold one
+    /// that is seconds away. Appended rather than inserted so the two
+    /// ordinals that already crossed the ABI keep their values.
+    abandoned,
 
     test "ghostty.h Health" {
         try lib.checkGhosttyHEnum(Health, "GHOSTTY_RENDERER_HEALTH_");

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -352,15 +352,19 @@ fn drainMailbox(self: *Thread) !void {
                 // Visibility affects our QoS class
                 self.setQosClass();
 
+                // Notify the renderer so it can update any state. Before the
+                // forced draw below, not after: becoming visible arms a
+                // health re-report that the next draw carries, and arming it
+                // afterwards would leave that to whatever draw happened to
+                // come next.
+                self.renderer.setVisible(v);
+
                 // If we became visible then we immediately rebuild cells
                 // (renderCallback skips updateFrame while invisible) and
                 // draw. Going through renderCallback also reschedules
                 // any Kitty graphics animation wakeup that lapsed
                 // while we were invisible.
                 if (v) _ = renderCallback(self, undefined, undefined, {});
-
-                // Notify the renderer so it can update any state.
-                self.renderer.setVisible(v);
 
                 // Hiding is the strongest "activity stopped" signal a
                 // surface gets, and it is also the moment this thread's

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1305,7 +1305,17 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 // the animation rate for the life of the tab -- and a
                 // custom shader is exactly what tends to get a surface
                 // abandoned in the first place.
-                if (self.device_recovery_abandoned) return null;
+                //
+                // One exception: a health report we still owe. The push is
+                // best-effort against a full mailbox and only retries from
+                // a draw, and an abandoned surface has no other draw source
+                // once its shell goes quiet -- so without this a pane the
+                // embedder has been told to stop watching could stay
+                // silently dark with nothing left to say so.
+                if (self.device_recovery_abandoned) {
+                    if (!self.health_report_pending.load(.acquire)) return null;
+                    return .{ .delay_ms = draw_interval_ms, .kind = .draw };
+                }
                 if (self.device_recovery_retry_at) |at| {
                     const now: std.Io.Timestamp = .now(global.io(), recovery_clock);
                     const remaining_ms = now.durationTo(at).toMilliseconds();
@@ -1392,6 +1402,16 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         pub fn setVisible(self: *Self, visible: bool) void {
             self.visible = visible;
             self.syncDisplayLink(null, null);
+
+            // Coming back into view, re-send the health we last reported
+            // even though it has not changed. Health is edge-triggered,
+            // and a surface that went unhealthy and was then hidden has
+            // no edge left to send: an embedder that stopped counting a
+            // pane it could not show the user has no other way to learn
+            // what it is looking at now. The push itself rides the retry
+            // in `drawFrame`, which runs on the draw the visible
+            // transition already forces.
+            if (visible) self.health_report_pending.store(true, .release);
 
             // When we're hidden, release our GPU resources if GPU
             // operations are allowed from this thread. Apprts where
@@ -2500,10 +2520,12 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         /// carries no clock tag, so two clocks would compare silently.
         const recovery_clock: std.Io.Clock = .boot;
 
-        /// Stop rebuilding this surface's device. It stays dark and
-        /// unhealthy until the tab is closed, because every remaining
-        /// option is worse: a rebuild loop burns a core and fills the log
-        /// forever, and there is nothing else here that can fix a GPU.
+        /// Stop rebuilding this surface's device. It stays dark until the
+        /// tab is closed, because every remaining option is worse: a
+        /// rebuild loop burns a core and fills the log forever, and there
+        /// is nothing else here that can fix a GPU. The surface reports
+        /// `.abandoned` so the embedder can say that rather than leave
+        /// the user waiting on a rebuild that is not coming.
         fn abandonRecovery(self: *Self, reason: AbandonReason) void {
             // Idempotent, so the first reason recorded is the true one.
             // An abandon on one path can be followed by the errdefer
@@ -2511,7 +2533,13 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // lines are worse than one.
             if (self.device_recovery_abandoned) return;
             self.device_recovery_abandoned = true;
-            self.reportHealth(.unhealthy);
+            // `.abandoned`, not `.unhealthy`. The surface is already
+            // unhealthy by the time anything gives up on it, and
+            // `reportHealth` drops a report that repeats the current
+            // value -- so reporting unhealthy here told nobody anything,
+            // and an embedder had no way to tell a rebuild in progress
+            // from one that will never come.
+            self.reportHealth(.abandoned);
 
             // Only blame a shader that was actually built and bound, and
             // only for the reason it could plausibly have caused. See

--- a/windows/Ghostty.Core/Renderer/RendererHealth.cs
+++ b/windows/Ghostty.Core/Renderer/RendererHealth.cs
@@ -19,4 +19,11 @@ public enum RendererHealth
 {
     Healthy = 0,
     Unhealthy = 1,
+
+    /// <summary>
+    /// The renderer has stopped trying to rebuild this surface. It will not
+    /// come back on its own, so the only advice that helps is to open a new
+    /// tab; waiting is exactly the wrong thing.
+    /// </summary>
+    Abandoned = 2,
 }

--- a/windows/Ghostty.Core/Renderer/RendererHealthNoticeSource.cs
+++ b/windows/Ghostty.Core/Renderer/RendererHealthNoticeSource.cs
@@ -48,14 +48,33 @@ public sealed class RendererHealthNoticeSource
     // frame-completion, not per change, on some paths -- cannot inflate it.
     private readonly HashSet<nint> _unhealthy = new();
 
+    // The surfaces the renderer has given up on. Held apart from _unhealthy
+    // rather than folded in, because the two need opposite advice: one is
+    // "wait", the other is "this pane is not coming back". The Update arms
+    // keep them disjoint, so a pane is in at most one.
+    private readonly HashSet<nint> _abandoned = new();
+
     // The banner currently on screen, kept because Dismiss takes the instance.
     private Notice? _active;
 
-    // Set when the viewer closed the banner themselves. Distinct from _active
-    // being null, because the two mean opposite things for what to do next:
-    // no banner because the outage ended, versus no banner because they have
-    // already read this one and put it away.
-    private bool _dismissedByViewer;
+    // Which of the two banners _active is, so a pane being given up on while
+    // the "rebuilding" banner is up replaces it rather than being swallowed.
+    private bool _activeIsAbandoned;
+
+    // How bad the news is. Ordered, because what the viewer has already been
+    // told is only worth repeating when it gets worse.
+    private enum Level
+    {
+        Rebuilding,
+        Abandoned,
+    }
+
+    // The most severe banner the viewer has closed during this outage, or
+    // null if they have closed none. A dismissal means "I have seen enough
+    // about this outage", so this level and anything below it stays quiet;
+    // only something worse is worth raising again. Cleared when every pane
+    // recovers, so the next outage speaks up.
+    private Level? _dismissed;
 
     /// <summary>
     /// Record what one surface reported.
@@ -66,9 +85,17 @@ public sealed class RendererHealthNoticeSource
     /// </returns>
     public RendererHealthNoticeChange Update(nint surface, RendererHealth health)
     {
-        var changed = health == RendererHealth.Unhealthy
-            ? _unhealthy.Add(surface)
-            : _unhealthy.Remove(surface);
+        var changed = health switch
+        {
+            // Abandoned is terminal, so the pane moves out of the set that
+            // still expects a recovery.
+            RendererHealth.Abandoned => _abandoned.Add(surface) | _unhealthy.Remove(surface),
+            // Removing from _abandoned keeps the sets disjoint by
+            // construction rather than by trusting the renderer never to
+            // walk that transition back.
+            RendererHealth.Unhealthy => _unhealthy.Add(surface) | _abandoned.Remove(surface),
+            _ => _unhealthy.Remove(surface) | _abandoned.Remove(surface),
+        };
 
         return changed ? Reconcile() : default;
     }
@@ -79,50 +106,90 @@ public sealed class RendererHealthNoticeSource
     /// </summary>
     /// <returns>What to do about the banner.</returns>
     public RendererHealthNoticeChange Forget(nint surface) =>
-        _unhealthy.Remove(surface) ? Reconcile() : default;
+        _unhealthy.Remove(surface) | _abandoned.Remove(surface) ? Reconcile() : default;
 
     private RendererHealthNoticeChange Reconcile()
     {
-        if (_unhealthy.Count > 0)
+        // A pane nothing will rebuild outranks one still being retried: its
+        // advice is the only advice that helps, and it is the only pane the
+        // user has to act on themselves.
+        var wantAbandoned = _abandoned.Count > 0;
+        var want = wantAbandoned || _unhealthy.Count > 0;
+
+        if (want)
         {
-            // One banner per outage. A viewer who closed it is not shown it
-            // again while the same panes are still down; the flag clears when
-            // they all recover, so the next outage speaks up.
-            if (_active is not null || _dismissedByViewer) return default;
+            var level = wantAbandoned ? Level.Abandoned : Level.Rebuilding;
+
+            // Already saying the right thing.
+            if (_active is not null && _activeIsAbandoned == wantAbandoned) return default;
+
+            // The viewer has already been told this much. Take down whatever
+            // is up if it now says the wrong thing, but do not raise it again.
+            if (_dismissed is { } seen && seen >= level)
+            {
+                return Retract();
+            }
+
+            // Changing level replaces the banner. Both share a DedupKey, so
+            // the old one has to come down first or Show is a no-op -- which
+            // is why the caller applies Dismiss before Show.
+            var stale = _active;
 
             // OnDismiss fires for our own Dismiss as well as for the close X,
             // and only the second one should latch. Comparing against _active
-            // tells them apart: the recovery path below always clears _active
-            // before handing the notice back, so by the time that dismissal
-            // lands this no longer matches.
+            // tells them apart: we always clear or replace _active before
+            // handing a notice back to be dismissed, so by the time that
+            // dismissal lands this no longer matches.
             Notice? raised = null;
-            raised = Build(() =>
+            raised = Build(wantAbandoned, () =>
             {
-                if (ReferenceEquals(_active, raised)) _dismissedByViewer = true;
+                if (!ReferenceEquals(_active, raised)) return;
+                _dismissed = level;
             });
             _active = raised;
-            return new RendererHealthNoticeChange(Show: raised, Dismiss: null);
+            _activeIsAbandoned = wantAbandoned;
+            return new RendererHealthNoticeChange(Show: raised, Dismiss: stale);
         }
 
-        _dismissedByViewer = false;
-        if (_active is null) return default;
-        var stale = _active;
-        _active = null;
-        return new RendererHealthNoticeChange(Show: null, Dismiss: stale);
+        // The outage is over, so the next one starts from a clean slate.
+        _dismissed = null;
+        return Retract();
     }
 
-    private static Notice Build(Action onDismiss) => new()
+    // Take the banner down, whatever it was saying, and report that.
+    private RendererHealthNoticeChange Retract()
     {
-        Title = "Graphics device lost",
-        Message =
-            "The GPU stopped responding and Wintty is trying to rebuild the "
-            + "renderer. Affected panes stay frozen until it succeeds, and some "
-            + "may not come back at all. This usually follows a graphics driver "
-            + "update or crash; if it keeps happening, check for a driver update "
-            + "and try clearing custom-shader.",
-        // Warning, not Error: the terminal session itself is untouched -- the
-        // shell keeps running and the scrollback is intact -- so nothing the
-        // user typed is at risk even when a pane never repaints.
+        if (_active is null) return default;
+        var last = _active;
+        _active = null;
+        _activeIsAbandoned = false;
+        return new RendererHealthNoticeChange(Show: null, Dismiss: last);
+    }
+
+    private static Notice Build(bool abandoned, Action onDismiss) => new()
+    {
+        Title = abandoned ? "Graphics device gave out" : "Graphics device lost",
+        Message = abandoned
+            // The only case where the user has something to do, and the only
+            // one where waiting is the wrong advice.
+            // The reason does not cross the ABI, only the state does, so this
+            // cannot say which of the three reasons applied. The renderer
+            // blames a custom-shader for exactly one of them and refuses to
+            // for the other two, so this offers it as something to try rather
+            // than as the likely cause; the log line names it when it is.
+            ? "Wintty has stopped trying to rebuild the renderer for one or more "
+              + "panes, so those will not come back on their own. Open a new tab "
+              + "to carry on; the shell in the frozen pane is still running and "
+              + "its scrollback is intact. If you use a custom-shader, it is "
+              + "worth checking whether this still happens without it."
+            : "The GPU stopped responding and Wintty is trying to rebuild the "
+              + "renderer. Affected panes stay frozen until it succeeds. This "
+              + "usually follows a graphics driver update or crash; if it keeps "
+              + "happening, check for a driver update and try clearing "
+              + "custom-shader.",
+        // Warning, not Error, in both cases: the terminal session itself is
+        // untouched -- the shell keeps running and the scrollback is intact --
+        // so nothing the user typed is at risk even when a pane never repaints.
         Severity = NoticeSeverity.Warning,
         DedupKey = DedupKey,
         // Fires for the close X as well as our own Dismiss, which is why the
@@ -138,6 +205,11 @@ public sealed class RendererHealthNoticeSource
 
 /// <summary>
 /// What <see cref="RendererHealthNoticeSource"/> wants done about the banner.
-/// At most one half is set; both are null when nothing changed.
+/// Both are null when nothing changed. Either half can be set on its own, and
+/// BOTH are set when one banner replaces another — callers must apply
+/// <see cref="Dismiss"/> before <see cref="Show"/>, because the two share a
+/// <see cref="Notice.DedupKey"/> and showing first makes the replacement a
+/// no-op. Every call site has to handle both halves; one that applies only
+/// the dismissal drops a banner other panes still need.
 /// </summary>
 public readonly record struct RendererHealthNoticeChange(Notice? Show, Notice? Dismiss);

--- a/windows/Ghostty.Tests/Renderer/RendererHealthNoticeSourceTests.cs
+++ b/windows/Ghostty.Tests/Renderer/RendererHealthNoticeSourceTests.cs
@@ -199,9 +199,8 @@ public class RendererHealthNoticeSourceTests
     [Fact]
     public void The_copy_never_promises_the_renderer_comes_back()
     {
-        // A surface the renderer has given up on stays dark for the life of
-        // the tab. Copy saying the rebuild finishes would leave that user
-        // waiting on something that is never going to happen.
+        // The rebuilding banner may say it is trying, never that it will
+        // succeed. When it does not, the abandoned banner replaces it.
         var notice = new RendererHealthNoticeSource().Update(PaneA, RendererHealth.Unhealthy).Show;
 
         Assert.NotNull(notice);
@@ -210,7 +209,170 @@ public class RendererHealthNoticeSourceTests
             Assert.DoesNotContain(phrase, notice!.Message, System.StringComparison.OrdinalIgnoreCase);
         }
 
-        // And says so positively, rather than only avoiding the promise.
-        Assert.Contains("may not come back", notice!.Message, System.StringComparison.OrdinalIgnoreCase);
+        // And says what it does mean, rather than only avoiding the promise:
+        // a message that said nothing at all would pass the check above.
+        Assert.Contains("trying to rebuild", notice!.Message, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Dropping_an_abandoned_pane_hands_back_the_rebuilding_banner()
+    {
+        // The case that made Forget able to return a Show for the first time.
+        // A caller applying only the Dismiss half here takes the banner away
+        // from panes that are still frozen, and then suppresses every later
+        // report because the source believes a banner is up.
+        var source = new RendererHealthNoticeSource();
+        source.Update(PaneB, RendererHealth.Unhealthy);
+        var abandoned = source.Update(PaneA, RendererHealth.Abandoned).Show;
+        Assert.NotNull(abandoned);
+
+        var change = source.Forget(PaneA);
+
+        Assert.Same(abandoned, change.Dismiss);
+        Assert.NotNull(change.Show);
+        Assert.NotSame(abandoned, change.Show);
+    }
+
+    [Fact]
+    public void A_pane_reported_unhealthy_after_abandoned_leaves_the_abandoned_set()
+    {
+        // The renderer does not walk that transition back today. The sets are
+        // kept disjoint by construction rather than by trusting it not to.
+        var source = new RendererHealthNoticeSource();
+        source.Update(PaneA, RendererHealth.Abandoned);
+
+        source.Update(PaneA, RendererHealth.Unhealthy);
+
+        // If PaneA were still counted as abandoned, this would have nothing
+        // to dismiss and the banner would outlive the outage.
+        Assert.NotNull(source.Update(PaneA, RendererHealth.Healthy).Dismiss);
+    }
+
+    [Fact]
+    public void Dismissing_the_abandoned_banner_is_not_undone_by_dropping_back()
+    {
+        var source = new RendererHealthNoticeSource();
+        source.Update(PaneB, RendererHealth.Unhealthy);
+        var abandoned = source.Update(PaneA, RendererHealth.Abandoned).Show;
+        abandoned!.OnDismiss!();
+
+        // Closing the abandoned pane's tab leaves PaneB still rebuilding.
+        // That is weaker news than what they just put away, so it must not
+        // come back at them.
+        var change = source.Forget(PaneA);
+        Assert.Null(change.Show);
+    }
+
+    [Fact]
+    public void Both_banners_keep_the_session_out_of_it()
+    {
+        // The shell keeps running through either state. Copy implying
+        // otherwise would send the user rebuilding a session that is fine.
+        foreach (var health in new[] { RendererHealth.Unhealthy, RendererHealth.Abandoned })
+        {
+            var notice = new RendererHealthNoticeSource().Update(PaneA, health).Show;
+            Assert.NotNull(notice);
+            var text = notice!.Title + " " + notice.Message;
+            foreach (var word in new[] { "closed", "lost your", "restart" })
+            {
+                Assert.DoesNotContain(word, text, System.StringComparison.OrdinalIgnoreCase);
+            }
+        }
+    }
+
+    [Fact]
+    public void The_abandoned_copy_does_not_call_a_shader_the_likely_cause()
+    {
+        // The renderer blames a custom-shader for one of its three abandon
+        // reasons and refuses to for the other two, and the reason does not
+        // cross the ABI. So this can offer the shader as something to try,
+        // never as the cause.
+        var notice = new RendererHealthNoticeSource().Update(PaneA, RendererHealth.Abandoned).Show;
+
+        Assert.NotNull(notice);
+        foreach (var phrase in new[] { "most likely cause", "is why", "because of" })
+        {
+            Assert.DoesNotContain(phrase, notice!.Message, System.StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
+    public void An_abandoned_pane_replaces_the_rebuilding_banner()
+    {
+        var source = new RendererHealthNoticeSource();
+        var rebuilding = source.Update(PaneA, RendererHealth.Unhealthy).Show;
+        Assert.NotNull(rebuilding);
+
+        var change = source.Update(PaneA, RendererHealth.Abandoned);
+
+        // Both halves, and the old one must come down: they share a DedupKey,
+        // so a Show on its own would be swallowed and the user would go on
+        // reading advice that no longer applies.
+        Assert.Same(rebuilding, change.Dismiss);
+        Assert.NotNull(change.Show);
+        Assert.NotSame(rebuilding, change.Show);
+    }
+
+    [Fact]
+    public void The_abandoned_copy_says_the_pane_is_not_coming_back()
+    {
+        var notice = new RendererHealthNoticeSource().Update(PaneA, RendererHealth.Abandoned).Show;
+
+        Assert.NotNull(notice);
+        var text = notice!.Message;
+        Assert.Contains("will not come back", text, System.StringComparison.OrdinalIgnoreCase);
+        // And tells them the one thing that actually helps.
+        Assert.Contains("new tab", text, System.StringComparison.OrdinalIgnoreCase);
+        // Without implying the session died with the pane.
+        Assert.Contains("still running", text, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void An_abandoned_pane_outranks_a_pane_still_being_retried()
+    {
+        var source = new RendererHealthNoticeSource();
+        var abandoned = source.Update(PaneA, RendererHealth.Abandoned).Show;
+        Assert.NotNull(abandoned);
+
+        // A second pane merely unhealthy must not downgrade the banner: the
+        // abandoned pane's advice is the only advice that helps.
+        var change = source.Update(PaneB, RendererHealth.Unhealthy);
+        Assert.Null(change.Show);
+        Assert.Null(change.Dismiss);
+    }
+
+    [Fact]
+    public void An_escalation_overrides_a_banner_the_viewer_dismissed()
+    {
+        var source = new RendererHealthNoticeSource();
+        var rebuilding = source.Update(PaneA, RendererHealth.Unhealthy).Show;
+        rebuilding!.OnDismiss!();
+
+        // They put away "we are rebuilding". "It is not coming back" is new
+        // information and has to reach them anyway.
+        Assert.NotNull(source.Update(PaneA, RendererHealth.Abandoned).Show);
+    }
+
+    [Fact]
+    public void An_abandoned_pane_that_closes_clears_the_banner()
+    {
+        // Abandoned is terminal, so closing the tab is the only way this pane
+        // ever leaves the set. If Forget missed it the banner would outlive
+        // every pane it referred to.
+        var source = new RendererHealthNoticeSource();
+        var raised = source.Update(PaneA, RendererHealth.Abandoned).Show;
+
+        Assert.Same(raised, source.Forget(PaneA).Dismiss);
+    }
+
+    [Fact]
+    public void Recovering_from_abandoned_is_still_handled()
+    {
+        // The renderer does not do this today -- abandoned is terminal -- but
+        // the set must not strand a pane if that ever changes.
+        var source = new RendererHealthNoticeSource();
+        var raised = source.Update(PaneA, RendererHealth.Abandoned).Show;
+
+        Assert.Same(raised, source.Update(PaneA, RendererHealth.Healthy).Dismiss);
     }
 }

--- a/windows/Ghostty.Tests/Wiring/RendererHealthNoticeWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/RendererHealthNoticeWiringTests.cs
@@ -21,13 +21,50 @@ public class RendererHealthNoticeWiringTests
     private static ShellSource Host() => ShellSource.Load("Hosting.GhosttyHost.cs");
 
     [Fact]
-    public void TheHealthCase_AppliesBothHalvesOfTheChange()
+    public void EveryHealthChange_GoesThroughTheOneApplier()
     {
-        var section = Host().Case("OnAction", "RendererHealth");
+        // All three producers hand their change to ApplyRendererHealth rather
+        // than unpacking it themselves. That is the whole defence against a
+        // call site applying only the Dismiss half: a change can carry both
+        // when one banner replaces another, and dropping the Show there takes
+        // the banner away from panes that are still broken.
+        var host = Host();
 
-        Assert.Single(section.Calls("_rendererHealthNotices.Update"));
-        Assert.Equal("show", section.Call("notifications.Show").Arg(0));
-        Assert.Equal("dismiss", section.Call("notifications.Dismiss").Arg(0));
+        Assert.Single(host.Case("OnAction", "RendererHealth").Calls("ApplyRendererHealth"));
+        Assert.Single(host.Method("Unregister").Calls("ApplyRendererHealth"));
+        Assert.Single(host.Method("ForgetRendererHealth").Calls("ApplyRendererHealth"));
+
+        // And none of them reaches past it to the service directly. Scoped to
+        // the health case rather than the whole of OnAction, which also holds
+        // the unrelated custom-shader notice.
+        foreach (var scope in new SyntaxNode[]
+                 {
+                     host.Case("OnAction", "RendererHealth"),
+                     host.Method("Unregister"),
+                     host.Method("ForgetRendererHealth"),
+                 })
+        {
+            Assert.Empty(scope.Calls("notifications.Show"));
+            Assert.Empty(scope.Calls("notifications.Dismiss"));
+        }
+    }
+
+    [Fact]
+    public void TheApplier_DismissesBeforeItShows()
+    {
+        var apply = Host().Method("ApplyRendererHealth");
+
+        Assert.Equal("show", apply.Call("notifications.Show").Arg(0));
+        Assert.Equal("dismiss", apply.Call("notifications.Dismiss").Arg(0));
+
+        // A pane being given up on replaces the rebuilding banner with the
+        // abandoned one, and both carry the same DedupKey -- so showing first
+        // makes the replacement a no-op and leaves the user reading advice
+        // that no longer applies.
+        Assert.True(
+            apply.Call("notifications.Dismiss").SpanStart
+                < apply.Call("notifications.Show").SpanStart,
+            "notifications.Dismiss must precede notifications.Show; they share a DedupKey");
     }
 
     [Fact]
@@ -49,34 +86,28 @@ public class RendererHealthNoticeWiringTests
     }
 
     [Fact]
-    public void ClosingASurface_ForgetsItsHealth_AndAppliesTheDismissal()
+    public void ClosingASurface_ForgetsItsHealth()
     {
-        var unregister = Host().Method("Unregister");
-
-        Assert.Single(unregister.Calls("_rendererHealthNotices.Forget"));
-
-        // The dismissal half matters as much as the Forget: without it the
-        // banner survives the close of the only pane that was ever broken,
-        // and nothing left alive can clear it.
-        Assert.Single(unregister.Calls("notifications.Dismiss"));
-        Assert.Equal("dismiss", unregister.Call("notifications.Dismiss").Arg(0));
+        Assert.Single(Host().Method("Unregister").Calls("_rendererHealthNotices.Forget"));
     }
 
     [Fact]
-    public void BothHealthPaths_GoThroughTheDispatcher()
+    public void EveryHealthPath_GoesThroughTheDispatcher()
     {
         // Two reasons, and the second is the one that bites. The source is
         // documented UI-thread-only and shared statically across windows, so
-        // hoisting either call out of a lambda is a silent data race. And they
-        // must share the queue: OnAction decodes off-thread and enqueues its
-        // Update, so a synchronous Forget racing a device loss runs first,
-        // finds nothing, and lets the Update strand a dead surface in the set.
+        // hoisting any of these out of a lambda is a silent data race. And
+        // they must share one queue: OnAction decodes off-thread and enqueues
+        // its Update, so a Forget that runs synchronously races ahead of it,
+        // finds nothing, and lets the Update strand a surface in the set that
+        // is gone or off screen and will never report again.
         var host = Host();
 
         foreach (var (method, call) in new[]
                  {
                      ("OnAction", "_rendererHealthNotices.Update"),
                      ("Unregister", "_rendererHealthNotices.Forget"),
+                     ("ForgetRendererHealth", "_rendererHealthNotices.Forget"),
                  })
         {
             var enqueued = host.Method(method)
@@ -85,6 +116,25 @@ public class RendererHealthNoticeWiringTests
 
             Assert.True(enqueued, $"{call} must sit inside a _dispatcher.TryEnqueue in {method}");
         }
+    }
+
+    [Fact]
+    public void HidingAPane_ForgetsItsHealth()
+    {
+        // A hidden pane cannot recover -- recovery runs from a draw and a
+        // hidden surface does not draw -- so leaving it counted holds the
+        // banner up over a window where everything visible is fine.
+        var hide = ShellSource.Load("Panes.PaneHost.cs").Method("SetSurfaceVisibility");
+
+        var call = Assert.Single(hide.Calls("_host.ForgetRendererHealth"));
+        Assert.Equal("handle", call.Arg(0));
+
+        // Only on the way out. Forgetting a pane that is becoming visible
+        // would drop the banner for a pane the user is about to look at.
+        var guard = Assert.Single(
+            hide.DescendantNodes().OfType<IfStatementSyntax>(),
+            s => s.Condition.ToString() == "!visible");
+        Assert.Contains("ForgetRendererHealth", guard.Statement.ToString());
     }
 
     [Fact]

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -332,17 +332,53 @@ internal sealed partial class GhosttyHost : IDisposable
         // SurfaceFree below: a reused address can only be added by a later
         // Update, which is queued behind this.
         var handle = surface.Handle;
-        _dispatcher.TryEnqueue(() =>
-        {
-            // Forget first, then guard -- the opposite order to the action
-            // case, deliberately. There the guard comes first so the set is
-            // never mutated without the change being applied; here the surface
-            // is gone whether or not there is anywhere to show it, and a
-            // missing service means shutdown, when no banner matters anyway.
-            var change = _rendererHealthNotices.Forget(handle);
-            if (Ghostty.App.NotificationService is not { } notifications) return;
-            if (change.Dismiss is { } dismiss) notifications.Dismiss(dismiss);
-        });
+        _dispatcher.TryEnqueue(() => ApplyRendererHealth(
+            // Forget unconditionally: the surface is gone whether or not there
+            // is anywhere left to show a banner, and ApplyRendererHealth is
+            // what tolerates the service being absent during shutdown.
+            _rendererHealthNotices.Forget(handle)));
+    }
+
+    /// <summary>
+    /// Stop counting a surface towards the renderer-health banner because it
+    /// has gone off screen, and apply whatever that does to the banner.
+    /// </summary>
+    /// <remarks>
+    /// A hidden pane cannot recover: recovery runs from a draw, and a hidden
+    /// surface does not draw. So a pane that went dark and was then switched
+    /// away from would hold the banner up over a window where everything the
+    /// user can see is fine, until they happened to return to that tab.
+    ///
+    /// Safe to drop because the renderer re-sends its health when a surface
+    /// becomes visible again, precisely so this can forget one meanwhile. UI
+    /// thread only, like everything else touching the source.
+    /// </remarks>
+    internal void ForgetRendererHealth(IntPtr surfaceHandle)
+    {
+        if (surfaceHandle == IntPtr.Zero) return;
+
+        // Enqueued for ordering, not for thread affinity: this already runs
+        // on the UI thread. OnAction decodes off-thread and enqueues its
+        // Update, so a tab switch racing a device loss can arrive here first,
+        // find an empty set, and let the Update behind it add a surface that
+        // is now off screen and will never draw or report again. Going
+        // through the same queue puts this behind that Update. Same reason as
+        // Unregister above.
+        _dispatcher.TryEnqueue(() => ApplyRendererHealth(
+            _rendererHealthNotices.Forget(surfaceHandle)));
+    }
+
+    // Both halves, always. A change can carry a Dismiss and a Show together
+    // when one banner replaces another, and dropping the Show there leaves
+    // panes that are still broken with no banner at all.
+    private static void ApplyRendererHealth(
+        Ghostty.Core.Renderer.RendererHealthNoticeChange change)
+    {
+        if (Ghostty.App.NotificationService is not { } notifications) return;
+        // Dismiss first: the two banners share a DedupKey, so showing before
+        // the old one comes down makes the replacement a no-op.
+        if (change.Dismiss is { } dismiss) notifications.Dismiss(dismiss);
+        if (change.Show is { } show) notifications.Show(show);
     }
 
     /// <summary>
@@ -1057,10 +1093,8 @@ internal sealed partial class GhosttyHost : IDisposable
                         Marshal.ReadInt32(actionPtr, 8);
                     _dispatcher.TryEnqueue(() =>
                     {
-                        if (Ghostty.App.NotificationService is not { } notifications) return;
-                        var change = _rendererHealthNotices.Update(surfaceHandle, health);
-                        if (change.Show is { } show) notifications.Show(show);
-                        if (change.Dismiss is { } dismiss) notifications.Dismiss(dismiss);
+                        ApplyRendererHealth(
+                            _rendererHealthNotices.Update(surfaceHandle, health));
                     });
                     return 1;
                 }

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -897,6 +897,14 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
             if (handle == IntPtr.Zero) continue;
             Interop.NativeMethods.SurfaceSetVisible(
                 new Interop.GhosttySurface(handle), visible);
+
+            // A hidden pane cannot recover a lost GPU device, because
+            // recovery runs from a draw and a hidden surface does not draw.
+            // Leaving it counted would hold the "graphics device lost"
+            // banner up over a window where every pane the user can see is
+            // fine. The renderer re-sends its health when the surface comes
+            // back, so nothing is lost by forgetting it here.
+            if (!visible) _host.ForgetRendererHealth(handle);
         }
     }
 


### PR DESCRIPTION
The two findings the reviews on #1047/#1048/#1049 turned up and I deliberately
did not absorb at the time. They are one defect, which is why they are one PR:
`reportHealth` drops a report that repeats the current value, so anything that
does not change the value tells the embedder nothing.

## A surface that was given up on looked identical to one being rebuilt

`abandonRecovery` reported `.unhealthy` -- but the surface was already unhealthy
by the time anything gave up on it, so the report went nowhere. The shell could
not tell a rebuild in progress from one that will never come, and its banner told
the user to wait for something that was not coming. Reachable on `windows` today
through composition-mode surfaces, and #1048 widened it to every surface mode.

Adds `.abandoned` to `renderer.Health`, appended so the two ordinals already
across the ABI keep their values, mirrored in `include/ghostty.h` and the C#
enum. Nothing switches exhaustively on `Health`; the consumers that read it
compare against `healthy`, so an appended variant reads as not-healthy wherever
it is not handled.

The banner escalates rather than accumulating. A pane nothing will rebuild
outranks one still being retried, because its advice is the only advice that
helps. Escalating replaces the standing banner and overrides an earlier
dismissal, since "it is not coming back" is new information rather than a repeat
of "we are rebuilding".

Both banners share a `DedupKey`, so the host now **dismisses before showing** --
otherwise the replacement is a no-op and the user keeps reading advice that no
longer applies. A wiring test pins that order.

## A pane hidden mid-outage held the banner up

Recovery runs from a draw, and a hidden surface does not draw. So a pane that
went dark and was then switched away from kept the banner over a window where
everything the user could see was fine, until they happened to return to that
tab.

The shell now drops a pane when it goes off screen. That is only safe because
the renderer re-sends its health when a surface becomes visible again: with
edge-triggered reporting there is no edge left to send otherwise, and the pane
would come back silently broken.

## Verification

- `zig build test -Dapp-runtime=none`: 87/87 steps, 4302/4383 passed, 81 skipped.
- The `ghostty.h Health` parity test passes, so the Zig enum and the header agree.
- `dotnet build windows/Ghostty.sln`: succeeded, 0 errors.
- `dotnet test`: 3808 passed, 0 failed. 27 renderer-health tests, up from 20.
