### PR TITLE
font, build: make the embedded emoji fallback reachable and default it off

### DIFF
--- a/src/build/Config.zig
+++ b/src/build/Config.zig
@@ -258,17 +258,18 @@ pub fn init(b: *std.Build, appVersion: []const u8, libVersion: []const u8) !Conf
         "embed-emoji-font",
         "Embed the Noto emoji fonts (about 11MB) for systems that have no " ++
             "emoji font of their own. A system emoji font found through font " ++
-            "discovery is preferred either way, so platforms that always have " ++
-            "one never pay for this. Turning it off makes such a system render " ++
-            "emoji as boxes. Defaults off on Windows.",
-    ) orelse switch (target.result.os.tag) {
-        // Segoe UI Emoji is an OS component, and the discovery pass finds
-        // it on every stock image, so on Windows the embed is 11MB that is
-        // compiled in and never read. Passing the option turns it back on
-        // for an image that has had the font stripped out.
-        .windows => false,
-        else => true,
-    };
+            "discovery is preferred either way, so a system that has one never " ++
+            "pays for this. Defaults off: turn it on for a build that has to " ++
+            "cover an image with no emoji font at all.",
+    ) orelse false;
+    // Off by default on every target. The fallback here is the *operating
+    // system's* emoji font, not a bundled one: none of the faces we ship
+    // (JetBrains Mono, the Nerd Font symbols, and the alternates) contains
+    // emoji, so the only emoji faces in the tree are the two Noto files this
+    // option controls. That is fine where the OS always supplies one --
+    // Segoe UI Emoji on Windows and Apple Color Emoji on macOS are both OS
+    // components that cannot be removed. A Linux image with no emoji font
+    // installed is the case that renders boxes, and is why the option exists.
 
     config.wayland = b.option(
         bool,

--- a/src/build/Config.zig
+++ b/src/build/Config.zig
@@ -260,8 +260,15 @@ pub fn init(b: *std.Build, appVersion: []const u8, libVersion: []const u8) !Conf
             "emoji font of their own. A system emoji font found through font " ++
             "discovery is preferred either way, so platforms that always have " ++
             "one never pay for this. Turning it off makes such a system render " ++
-            "emoji as boxes.",
-    ) orelse true;
+            "emoji as boxes. Defaults off on Windows.",
+    ) orelse switch (target.result.os.tag) {
+        // Segoe UI Emoji is an OS component, and the discovery pass finds
+        // it on every stock image, so on Windows the embed is 11MB that is
+        // compiled in and never read. Passing the option turns it back on
+        // for an image that has had the font stripped out.
+        .windows => false,
+        else => true,
+    };
 
     config.wayland = b.option(
         bool,

--- a/src/build/Config.zig
+++ b/src/build/Config.zig
@@ -34,6 +34,7 @@ sentry: bool = true,
 simd: bool = true,
 i18n: bool = true,
 wasm_shared: bool = true,
+embed_emoji_font: bool = true,
 
 /// Ghostty exe properties
 exe_entrypoint: ExeEntrypoint = .ghostty,
@@ -251,6 +252,16 @@ pub fn init(b: *std.Build, appVersion: []const u8, libVersion: []const u8) !Conf
 
         break :simd true;
     };
