### PR TITLE
config: the profile pass reads the ini cache, not the file a third time

### DIFF
--- a/windows/Ghostty.Core/Config/ConfigServiceProfileParser.cs
+++ b/windows/Ghostty.Core/Config/ConfigServiceProfileParser.cs
@@ -19,7 +19,10 @@ public static class ConfigServiceProfileParser
     /// <paramref name="fileValueReader"/> delegate is a thin adapter
     /// over <c>ConfigService</c>'s existing <c>GetFileValue</c>
     /// helper: it returns the last raw value for a key, or
-    /// <see langword="null"/> when the key is absent.
+    /// <see langword="null"/> when the key is absent. Has no production
+    /// caller since <c>ConfigService.ReadFlagsCore</c> reads the ini
+    /// cache; kept as the reference implementation the pairs overload is
+    /// tested against and as the simpler fixture API for tests.
     /// </summary>
     public static ProfileView ParseAll(
         string configText,
@@ -30,7 +33,38 @@ public static class ConfigServiceProfileParser
 
         var parsed = ProfileSourceParser.Parse(configText);
         var hidden = ProfileSourceParser.ExtractHiddenIds(configText);
+        var hiddenMentions = ProfileSourceParser.ExtractHiddenMentionIds(configText);
 
+        return BuildView(parsed, hidden, hiddenMentions, fileValueReader);
+    }
+
+    /// <summary>
+    /// Same result as <see cref="ParseAll(string, Func{string, string?})"/>,
+    /// built from the config-file cache <c>ConfigService.ReadFlags</c>
+    /// already populated (<see cref="ConfigIniFile.Load"/>'s shape), instead
+    /// of a second raw-text read of the same file. Callers on the hot path
+    /// (<c>ConfigService.ReadFlagsCore</c>) should prefer this overload.
+    /// </summary>
+    public static ProfileView ParseAll(
+        IReadOnlyDictionary<string, List<string>> configPairs,
+        Func<string, string?> fileValueReader)
+    {
+        ArgumentNullException.ThrowIfNull(configPairs);
+        ArgumentNullException.ThrowIfNull(fileValueReader);
+
+        var parsed = ProfileSourceParser.Parse(configPairs);
+        var hidden = ProfileSourceParser.ExtractHiddenIds(configPairs);
+        var hiddenMentions = ProfileSourceParser.ExtractHiddenMentionIds(configPairs);
+
+        return BuildView(parsed, hidden, hiddenMentions, fileValueReader);
+    }
+
+    private static ProfileView BuildView(
+        ProfileParseResult parsed,
+        IReadOnlySet<string> hidden,
+        IReadOnlySet<string> hiddenMentions,
+        Func<string, string?> fileValueReader)
+    {
         var defaultId = fileValueReader("default-profile");
         if (string.IsNullOrEmpty(defaultId)) defaultId = null;
 
@@ -43,7 +77,6 @@ public static class ConfigServiceProfileParser
         // markers, not malformed definitions; the un-hide path of the
         // settings-page toggle writes hidden = false, so filtering only
         // on the true-set would leak false-positive warnings.
-        var hiddenMentions = ProfileSourceParser.ExtractHiddenMentionIds(configText);
         var warnings = FilterHiddenOnlyWarnings(parsed.Warnings, parsed.Profiles, hiddenMentions);
 
         return new ProfileView(

--- a/windows/Ghostty.Core/Profiles/ProfileSourceParser.cs
+++ b/windows/Ghostty.Core/Profiles/ProfileSourceParser.cs
@@ -28,6 +28,26 @@ public static partial class ProfileSourceParser
         RegexOptions.IgnoreCase)]
     private static partial Regex LineRegex();
 
