### PR TITLE
surface: log the phases of a surface's synchronous bring-up

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -41,6 +41,14 @@ const ProcessInfo = @import("pty.zig").ProcessInfo;
 
 const log = std.log.scoped(.surface);
 
+/// Behavior-neutral bring-up timing. Attributes the synchronous
+/// UI-thread work inside `init` and the later hand-off to first render,
+/// all under one scope so the C# host's log bridge carries every phase
+/// into a single `Ghostty.Zig.surface_init` category. INFO because
+/// `main_ghostty.zig`'s `std_options.log_level` is always at least
+/// `.info`, in every build mode, so these are never compiled out.
+const init_log = std.log.scoped(.surface_init);
+
 // The renderer implementation to use.
 const Renderer = rendererpkg.Renderer;
 
@@ -61,6 +69,15 @@ const max_active_key_tables = 8;
 /// value when communicating an ID over DBus as DBus does not allow null/maybe
 /// values.
 id: u64,
+
+/// Wall-clock (`.awake` clock) timestamp captured at the very top of
+/// `init`, before any of its synchronous UI-thread work starts. Used to
+/// attribute `surface_init` phase log lines (see `init_log` above).
+/// Written once here; the only other read is from the `.first_render`
+/// message handler in `handleMessage`, which runs on this same main
+/// thread (via `App`'s mailbox drain), so no cross-thread
+/// synchronization is required.
+init_started: std.Io.Timestamp,
 
 /// Allocator
 alloc: Allocator,