+
+    config.embed_emoji_font = b.option(
+        bool,
+        "embed-emoji-font",
+        "Embed the Noto emoji fonts (about 11MB) for systems that have no " ++
+            "emoji font of their own. A system emoji font found through font " ++
+            "discovery is preferred either way, so platforms that always have " ++
+            "one never pay for this. Turning it off makes such a system render " ++
+            "emoji as boxes.",
+    ) orelse true;
 
     config.wayland = b.option(
         bool,
@@ -668,6 +679,7 @@ pub fn addOptions(self: *const Config, step: *std.Build.Step.Options) !void {
     step.addOption(bool, "sentry", self.sentry);
     step.addOption(bool, "simd", self.simd);
     step.addOption(bool, "i18n", self.i18n);
+    step.addOption(bool, "embed_emoji_font", self.embed_emoji_font);
     step.addOption(ApprtRuntime, "app_runtime", self.app_runtime);
     step.addOption(FontBackend, "font_backend", self.font_backend);
     step.addOption(RendererBackend, "renderer", self.renderer);
@@ -772,6 +784,7 @@ pub fn fromOptions() Config {
         .wasm_target = std.meta.stringToEnum(WasmTarget, @tagName(options.wasm_target)).?,
         .wasm_shared = options.wasm_shared,
         .i18n = options.i18n,
+        .embed_emoji_font = options.embed_emoji_font,
     };
 }
 

--- a/src/build_config.zig
+++ b/src/build_config.zig
@@ -43,6 +43,11 @@ pub const font_backend: font.Backend = config.font_backend;
 pub const renderer: rendererpkg.Backend = config.renderer;
 pub const i18n: bool = config.i18n;
 
+/// Whether the Noto emoji fonts are embedded as a fallback for systems
+/// with no emoji font of their own. A system emoji font found through
+/// font discovery is preferred regardless of this.
+pub const embed_emoji_font: bool = config.embed_emoji_font;
+
 /// The bundle ID for the app. This is used in many places and is currently
 /// hardcoded here. We could make this configurable in the future if there
 /// is a reason to do so.

--- a/src/font/SharedGridSet.zig
+++ b/src/font/SharedGridSet.zig
@@ -29,6 +29,7 @@ const discovery = @import("discovery.zig");
 const configpkg = @import("../config.zig");
 const Config = configpkg.Config;
 const global = @import("../global.zig");
+const build_config = @import("../build_config.zig");
 
 const log = std.log.scoped(.font_shared_grid_set);
 
@@ -425,7 +426,10 @@ fn collection(
 /// be removed, so discovery always finds it and the embedded faces would
 /// never be used. Excluding them at compile time keeps roughly 11MB of
 /// font data out of the binary, since Zig only embeds what is referenced.
-const embed_emoji: bool = !(builtin.target.os.tag.isDarwin() and Discover != void);
+/// `-Dembed-emoji-font=false` excludes them everywhere, which buys that
+/// space back at the cost of boxes on a system with no emoji font.
+const embed_emoji: bool = build_config.embed_emoji_font and
+    !(builtin.target.os.tag.isDarwin() and Discover != void);
 
 /// Add the embedded Noto emoji faces to a fallback collection. Both are
 /// needed: NotoColorEmoji covers the emoji presentation and NotoEmoji the

--- a/src/font/SharedGridSet.zig
+++ b/src/font/SharedGridSet.zig
@@ -482,7 +482,7 @@ fn addEmbeddedEmojiFallback(
 }
 
 /// Decrement the ref count for the given key. If the ref count is zero,
-/// the grid will be deinitialized and removed from the map.j:w
+/// the grid will be deinitialized and removed from the map.
 pub fn deref(self: *SharedGridSet, key: Key) void {
     self.lock.lockUncancelable(global.io());
     defer self.lock.unlock(global.io());

--- a/src/font/SharedGridSet.zig
+++ b/src/font/SharedGridSet.zig
@@ -333,6 +333,13 @@ fn collection(
         },
     );
 
+    // Whether font discovery handed us a system colour emoji font. A system
+    // font is preferred over the embedded faces below: it is what the rest
+    // of the platform draws and it tracks OS updates. The embedded faces
+    // are what is left when the search finds nothing, so that a machine
+    // without a system emoji font still draws emoji instead of boxes.
+    var system_emoji_found = false;
+
     // On macOS, always search for and add the Apple Emoji font
     // as our preferred emoji font for fallback. We do this in case
     // people add other emoji fonts to their system, we always want to
@@ -354,6 +361,7 @@ fn collection(
                     // No size adjustment for emojis.
                     .size_adjustment = .none,
                 });
+                system_emoji_found = true;
                 break :apple_emoji;
             }
         }
@@ -369,6 +377,7 @@ fn collection(
                 // No size adjustment for emojis.
                 .size_adjustment = .none,
             });
+            system_emoji_found = true;
         }
     }
 
@@ -390,44 +399,72 @@ fn collection(
                 // No size adjustment for emojis.
                 .size_adjustment = .none,
             });
