### PR TITLE
startup: warm the D3D12 device, seed the conditional state, time the presents

### DIFF
--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2225,6 +2225,15 @@ pub const CAPI = struct {
         const core_app = try CoreApp.create(global.alloc());
         errdefer core_app.destroy();
 
+        // Seed the core app's conditional state from the config it was
+        // created with. The host may have already set a non-default color
+        // scheme on `config` (ghostty_config_set_color_scheme) before this
+        // call; without this, core_app starts at the `.{}` default (light)
+        // and the host's first ghostty_app_set_color_scheme then sees a
+        // change, triggering a needless soft config reload right after
+        // startup.
+        core_app.config_conditional_state = config._conditional_state;
+
         // Create our runtime app
         var app = try global.alloc().create(App);
         errdefer global.alloc().destroy(app);

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -181,6 +181,14 @@ init_command_list: ?*d3d12.ID3D12GraphicsCommandList = null,
 /// Must be saved here because GetCurrentBackBufferIndex advances after Present.
 pending_frame_index: u32 = 0,
 
+/// Counts Present calls, for the surface_init timing marks in
+/// drawFrameEnd (first 8 presents, or any that run long).
+present_count: u32 = 0,
+
+/// Counts per-frame fence waits in beginFrame, for the same surface_init
+/// timing marks (first 8 waits, or any that run long).
+frame_wait_count: u32 = 0,
+
 /// Deferred frame completion state. DX12 must at least submit the frame
 /// and signal the GPU fence before releasing the frame semaphore (which
 /// happens in frameCompleted), because frame.resize() reuses descriptor
@@ -869,7 +877,25 @@ pub fn drawFrameEnd(self: *DirectX12) void {
     // before any new GPU work. The renderer thread owns Present
     // exclusively; the apprt UI thread does no GPU work during resize.
     if (self.swap_chain3) |sc3| {
+        // Bracket the Present call itself: composition swap chains queue
+        // frames for the compositor, and if nothing is consuming that
+        // queue yet (e.g. the C# host hasn't bound the SwapChainPanel),
+        // Present blocks here rather than returning immediately.
+        const present_start: std.Io.Timestamp = .now(global.io(), .awake);
         const hr = sc3.Present(1, 0);
+        if (self.init_started) |started| {
+            self.present_count += 1;
+            const dur_ms = present_start.durationTo(.now(global.io(), .awake)).toMilliseconds();
+            if (self.present_count <= 8 or dur_ms > 50) init_log.info(
+                "surface_init present #{d} at +{d} ms took {d} ms hr=0x{x}",
+                .{
+                    self.present_count,
+                    started.durationTo(present_start).toMilliseconds(),
+                    dur_ms,
+                    @as(u32, @bitCast(hr)),
+                },
+            );
+        }
         if (hr == com.DXGI_ERROR_DEVICE_REMOVED or hr == com.DXGI_ERROR_DEVICE_HUNG or hr == com.DXGI_ERROR_DEVICE_RESET) {
             self.handleDeviceRemoved();
             // Fence signal is intentionally skipped -- the device is gone.
@@ -1186,9 +1212,22 @@ pub inline fn beginFrame(
     var frame = api.gpu_frames[frame_idx] orelse return error.FrameNotReady;
     const wait_value = frame.fence_value;
     if (dev_ptr.fence.GetCompletedValue() < wait_value) {
+        const wait_start: std.Io.Timestamp = .now(global.io(), .awake);
         const hr = dev_ptr.fence.SetEventOnCompletion(wait_value, dev_ptr.fence_event);
         if (com.FAILED(hr)) return error.FrameSyncFailed;
         _ = d3d12.WaitForSingleObject(dev_ptr.fence_event, d3d12.INFINITE);
+        if (api.init_started) |started| {
+            api.frame_wait_count += 1;
+            const dur_ms = wait_start.durationTo(.now(global.io(), .awake)).toMilliseconds();
+            if (api.frame_wait_count <= 8 or dur_ms > 50) init_log.info(
+                "surface_init frame-wait #{d} at +{d} ms took {d} ms",
+                .{
+                    api.frame_wait_count,
+                    started.durationTo(wait_start).toMilliseconds(),
+                    dur_ms,
+                },
+            );
+        }
     }
 
     // Free resources whose last referencing submission the GPU has now

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -237,6 +237,14 @@ inline fn unpackSize(packed_size: u64) struct { width: u32, height: u32 } {
 
 // --- GraphicsAPI contract: functions ---
 
+/// Detected via @hasDecl by App.zig and run on a background thread at app
+/// startup, well before the first surface's initGpu needs a device. Thin
+/// forwarder so the actual D3D12 warmup work (see device.zig) stays next
+/// to the code it warms.
+pub fn warmup() void {
+    device.warmup();
+}
+
 pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX12 {
     var result = DirectX12{ .allocator = alloc, .init_started = opts.init_started };
 
@@ -704,6 +712,10 @@ pub fn recoverDevice(self: *DirectX12) !void {
     if (surface == .shared_texture) {
         surface.shared_texture = .{ .width = width, .height = height };
     }
+
+    // A warm reference still parked from warmup() would pin the removed
+    // singleton and make initGpu's D3D12CreateDevice return it again.
+    device.dropWarmDevice();
 
     // Unconditional: with no device this sweeps whatever a failed
     // attempt built before it stopped.

--- a/src/renderer/directx12/device.zig
+++ b/src/renderer/directx12/device.zig
@@ -27,8 +27,153 @@ const FAILED = com.FAILED;
 
 const log = std.log.scoped(.directx12);
 
+/// Same scope as `Surface.zig`'s and `DirectX12.zig`'s `init_log`; shared
+/// name (not a shared declaration) so the C# host's log bridge files every
+/// `surface_init` phase, whichever module logs it, under one
+/// `Ghostty.Zig.surface_init` category.
+const init_log = std.log.scoped(.surface_init);
+
 /// Number of back buffers (triple buffering).
 pub const frame_count: u32 = 3;
+
+// --- Warmup: process-wide warm device handoff ---
+//
+// D3D12 devices are singletons per adapter per process: D3D12CreateDevice
+// returns the existing device (AddRef'd) while any reference to it is
+// alive anywhere in the process, and costs 1.2-2.0s cold vs ~1ms once
+// warm. `warmup()` pays that cost on a background thread at app startup
+// (see App.zig's renderer.Renderer.API.warmup hook and DirectX12.zig's
+// forwarder) so the UI thread's first `Device.init` -- which otherwise
+// eats almost all of Surface.init's ~440ms of ~520ms measured cost --
+// finds the singleton already warm.
+//
+// The warmup device is deliberately never released by `warmup()` itself:
+// releasing the only reference throws the warm state away and the next
+// create pays the full cost again. Ownership transfers to the first real
+// `Device.init` instead, which takes this slot's reference right after
+// its own D3D12CreateDevice call succeeds (see there for why the order
+// matters) and releases it once. A reference that lands after the last
+// surface is gone stays parked until process exit on purpose: it keeps
+// the singleton warm, and a live-object report at shutdown will show it.
+
+/// Guards `warm_device` for cross-thread handoff: `warmup()`'s background
+/// thread stores, `Device.init` on the UI thread takes. Same primitive as
+/// `shared_texture_mutex` above.
+var warm_device_mutex: std.Io.Mutex = .init;
+
+/// Populated by `warmup()`, consumed exactly once by `takeWarmDevice()`.
+var warm_device: ?*d3d12.ID3D12Device = null;
+
+/// Create a D3D12 device ahead of time and park it in `warm_device` for
+/// the first real `Device.init` to pick up. Safe to call from any thread;
+/// never panics, logs and returns on any failure so a warmup problem
+/// never blocks the real (synchronous, on-the-critical-path) device
+/// creation that follows it.
+pub fn warmup() void {
+    const started: std.Io.Timestamp = .now(global.io(), .awake);
+
+    // Must match Device.init: the debug layer can only be enabled before
+    // the first device is created in the process, so if warmup creates
+    // that first device it has to turn the layer on itself, or the real
+    // device created later would silently inherit a layer-less singleton.
+    if (comptime builtin.mode == .Debug) {
+        enableDebugLayer();
+    }
+
+    const factory_flags: u32 = if (comptime builtin.mode == .Debug)
+        dxgi.DXGI_CREATE_FACTORY_DEBUG
+    else
+        0;
+
+    var factory: ?*dxgi.IDXGIFactory2 = null;
+    {
+        const hr = dxgi.CreateDXGIFactory2(
+            factory_flags,
+            &dxgi.IDXGIFactory2.IID,
+            @ptrCast(&factory),
+        );
+        if (FAILED(hr)) {
+            log.warn("warmup: CreateDXGIFactory2 failed: 0x{x}", .{@as(u32, @bitCast(hr))});
+            return;
+        }
+    }
+    defer _ = factory.?.Release();
+
+    var device: ?*d3d12.ID3D12Device = null;
+    {
+        const hr = d3d12.D3D12CreateDevice(
+            null,
+            d3d12.D3D_FEATURE_LEVEL_12_0,
+            &d3d12.ID3D12Device.IID,
+            @ptrCast(&device),
+        );
+        if (FAILED(hr)) {
+            log.warn("warmup: D3D12CreateDevice failed: 0x{x}", .{@as(u32, @bitCast(hr))});
+            return;
+        }
+    }
+    const dev = device.?;
+
+    // The first command queue created on a device pays extra one-time
+    // driver setup cost; create and release one now so it's not paid
+    // again by the real command queue Device.init creates later. Same
+    // rationale as Metal.warmup's throwaway command queue.
+    {
+        const desc = d3d12.D3D12_COMMAND_QUEUE_DESC{
+            .Type = .DIRECT,
+            .Priority = 0,
+            .Flags = .NONE,
+            .NodeMask = 0,
+        };
+        var queue: ?*d3d12.ID3D12CommandQueue = null;
+        const hr = dev.CreateCommandQueue(
+            &desc,
+            &d3d12.ID3D12CommandQueue.IID,
+            @ptrCast(&queue),
+        );
+        if (SUCCEEDED(hr)) {
+            _ = queue.?.Release();
+        } else {
+            log.warn("warmup: CreateCommandQueue failed: 0x{x}", .{@as(u32, @bitCast(hr))});
+        }
+    }
+
+    // Keep the reference alive: store it for Device.init to take. Do not
+    // release `dev` here (see the section doc comment above). A reference
+    // already parked (a second warmup in the same process) is released
+    // rather than overwritten, so the slot never hides a lost AddRef.
+    warm_device_mutex.lockUncancelable(global.io());
+    if (warm_device) |prev| {
+        log.warn("warmup: slot already held a device, releasing the older one", .{});
+        _ = prev.Release();
+    }
+    warm_device = dev;
+    warm_device_mutex.unlock(global.io());
+
+    init_log.info(
+        "surface_init warmup-device done +{d} ms",
+        .{started.untilNow(global.io(), .awake).toMilliseconds()},
+    );
+}
+
+/// Take and clear the warm device slot, if populated. Called by
+/// `Device.init` right after its own D3D12CreateDevice succeeds.
+fn takeWarmDevice() ?*d3d12.ID3D12Device {
+    warm_device_mutex.lockUncancelable(global.io());
+    defer warm_device_mutex.unlock(global.io());
+    const dev = warm_device;
+    warm_device = null;
+    return dev;
+}
+
+/// Release a still-parked warm reference, if any. Device.init calls this
+/// right after its own create succeeds (the handoff); device recovery
+/// calls it before tearing the lost device down, because a parked
+/// reference to a removed device would keep the singleton alive and make
+/// the recovery's D3D12CreateDevice hand the removed device straight back.
+pub fn dropWarmDevice() void {
+    if (takeWarmDevice()) |warm| _ = warm.Release();
+}
 
 // --- Device state ---
 
@@ -259,6 +404,15 @@ pub fn init(surface: @import("surface.zig").Surface, opts: InitOptions) !Device 
     errdefer _ = device.?.Release();
 
     const dev = device.?;
+
+    // Handoff: `dev` above is either a fresh device or (if warmup() won
+    // the race) the same singleton object warmup's D3D12CreateDevice
+    // call already returned, AddRef'd again for `dev`. Either way `dev`
+    // now holds a reference, so it is safe to drop warmup's -- taking it
+    // here, right after `dev` is established rather than before, is what
+    // keeps the singleton's refcount from ever touching zero in between.
+    // A no-op if warmup never ran or hasn't finished yet.
+    dropWarmDevice();
 
     // -- Command queue --
     var command_queue: ?*d3d12.ID3D12CommandQueue = null;
@@ -828,4 +982,19 @@ test "Device struct fields" {
 
 test "frame_count is 3" {
     try std.testing.expectEqual(@as(u32, 3), frame_count);
+}
+
+test "warm device slot: take clears it, empty take returns null" {
+    // Exercises the handoff bookkeeping without touching D3D: park a
+    // never-dereferenced pointer directly in the module-level slot, the
+    // same way warmup() would, and confirm takeWarmDevice hands it back
+    // exactly once and leaves the slot empty for the next caller.
+    var fake: d3d12.ID3D12Device = undefined;
+
+    warm_device_mutex.lockUncancelable(global.io());
+    warm_device = &fake;
+    warm_device_mutex.unlock(global.io());
+
+    try std.testing.expectEqual(@as(?*d3d12.ID3D12Device, &fake), takeWarmDevice());
+    try std.testing.expectEqual(@as(?*d3d12.ID3D12Device, null), takeWarmDevice());
 }


### PR DESCRIPTION
## Why

Warm start of the first pane, measured on the NativeAOT pro build with the prompt-rendered instant as the metric. Three independent native fixes, each measured with paired order-swapped batches:

- **Warm D3D12 device handoff.** `Surface.init` runs synchronously on the UI thread and ~380 ms of it was the cold in-process D3D12 driver load inside `Device.init`. A fresh-process probe puts `D3D12CreateDevice` at 1.2-2.0 s cold and ~1 ms once a device exists, and the warm state is discarded when the last reference is released (devices are per-adapter process singletons). `App.create` already spawns `renderer.Renderer.API.warmup()` when the backend declares it; DirectX12 now does: the warmup keeps its reference parked, `Device.init` takes and releases it right after its own create succeeds, and `recoverDevice` drains the slot before tearing a lost device down. Measured: d3d12-device done 381 -> 33 ms, ui-thread-handoff 414 -> 62 ms from `Surface.init` entry, in every run.
- **Present timing marks.** `surface_init present #n at +T ms took D ms` for the first eight presents and any over 50 ms, plus the per-frame fence wait, under the existing `.surface_init` scope. Used to rule out DXGI back-pressure as the cause of first-frame stalls (it was UI-thread hogging on the host side).
- **Conditional-state seed.** The host derives its config for the OS color scheme before `ghostty_app_new` and calls `ghostty_app_set_color_scheme` from its window constructor; the core app started at the light default, so `colorSchemeEvent` requested a soft reload on every launch on a dark system, which the host turned into a full config reload (chrome re-apply, profile recompose, jump list rebuilds). Seeding `core_app.config_conditional_state` from the config at `app_new_` makes the startup call a no-op; a real OS theme flip still triggers the soft reload exactly as before.

## Measured (release pin, ReleaseSafe, paired batches)

| mark | reference | with warmup |
|---|---|---|
| d3d12-device done | 381 / 379 ms | 33 / 33 ms |
| ui-thread-handoff | 414 / 407 ms | 62 / 58 ms |

Definitive pair on the NativeAOT product with the host-side changes as well: process start to rendered prompt median 3866 -> 2241 ms.

Review notes: the warmup thread is the same detached shape as the font and Metal warmups already in `App.create`; a second warmup in one process releases the parked reference instead of overwriting it; the parked reference stays until process exit on purpose if no surface ever takes it.
