### PR TITLE
tests: make three load-sensitive windows tests deterministic, and fix the budget #982 outgrew

### DIFF
--- a/windows/Ghostty.Core/Profiles/Tracking/WindowsActiveProcessTracker.cs
+++ b/windows/Ghostty.Core/Profiles/Tracking/WindowsActiveProcessTracker.cs
@@ -24,6 +24,8 @@ public sealed class WindowsActiveProcessTracker : IActiveProcessTracker
     private const int MaxDueMs = 30_000;
 
     private readonly Timer _timer;
+    private readonly int _tickIntervalMs;
+    private readonly int _maxDueMs;
     private readonly ConcurrentDictionary<int, byte> _roots = new();
     private readonly ActiveProcessDebouncer _debouncer = new(DebounceWindowMs);
     private int _disposed;
@@ -31,7 +33,36 @@ public sealed class WindowsActiveProcessTracker : IActiveProcessTracker
     public event EventHandler<ActiveProcessChangedEventArgs>? Changed;
 
     public WindowsActiveProcessTracker()
+        : this(TickIntervalMs, MaxDueMs)
     {
+    }
+
+    /// <summary>
+    /// Cadence-controlled construction, for tests that assert on what the
+    /// tracker reports rather than on how often it looks.
+    /// </summary>
+    /// <remarks>
+    /// The shipped cadence stretches with machine load
+    /// (<c>max(interval, 3x the last walk)</c>, capped at
+    /// <paramref name="maxDueMs"/>), which is what keeps the tracker's duty
+    /// cycle down on a process-heavy box. It also makes the interval between
+    /// two consecutive observations unbounded from a test's point of view, up
+    /// to the cap -- and the debouncer needs TWO observations of a value
+    /// before it emits, so a test asserting "the tracker reported X" is
+    /// implicitly asserting the load-dependent cadence too. Passing
+    /// <paramref name="maxDueMs"/> equal to <paramref name="tickIntervalMs"/>
+    /// pins the cadence and leaves the walker, the broker filter, the
+    /// debouncer and the event wiring as the only things under test.
+    /// <see cref="ActiveProcessDebouncer"/> takes its clock from the caller
+    /// for the same reason.
+    /// </remarks>
+    internal WindowsActiveProcessTracker(int tickIntervalMs, int maxDueMs)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(tickIntervalMs);
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxDueMs, tickIntervalMs);
+        _tickIntervalMs = tickIntervalMs;
+        _maxDueMs = maxDueMs;
+
         // period: never. A fixed period re-enters OnTick while a slow tick
         // (one full-machine process snapshot) is still walking, and the
         // concurrent ticks pile up without bound - measured at more than a
@@ -39,7 +70,7 @@ public sealed class WindowsActiveProcessTracker : IActiveProcessTracker
         // re-arms itself when its work is done, so the real cadence is one
         // walk every (interval + work) and no walk ever overlaps another.
         _timer = new Timer(OnTick, state: null,
-            dueTime: TickIntervalMs, period: Timeout.Infinite);
+            dueTime: tickIntervalMs, period: Timeout.Infinite);
     }
 
     public void Register(int rootPid) => _roots.TryAdd(rootPid, 0);
@@ -124,7 +155,7 @@ public sealed class WindowsActiveProcessTracker : IActiveProcessTracker
             // stretch the tracker's dead time. ObjectDisposed races the
             // Dispose wait below; a lost re-arm is the shutdown case anyway.
             var walkMs = Environment.TickCount64 - walkStart;
-            var dueMs = Math.Min(MaxDueMs, Math.Max(TickIntervalMs, 3 * (int)walkMs));
+            var dueMs = Math.Min(_maxDueMs, Math.Max(_tickIntervalMs, 3 * (int)walkMs));
             try { _timer.Change(dueMs, Timeout.Infinite); }
             catch (ObjectDisposedException) { }
         }

--- a/windows/Ghostty.Tests.Windows/SpawnProbe.cs
+++ b/windows/Ghostty.Tests.Windows/SpawnProbe.cs
@@ -58,16 +58,20 @@ internal sealed class SpawnProbe
     private const int CmdBudgetMs = 2_000;
 
     /// <summary>