+    /// <summary>
+    /// The key half of <see cref="LineRegex"/> (the "profile.&lt;id&gt;.&lt;subkey&gt;"
+    /// shape, with no "= value" suffix), for the overloads that start from an
+    /// already-split key/value cache (<see cref="ConfigIniFile"/>'s
+    /// dictionary) instead of raw file text. Same character classes and the
+    /// same <see cref="RegexOptions.IgnoreCase"/>, so a key this rejects is a
+    /// key <see cref="LineRegex"/> would also have rejected, and vice versa.
+    /// </summary>
+    [GeneratedRegex(
+        @"^profile\.([a-z0-9-]+)\.([a-z0-9-]+)$",
+        RegexOptions.IgnoreCase)]
+    private static partial Regex KeyRegex();
+
+    /// <summary>
+    /// Has no production caller: the profile pass reads the ini cache via
+    /// <see cref="Parse(IReadOnlyDictionary{string, List{string}})"/>
+    /// instead. Kept as the reference implementation the pairs overload is
+    /// tested against (equivalence tests) and as the simpler fixture API
+    /// for tests that don't need a config-file cache.
+    /// </summary>
     public static ProfileParseResult Parse(string configText)
     {
         ArgumentNullException.ThrowIfNull(configText);
@@ -36,7 +56,6 @@ public static partial class ProfileSourceParser
             configText = configText.Substring(1);
 
         var groups = new Dictionary<string, Dictionary<string, string>>();
-        var warnings = new List<string>();
 
         foreach (var rawLine in configText.Split('\n'))
         {
@@ -55,6 +74,64 @@ public static partial class ProfileSourceParser
             bag[subKey] = value;
         }
 
+        return BuildProfiles(groups);
+    }
+
+    /// <summary>
+    /// Same result as <see cref="Parse(string)"/>, built from the parsed-pairs
+    /// cache <see cref="ConfigIniFile.Load"/> already produced, instead of a
+    /// second raw-text read of the same file.
+    ///
+    /// <paramref name="configPairs"/> is keyed by the untouched "key" half of
+    /// each "key = value" line (whatever casing the file used), with every
+    /// occurrence's value in file order -- the shape
+    /// <see cref="ConfigIniFile.Load"/> already returns. Each key is matched
+    /// against <see cref="KeyRegex"/> exactly the way <see cref="LineRegex"/>
+    /// would match the key half of the original line, so a line this drops
+    /// is a line <see cref="Parse(string)"/> would also have dropped. Last
+    /// value wins per (id, subkey) pair, matching the forward-order
+    /// <c>bag[subKey] = value</c> overwrite in the text path -- which is
+    /// exactly the cache list's last element, since
+    /// <see cref="ConfigIniFile.Load"/> appends every occurrence of a key in
+    /// the order it read them.
+    ///
+    /// A whitespace-only value, e.g. "profile.x.name =    ", is dropped
+    /// identically by both paths: <see cref="Parse(string)"/> trims the
+    /// whole line first, leaving "profile.x.name =" with nothing left for
+    /// <see cref="LineRegex"/> to capture, the same way <see cref="ConfigIniFile.Load"/>
+    /// skips a key whose value is empty after trimming.
+    /// </summary>
+    public static ProfileParseResult Parse(IReadOnlyDictionary<string, List<string>> configPairs)
+    {
+        ArgumentNullException.ThrowIfNull(configPairs);
+
+        var groups = new Dictionary<string, Dictionary<string, string>>();
+
+        foreach (var (rawKey, values) in configPairs)
+        {
+            if (values.Count == 0) continue;
+
+            var match = KeyRegex().Match(rawKey);
+            if (!match.Success) continue;
+
+            var id = match.Groups[1].Value.ToLowerInvariant();
+            var subKey = match.Groups[2].Value.ToLowerInvariant();
+            // Last occurrence wins, same as the forward-order overwrite in
+            // Parse(string) above -- the cache list is already in file order.
+            var value = values[^1];
+
+            if (!groups.TryGetValue(id, out var bag))
+                groups[id] = bag = new Dictionary<string, string>();
+            bag[subKey] = value;
+        }
+
+        return BuildProfiles(groups);
+    }
+
+    private static ProfileParseResult BuildProfiles(
+        Dictionary<string, Dictionary<string, string>> groups)
+    {
+        var warnings = new List<string>();
         var profiles = new Dictionary<string, ProfileDef>();
         foreach (var (id, bag) in groups)
         {
@@ -117,6 +194,26 @@ public static partial class ProfileSourceParser
     public static IReadOnlySet<string> ExtractHiddenMentionIds(string configText)
         => ExtractHiddenIdsCore(configText, requireTrue: false);
 
+    /// <summary>
+    /// Pairs-cache counterpart of <see cref="ExtractHiddenIds(string)"/>. See
+    /// <see cref="Parse(IReadOnlyDictionary{string, List{string}})"/> for the
+    /// shape <paramref name="configPairs"/> is expected in.
+    ///
+    /// The text path adds an id as soon as any one occurrence of its
+    /// <c>hidden</c> line parses to <see langword="true"/> -- later
+    /// occurrences overwriting it back to <see langword="false"/> do not
+    /// remove it, since <c>ids</c> is a set with no un-add. So this checks
+    /// whether *any* cached value for that key parses to <see langword="true"/>,
+    /// which is the same test applied to every occurrence instead of just the
+    /// last one.
+    /// </summary>
+    public static IReadOnlySet<string> ExtractHiddenIds(IReadOnlyDictionary<string, List<string>> configPairs)
+        => ExtractHiddenIdsCore(configPairs, requireTrue: true);
+
+    /// <summary>Pairs-cache counterpart of <see cref="ExtractHiddenMentionIds(string)"/>.</summary>
+    public static IReadOnlySet<string> ExtractHiddenMentionIds(IReadOnlyDictionary<string, List<string>> configPairs)
+        => ExtractHiddenIdsCore(configPairs, requireTrue: false);
+
     private static IReadOnlySet<string> ExtractHiddenIdsCore(string configText, bool requireTrue)
     {
         ArgumentNullException.ThrowIfNull(configText);
@@ -142,6 +239,45 @@ public static partial class ProfileSourceParser
             {
                 var value = match.Groups[3].Value;
                 if (!bool.TryParse(value, out var flag) || !flag) continue;
+            }
+
+            var id = match.Groups[1].Value.ToLowerInvariant();
+            ids.Add(id);
+        }
+
+        return ids;
+    }
+
+    private static IReadOnlySet<string> ExtractHiddenIdsCore(
+        IReadOnlyDictionary<string, List<string>> configPairs, bool requireTrue)
+    {
+        ArgumentNullException.ThrowIfNull(configPairs);
+
+        var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var (rawKey, values) in configPairs)
+        {
+            if (values.Count == 0) continue;
+
+            var match = KeyRegex().Match(rawKey);
+            if (!match.Success) continue;
+
+            var subKey = match.Groups[2].Value;
+            if (!string.Equals(subKey, "hidden", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            if (requireTrue)
+            {
+                var anyTrue = false;
+                foreach (var value in values)
+                {
+                    if (bool.TryParse(value, out var flag) && flag)
+                    {
+                        anyTrue = true;
+                        break;
+                    }
+                }
+                if (!anyTrue) continue;
             }
 
             var id = match.Groups[1].Value.ToLowerInvariant();

--- a/windows/Ghostty.Tests/Config/ConfigServiceProfileParserTests.cs
+++ b/windows/Ghostty.Tests/Config/ConfigServiceProfileParserTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Ghostty.Core.Config;
 using Ghostty.Core.Profiles;
 using Xunit;
@@ -145,5 +146,82 @@ public class ConfigServiceProfileParserTests
         Assert.Contains("bro", result.HiddenProfileIds);
         Assert.Single(result.ProfileWarnings);
         Assert.Contains("broken", result.ProfileWarnings[0]);
+    }
+
+    /// <summary>
+    /// The overload ConfigService.ReadFlagsCore is switching to (consuming
+    /// the already-populated <see cref="ConfigIniFile"/> pairs cache instead
+    /// of a second <c>File.ReadAllText</c> of the same file) has to produce
+    /// the same <see cref="ProfileView"/> the old text-based call did, for
+    /// the same underlying file content. This fixture exercises every knob
+    /// called out in the redundant-read diagnosis: multiple profiles,
+    /// duplicate subkey lines (last wins), values with surrounding spaces,
+    /// a hidden id (true), a hidden-mention-only id (false, still
+    /// suppresses its own missing-key warning), comment and blank lines, a
+    /// non-profile key, and a mixed-case "Profile." key.
+    /// </summary>
+    [Fact]
+    public void ParseAll_TextAndPairsCache_ProduceIdenticalResults()
+    {
+        const string text = """
+            # a leading comment
+
+            profile.web.name = Web Browser
+            profile.web.command = firefox.exe
+            profile.web.command = chrome.exe
+            profile.mail.name =   Mail Client
+            profile.mail.command = outlook.exe
+            profile.mail.hidden = true
+
+            profile.archived.hidden = false
+            Profile.CASED.name = Cased Profile
+            Profile.CASED.command = cased.exe
+            font-family = Cascadia Code
+            """;
+        var values = new Dictionary<string, string?>
+        {
+            ["default-profile"] = "web",
+            // Deliberately leaves "cased" uncovered: ProfileOrderResolver.
+            // ResolveDefault falls back to ParsedProfiles enumeration order
+            // when profile-order does not disambiguate, so this fixture only
+            // exercises that fallback path if profile-order is partial.
+            ["profile-order"] = "mail, web",
+        };
+
+        var fromText = ConfigServiceProfileParser.ParseAll(text, key => FileValue(values, key));
+        var pairs = ConfigIniFile.ParseText(text);
+        var fromPairs = ConfigServiceProfileParser.ParseAll(pairs, key => FileValue(values, key));
+
+        Assert.Equal(fromText.ParsedProfiles.Count, fromPairs.ParsedProfiles.Count);
+        foreach (var (id, def) in fromText.ParsedProfiles)
+        {
+            Assert.True(fromPairs.ParsedProfiles.TryGetValue(id, out var otherDef));
+            Assert.Equal(def, otherDef);
+        }
+        // Order-preserving, not just membership: ProfileOrderResolver.
+        // ResolveDefault falls back to ParsedProfiles enumeration order when
+        // profile-order does not disambiguate, so the pairs path must yield
+        // the same key sequence as the text path, first valid line wins.
+        Assert.Equal(fromText.ParsedProfiles.Keys.ToList(), fromPairs.ParsedProfiles.Keys.ToList());
+        Assert.Equal(fromText.ProfileOrder, fromPairs.ProfileOrder);
+        Assert.Equal(fromText.DefaultProfileId, fromPairs.DefaultProfileId);
+        // Set-compared: iteration order over a HashSet is not itself a
+        // behavioral guarantee either path makes.
+        Assert.Equal(
+            fromText.HiddenProfileIds.OrderBy(x => x, System.StringComparer.Ordinal),
+            fromPairs.HiddenProfileIds.OrderBy(x => x, System.StringComparer.Ordinal));
+        Assert.Equal(
+            fromText.ProfileWarnings.OrderBy(x => x, System.StringComparer.Ordinal),
+            fromPairs.ProfileWarnings.OrderBy(x => x, System.StringComparer.Ordinal));
+
+        // Pin the concrete values, not just that the two paths agree with
+        // each other -- two paths agreeing on the wrong answer would still
+        // pass the assertions above.
+        Assert.Equal("chrome.exe", fromPairs.ParsedProfiles["web"].Command); // duplicate subkey, last wins
+        Assert.Equal("Mail Client", fromPairs.ParsedProfiles["mail"].Name); // surrounding spaces trimmed
+        Assert.Contains("mail", fromPairs.HiddenProfileIds); // hidden = true
+        Assert.DoesNotContain("archived", fromPairs.HiddenProfileIds); // hidden = false
+        Assert.Empty(fromPairs.ProfileWarnings); // archived's missing-name warning is suppressed
+        Assert.Equal("Cased Profile", fromPairs.ParsedProfiles["cased"].Name); // "Profile." (mixed case) still matches
     }
 }

--- a/windows/Ghostty.Tests/Profiles/ProfileSourceParserHiddenIdsTests.cs
+++ b/windows/Ghostty.Tests/Profiles/ProfileSourceParserHiddenIdsTests.cs
@@ -1,3 +1,4 @@
+using Ghostty.Core.Config;
 using Ghostty.Core.Profiles;
 using Xunit;
 
@@ -132,6 +133,100 @@ public sealed class ProfileSourceParserHiddenIdsTests
     {
         const string text = "profile.azure.name = Azure";
         var result = ProfileSourceParser.ExtractHiddenMentionIds(text);
+        Assert.Empty(result);
+    }
+
+    // -- ExtractHiddenIds/ExtractHiddenMentionIds(pairs cache) ----------
+
+    [Fact]
+    public void ExtractHiddenIds_Pairs_HiddenTrue_ReturnsId()
+    {
+        const string text = "profile.azure.hidden = true";
+        var result = ProfileSourceParser.ExtractHiddenIds(ConfigIniFile.ParseText(text));
+        Assert.Single(result);
+        Assert.Contains("azure", result);
+    }
+
+    [Fact]
+    public void ExtractHiddenIds_Pairs_HiddenFalse_IsIgnored()
+    {
+        const string text = "profile.azure.hidden = false";
+        var result = ProfileSourceParser.ExtractHiddenIds(ConfigIniFile.ParseText(text));
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ExtractHiddenIds_Pairs_NonHiddenSubkey_Ignored()
+    {
+        const string text = "profile.azure.name = Azure";
+        var result = ProfileSourceParser.ExtractHiddenIds(ConfigIniFile.ParseText(text));
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ExtractHiddenIds_Pairs_InvalidIdCharacters_AreIgnored()
+    {
+        const string text = "profile.BAD_ID.hidden = true";
+        var result = ProfileSourceParser.ExtractHiddenIds(ConfigIniFile.ParseText(text));
+        Assert.Empty(result);
+    }
+
+    /// <summary>
+    /// The text path's `ids` set has no un-add: once a line sets
+    /// `hidden = true` the id stays in the set even if a later line for the
+    /// same id sets `hidden = false` (see <see cref="ExtractHiddenIds_HiddenFalse_IsIgnored"/>
+    /// for the single-line case; here two lines for the same id disagree).
+    /// The pairs overload has to reproduce that "any occurrence true" rule,
+    /// not "last occurrence wins" -- pin both directions so a future rewrite
+    /// toward the more intuitive last-wins semantics fails loudly here
+    /// instead of silently changing behavior.
+    /// </summary>
+    [Fact]
+    public void ExtractHiddenIds_Pairs_MultipleOccurrences_AnyTrueWinsOverALaterFalse()
+    {
+        const string text = "profile.azure.hidden = true\nprofile.azure.hidden = false\n";
+
+        var fromText = ProfileSourceParser.ExtractHiddenIds(text);
+        var fromPairs = ProfileSourceParser.ExtractHiddenIds(ConfigIniFile.ParseText(text));
+
+        Assert.Contains("azure", fromText);
+        Assert.Contains("azure", fromPairs);
+    }
+
+    [Fact]
+    public void ExtractHiddenIds_Pairs_MultipleOccurrences_AnEarlierFalseDoesNotSuppressALaterTrue()
+    {
+        const string text = "profile.azure.hidden = false\nprofile.azure.hidden = true\n";
+
+        var fromText = ProfileSourceParser.ExtractHiddenIds(text);
+        var fromPairs = ProfileSourceParser.ExtractHiddenIds(ConfigIniFile.ParseText(text));
+
+        Assert.Contains("azure", fromText);
+        Assert.Contains("azure", fromPairs);
+    }
+
+    [Fact]
+    public void ExtractHiddenMentionIds_Pairs_HiddenFalse_Included()
+    {
+        const string text = "profile.azure.hidden = false";
+        var result = ProfileSourceParser.ExtractHiddenMentionIds(ConfigIniFile.ParseText(text));
+        Assert.Single(result);
+        Assert.Contains("azure", result);
+    }
+
+    [Fact]
+    public void ExtractHiddenMentionIds_Pairs_NonBoolValue_StillIncluded()
+    {
+        const string text = "profile.weird.hidden = oops";
+        var result = ProfileSourceParser.ExtractHiddenMentionIds(ConfigIniFile.ParseText(text));
+        Assert.Contains("weird", result);
+    }
+
+    [Fact]
+    public void ExtractHiddenMentionIds_Pairs_NonHiddenSubkey_Ignored()
+    {
+        const string text = "profile.azure.name = Azure";
+        var result = ProfileSourceParser.ExtractHiddenMentionIds(ConfigIniFile.ParseText(text));
         Assert.Empty(result);
     }
 }

--- a/windows/Ghostty.Tests/Profiles/ProfileSourceParserTests.cs
+++ b/windows/Ghostty.Tests/Profiles/ProfileSourceParserTests.cs
@@ -1,3 +1,4 @@
+using Ghostty.Core.Config;
 using Ghostty.Core.Profiles;
 using Xunit;
 
@@ -351,5 +352,121 @@ public sealed class ProfileSourceParserTests
             "profile.foo.name = Foo\nprofile.foo.command = pwsh\nprofile.foo.tab-icon-tracks-foreground = FALSE\n"
         ).Profiles["foo"];
         Assert.False(parsed.TabIconTracksForeground);
+    }
+
+    // -- Parse(IReadOnlyDictionary<string, List<string>>) --------------
+    //
+    // The pairs-cache overload consumed by ConfigService.ReadFlagsCore
+    // instead of a second raw-text read. Each fixture below is built with
+    // ConfigIniFile.ParseText, the same helper the production cache is
+    // populated with, so these tests exercise the real handoff shape
+    // rather than a hand-built dictionary.
+
+    [Fact]
+    public void Parse_Pairs_SingleProfile_AllRequiredKeys()
+    {
+        const string config = """
+            profile.pwsh.name = PowerShell
+            profile.pwsh.command = pwsh.exe
+            """;
+
+        var result = ProfileSourceParser.Parse(ConfigIniFile.ParseText(config));
+
+        Assert.Single(result.Profiles);
+        var p = result.Profiles["pwsh"];
+        Assert.Equal("pwsh", p.Id);
+        Assert.Equal("PowerShell", p.Name);
+        Assert.Equal("pwsh.exe", p.Command);
+        Assert.Empty(result.Warnings);
+    }
+
+    [Fact]
+    public void Parse_Pairs_DuplicateKeys_LastWins()
+    {
+        const string config = """
+            profile.pwsh.name = PowerShell
+            profile.pwsh.command = pwsh.exe
+            profile.pwsh.command = pwsh-preview.exe
+            """;
+
+        var p = ProfileSourceParser.Parse(ConfigIniFile.ParseText(config)).Profiles["pwsh"];
+        Assert.Equal("pwsh-preview.exe", p.Command);
+    }
+
+    [Fact]
+    public void Parse_Pairs_IgnoresNonProfileLines()
+    {
+        const string config = """
+            font-family = Cascadia Code
+            theme = GruvboxDark
+            profile.pwsh.name = PowerShell
+            profile.pwsh.command = pwsh.exe
+            background-opacity = 0.9
+            """;
+
+        var result = ProfileSourceParser.Parse(ConfigIniFile.ParseText(config));
+
+        Assert.Single(result.Profiles);
+        Assert.True(result.Profiles.ContainsKey("pwsh"));
+    }
+
+    [Theory]
+    [InlineData("with space")]
+    [InlineData("under_score")]
+    [InlineData("dot.in.id")]
+    public void Parse_Pairs_InvalidIdFormat_LineIgnored(string id)
+    {
+        var config = $"profile.{id}.name = X\nprofile.{id}.command = x\n";
+
+        var result = ProfileSourceParser.Parse(ConfigIniFile.ParseText(config));
+
+        Assert.Empty(result.Profiles);
+    }
+
+    [Fact]
+    public void Parse_Pairs_MissingCommand_DropsProfileAndWarns()
+    {
+        const string config = "profile.pwsh.name = PowerShell";
+
+        var result = ProfileSourceParser.Parse(ConfigIniFile.ParseText(config));
+
+        Assert.Empty(result.Profiles);
+        Assert.Single(result.Warnings);
+        Assert.Contains("pwsh", result.Warnings[0]);
+        Assert.Contains("command", result.Warnings[0]);
+    }
+
+    [Fact]
+    public void Parse_Pairs_ValuesAreAlreadyTrimmedByTheCache()
+    {
+        // ConfigIniFile trims each value when it parses the file, so the
+        // pairs overload does not re-trim: it just takes the cache's value
+        // as-is. Pin that the end-to-end result still matches a config
+        // with spaces around the value.
+        const string config = "profile.pwsh.name =   PowerShell   \nprofile.pwsh.command = pwsh.exe\n";
+
+        var p = ProfileSourceParser.Parse(ConfigIniFile.ParseText(config)).Profiles["pwsh"];
+        Assert.Equal("PowerShell", p.Name);
+    }
+
+    [Fact]
+    public void Parse_Pairs_EmptyCache_ReturnsEmptyResult()
+    {
+        var result = ProfileSourceParser.Parse(ConfigIniFile.ParseText(string.Empty));
+        Assert.Empty(result.Profiles);
+        Assert.Empty(result.Warnings);
+    }
+
+    [Fact]
+    public void Parse_Pairs_MixedCaseProfileKey_MatchesLikeTheTextPath()
+    {
+        const string config = "Profile.CASED.Name = Cased\nProfile.CASED.Command = cased.exe\n";
+
+        var fromText = ProfileSourceParser.Parse(config);
+        var fromPairs = ProfileSourceParser.Parse(ConfigIniFile.ParseText(config));
+
+        Assert.Equal(fromText.Profiles.Count, fromPairs.Profiles.Count);
+        Assert.True(fromPairs.Profiles.ContainsKey("cased"));
+        Assert.Equal(fromText.Profiles["cased"], fromPairs.Profiles["cased"]);
     }
 }

