### PR TITLE
build: drop the stale test-reachability entry for os/open.zig

### DIFF
--- a/.agents/scripts/test_reachability.py
+++ b/.agents/scripts/test_reachability.py
@@ -133,8 +133,6 @@ NOT_ROOTED = {
         "src/lib/allocator.zig names it with a plain pub const",
     "src/os/desktop.zig":
         "absent from src/os/main.zig's test block",
-    "src/os/open.zig":
-        "absent from src/os/main.zig's test block",
     "src/os/passwd.zig":
         "absent from src/os/main.zig's test block",
     "src/renderer/directx12/inspector_surface.zig":


### PR DESCRIPTION
`just signoff` failed on `windows` at c4d268a294 with:

```
FAIL: registered entries whose reason has expired
  src/os/open.zig: its tests now run; drop the entry
```

PR 1026 added `_ = openpkg;` to `src/os/main.zig`'s test block, so `open.zig`'s tests now run. The registry entry claiming they do not has expired, and the gate refuses a registry that has drifted rather than quietly carrying a false reason. That is the gate working; this drops the entry.

`just test-reachability` passes with it removed. The other eight entries are untouched and re-checked in the same run: `apprt/ipc.zig`, `config/path.zig`, `input/mouse.zig`, `lib/allocator/wasm.zig`, `os/desktop.zig`, `os/passwd.zig`, `renderer/directx12/inspector_surface.zig`, `termio/wsl_shell_integration.zig`.

No source change; this is registry bookkeeping only.