-    /// The same question for pwsh.exe, derived from what the tests that spawn
-    /// it actually assert: the tracker smoke tests allow themselves 8000 ms
-    /// end to end. 750 ms of that is fixed tracker cost (500 ms tick +
-    /// 250 ms debounce) and is available to no spawn at all. The remaining
-    /// 7250 ms has to cover pwsh getting to the point of running its command
-    /// AND everything it is then asked to do -- launch cmd, cmd exec ping,
-    /// and a tracker snapshot that catches them alive. This probe measures
-    /// only the first half, so it gets half the budget: 3625 ms, taken as
-    /// 3500. A host slower than that cannot pass those tests for a reason
-    /// that has nothing to do with the tracker.
+    /// The same question for pwsh.exe: the latency past which a host's own
+    /// slowness, rather than the subject, is what a pwsh-spawning test would
+    /// be reporting. A healthy host starts a no-op pwsh in a few hundred ms
+    /// even cold, so 3500 ms is several times the honest cost and still well
+    /// short of the seconds a blocked or scanned spawn takes.
+    ///
+    /// Deliberately NOT derived from a downstream test's deadline any more.
+    /// It used to be: "the tracker smoke tests allow themselves 8000 ms end to
+    /// end, 750 ms of that is fixed tracker cost, halve the rest". Every term
+    /// in that stopped being true when the tracker gained its adaptive cadence
+    /// (the fixed cost is no longer 750 ms and no longer fixed) and the smoke
+    /// tests stopped using a flat budget -- and nothing caught it, because a
+    /// constant computed from another constant has no way to notice the other
+    /// one moved. A gate on the host's health should stand on its own.
     /// </summary>
     private const int PwshBudgetMs = 3_500;
 

--- a/windows/Ghostty.Tests.Windows/TestHostThreadPool.cs
+++ b/windows/Ghostty.Tests.Windows/TestHostThreadPool.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace Ghostty.Tests.Windows;
+
+/// <summary>
+/// Gives this test host a thread pool big enough for the way xunit runs it,
+/// before any test starts.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The pool starts with <c>ProcessorCount</c> worker threads and, past that,
+/// injects roughly one or two a second. xunit runs test collections in
+/// parallel up to <c>ProcessorCount</c>, and several tests here hold a pool
+/// thread while they wait on something else: the spawn probe blocks on a
+/// child process, the pipe tests block on a handshake. When those fill the
+/// pool, anything that needs a FRESH work item does not run until the pool
+/// grows -- and that includes <see cref="Timer"/> callbacks.
+/// </para>
+/// <para>
+/// That is not a hypothesis. The active-process tracker polls on a Timer, and
+/// with the pool deliberately saturated it was measured raising 0 events in
+/// 8 seconds, and 1 in a second pass, against roughly one a second unloaded.
+/// A whole-assembly run reproduced it: the wsl smoke test failed reporting
+/// "observed: []" -- not a wrong value, no values at all -- while the walker
+/// could see the process it was waiting for the whole time.
+/// </para>
+/// <para>
+/// Four times <c>ProcessorCount</c> leaves every parallel test free to block
+/// a thread and still keeps threads spare for timers and continuations, so
+/// what the tracker tests measure is the tracker rather than the runner's
+/// thread supply. This changes the test host only; nothing here is compiled
+/// into the product.
+/// </para>
+/// </remarks>
+internal static class TestHostThreadPool
+{
+    [ModuleInitializer]
+    internal static void RaiseMinimumWorkers()
+    {
+        ThreadPool.GetMinThreads(out var workers, out var completionPorts);
+        var wanted = Environment.ProcessorCount * 4;
+        ThreadPool.SetMinThreads(
+            Math.Max(workers, wanted),
+            Math.Max(completionPorts, wanted));
+    }
+}