--- a/windows/Ghostty.Tests/Wiring/ConfigLoadOrderWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/ConfigLoadOrderWiringTests.cs
@@ -109,21 +109,35 @@ public class ConfigLoadOrderWiringTests
     }
 
     /// <summary>
-    /// The profile keys are read out of the raw file text rather than the
-    /// parsed cache, so emptying that cache does not stop them. This read
-    /// needs the suppression at its own site.
+    /// The profile keys used to come from a second raw-text read of the
+    /// config file (<c>File.ReadAllText</c>), a third read of the same file
+    /// on top of the native ConfigNew..ConfigFinalize read and the managed
+    /// <c>_configFileCache = LoadIniFile(...)</c> read that ReadFlags already
+    /// does. That call is gone: the profile pass now consumes the same
+    /// pairs cache <c>GetFileValue</c> and friends already read from, so a
+    /// reload is bounded by the native read plus the two <c>LoadIniFile</c>
+    /// calls ReadFlags documents (config file, active theme file), not a
+    /// third file open.
+    ///
+    /// Scanning the whole file rather than just ReadFlagsCore, so a
+    /// File.ReadAllText that migrates to some other method in this class
+    /// still trips the guard.
     /// </summary>
     [Fact]
-    public void TheProfileTextReadIsSuppressedAtItsOwnSite()
+    public void TheProfilePassReadsFromTheSharedCacheNotAThirdFileRead()
     {
-        var core = ShellSource.Load(ConfigService).Method("ReadFlagsCore");
+        var source = ShellSource.Load(ConfigService);
 
-        var read = core.Call("File.ReadAllText");
-        var conditional = read.Ancestors().OfType<ConditionalExpressionSyntax>().First();
+        Assert.Empty(source.Root.Calls("File.ReadAllText"));
 
-        Assert.Contains("ConfigSourcePath", conditional.Condition.ToString());
-        Assert.DoesNotContain("ConfigFilePath", conditional.Condition.ToString());
-        Assert.DoesNotContain("ConfigFilePath", read.Arg(0));
+        var core = source.Method("ReadFlagsCore");
+        var cacheReferences = core.DescendantNodes().OfType<IdentifierNameSyntax>()
+            .Where(id => id.Identifier.ValueText == "_configFileCache")
+            .ToList();
+        Assert.True(
+            cacheReferences.Count > 0,
+            "ReadFlagsCore no longer references _configFileCache -- the profile pass "
+                + "has to read the same cache ReadFlags populated, not some other source.");
     }
 
     /// <summary>

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -1155,23 +1155,35 @@ internal sealed partial class ConfigService : IConfigService, Ghostty.Core.Profi
         AnsiPalette = GetAllPaletteColors();
 
         // Profile-view second pass. The scalar keys (default-profile