+            system_emoji_found = true;
         }
     }
 
-    // Embedded emoji fallback for platforms without a system emoji font.
-    // macOS and Windows use their native emoji fonts (added above) when
-    // discovery is available.
-    if (comptime !(builtin.target.os.tag.isDarwin() or builtin.target.os.tag == .windows) or Discover == void) {
-        _ = try c.add(
+    // Embedded emoji fallback, used only when the search above came up
+    // empty. Segoe UI Emoji can be missing from a stripped Windows image
+    // and DirectWrite can fail to enumerate it, and without this the
+    // collection would carry no emoji face at all.
+    if (comptime embed_emoji) {
+        if (!system_emoji_found) try addEmbeddedEmoji(
             self.alloc,
-            try .init(
-                self.font_lib,
-                font.embedded.emoji,
-                load_options.faceOptions(),
-            ),
-            .{
-                .style = .regular,
-                .fallback = true,
-                // No size adjustment for emojis.
-                .size_adjustment = .none,
-            },
-        );
-        _ = try c.add(
-            self.alloc,
-            try .init(
-                self.font_lib,
-                font.embedded.emoji_text,
-                load_options.faceOptions(),
-            ),
-            .{
-                .style = .regular,
-                .fallback = true,
-                // No size adjustment for emojis.
-                .size_adjustment = .none,
-            },
+            self.font_lib,
+            &c,
+            load_options,
         );
     }
 
     return c;
+}
+
+/// Whether the embedded Noto emoji faces are compiled in and reachable.
+///
+/// macOS is the exception: Apple Color Emoji is part of the OS and cannot
+/// be removed, so discovery always finds it and the embedded faces would
+/// never be used. Excluding them at compile time keeps roughly 11MB of
+/// font data out of the binary, since Zig only embeds what is referenced.
+const embed_emoji: bool = !(builtin.target.os.tag.isDarwin() and Discover != void);
+
+/// Add the embedded Noto emoji faces to a fallback collection. Both are
+/// needed: NotoColorEmoji covers the emoji presentation and NotoEmoji the
+/// text presentation, and a codepoint requested with an explicit
+/// presentation only matches a face that provides it.
+fn addEmbeddedEmoji(
+    alloc: Allocator,
+    lib: Library,
+    c: *Collection,
+    load_options: Collection.LoadOptions,
+) !void {
+    _ = try c.add(
+        alloc,
+        try .init(
+            lib,
+            font.embedded.emoji,
+            load_options.faceOptions(),
+        ),
+        .{
+            .style = .regular,
+            .fallback = true,
+            // No size adjustment for emojis.
+            .size_adjustment = .none,
+        },
+    );
+    _ = try c.add(
+        alloc,
+        try .init(
+            lib,
+            font.embedded.emoji_text,
+            load_options.faceOptions(),
+        ),
+        .{
+            .style = .regular,
+            .fallback = true,
+            // No size adjustment for emojis.
+            .size_adjustment = .none,
+        },
+    );
 }
 
 /// Decrement the ref count for the given key. If the ref count is zero,
@@ -872,4 +909,28 @@ test SharedGridSet {
     // If I deref grid1 then we should have a count of 0
     set.deref(key1);
     try testing.expectEqual(@as(usize, 0), set.count());
+}
+
+test addEmbeddedEmoji {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var lib: Library = try .init(alloc);
+    defer lib.deinit();
+
+    var c = Collection.init();
+    defer c.deinit(alloc);
+    const load_options: Collection.LoadOptions = .{
+        .library = lib,
+        .size = .{ .points = 12, .xdpi = 96, .ydpi = 96 },
+    };
+    c.load_options = load_options;
+
+    try addEmbeddedEmoji(alloc, lib, &c, load_options);
+
+    // The whole point of the fallback is that it renders emoji. Adding
+    // faces that cannot cover both presentations would leave the user
+    // looking at boxes, which is what this fallback exists to prevent.
+    try testing.expect(c.getIndex('🥸', .regular, .{ .explicit = .emoji }) != null);
+    try testing.expect(c.getIndex('🥸', .regular, .{ .explicit = .text }) != null);
 }

--- a/src/font/SharedGridSet.zig
+++ b/src/font/SharedGridSet.zig
@@ -408,14 +408,13 @@ fn collection(
     // empty. Segoe UI Emoji can be missing from a stripped Windows image
     // and DirectWrite can fail to enumerate it, and without this the
     // collection would carry no emoji face at all.
-    if (comptime embed_emoji) {
-        if (!system_emoji_found) try addEmbeddedEmoji(
-            self.alloc,
-            self.font_lib,
-            &c,
-            load_options,
-        );
-    }
+    if (comptime embed_emoji) try addEmbeddedEmojiFallback(
+        self.alloc,
+        self.font_lib,
+        &c,
+        load_options,
+        system_emoji_found,
+    );
 
     return c;
 }
@@ -426,21 +425,32 @@ fn collection(
 /// be removed, so discovery always finds it and the embedded faces would
 /// never be used. Excluding them at compile time keeps roughly 11MB of
 /// font data out of the binary, since Zig only embeds what is referenced.
-/// `-Dembed-emoji-font=false` excludes them everywhere, which buys that
-/// space back at the cost of boxes on a system with no emoji font.
+/// `-Dembed-emoji-font` says whether to embed them elsewhere; it is off by
+/// default on Windows, where Segoe UI Emoji ships with the OS, and on
+/// means the fallback below is armed at the cost of that 11MB.
 const embed_emoji: bool = build_config.embed_emoji_font and
     !(builtin.target.os.tag.isDarwin() and Discover != void);
 
-/// Add the embedded Noto emoji faces to a fallback collection. Both are
-/// needed: NotoColorEmoji covers the emoji presentation and NotoEmoji the
-/// text presentation, and a codepoint requested with an explicit
-/// presentation only matches a face that provides it.
-fn addEmbeddedEmoji(
+/// Add the embedded Noto emoji faces to a fallback collection, unless
+/// font discovery already found a system emoji font.
+///
+/// The system font wins when there is one: it is what the rest of the
+/// platform draws and it tracks OS updates. The embedded faces are what is
+/// left when the search finds nothing, so that a machine without a system
+/// emoji font still draws emoji instead of boxes.
+///
+/// Both faces are needed: NotoColorEmoji covers the emoji presentation and
+/// NotoEmoji the text presentation, and a codepoint requested with an
+/// explicit presentation only matches a face that provides it.
+fn addEmbeddedEmojiFallback(
     alloc: Allocator,
     lib: Library,
     c: *Collection,
     load_options: Collection.LoadOptions,
+    system_emoji_found: bool,
 ) !void {
+    if (system_emoji_found) return;
+
     _ = try c.add(
         alloc,
         try .init(
@@ -915,7 +925,7 @@ test SharedGridSet {
     try testing.expectEqual(@as(usize, 0), set.count());
 }
 
-test addEmbeddedEmoji {
+test "addEmbeddedEmojiFallback adds both faces when discovery found none" {
     const testing = std.testing;
     const alloc = testing.allocator;
 
@@ -930,11 +940,35 @@ test addEmbeddedEmoji {
     };
     c.load_options = load_options;
 
-    try addEmbeddedEmoji(alloc, lib, &c, load_options);
+    try addEmbeddedEmojiFallback(alloc, lib, &c, load_options, false);
 
     // The whole point of the fallback is that it renders emoji. Adding
     // faces that cannot cover both presentations would leave the user
     // looking at boxes, which is what this fallback exists to prevent.
     try testing.expect(c.getIndex('🥸', .regular, .{ .explicit = .emoji }) != null);
     try testing.expect(c.getIndex('🥸', .regular, .{ .explicit = .text }) != null);
+}
+
+test "addEmbeddedEmojiFallback adds nothing when discovery found a face" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var lib: Library = try .init(alloc);
+    defer lib.deinit();
+
+    var c = Collection.init();
+    defer c.deinit(alloc);
+    const load_options: Collection.LoadOptions = .{
+        .library = lib,
+        .size = .{ .points = 12, .xdpi = 96, .ydpi = 96 },
+    };
+    c.load_options = load_options;
+
+    try addEmbeddedEmojiFallback(alloc, lib, &c, load_options, true);
+
+    // A system emoji font was already added by the caller, so adding the
+    // embedded copies on top would shadow it with a face that does not
+    // track OS updates. The collection stays as the caller left it.
+    try testing.expect(c.getIndex('🥸', .regular, .{ .explicit = .emoji }) == null);
+    try testing.expect(c.getIndex('🥸', .regular, .{ .explicit = .text }) == null);
 }


### PR DESCRIPTION
The Noto emoji faces, about 11 MB, were embedded into every non-macOS binary as a fallback for systems with no emoji font of their own. On Windows that fallback was **unreachable**: the embedded block was excluded at compile time on both Windows and macOS, so a Windows image with Segoe UI Emoji stripped out, or one where DirectWrite fails to enumerate the family, had no emoji face at all and drew boxes.

## What this does

Font discovery already runs first on Windows and macOS. This tracks whether it actually returned a face, and adds the embedded faces only when it did not, so a system font still wins wherever there is one.

`-Dembed-emoji-font` controls whether the faces are compiled in at all. **It defaults off on every target.** The release build passes `-Dembed-emoji-font=true` for the pro legacy tier; every other build in this repo — CI, the fuzz recipes, `just build-dll`, contributor builds — is 11 MB smaller and behaves the same as the shipped artifact.

Making the default a build option rather than a hard exclusion is the fix. Changing only the release recipe would leave every other build behaviourally different from the shipped one, which is worse than the thing it fixes.

## The fallback is the OS font, not a bundled one

Worth stating plainly, because it is easy to assume otherwise: **none of the faces this project ships contains emoji.** JetBrains Mono, the Nerd Font *symbols*, and the alternates (Geist, JuliaMono, Inconsolata, Terminus, Spleen, Cozette, Monaspace, CodeNewRoman, KawkabMono) are all glyph fonts. The only emoji faces in the tree are the two Noto files this option controls.

So turning the embed off does not fall back to a bundled face; it falls back to the operating system:

- **Windows** — Segoe UI Emoji is an OS component present on every stock image.
- **macOS** — Apple Color Emoji cannot be removed. Unchanged here: the faces stay excluded at compile time as before.
- **Linux** — the real exposure. Most desktop distributions ship Noto Color Emoji, but a minimal container or a stripped image has none, and JetBrains Mono will not cover it. Those builds should pass `-Dembed-emoji-font=true`.

## Sizes

Measured on this branch, `zig build -Dapp-runtime=none` (Debug), size of the emitted Windows DLL:

| Build | Bytes |
| --- | ---: |
| default (faces omitted) | 39,378,432 |
| `-Dembed-emoji-font=true` | 50,933,760 |
| delta | **11,555,328** |

`NotoColorEmoji.ttf` plus `NotoEmoji-Regular.ttf` is 11,554,340 bytes, so the delta is the font data to within 988 bytes. That is what proves the option still works: the data is in the binary only when the flag is on, so `-Dembed-emoji-font=true` genuinely arms the fallback rather than compiling in a dead reference.

## Tests

`addEmbeddedEmojiFallback` takes the discovery result and returns early on it, so the decision sits inside the function the tests call rather than at the call site where nothing could reach it. Two tests: the faces are added, covering both the emoji and the text presentation, when discovery found nothing; and nothing is added when it did. Both were mutation-checked — deleting the early return fails the second test.

`zig build test -Dapp-runtime=none`: 87/87 steps, 4434/4516 tests passed (82 skipped).

## What is not covered

- The comptime decision cannot see what discovery found at runtime, so a build with `-Dembed-emoji-font=true` on a stock image carries 11 MB it never reads. There is no way to decide that at runtime, which is why the default is the whole question.
- A system emoji font that loads at discovery time and then fails to load its face later is still not rescued: `src/font/Collection.zig:226` propagates the error out of `getFaceFromEntry` with no re-resolution, and the resolver committed to the system index before loading. Having the embedded faces later in the chain cannot help, before or after this change.
- With the faces omitted the tests still reference them, so a test binary still carries the 11 MB. That is deliberate: gating the tests on the option would stop them running at all on the default build, which is the build that matters most here.