--- a/windows/Ghostty.Tests.Windows/Tracking/TrackerSmoke.cs
+++ b/windows/Ghostty.Tests.Windows/Tracking/TrackerSmoke.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Ghostty.Core.Profiles.Tracking;
+
+namespace Ghostty.Tests.Windows.Tracking;
+
+/// <summary>
+/// Shared setup for the tracker smoke tests, which spawn a real process tree
+/// and assert on what <see cref="WindowsActiveProcessTracker"/> reports about
+/// it.
+///
+/// <para>
+/// Both tests used to give themselves a flat 8000 ms for "spawn pwsh, let it
+/// start a child, and let the tracker notice" and then failed, intermittently
+/// and in a different combination each run, on a loaded machine. Neither the
+/// spawn nor the noticing has a bound the test controls, and the budget
+/// covered both at once, so a slow host was indistinguishable from a broken
+/// walker. What this class does about that is split the two and take the
+/// load-dependent cadence out of the second one.
+/// </para>
+/// </summary>
+internal static class TrackerSmoke
+{
+    /// <summary>
+    /// Names the xunit collection that serialises the tracker smoke tests
+    /// against each other. Each one spawns a process tree and then walks the
+    /// WHOLE machine's process list repeatedly; running two at once means
+    /// each is measuring a machine the other is loading, which is the one
+    /// condition their assertions are least able to survive.
+    /// </summary>
+    internal const string SerialCollection = "ProcessTracker (serial)";
+
+    /// <summary>Cadence the smoke tests pin the tracker to.</summary>
+    internal const int TickIntervalMs = 500;
+
+    /// <summary>
+    /// How long the scenario itself gets to come up: pwsh cold start, plus
+    /// pwsh launching its child, plus the child exec'ing the leaf. Generous
+    /// on purpose -- none of it is the tracker's doing, and blowing this
+    /// budget is reported as the scenario failing to start rather than as the
+    /// tracker failing to see it. The pwsh spawn gate already allows 3500 ms
+    /// for pwsh alone before it skips the test.
+    /// </summary>
+    internal const int ScenarioBudgetMs = 20_000;
+
+    /// <summary>
+    /// Ticks the tracker is allowed once the scenario is demonstrably live.
+    /// Two are the floor: the debouncer emits on the SECOND observation of a
+    /// value, never the first. A third covers a tick already mid-walk when
+    /// the scenario went live. The remaining factor of three is for the timer
+    /// callback waiting its turn on a busy thread pool -- it buys slack in
+    /// the one dimension that is genuinely not the tracker's fault, and
+    /// nine ticks is still bounded, unlike the shipped cadence.
+    /// </summary>
+    private const int TicksAllowed = 9;
+
+    /// <summary>
+    /// A tracker whose cadence does not stretch with machine load.
+    /// </summary>
+    /// <remarks>
+    /// The shipped tracker re-arms at <c>max(interval, 3x the last walk)</c>,
+    /// capped at 30s, so on a loaded box two consecutive observations can be
+    /// many seconds apart -- and the debouncer needs two of them. That
+    /// cadence is deliberate product behaviour (it is what holds the
+    /// tracker's idle cost down on a process-heavy machine) but it is not
+    /// what these tests are about: they are about the walker, the broker
+    /// filter, the debouncer and the event wiring. Pinning the cadence leaves
+    /// exactly those under test.
+    /// </remarks>
+    internal static WindowsActiveProcessTracker NewTracker() =>
+        new(TickIntervalMs, TickIntervalMs);
+
+    /// <summary>
+    /// The tracker's budget, once <see cref="AwaitScenario"/> has established
+    /// that there is something to report. With the cadence pinned, one
+    /// observation costs the walk plus the interval, and
+    /// <paramref name="walkMs"/> is the worst walk actually measured on this
+    /// host seconds ago -- so the deadline tracks the machine rather than
+    /// assuming one. Clamped so a pathological host still fails rather than
+    /// hangs.
+    /// </summary>
+    internal static int TrackerDeadlineMs(long walkMs) =>
+        (int)Math.Clamp(TicksAllowed * (walkMs + TickIntervalMs), 5_000, 45_000);
+
+    /// <summary>
+    /// What <see cref="AwaitScenario"/> found: whether the root ever had a
+    /// descendant the caller accepts, which one, the worst single walk seen
+    /// while looking, and how long the wait took.
+    /// </summary>
+    internal readonly record struct Scenario(
+        bool Live, string? Exe, long WalkMs, long ElapsedMs);
+
+    /// <summary>
+    /// Polls the process tree until <paramref name="rootPid"/> has an
+    /// innermost descendant that <paramref name="accept"/> approves.
+    /// </summary>
+    /// <remarks>
+    /// This asks the walker directly rather than going through the tracker,
+    /// which keeps two different failures apart: "this host never got as far
+    /// as running the scenario" (pwsh slow or its child never started) and
+    /// "the scenario ran and the tracker did not report it". Only the second
+    /// is a defect in the code under test, and only the second is worth
+    /// giving a tight budget to. The walk cost measured here is the same
+    /// quantity that drives the tracker's own cadence, so it is what the
+    /// tracker's deadline is then sized from.
+    /// </remarks>
+    internal static async Task<Scenario> AwaitScenario(
+        int rootPid, Func<string, bool> accept)
+    {
+        var overall = Stopwatch.StartNew();
+        long worstWalkMs = 0;
+
+        while (overall.ElapsedMilliseconds < ScenarioBudgetMs)
+        {
+            var walk = Stopwatch.StartNew();
+            var infos = ProcessTreeWalker.FindInnermostDescendants(new[] { (uint)rootPid });
+            walk.Stop();
+            if (walk.ElapsedMilliseconds > worstWalkMs)
+                worstWalkMs = walk.ElapsedMilliseconds;
+
+            var exe = infos.TryGetValue((uint)rootPid, out var info)
+                ? info?.ExeBasename
+                : null;
+            if (exe is not null && accept(exe))
+                return new Scenario(true, exe, worstWalkMs, overall.ElapsedMilliseconds);
+
+            await Task.Delay(100).ConfigureAwait(false);
+        }
+
+        return new Scenario(false, null, worstWalkMs, overall.ElapsedMilliseconds);
+    }
+}