@@ -482,6 +499,12 @@ pub fn init(
     rt_app: *apprt.runtime.App,
     rt_surface: *apprt.runtime.Surface,
 ) !void {
+    // Captured before any other work below so every `surface_init` phase
+    // (here and in the DX12 backend, threaded through via
+    // `rendererpkg.Options.init_started`) can report elapsed time from
+    // the same reference point.
+    const init_started: std.Io.Timestamp = .now(global.io(), .awake);
+
     // Apply our conditional state. If we fail to apply the conditional state
     // then we log and attempt to move forward with the old config.
     var config_: ?configpkg.Config = config_original.changeConditionalState(
@@ -536,6 +559,12 @@ pub fn init(
     );
     errdefer app.font_grid_set.deref(font_grid_key);
 
+    // No surface id yet: `self` isn't populated until the struct literal
+    // below.
+    init_log.info("surface_init font-grid-ref done +{d} ms", .{
+        init_started.untilNow(global.io(), .awake).toMilliseconds(),
+    });
+
     // Build our size struct which has all the sizes we need.
     const size: rendererpkg.Size = size: {
         var size: rendererpkg.Size = .{
@@ -572,6 +601,7 @@ pub fn init(
     errdefer alloc.destroy(mutex);
 
     self.* = .{
+        .init_started = init_started,
         .id = id: {
             while (true) {
                 const candidate = candidate: {
@@ -631,8 +661,13 @@ pub fn init(
             .surface_mailbox = .{ .surface = self, .app = app_mailbox },
             .rt_surface = rt_surface,
             .thread = &self.renderer_thread,
+            .init_started = init_started,
         });
     };
+    init_log.info("surface_init renderer-init done +{d} ms id=0x{x:0>16}", .{
+        self.init_started.untilNow(global.io(), .awake).toMilliseconds(),
+        self.id,
+    });
     errdefer self.renderer.deinit();
 
     self.renderer_thread = try rendererpkg.Thread.init(
@@ -754,6 +789,11 @@ pub fn init(
     // Give the renderer one more opportunity to finalize any surface
     // setup on the main thread prior to spinning up the rendering thread.
     try self.renderer.finalizeSurfaceInit(rt_surface);
+
+    init_log.info("surface_init ui-thread-handoff +{d} ms id=0x{x:0>16}", .{
+        self.init_started.untilNow(global.io(), .awake).toMilliseconds(),
+        self.id,
+    });
 
     // Start our renderer thread
     self.renderer_thr = try std.Thread.spawn(
@@ -1273,6 +1313,10 @@ pub fn handleMessage(self: *Surface, msg: Message) !void {
         },
 
         .first_render => {
+            init_log.info("surface_init first-render +{d} ms id=0x{x:0>16}", .{
+                self.init_started.untilNow(global.io(), .awake).toMilliseconds(),
+                self.id,
+            });
             _ = self.rt_app.performAction(
                 .{ .surface = self },
                 .first_render,

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -17,6 +17,13 @@ const Renderer = rendererpkg.GenericRenderer(DirectX12);
 const shadertoy = @import("shadertoy.zig");
 const log = std.log.scoped(.directx12);
 
+/// Same scope as `Surface.zig`'s `init_log`; shared name (not a shared
+/// declaration, each file's `std.log.scoped(.surface_init)` is its own
+/// comptime value) so the C# host's log bridge files every
+/// `surface_init` phase, whichever module logs it, under one
+/// `Ghostty.Zig.surface_init` category.
+const init_log = std.log.scoped(.surface_init);
+
 // --- GraphicsAPI contract: types ---
 
 pub const GraphicsAPI = DirectX12;
@@ -112,6 +119,14 @@ dev: ?device.Device = null,
 swap_chain3: ?*dxgi.IDXGISwapChain3 = null,
 
 allocator: Allocator = undefined,
+
+/// Copied from `rendererpkg.Options.init_started` at the top of `init`,
+/// so the GPU bring-up phases below (device creation, init-fence wait,
+/// PSO build in `initShaders`) can log elapsed time from the same
+/// reference `Surface.init` used, without their own plumbing. Null
+/// when unset (e.g. the non-Windows early return in `init`, or a
+/// caller that never threaded it through `Options`).
+init_started: ?std.Io.Timestamp = null,
 
 /// RTV descriptor heap for swap chain back buffers.
 /// Heap-allocated so copies of DirectX12 share the same mutable state
@@ -223,7 +238,7 @@ inline fn unpackSize(packed_size: u64) struct { width: u32, height: u32 } {
 // --- GraphicsAPI contract: functions ---
 
 pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX12 {
-    var result = DirectX12{ .allocator = alloc };
+    var result = DirectX12{ .allocator = alloc, .init_started = opts.init_started };
 
     if (comptime builtin.os.tag != .windows) {
         return result;
@@ -293,6 +308,10 @@ pub fn initGpu(self: *DirectX12, surface: Surface, width: u32, height: u32) !voi
         if (self.shared_texture_version != 0) st.version = self.shared_texture_version + 1;
     }
     self.dev = dev;
+    if (self.init_started) |started| init_log.info(
+        "surface_init d3d12-device done +{d} ms",
+        .{started.untilNow(global.io(), .awake).toMilliseconds()},
+    );
     errdefer {
         // A reused surface handle stays ours until this whole build
         // lands: take it back before Device.deinit would close it, or a
@@ -712,6 +731,10 @@ pub fn flushInitCommands(self: *DirectX12) void {
             dev_ptr.waitForGpu() catch |err| {
                 log.err("waitForGpu after init commands failed: {}", .{err});
             };
+            if (self.init_started) |started| init_log.info(
+                "surface_init init-fence-wait done +{d} ms",
+                .{started.untilNow(global.io(), .awake).toMilliseconds()},
+            );
         } else {
             // Close failed -- the recorded barriers won't reach the GPU.
             // Texture.state already reads PIXEL_SHADER_RESOURCE but the
@@ -894,7 +917,19 @@ pub fn initShaders(
     custom_shaders: []const [:0]const u8,
 ) !shaders.Shaders {
     const dev_device = if (self.dev) |*d| d.device else null;
-    return shaders.Shaders.init(dev_device, alloc, custom_shaders);
+    const result = try shaders.Shaders.init(dev_device, alloc, custom_shaders);
+    // Logged here rather than inside `shaders.Shaders.init` itself: that
+    // function is shared with Metal.zig and OpenGL.zig, and threading
+    // `init_started` into its signature (or the shared `shaders.zig`
+    // module) would ripple into those backends and their tests for a
+    // Windows-only bring-up trace. This wrapper is DX12-specific and
+    // already has `self.init_started`, and covers the same "all 5 PSOs
+    // built" boundary as a log placed inside `Shaders.init` would.
+    if (self.init_started) |started| init_log.info(
+        "surface_init pso-build done +{d} ms",
+        .{started.untilNow(global.io(), .awake).toMilliseconds()},
+    );
+    return result;
 }
 
 /// Called by the apprt (via generic.zig) when the surface is resized.

--- a/src/renderer/Options.zig
+++ b/src/renderer/Options.zig
@@ -1,5 +1,6 @@
 //! The options that are used to configure a renderer.
 
+const std = @import("std");
 const apprt = @import("../apprt.zig");
 const font = @import("../font/main.zig");
 const renderer = @import("../renderer.zig");
@@ -22,3 +23,11 @@ rt_surface: *apprt.Surface,
 
 /// The renderer thread.
 thread: *renderer.Thread,
+
+/// Wall-clock timestamp (`.awake` clock) captured at the top of
+/// `Surface.init`, threaded through so GPU backend init phases (device
+/// creation, PSO build, init-fence wait) can report elapsed time under
+/// the `surface_init` scoped logger without their own plumbing. Optional
+/// and defaults to null so this struct's other constructors, if any are
+/// ever added, are not forced to supply it.
+init_started: ?std.Io.Timestamp = null,


### PR DESCRIPTION
Everything ghostty_surface_new does before the renderer thread spawns runs on the caller's thread: the font grid ref (DirectWrite discovery on a cold miss), the D3D12 device and its heaps, the swap chain's frame states, the init command list with its GPU fence wait, and the five pipeline states. On the Windows host that caller is the UI thread and the span sits between the first pane's Loaded and its first frame. Nothing timed any of it.

Seven INFO lines under one scope (surface_init) report elapsed ms from the top of Surface.init: font-grid-ref, renderer-init, d3d12-device, init-fence-wait, pso-build, ui-thread-handoff, first-render. The DX12 backend receives the start timestamp through a new optional field on renderer.Options (one construction site; Metal and OpenGL leave it null and log nothing). The PSO mark sits in the DX12 initShaders wrapper rather than the shared Shaders.init so the other backends and their tests are untouched. Clock: std.Io.Timestamp.now(io, .awake), the idiom the surface and app already use. Behavior-neutral: no control flow changes, one clock read per mark, once per surface; INFO is never filtered in the embedded build (std_options.log_level is at least .info), so the lines reach the host's log bridge in every mode.

Review (Zig/Ghostty persona, file:line): API usage matches App.zig/Thread.zig and the 0.16 std.Io signatures; gpu_test.zig's direct DirectX12 literals keep init_started null and the gated marks no-op; the first-render mark runs on the main thread that wrote init_started; insertions sit outside the release series' Surface.zig hunks. Startup-campaign context: the measured surface block is ~1.0-1.6 s at ReleaseSafe on the dev box; these marks are the attribution needed before any optimization of it.