-        // and profile-order) are read through GetFileValue which hits
-        // the parsed line cache populated at the top of ReadFlags.
-        // The profile.<id>.* regex and hidden-id extraction need the
-        // raw file text though, and _configFileCache stores parsed
-        // pairs rather than the original bytes, so this second read is
-        // deliberate -- the reload is already cold-path and the config
-        // is small. Readers of the five profile-view properties see a
-        // consistent snapshot via the single volatile _profileView
-        // assignment below.
-        // Reads the path rather than the cache, so it needs the same
-        // suppression: _configFileCache being empty under --no-config would
-        // not stop this one from putting the file's profiles back in force.
-        var rawConfigText = ConfigSourcePath is { } profileSource && File.Exists(profileSource)
-            ? File.ReadAllText(profileSource)
-            : string.Empty;
+        // and profile-order) are read through GetFileValue, which hits
+        // the parsed cache populated at the top of ReadFlags. The
+        // profile.<id>.* regex and hidden-id extraction used to need
+        // the raw file text -- ConfigServiceProfileParser.ParseAll's
+        // string overload -- because _configFileCache stores parsed
+        // pairs keyed by whole "profile.<id>.<subkey>" strings rather
+        // than the original bytes, and nothing walked that cache
+        // looking for the profile.* shape.
+        //
+        // That second read is gone: ProfileSourceParser now has a
+        // sibling that walks the same cache instead of raw text (same
+        // "profile.<id>.<subkey>" regex, applied to each cache key
+        // instead of each line), taking the cache's last value per key
+        // as "last occurrence wins" -- the cache already stores every
+        // occurrence in file order, so its last element is the same
+        // value the forward-order text scan would have landed on. A
+        // reload is now bounded by the native read plus the two
+        // LoadIniFile calls above (config file, active theme file),
+        // not a third file open. Readers of the five profile-view
+        // properties see a consistent snapshot via the single volatile
+        // _profileView assignment below.
+        //
+        // No separate --no-config gate is needed here: _configFileCache
+        // is already the suppressible one (LoadIniFile(ConfigSourcePath)
+        // at the top of this method returns empty under --no-config), so
+        // the profile pass inherits the same suppression the scalar
+        // reads above it already have.
         var view = Ghostty.Core.Config.ConfigServiceProfileParser.ParseAll(
-            rawConfigText,
+            _configFileCache ?? new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase),
             key =>
             {
                 var v = GetFileValue(key, string.Empty);


### PR DESCRIPTION
ConfigService's constructor and every Reload opened the main config file three times: natively (ConfigNew..ConfigFinalize), through ConfigIniFile.Load to fill _configFileCache, and a third time through a bare File.ReadAllText in ReadFlagsCore so the profile.<id>.<subkey> regex pass could see raw text. The third open was also the narrowest of the three (default FileShare.Read where the ini loader deliberately opens ReadWrite|Delete because the settings UI and libghostty hold writers on this file, pinned by ConfigIniFileSharingTests), so a writer holding the file at the wrong moment made the profile pass the one reader that could throw.

The ini parser does not restrict key shape, so every profile.* line is already in the cache with all its values in file order. The profile pass now consumes the cache through pairs overloads of ProfileSourceParser and ConfigServiceProfileParser that reproduce the text path exactly: same key regex (IgnoreCase, ids and subkeys lowercased), last occurrence wins for duplicate subkey lines (the cache getter's first-wins is not used here), hidden-id extraction keeps its any-true-occurrence rule, and profile ORDER (which ProfileOrderResolver.ResolveDefault falls back to) is asserted equal as a sequence. The text overloads stay as the reference implementation the pairs path is tested against.

Tests: pairs-vs-text equivalence (duplicates, padding, hidden ids, comments, blanks, a non-profile key, a mixed-case Profile. key, order with profile-order not covering every id); the wiring pin that used to require the File.ReadAllText now requires its absence anywhere in ConfigService.cs plus the cache reference in ReadFlagsCore. Ghostty.Tests 3834/3834 at the pre-review state; the review-fix subset 82/82 after.

Timing: this is the configuration-side lever from the startup campaign; its effect is one small synchronous file open per ctor/Reload, below the measurement noise floor on the dev box, so it is shipped as hygiene plus the share-mode fix, not claimed as a measured win.