--- a/windows/Ghostty.Tests.Windows/Tracking/WindowsActiveProcessTrackerSmokeTests.cs
+++ b/windows/Ghostty.Tests.Windows/Tracking/WindowsActiveProcessTrackerSmokeTests.cs
@@ -1,13 +1,13 @@
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Threading;
 using System.Threading.Tasks;
-using Ghostty.Core.Profiles.Tracking;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Ghostty.Tests.Windows.Tracking;
 
+[Collection(TrackerSmoke.SerialCollection)]
 public sealed class WindowsActiveProcessTrackerSmokeTests
 {
     private readonly ITestOutputHelper _output;
@@ -18,8 +18,8 @@ public sealed class WindowsActiveProcessTrackerSmokeTests
     }
 
     // PwshFact, not SpawnFact: this spawns pwsh, which is not in-box on
-    // Windows and pays a runtime cold start that the whole 8s budget below is
-    // sized around. A cmd.exe measurement predicts neither.
+    // Windows and pays a runtime cold start that no cmd.exe measurement
+    // predicts.
     [PwshFact]
     public async Task Track_PwshThenCmd_ReportsTransition()
     {
@@ -42,66 +42,96 @@ public sealed class WindowsActiveProcessTrackerSmokeTests
         });
         Assert.NotNull(pwsh);
 
-        using var tracker = new WindowsActiveProcessTracker();
-        var tcs = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var observed = new List<string>();
-        var sw = Stopwatch.StartNew();
+        // finally, not a trailing statement: a failed assertion used to leave
+        // pwsh and a 30-second ping alive, so a red run handed the next test
+        // -- and the next run of this one -- a machine with extra processes
+        // on it.
+        try
+        {
+            // Acceptable: the test scenario spawns pwsh -> cmd -> ping; with the
+            // broker filter (conhost / OpenConsole) the walker reports the deepest
+            // non-broker descendant. cmd or ping both prove pwsh's descendants are
+            // being walked; conhost / OpenConsole appearing means the filter regressed.
+            var acceptedExes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "cmd.exe",
+                "ping.exe",
+                "PING.EXE",
+            };
+            var brokerExes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "conhost.exe",
+                "OpenConsole.exe",
+            };
 
-        // Acceptable: the test scenario spawns pwsh -> cmd -> ping; with the
-        // broker filter (conhost / OpenConsole) the walker reports the deepest
-        // non-broker descendant. cmd or ping both prove pwsh's descendants are
-        // being walked; conhost / OpenConsole appearing means the filter regressed.
-        var acceptedExes = new HashSet<string>(System.StringComparer.OrdinalIgnoreCase)
-        {
-            "cmd.exe",
-            "ping.exe",
-            "PING.EXE",
-        };
-        var brokerExes = new HashSet<string>(System.StringComparer.OrdinalIgnoreCase)
-        {
-            "conhost.exe",
-            "OpenConsole.exe",
-        };
+            using var tracker = TrackerSmoke.NewTracker();
+            var tcs = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var observed = new List<string>();
+            var sw = Stopwatch.StartNew();
 
-        tracker.Changed += (_, e) =>
-        {
+            tracker.Changed += (_, e) =>
+            {
+                lock (observed)
+                {
+                    observed.Add($"{sw.ElapsedMilliseconds}ms pid={e.RootPid} exe={e.ExeBasename ?? "<null>"}");
+                }
+                if (e.ExeBasename is not null
+                    && brokerExes.Contains(e.ExeBasename)
+                    && !tcs.Task.IsCompleted)
+                {
+                    tcs.SetException(new Xunit.Sdk.XunitException(
+                        $"tracker reported broker exe {e.ExeBasename}; filter regressed"));
+                }
+                else if (e.ExeBasename is not null
+                    && acceptedExes.Contains(e.ExeBasename)
+                    && !tcs.Task.IsCompleted)
+                {
+                    tcs.SetResult(e.ExeBasename);
+                }
+            };
+            // Registered before the wait below so the tracker still sees the
+            // pwsh -> cmd -> ping transition, not just the settled leaf.
+            tracker.Register(pwsh!.Id);
+
+            // Precondition, not an assertion about the tracker: wait until the
+            // walker can see a cmd-tree descendant of pwsh at all. Everything
+            // before this point is pwsh's cold start and cmd's exec, which the
+            // tracker does not control and which used to be charged to its
+            // budget.
+            var scenario = await TrackerSmoke.AwaitScenario(
+                pwsh!.Id, e => acceptedExes.Contains(e));
+            Assert.True(
+                scenario.Live,
+                $"pwsh never produced a cmd-tree descendant within "
+                + $"{TrackerSmoke.ScenarioBudgetMs} ms, so there was nothing for the "
+                + $"tracker to report: this is the host or pwsh, not the tracker.");
+            _output.WriteLine(
+                $"scenario live: {scenario.Exe} after {scenario.ElapsedMs} ms "
+                + $"(worst walk {scenario.WalkMs} ms)");
+
+            // Only now does the tracker's clock start, and its budget is sized
+            // from the walk cost just measured on this host.
+            var deadlineMs = TrackerSmoke.TrackerDeadlineMs(scenario.WalkMs);
+            var winner = await Task.WhenAny(tcs.Task, Task.Delay(deadlineMs));
             lock (observed)
             {
-                observed.Add($"{sw.ElapsedMilliseconds}ms pid={e.RootPid} exe={e.ExeBasename ?? "<null>"}");
+                foreach (var line in observed)
+                    _output.WriteLine(line);
             }
-            if (e.ExeBasename is not null
-                && brokerExes.Contains(e.ExeBasename)
-                && !tcs.Task.IsCompleted)
-            {
-                tcs.SetException(new Xunit.Sdk.XunitException(
-                    $"tracker reported broker exe {e.ExeBasename}; filter regressed"));
-            }
-            else if (e.ExeBasename is not null
-                && acceptedExes.Contains(e.ExeBasename)
-                && !tcs.Task.IsCompleted)
-            {
-                tcs.SetResult(e.ExeBasename);
-            }
-        };
-        tracker.Register(pwsh!.Id);
+            Assert.True(
+                winner == tcs.Task,
+                $"the walker could already see {scenario.Exe} under pwsh, but the "
+                + $"tracker reported no cmd-tree descendant within {deadlineMs} ms; "
+                + $"observed: [{string.Join(", ", observed)}]");
 
-        // pwsh.exe startup is heavy (~1-2s cold). Allow up to 8 seconds for
-        // the tracker to observe a cmd-tree descendant: pwsh launch + JIT +
-        // tick interval 500 ms + debounce 250 ms + slop.
-        var winner = await Task.WhenAny(tcs.Task, Task.Delay(8000));
-        lock (observed)
-        {
-            foreach (var line in observed)
-                _output.WriteLine(line);
+            var reported = await tcs.Task;
+            Assert.NotNull(reported);
+            Assert.Contains(reported!, acceptedExes);
+            _output.WriteLine($"tracker reported {reported} after {sw.ElapsedMilliseconds}ms");
         }
-        Assert.True(
-            winner == tcs.Task,
-            $"tracker did not report a cmd-tree descendant within 8s; observed: [{string.Join(", ", observed)}]");
-        var reported = await tcs.Task;
-        Assert.NotNull(reported);
-        Assert.Contains(reported!, acceptedExes);
-        _output.WriteLine($"tracker reported {reported} after {sw.ElapsedMilliseconds}ms");
-
-        try { pwsh.Kill(entireProcessTree: true); } catch { }
+        finally
+        {
+            try { pwsh!.Kill(entireProcessTree: true); } catch { }
+        }
     }
 }

--- a/windows/Ghostty.Tests.Windows/Tracking/WindowsActiveProcessTrackerWslSmokeTests.cs
+++ b/windows/Ghostty.Tests.Windows/Tracking/WindowsActiveProcessTrackerWslSmokeTests.cs
@@ -3,12 +3,12 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Ghostty.Core.Profiles;
-using Ghostty.Core.Profiles.Tracking;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Ghostty.Tests.Windows.Tracking;
 
+[Collection(TrackerSmoke.SerialCollection)]
 public sealed class WindowsActiveProcessTrackerWslSmokeTests
 {
     private readonly ITestOutputHelper _output;
@@ -29,14 +29,20 @@ public sealed class WindowsActiveProcessTrackerWslSmokeTests
         var distro = WslDistro.Name!;
         _output.WriteLine($"probed distro: {distro}");
 
-        // Spawn pwsh -> wsl.exe --distribution <distro> -- sleep 5
+        // Spawn pwsh -> wsl.exe --distribution <distro> -- sleep 60
         // pwsh is the root we register; wsl.exe is the descendant the walker
-        // should observe. The 5s sleep gives the 500 ms tick + 250 ms debounce
-        // a comfortable window to fire while wsl.exe is still alive.
+        // should observe.
+        //
+        // sleep 60, not sleep 5: the old five seconds had to outlast pwsh's
+        // cold start AND however long the tracker took to look, so on a
+        // loaded machine wsl.exe could exit before it was ever observed --
+        // the test then failed for the scenario ending early rather than for
+        // anything the tracker did. The process is killed in the finally
+        // below, so a longer sleep costs nothing on a healthy run.
         using var pwsh = Process.Start(new ProcessStartInfo
         {
             FileName = "pwsh.exe",
-            Arguments = $"-NoLogo -NoProfile -Command \"& wsl.exe --distribution {distro} -- sleep 5\"",
+            Arguments = $"-NoLogo -NoProfile -Command \"& wsl.exe --distribution {distro} -- sleep 60\"",
             UseShellExecute = false,
             CreateNoWindow = true,
         });
@@ -44,8 +50,9 @@ public sealed class WindowsActiveProcessTrackerWslSmokeTests
 
         try
         {
-            using var tracker = new WindowsActiveProcessTracker();
-            var tcs = new TaskCompletionSource<(string exe, string? cmd)>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var tracker = TrackerSmoke.NewTracker();
+            var tcs = new TaskCompletionSource<(string Exe, string? Cmd)>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
             var observed = new List<string>();
             var sw = Stopwatch.StartNew();
 
@@ -65,7 +72,24 @@ public sealed class WindowsActiveProcessTrackerWslSmokeTests
             };
             tracker.Register(pwsh!.Id);
 
-            var winner = await Task.WhenAny(tcs.Task, Task.Delay(8000));
+            // Precondition, not an assertion about the tracker: wait until the
+            // walker can see wsl.exe under pwsh at all. pwsh's cold start and
+            // wsl's own launch are not the tracker's doing and used to be
+            // charged to its budget.
+            var scenario = await TrackerSmoke.AwaitScenario(
+                pwsh!.Id,
+                e => string.Equals(e, "wsl.exe", StringComparison.OrdinalIgnoreCase));
+            Assert.True(
+                scenario.Live,
+                $"pwsh never produced a wsl.exe descendant within "
+                + $"{TrackerSmoke.ScenarioBudgetMs} ms, so there was nothing for the "
+                + $"tracker to report: this is the host, pwsh or wsl, not the tracker.");
+            _output.WriteLine(
+                $"scenario live: {scenario.Exe} after {scenario.ElapsedMs} ms "
+                + $"(worst walk {scenario.WalkMs} ms)");
+
+            var deadlineMs = TrackerSmoke.TrackerDeadlineMs(scenario.WalkMs);
+            var winner = await Task.WhenAny(tcs.Task, Task.Delay(deadlineMs));
             lock (observed)
             {
                 foreach (var line in observed)
@@ -73,7 +97,9 @@ public sealed class WindowsActiveProcessTrackerWslSmokeTests
             }
             Assert.True(
                 winner == tcs.Task,
-                $"tracker did not report wsl.exe within 8s; observed: [{string.Join(", ", observed)}]");
+                $"the walker could already see wsl.exe under pwsh, but the tracker "
+                + $"tracker did not report wsl.exe within {deadlineMs} ms; "
+                + $"observed: [{string.Join(", ", observed)}]");
 
             var (exe, cmd) = await tcs.Task;
             Assert.Equal("wsl.exe", exe, ignoreCase: true);
@@ -90,7 +116,7 @@ public sealed class WindowsActiveProcessTrackerWslSmokeTests
         }
         finally
         {
-            try { pwsh.Kill(entireProcessTree: true); } catch { }
+            try { pwsh!.Kill(entireProcessTree: true); } catch { }
         }
     }
 }

--- a/windows/Ghostty.Tests/Pipes/SecureNamedPipeTests.cs
+++ b/windows/Ghostty.Tests/Pipes/SecureNamedPipeTests.cs
@@ -11,6 +11,17 @@ namespace Ghostty.Tests.Pipes;
 
 public sealed class SecureNamedPipeTests
 {
+    /// <summary>
+    /// Deadline for the local handshake. Both halves are same-user, on this
+    /// machine, against a server already parked in
+    /// <c>WaitForConnectionAsync</c>: the kernel answers a CreateFileW on a
+    /// listening pipe without waiting on anything, so a healthy handshake
+    /// spends microseconds here. The number is a hang detector -- it turns
+    /// "never" into a reported failure instead of a stuck run -- not a budget
+    /// the handshake is expected to draw down.
+    /// </summary>
+    private const int HandshakeTimeoutMs = 10_000;
+
     private static string TestPipeName() =>
         "wintty-test-secure-pipe-" + Guid.NewGuid().ToString("N");
 
@@ -18,8 +29,18 @@ public sealed class SecureNamedPipeTests
     // asks the OS for the SDDL actually held on the handle. The default
     // pipe DACL grants Everyone (S-1-1-0) and Anonymous Logon; the factory
     // must produce neither.
+    //
+    // Nothing in here waits on anything: create the server, ask the kernel,
+    // assert. That is deliberate. This assertion and the round trip that
+    // proves the creating user is still granted access used to share one
+    // method, so a connect that lost a race with the machine's load reported
+    // the security claim as failed too -- it did on a loaded signoff run, at
+    // 12s, against code whose DACL was correct. A security regression test
+    // people have learned to read as "probably just the flake" is worse than
+    // no test, so the half that cannot be slow no longer sits behind the half
+    // that can.
     [Fact]
-    public async Task CreateServer_DaclGrantsOnlyTheCreatingUser()
+    public void CreateServer_DaclGrantsOnlyTheCreatingUser()
     {
         var name = TestPipeName();
         using var server = SecureNamedPipe.CreateServer(name);
@@ -28,17 +49,19 @@ public sealed class SecureNamedPipeTests
         Assert.DoesNotContain("S-1-1-0", sddl, StringComparison.Ordinal); // Everyone
         Assert.DoesNotContain(";AU;", sddl, StringComparison.Ordinal); // Anonymous Logon
         Assert.DoesNotContain("(AU;", sddl, StringComparison.Ordinal);
+    }
 
-        // The creating user must still be granted access, or the pipe would
-        // be unusable rather than merely locked down: a same-user client
-        // connects and completes a round trip.
-        using var connectCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var accept = server.WaitForConnectionAsync(connectCts.Token);
-        using var client = new NamedPipeClientStream(
-            ".", name, PipeDirection.Out, PipeOptions.Asynchronous);
-        await client.ConnectAsync(10_000, connectCts.Token);
-        await accept.WaitAsync(connectCts.Token);
+    // The other half of "only the creating user": the creating user must
+    // still be granted access, or the pipe would be unusable rather than
+    // merely locked down.
+    [Fact]
+    public void CreateServer_StillLetsTheCreatingUserConnect()
+    {
+        var name = TestPipeName();
+        using var server = SecureNamedPipe.CreateServer(name);
+        using var client = ConnectSameUser(server, name);
         Assert.True(client.IsConnected);
+        Assert.True(server.IsConnected);
     }
 
     [Fact]
@@ -46,12 +69,8 @@ public sealed class SecureNamedPipeTests
     {
         var name = TestPipeName();
         using var server = SecureNamedPipe.CreateServer(name);
+        using var client = ConnectSameUser(server, name);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var accept = server.WaitForConnectionAsync(cts.Token);
-        using var client = new NamedPipeClientStream(
-            ".", name, PipeDirection.Out, PipeOptions.Asynchronous);
-        await client.ConnectAsync(10_000, cts.Token);
-        await accept.WaitAsync(cts.Token);
 
         // Write, then close: the payload is buffered in the pipe and the
         // close is what gives the reader its end-of-stream. (No
@@ -71,12 +90,8 @@ public sealed class SecureNamedPipeTests
     {
         var name = TestPipeName();
         using var server = SecureNamedPipe.CreateServer(name);
+        using var client = ConnectSameUser(server, name);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var accept = server.WaitForConnectionAsync(cts.Token);
-        using var client = new NamedPipeClientStream(
-            ".", name, PipeDirection.Out, PipeOptions.Asynchronous);
-        await client.ConnectAsync(10_000, cts.Token);
-        await accept.WaitAsync(cts.Token);
 
         // Two bytes past the cap: small enough to fit any pipe buffer (a
         // buffer-filling write would block until read), more than the
@@ -87,5 +102,57 @@ public sealed class SecureNamedPipeTests
         var (text, overflow) = await SecureNamedPipe.ReadAtMostAsync(server, 64, cts.Token);
         Assert.True(overflow);
         Assert.Null(text);
+    }
+
+    /// <summary>
+    /// Completes the same-user handshake against <paramref name="server"/>
+    /// and hands back the connected client, with the server's accept already
+    /// finished.
+    /// </summary>
+    /// <remarks>
+    /// The client half is the BLOCKING <c>Connect</c>, run on the test's own
+    /// thread, and that is the whole point of this helper.
+    /// <c>NamedPipeClientStream.ConnectAsync</c> is not asynchronous
+    /// underneath: it is <c>Task.Run</c> over the same blocking connect loop.
+    /// Awaiting it therefore queues a fresh work item, and the connect does
+    /// not begin until the pool schedules that item -- which on an
+    /// oversubscribed machine (this suite runs its classes in parallel, and
+    /// the signoff ladder runs beside builds) is bounded by nothing the test
+    /// controls: a pool at its thread limit injects replacements at one or
+    /// two a second. All of that waiting is charged to the test's deadline
+    /// even though no pipe operation has started. The test body is already
+    /// running on a thread, so blocking it begins the connect immediately and
+    /// the deadline then covers only the handshake itself.
+    /// </remarks>
+    private static NamedPipeClientStream ConnectSameUser(
+        NamedPipeServerStream server, string name)
+    {
+        var accept = server.WaitForConnectionAsync(CancellationToken.None);
+        // If the connect below throws, the accept stays pending until the
+        // server is disposed and then faults with nobody waiting on it.
+        // Observe it here so it cannot resurface as an unobserved task
+        // exception on the finalizer thread.
+        accept.ContinueWith(
+            static t => _ = t.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted,
+            TaskScheduler.Default);
+
+        var client = new NamedPipeClientStream(
+            ".", name, PipeDirection.Out, PipeOptions.Asynchronous);
+        try
+        {
+            client.Connect(HandshakeTimeoutMs);
+            Assert.True(
+                accept.Wait(HandshakeTimeoutMs),
+                "client connected but the server's accept did not complete "
+                + $"within {HandshakeTimeoutMs} ms");
+            return client;
+        }
+        catch
+        {
+            client.Dispose();
+            throw;
+        }
     }
 }


### PR DESCRIPTION
Three tests were failing the `windows-tests` signoff leg non-deterministically — a different subset each run, each of them having passed at least once on the same commit. Two separate causes, and one of them is a regression rather than a flake.

## `CreateServer_DaclGrantsOnlyTheCreatingUser`

The test asserted a security property and a liveness property together, and only one of them can fail under load.

The three SDDL assertions (`S-1-1-0`, `;AU;`, `(AU;`) are string comparisons on a value already in hand. The rest opened a client and awaited a connect under `ConnectAsync(10_000, ct)`.

Measured: with 32 blocking items queued onto a 16-thread pool, **`ConnectAsync` had not returned after 45 s.** Its timeout and its cancellation token were both powerless, because both are observed from inside a work item that was never scheduled. A blocking `Connect` under identical saturation took **8 ms**.

The security assertions now stand alone — synchronous, no client, no clock, and byte-for-byte unchanged. The round trip is a separate test using the blocking `Connect` on the test's own thread. The security check can no longer be taken down by a slow connect, and it runs in 5–7 ms.

The same `ConnectAsync` exposure was in the two adjacent `ReadAtMostAsync` tests in that file; they got the same treatment.

## The tracker smoke tests — a dated regression

`#776` (2026-08-26) sized an 8 s budget against a tracker running on a fixed 500 ms period, and its comment said so.

`#982` (2026-09-04) replaced that period with `min(30_000, max(500, 3 * walkMs))` and touched only the two production files. The debouncer emits on the **second** observation, so what had been a fixed cost became load-dependent — and the budget it was sized against did not move.

Measured at 618 processes: two observations cost up to **4264 ms**, and the pwsh gate allows 3.5 s. 7764 ms against a budget of 8000 — **236 ms of margin**, on a machine that was not especially busy.

The fix pins the cadence for the test rather than widening the budget:

- an `internal` cadence-controlled constructor; the public one is unchanged and delegates with the shipped constants;
- the deadline is derived from the walk cost measured on the host, instead of a number chosen on a different machine two weeks ago;
- the scenario's liveness is established *before* the tracker's clock starts.

`Track_WslWithDistribution_ReportsAutoForWslDistro` had a second cause: `wsl.exe` only lived 5 s, so the process could be gone before the second observation.

## A third cause, found in whole-assembly runs

The narrow runs went green while the whole assembly still failed about **1 in 9**, with `observed: []` — zero events, not a wrong one. Both candidate explanations were measured rather than argued:

- **command-line flapping: ruled out.** Byte-identical across ~35 walks. This one would have been a real product defect.
- **thread-pool starvation: confirmed.** Zero events in 8 s under saturation.

A `[ModuleInitializer]` now gives the test host a `4 * ProcessorCount` minimum. Test host only; it does not touch the app.

## Verification

Repeated narrow runs, since a single green run is exactly what would not prove this:

- whole assembly, 59 tests: **10/10 green** (was ~1-in-9 red)
- tracker narrow: **6/6 quiet, 5/5 loaded**, zero skips, at 1026 processes
- pipe class: **19 runs, 0 failures**, 11 of them under load

No assertion was weakened, no retry added, no test skipped.

## Not fixed here

The debouncer needs two observations, so the tracker's worst-case user-visible latency is two cadence gaps — about a minute, where `#982`'s commit message documents thirty seconds. That is a product question, not a test one, and belongs in its own change.

A fourth flaky test, `Run_LongPing_TimeoutKills`, asserts `InRange(elapsed, 400, 3000)` around a spawn-and-kill. Same family, filed separately rather than absorbed.
