### PR TITLE
Update pill host in both layouts, and a self-healing toast registration

### DIFF
--- a/windows/Ghostty.Core/Windows/ToastRegistration.cs
+++ b/windows/Ghostty.Core/Windows/ToastRegistration.cs
@@ -1,0 +1,321 @@
+using System;
+using System.Runtime.Versioning;
+using Microsoft.Win32;
+
+namespace Ghostty.Core.Windows;
+
+/// <summary>
+/// The values a toast registration carries, as read off
+/// <c>HKCU\Software\Classes\AppUserModelId\&lt;aumid&gt;</c> and the COM class
+/// its <c>CustomActivator</c> names.
+/// </summary>
+/// <param name="Exists">Whether the AUMID key is there at all.</param>
+/// <param name="DisplayName">The name Windows shows above a toast.</param>
+/// <param name="IconUri">The icon Windows shows on a toast.</param>
+/// <param name="ActivatorClsid">
+/// The <c>CustomActivator</c> value: the COM class a toast click activates.
+/// </param>
+/// <param name="ActivatorServer">
+/// That class's <c>LocalServer32</c> default value: the command line Windows
+/// runs to deliver the click. An executable, usually quoted, usually with
+/// arguments after it.
+/// </param>
+internal readonly record struct ToastRegistrationValues(
+    bool Exists,
+    string? DisplayName,
+    string? IconUri,
+    string? ActivatorClsid,
+    string? ActivatorServer);
+
+/// <summary>
+/// What a launch has to do to an existing registration before it is usable
+/// again. See <see cref="ToastRegistration.Diagnose"/>.
+/// </summary>
+/// <param name="Recreate">
+/// The activator cannot reach this process, so the whole key has to go and be
+/// written again by <c>Register()</c>.
+/// </param>
+/// <param name="RewriteDisplayName">The shown name is not this build's.</param>
+/// <param name="RewriteIconUri">The shown icon is not this build's.</param>
+internal readonly record struct ToastRegistrationRepair(
+    bool Recreate,
+    bool RewriteDisplayName,
+    bool RewriteIconUri)
+{
+    public bool Any => Recreate || RewriteDisplayName || RewriteIconUri;
+}
+
+/// <summary>
+/// Keeps this build's toast registration pointing at this build.
+///
+/// <c>AppNotificationManager.Register()</c> writes
+/// <c>HKCU\Software\Classes\AppUserModelId\&lt;aumid&gt;</c> once and then
+/// leaves it alone: on a machine that already has the key, a later launch
+/// re-registers against values an EARLIER install wrote. The two that go
+/// wrong are the ones nothing else ever corrects. The <c>CustomActivator</c>
+/// CLSID's <c>LocalServer32</c> still names the exe that first registered, so
+/// once that install is gone a toast click launches a path that is not there
+/// (deblasis/wintty-release#656, and the click half of #317); and the
+/// <c>DisplayName</c> still reads whatever that install called itself, so a
+/// tier installed over another one keeps the other one's name over every
+/// toast it sends.
+///
+/// Neither is visible from inside the process: <c>Show()</c> keeps working
+/// against the stale registration, so the toasts appear and only the click
+/// is dead.
+/// </summary>
+/// <remarks>
+/// <see cref="Diagnose"/> is the whole decision and is pure, so the rules can
+/// be tested without a registry. The two registry halves around it are
+/// deliberately thin, and neither throws: a notification identity is not
+/// worth failing a launch over, and a hive can be locked down or redirected
+/// in ways this cannot anticipate.
+/// </remarks>
+internal static class ToastRegistration
+{
+    private const string AumidRoot = @"Software\Classes\AppUserModelId";
+    private const string ClsidRoot = @"Software\Classes\CLSID";
+
+    /// <summary>
+    /// What has to change, given what is on the machine and what this build
+    /// wants.
+    ///
+    /// A missing key is not a repair: <c>Register()</c> is what creates one,
+    /// and reporting work to do before it has run would delete nothing and
+    /// say so every launch of a clean machine.
+    ///
+    /// An empty <paramref name="wantDisplayName"/> or
+    /// <paramref name="wantIconUri"/> means the caller has no opinion, and an
+    /// empty <paramref name="currentExePath"/> means the process could not
+    /// name its own image. Neither is grounds for touching anything: this
+    /// deletes registry keys unattended, so every rule here is a positive
+    /// disagreement between two known values, never an absence.
+    /// </summary>
+    public static ToastRegistrationRepair Diagnose(
+        in ToastRegistrationValues observed,
+        string? currentExePath,
+        string? wantDisplayName,
+        string? wantIconUri)
+    {
+        if (!observed.Exists) return default;
+
+        // A key with no activator can never deliver a click either, and it is
+        // the same repair: let Register() write the pair again.
+        var recreate = !string.IsNullOrWhiteSpace(currentExePath)
+            && (string.IsNullOrWhiteSpace(observed.ActivatorClsid)
+                || !SameExecutable(ServerExecutable(observed.ActivatorServer), currentExePath));
+
+        var rewriteName = !string.IsNullOrWhiteSpace(wantDisplayName)
+            && !string.Equals(observed.DisplayName, wantDisplayName, StringComparison.Ordinal);
+
+        var rewriteIcon = !string.IsNullOrWhiteSpace(wantIconUri)
+            && !string.Equals(observed.IconUri, wantIconUri, StringComparison.OrdinalIgnoreCase);
+
+        return new ToastRegistrationRepair(recreate, rewriteName, rewriteIcon);
+    }
+
+    /// <summary>
+    /// The executable out of a <c>LocalServer32</c> command line.
+    ///
+    /// The platform writes the path quoted and follows it with the activation
+    /// argument, so the first quoted run is the answer when there is one. An
+    /// unquoted value is taken whole: a path with a space in it and no quotes
+    /// is already broken, and guessing where it ends would invent a
+    /// disagreement out of a value nothing can use anyway.
+    /// </summary>
+    public static string? ServerExecutable(string? localServer32)
+    {
+        if (string.IsNullOrWhiteSpace(localServer32)) return null;
+
+        var command = localServer32.Trim();
+        if (command[0] != '"') return command;
+
+        var close = command.IndexOf('"', 1);
+        return close > 1 ? command[1..close] : null;
+    }
+
+    /// <summary>
+    /// Whether two paths name the same image. Case-insensitive and separator-
+    /// insensitive, because Windows paths are both; no filesystem probe,
+    /// because this has to stay a decision over the values in hand.
+    /// </summary>
+    public static bool SameExecutable(string? a, string? b)
+    {
+        if (string.IsNullOrWhiteSpace(a) || string.IsNullOrWhiteSpace(b)) return false;
+        return string.Equals(Normalize(a), Normalize(b), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string Normalize(string path) =>
+        path.Trim().Trim('"').Replace('/', '\\').TrimEnd('\\');
+
+    /// <summary>
+    /// Read the registration for <paramref name="aumid"/>. Never throws; an
+    /// unreadable hive reads as "no key", which asks for no repair.
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    public static ToastRegistrationValues Read(string aumid)
+    {
+        if (!IsPlainAumid(aumid)) return default;
+
+        try
+        {
+            using var key = Registry.CurrentUser.OpenSubKey($@"{AumidRoot}\{aumid}");
+            if (key is null) return default;
+
+            var clsid = key.GetValue("CustomActivator") as string;
+            return new ToastRegistrationValues(
+                Exists: true,
+                DisplayName: key.GetValue("DisplayName") as string,
+                IconUri: key.GetValue("IconUri") as string,
+                ActivatorClsid: clsid,
+                ActivatorServer: ReadLocalServer(clsid));
+        }
+        catch
+        {
+            return default;
+        }
+    }
+
+    /// <summary>
+    /// Remove the registration and the COM class it names, so the next
+    /// <c>Register()</c> writes both against this process. Returns whether
+    /// the AUMID key was removed. Never throws.
+    /// </summary>
+    /// <param name="refused">
+    /// Why a half that should have gone did not, naming the key and the OS
+    /// message, so a refusal can be logged instead of leaving the launch
+    /// half-repaired in silence. Null when nothing was refused; both halves'
+    /// refusals arrive together when both refuse. This API swallows by
+    /// contract - a notification identity is not worth failing a launch over
+    /// - which is exactly why the reason has to come back out.
+    /// </param>
+    /// <remarks>
+    /// The activator's CLSID key goes with it. Left behind it is a COM class
+    /// whose server is a path that does not exist, which is the half of the
+    /// defect that outlives the AUMID key: <c>Register()</c> mints a fresh
+    /// CLSID rather than reusing the one it finds, so the orphan is never
+    /// visited again and never corrected.
+    /// </remarks>
+    [SupportedOSPlatform("windows")]
+    public static bool Remove(string aumid, string? activatorClsid, out string? refused)
+    {
+        refused = null;
+        if (!IsPlainAumid(aumid))
+        {
+            refused = $"\"{aumid}\" is not a name a subkey operation can be aimed at";
+            return false;
+        }
+
+        var removed = false;
+        try
+        {
+            using var root = Registry.CurrentUser.OpenSubKey(AumidRoot, writable: true);
+            if (root is null)
+            {
+                refused = $@"HKCU\{AumidRoot} could not be opened for writing";
+            }
+            else
+            {
+                using (var existing = root.OpenSubKey(aumid)) removed = existing is not null;
+                if (removed) root.DeleteSubKeyTree(aumid, throwOnMissingSubKey: false);
+            }
+        }
+        catch (Exception ex)
+        {
+            // A key this user cannot delete is not worth a failed launch, and
+            // the CLSID below is still worth trying.
+            refused = $@"HKCU\{AumidRoot}\{aumid}: {ex.Message}";
+        }
+
+        if (IsPlainAumid(activatorClsid))
+        {
+            try
+            {
+                using var classes = Registry.CurrentUser.OpenSubKey(ClsidRoot, writable: true);
+                if (classes is null)
+                {
+                    refused = JoinRefusals(
+                        refused, $@"HKCU\{ClsidRoot} could not be opened for writing");
+                }
+                else
+                {
+                    classes.DeleteSubKeyTree(activatorClsid!, throwOnMissingSubKey: false);
+                }
+            }
+            catch (Exception ex)
+            {
+                // Same: an orphaned COM class is inert, not fatal.
+                refused = JoinRefusals(
+                    refused, $@"HKCU\{ClsidRoot}\{activatorClsid}: {ex.Message}");
+            }
+        }
+
+        return removed;
+    }
+
+    /// <summary>Both halves can refuse in one call; the caller gets one
+    /// reason carrying both, not only the first.</summary>
+    private static string JoinRefusals(string? first, string second) =>
+        first is null ? second : first + "; " + second;
+
+    /// <summary>
+    /// Write this build's <c>DisplayName</c> and <c>IconUri</c> straight onto
+    /// an existing registration. Returns whether anything was written; never
+    /// throws.
+    /// </summary>
+    /// <remarks>
+    /// A direct write rather than another delete-and-re-register, because
+    /// <c>Register()</c> derives these two from the process image and would
+    /// write the same values back. Deleting on a disagreement it is going to
+    /// reproduce is a delete on every single launch, forever.
+    /// </remarks>
+    [SupportedOSPlatform("windows")]
+    public static bool Apply(string aumid, in ToastRegistrationRepair repair, string? displayName, string? iconUri)
+    {
+        if (!IsPlainAumid(aumid)) return false;
+        if (!repair.RewriteDisplayName && !repair.RewriteIconUri) return false;
+
+        try
+        {
+            using var key = Registry.CurrentUser.OpenSubKey($@"{AumidRoot}\{aumid}", writable: true);
+            if (key is null) return false;
+
+            if (repair.RewriteDisplayName) key.SetValue("DisplayName", displayName!, RegistryValueKind.String);
+            if (repair.RewriteIconUri) key.SetValue("IconUri", iconUri!, RegistryValueKind.String);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static string? ReadLocalServer(string? clsid)
+    {
+        if (!IsPlainAumid(clsid)) return null;
+
+        try
+        {
+            using var server = Registry.CurrentUser.OpenSubKey($@"{ClsidRoot}\{clsid}\LocalServer32");
+            return server?.GetValue(null) as string;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Whether a name is safe to hand to a subkey operation.
+    ///
+    /// The separator check is the same class of hazard
+    /// <see cref="StaleAppUserModelRegistrations"/> refuses: a name made of
+    /// separators fixes up to the empty string, and DeleteSubKeyTree on that
+    /// deletes the key the handle is open on, which here is the whole
+    /// AppUserModelId or CLSID hive. Neither a legal AUMID nor a CLSID ever
+    /// contains one.
+    /// </summary>
+    private static bool IsPlainAumid(string? name) =>
+        !string.IsNullOrWhiteSpace(name) && !name.Contains('\\') && !name.Contains('/');
+}

--- a/windows/Ghostty.Tests/Notifications/ToastRegistrationTests.cs
+++ b/windows/Ghostty.Tests/Notifications/ToastRegistrationTests.cs
@@ -1,0 +1,366 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.Versioning;
+using Ghostty.Core.Windows;
+using Microsoft.Win32;
+using Xunit;
+
+namespace Ghostty.Tests.Notifications;
+
+/// <summary>
+/// The decision behind the toast-registration self-heal.
+///
+/// <c>AppNotificationManager.Register()</c> writes the AUMID key once and
+/// never revisits it, so an install that follows another one re-registers
+/// against the first one's values: a <c>CustomActivator</c> whose
+/// <c>LocalServer32</c> names an exe that is gone, and a <c>DisplayName</c>
+/// that is the other install's (deblasis/wintty-release#656). Nothing in the
+/// process notices, because <c>Show()</c> keeps working against the stale
+/// registration and only the click is dead.
+///
+/// These cover <see cref="ToastRegistration.Diagnose"/>, which is the whole
+/// decision and is pure. What it decides is destructive - a Recreate deletes
+/// registry keys unattended on a user's machine - so the cases that matter
+/// most here are the ones where it must decide to do NOTHING.
+///
+/// The registry halves around the decision are covered too, against the real
+/// HKCU hive under names minted for the one test instance and taken back out
+/// in Dispose: Read, Remove and Apply are thin, but one of them deletes keys
+/// unattended, so what they actually do to the hive is pinned, not assumed.
+/// The shared parents (AppUserModelId, CLSID) are never deleted.
+/// </summary>
+[SupportedOSPlatform("windows")]
+public class ToastRegistrationTests : IDisposable
+{
+    private const string Exe = @"C:\Program Files\Wintty\wintty.exe";
+    private const string Clsid = "{1B7C4E2A-0000-0000-0000-00000000BEEF}";
+
+    private static ToastRegistrationValues Registered(
+        string? displayName = "Wintty",
+        string? iconUri = null,
+        string? clsid = Clsid,
+        string? server = "\"" + Exe + "\" ----AppNotificationActivated:")
+        => new(Exists: true, displayName, iconUri, clsid, server);
+
+    // --- the cases that must not touch anything ---
+
+    [Fact]
+    public void A_machine_with_no_registration_needs_no_repair()
+    {
+        var repair = ToastRegistration.Diagnose(default, Exe, "Wintty", null);
+
+        // Register() is what creates the key. Reporting work here would delete
+        // nothing and say so on every launch of a clean machine.
+        Assert.False(repair.Any);
+    }
+
+    [Fact]
+    public void A_registration_that_already_names_this_exe_is_left_alone()
+    {
+        var repair = ToastRegistration.Diagnose(Registered(), Exe, "Wintty", null);
+
+        Assert.False(repair.Any);
+    }
+
+    [Fact]
+    public void An_unknown_process_path_never_recreates()
+    {
+        // Environment.ProcessPath can be null. "I do not know where I am" is
+        // not evidence that the activator is wrong, and acting on it would
+        // delete a healthy registration.
+        Assert.False(ToastRegistration.Diagnose(Registered(), null, "Wintty", null).Recreate);
+        Assert.False(ToastRegistration.Diagnose(Registered(), "  ", "Wintty", null).Recreate);
+    }
+
+    [Fact]
+    public void A_caller_with_no_opinion_leaves_the_shown_values_alone()
+    {
+        var observed = Registered(displayName: "Something Else", iconUri: "file:///old.png");
+
+        var repair = ToastRegistration.Diagnose(observed, Exe, null, null);
+
+        Assert.False(repair.RewriteDisplayName);
+        Assert.False(repair.RewriteIconUri);
+    }
+
+    // --- the reported defects ---
+
+    [Fact]
+    public void An_activator_pointing_at_a_departed_install_is_recreated()
+    {
+        var observed = Registered(
+            server: "\"C:\\wt\\sandbox-august\\wintty.exe\" ----AppNotificationActivated:");
+
+        var repair = ToastRegistration.Diagnose(observed, Exe, "Wintty", null);
+
+        Assert.True(repair.Recreate);
+    }
+
+    [Fact]
+    public void A_key_with_no_activator_at_all_is_recreated()
+    {
+        // It can never deliver a click either, and it is the same repair:
+        // let Register() write the pair again.
+        Assert.True(ToastRegistration.Diagnose(Registered(clsid: null), Exe, "Wintty", null).Recreate);
+        Assert.True(ToastRegistration.Diagnose(Registered(server: null), Exe, "Wintty", null).Recreate);
+        Assert.True(ToastRegistration.Diagnose(Registered(server: "   "), Exe, "Wintty", null).Recreate);
+    }
+
+    [Fact]
+    public void A_display_name_from_another_edition_is_rewritten()
+    {
+        // The reported shape: Pro and Enterprise installed over a build that
+        // called itself "Wintty", and every toast kept saying so.
+        var repair = ToastRegistration.Diagnose(Registered(), Exe, "Wintty Pro", null);
+
+        Assert.True(repair.RewriteDisplayName);
+        // Independent of the activator: that one was fine here.
+        Assert.False(repair.Recreate);
+    }
+
+    [Fact]
+    public void The_display_name_is_compared_exactly()
+    {
+        // Case is what distinguishes the tiers on screen, so a case-only
+        // difference is a real difference here, unlike a path.
+        Assert.True(ToastRegistration.Diagnose(Registered("wintty"), Exe, "Wintty", null).RewriteDisplayName);
+        Assert.False(ToastRegistration.Diagnose(Registered("Wintty"), Exe, "Wintty", null).RewriteDisplayName);
+    }
+
+    [Fact]
+    public void An_icon_from_another_install_is_rewritten()
+    {
+        var observed = Registered(iconUri: "file:///C:/wt/sandbox-august/icon.png");
+
+        var repair = ToastRegistration.Diagnose(observed, Exe, "Wintty", "file:///C:/Program%20Files/Wintty/icon.png");
+
+        Assert.True(repair.RewriteIconUri);
+    }
+
+    [Fact]
+    public void An_absent_icon_counts_as_a_disagreement_when_one_is_wanted()
+    {
+        var repair = ToastRegistration.Diagnose(Registered(iconUri: null), Exe, "Wintty", "file:///icon.png");
+
+        Assert.True(repair.RewriteIconUri);
+    }
+
+    // --- reading the activator command line ---
+
+    [Theory]
+    // The shape the platform writes: quoted path, activation argument after.
+    [InlineData("\"C:\\a b\\wintty.exe\" ----AppNotificationActivated:", "C:\\a b\\wintty.exe")]
+    // No arguments, still quoted.
+    [InlineData("\"C:\\a b\\wintty.exe\"", "C:\\a b\\wintty.exe")]
+    // Unquoted is taken whole. A path with a space and no quotes is already
+    // broken; guessing where it ends would invent a disagreement out of a
+    // value nothing can use anyway.
+    [InlineData("C:\\dir\\wintty.exe", "C:\\dir\\wintty.exe")]
+    [InlineData("  C:\\dir\\wintty.exe  ", "C:\\dir\\wintty.exe")]
+    public void The_server_executable_is_read_off_the_command_line(string command, string expected)
+    {
+        Assert.Equal(expected, ToastRegistration.ServerExecutable(command));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    // An unterminated quote names nothing rather than everything: reading the
+    // rest of the line as a path would compare a path against a command line.
+    [InlineData("\"C:\\dir\\wintty.exe")]
+    public void An_unusable_command_line_names_no_executable(string? command)
+    {
+        Assert.Null(ToastRegistration.ServerExecutable(command));
+    }
+
+    // --- comparing the two paths ---
+
+    [Theory]
+    [InlineData(@"C:\Dir\Wintty.exe", @"c:\dir\wintty.exe")]
+    [InlineData(@"C:/Dir/Wintty.exe", @"C:\Dir\Wintty.exe")]
+    [InlineData(@"  C:\Dir\Wintty.exe  ", @"C:\Dir\Wintty.exe")]
+    [InlineData("\"C:\\Dir\\Wintty.exe\"", @"C:\Dir\Wintty.exe")]
+    public void Paths_that_differ_only_the_ways_windows_does_not_care_about_match(string a, string b)
+    {
+        Assert.True(ToastRegistration.SameExecutable(a, b));
+    }
+
+    [Theory]
+    [InlineData(@"C:\Dir\Wintty.exe", @"C:\Other\Wintty.exe")]
+    [InlineData(null, @"C:\Dir\Wintty.exe")]
+    [InlineData(@"C:\Dir\Wintty.exe", null)]
+    [InlineData("", "")]
+    public void Anything_else_is_a_different_executable(string? a, string? b)
+    {
+        // Including two absences: "neither of us knows" is not a match, or an
+        // unreadable activator would read as healthy.
+        Assert.False(ToastRegistration.SameExecutable(a, b));
+    }
+
+    // --- the registry halves, against a throwaway corner of the real hive ---
+
+    private const string AumidRoot = @"Software\Classes\AppUserModelId";
+    private const string ClsidRoot = @"Software\Classes\CLSID";
+
+    private readonly string _aumid = $"Ghostty.Tests.ToastRegistration.{Guid.NewGuid():N}";
+    private readonly string _otherAumid = $"Ghostty.Tests.ToastRegistration.{Guid.NewGuid():N}";
+    private readonly string _clsid = $"{{{Guid.NewGuid().ToString().ToUpperInvariant()}}}";
+    private readonly string _otherClsid = $"{{{Guid.NewGuid().ToString().ToUpperInvariant()}}}";
+    private readonly List<string> _created = new();
+
+    public void Dispose()
+    {
+        foreach (var path in _created)
+        {
+            try
+            {
+                var cut = path.LastIndexOf('\\');
+                using var parent = Registry.CurrentUser.OpenSubKey(path[..cut], writable: true);
+                parent?.DeleteSubKeyTree(path[(cut + 1)..], throwOnMissingSubKey: false);
+            }
+            catch
+            {
+                // Teardown is best effort; a failed cleanup must not fail the run.
+            }
+        }
+    }
+
+    private void CreateAumidKey(
+        string name, string? displayName = null, string? iconUri = null, string? activator = null)
+    {
+        _created.Add($@"{AumidRoot}\{name}");
+        using var key = Registry.CurrentUser.CreateSubKey($@"{AumidRoot}\{name}");
+        if (displayName is not null) key.SetValue("DisplayName", displayName, RegistryValueKind.String);
+        if (iconUri is not null) key.SetValue("IconUri", iconUri, RegistryValueKind.String);
+        if (activator is not null) key.SetValue("CustomActivator", activator, RegistryValueKind.String);
+    }
+
+    private void CreateClsidKey(string name, string localServer32)
+    {
+        _created.Add($@"{ClsidRoot}\{name}");
+        using var key = Registry.CurrentUser.CreateSubKey($@"{ClsidRoot}\{name}\LocalServer32");
+        key.SetValue(null, localServer32, RegistryValueKind.String);
+    }
+
+    private static bool KeyExists(string path)
+    {
+        using var key = Registry.CurrentUser.OpenSubKey(path);
+        return key is not null;
+    }
+
+    private static string? ValueOf(string path, string name)
+    {
+        using var key = Registry.CurrentUser.OpenSubKey(path);
+        return key?.GetValue(name) as string;
+    }
+
+    [Fact]
+    public void Read_returns_the_key_and_its_activator()
+    {
+        CreateClsidKey(_clsid, $"\"{Exe}\" ----AppNotificationActivated:");
+        CreateAumidKey(_aumid, displayName: "Wintty", iconUri: "file:///icon.png", activator: _clsid);
+
+        var read = ToastRegistration.Read(_aumid);
+
+        Assert.True(read.Exists);
+        Assert.Equal("Wintty", read.DisplayName);
+        Assert.Equal("file:///icon.png", read.IconUri);
+        Assert.Equal(_clsid, read.ActivatorClsid);
+        Assert.Equal($"\"{Exe}\" ----AppNotificationActivated:", read.ActivatorServer);
+    }
+
+    [Fact]
+    public void Read_of_a_key_that_is_not_there_asks_for_nothing()
+    {
+        // Nothing created this instance's key: an unreadable hive reads as
+        // "no key", which asks for no repair.
+        Assert.False(ToastRegistration.Read(_aumid).Exists);
+    }
+
+    [Fact]
+    public void Remove_deletes_only_the_aumid_key_and_the_one_clsid_it_names()
+    {
+        // Two AUMIDs and two COM classes under the shared parents, the shape
+        // a machine with two installs actually has. The repair names one of
+        // each; the neighbours are what an overbroad delete would take with
+        // it - the "nothing else under the parent" half of the contract.
+        CreateAumidKey(_aumid, activator: _clsid);
+        CreateAumidKey(_otherAumid, displayName: "someone else");
+        CreateClsidKey(_clsid, $"\"{Exe}\" ----AppNotificationActivated:");
+        CreateClsidKey(_otherClsid, "C:\\elsewhere\\other.exe");
+
+        Assert.True(ToastRegistration.Remove(_aumid, _clsid, out var refused));
+        Assert.Null(refused);
+
+        Assert.False(KeyExists($@"{AumidRoot}\{_aumid}"));
+        Assert.False(KeyExists($@"{ClsidRoot}\{_clsid}"));
+        Assert.True(KeyExists($@"{AumidRoot}\{_otherAumid}"));
+        Assert.True(KeyExists($@"{ClsidRoot}\{_otherClsid}"));
+    }
+
+    [Fact]
+    public void Remove_of_a_key_that_is_not_there_removes_nothing_and_refuses_nothing()
+    {
+        Assert.False(ToastRegistration.Remove(_aumid, _clsid, out var refused));
+        Assert.Null(refused);
+    }
+
+    [Fact]
+    public void A_name_unsafe_for_a_subkey_operation_never_reaches_the_registry()
+    {
+        // The hazard IsPlainAumid names: a name made of separators fixes up
+        // to the empty string, and DeleteSubKeyTree on that deletes the key
+        // the handle is open on - here the whole AppUserModelId or CLSID
+        // hive, with every other install's identity in it. The guard refuses
+        // first and both hives keep all their tenants.
+        CreateAumidKey(_aumid, displayName: "kept");
+        CreateClsidKey(_clsid, $"\"{Exe}\" ----AppNotificationActivated:");
+
+        Assert.False(ToastRegistration.Remove(@"a\b", _clsid, out var refused));
+        Assert.NotNull(refused);
+        Assert.True(KeyExists(AumidRoot));
+        Assert.True(KeyExists($@"{AumidRoot}\{_aumid}"));
+        Assert.True(KeyExists(ClsidRoot));
+        Assert.True(KeyExists($@"{ClsidRoot}\{_clsid}"));
+
+        // The same refusal at the other two doors, and the other separator.
+        Assert.False(ToastRegistration.Read("a/b").Exists);
+        Assert.False(ToastRegistration.Apply(
+            @"a\b", new ToastRegistrationRepair(false, true, true), "Wintty", null));
+    }
+
+    [Fact]
+    public void Apply_writes_what_the_repair_names()
+    {
+        CreateAumidKey(_aumid, displayName: "Someone Else", iconUri: "file:///old.png");
+
+        Assert.True(ToastRegistration.Apply(
+            _aumid,
+            new ToastRegistrationRepair(Recreate: false, RewriteDisplayName: true, RewriteIconUri: true),
+            "Wintty Pro", "file:///new.png"));
+
+        Assert.Equal("Wintty Pro", ValueOf($@"{AumidRoot}\{_aumid}", "DisplayName"));
+        Assert.Equal("file:///new.png", ValueOf($@"{AumidRoot}\{_aumid}", "IconUri"));
+    }
+
+    [Fact]
+    public void Apply_with_nothing_to_rewrite_touches_nothing()
+    {
+        CreateAumidKey(_aumid, displayName: "Someone Else");
+
+        Assert.False(ToastRegistration.Apply(_aumid, default, "Wintty Pro", "file:///new.png"));
+
+        Assert.Equal("Someone Else", ValueOf($@"{AumidRoot}\{_aumid}", "DisplayName"));
+        Assert.Null(ValueOf($@"{AumidRoot}\{_aumid}", "IconUri"));
+    }
+
+    [Fact]
+    public void Apply_to_a_key_that_is_not_there_writes_nothing()
+    {
+        Assert.False(ToastRegistration.Apply(
+            _aumid,
+            new ToastRegistrationRepair(Recreate: false, RewriteDisplayName: true, RewriteIconUri: false),
+            "Wintty Pro", null));
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/SponsorOverlayHostWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/SponsorOverlayHostWiringTests.cs
@@ -1,0 +1,203 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Xml.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// Where the sponsor update pill is allowed to live.
+///
+/// A downstream tier renders the pill into a presenter this shell owns. For
+/// as long as there was one presenter it sat inside <c>VerticalTitleBar</c>,
+/// which is Collapsed unless <c>vertical-tabs</c> is on, so on the default
+/// layout the pill was never rendered at all: not Checking, not Update
+/// Available, not Restart to Complete Update
+/// (deblasis/wintty-release#655).
+///
+/// So there are two presenters, one per title row, and the shell moves the
+/// content to whichever row is on screen. These guards hold that shape: that
+/// the horizontal half exists at all, that the two are separately named, that
+/// the switch re-homes the content, and that the horizontal one is kept clear
+/// of the caption buttons. The pill's own behaviour lives in the tier that
+/// owns it and is not visible from here.
+/// </summary>
+public class SponsorOverlayHostWiringTests
+{
+    private const string MainWindowXaml = "Ghostty.Tests.MainWindow.xaml";
+    private const string TabHostXaml = "Ghostty.Tests.Tabs.TabHost.xaml";
+    private const string MainWindowSource = "MainWindow.xaml.cs";
+    private const string TitleBarSource = "Shell.TitleBarCoordinator.cs";
+
+    private static readonly XNamespace Xaml =
+        "http://schemas.microsoft.com/winfx/2006/xaml";
+
+    /// <summary>
+    /// The half that did not exist. Without it the pill has nowhere to render
+    /// in the layout almost every user is on.
+    /// </summary>
+    [Fact]
+    public void The_horizontal_strip_carries_an_overlay_host()
+    {
+        var host = Named(Parse(TabHostXaml), "SponsorOverlayHostHorizontal");
+
+        Assert.True(
+            host is not null,
+            "TabHost.xaml has no SponsorOverlayHostHorizontal. The horizontal "
+            + "strip is the default layout, and with no presenter there the "
+            + "update pill renders in no layout but vertical-tabs.");
+        Assert.Equal("ContentPresenter", host!.Name.LocalName);
+
+        // Beside the drag region, never inside it. MainWindow hands
+        // CustomDragRegion to SetTitleBar, and the SetTitleBar element's
+        // subtree is caption input to the OS: a pill inside it rendered but
+        // could not take a click, and the pill IS a click target. The
+        // new-tab control beside it in the same footer is the precedent.
+        Assert.True(
+            !host.Ancestors().Any(a => NameOf(a) == "CustomDragRegion"),
+            "The horizontal host must sit OUTSIDE CustomDragRegion, which is "
+            + "what MainWindow hands to SetTitleBar: inside it the pill is "
+            + "caption input and cannot take a click.");
+        Assert.True(
+            host.Ancestors().Any(a => NameOf(a) == "FooterRoot"),
+            "The horizontal host belongs in the strip footer (FooterRoot), "
+            + "inside the title row but beside its drag region.");
+
+        // Nothing hides it on its own account: the layout hides the whole
+        // host, which is the one visibility decision there should be.
+        Assert.Null(host.Attribute("Visibility"));
+        foreach (var ancestor in host.Ancestors())
+        {
+            Assert.True(
+                (string?)ancestor.Attribute("Visibility") != "Collapsed",
+                $"<{ancestor.Name.LocalName} x:Name=\"{NameOf(ancestor)}\"> collapses the "
+                + "horizontal overlay host, which is the whole defect this pair exists to fix.");
+        }
+    }
+
+    /// <summary>
+    /// The vertical half, and the reason the names differ. Two presenters that
+    /// shared a name would be a duplicate x:Name the moment they were in one
+    /// namescope, and a single name is what let a lookup believe it had found
+    /// the host when it had found the hidden one.
+    /// </summary>
+    [Fact]
+    public void The_vertical_host_is_separately_named_and_lives_in_the_title_row()
+    {
+        var window = Parse(MainWindowXaml);
+        var host = Named(window, "SponsorOverlayHost");
+
+        Assert.True(host is not null, "MainWindow.xaml has no SponsorOverlayHost.");
+        Assert.Equal("ContentPresenter", host!.Name.LocalName);
+
+        // Beside the drag region, never inside it, for the same reason the
+        // horizontal one is: VerticalTitleDragRegion is what MainWindow
+        // hands to SetTitleBar, and its subtree is caption input.
+        Assert.True(
+            !host.Ancestors().Any(a => NameOf(a) == "VerticalTitleDragRegion"),
+            "The vertical host must sit OUTSIDE VerticalTitleDragRegion, "
+            + "which is what MainWindow hands to SetTitleBar: inside it the "
+            + "pill is caption input and cannot take a click.");
+        Assert.True(
+            host.Ancestors().Any(a => NameOf(a) == "VerticalTitleBar"),
+            "The vertical host belongs in the vertical title row, beside "
+            + "the drag region and ahead of the caption column.");
+
+        // The row it is in is Collapsed by default, which is the fact that
+        // makes a second presenter necessary rather than optional.
+        var row = window.Descendants().Single(e => NameOf(e) == "VerticalTitleBar");
+        Assert.Equal("Collapsed", (string?)row.Attribute("Visibility"));
+
+        // And the horizontal one is not also in this file under this name.
+        Assert.Null(Named(window, "SponsorOverlayHostHorizontal"));
+    }
+
+    /// <summary>
+    /// A switch has to move the content, or the pill renders into the row that
+    /// just left and disappears with it.
+    /// </summary>
+    [Fact]
+    public void The_layout_switch_re_homes_the_overlay_content()
+    {
+        var animate = ShellSource.Load(MainWindowSource).Method("AnimateTabLayoutTo");
+
+        var rehome = animate.Calls("ReHomeSponsorOverlay");
+        Assert.True(
+            rehome.Count == 1,
+            $"AnimateTabLayoutTo must re-home the overlay content exactly once; found {rehome.Count}.");
+
+        // After the flag, not before: the re-home reads _verticalTabsVisible
+        // to decide which presenter is the arriving one, so running it first
+        // parks the pill back in the row that is leaving.
+        var flag = animate.AssignsTo("_verticalTabsVisible").ToList();
+        Assert.True(flag.Count == 1, $"expected one _verticalTabsVisible assignment, found {flag.Count}");
+        Assert.True(
+            flag[0].SpanStart < rehome[0].SpanStart,
+            "ReHomeSponsorOverlay reads _verticalTabsVisible; it must run after the flag is set.");
+    }
+
+    /// <summary>
+    /// The order inside the move. A UIElement has one parent, so handing it to
+    /// the arriving presenter while the leaving one still holds it throws
+    /// instead of moving it, and the pill is lost for the rest of the session.
+    /// </summary>
+    [Fact]
+    public void The_idle_presenter_is_cleared_before_the_active_one_is_filled()
+    {
+        var rehome = ShellSource.Load(MainWindowSource).Method("ReHomeSponsorOverlay");
+
+        var clear = rehome.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.Left.ToString() == "idle.Content"
+                        && a.Right.ToString() == "null")
+            .ToList();
+        var fill = rehome.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.Left.ToString() == "active.Content")
+            .ToList();
+
+        Assert.True(clear.Count == 1, $"expected one 'idle.Content = null', found {clear.Count}");
+        Assert.True(fill.Count == 1, $"expected one write to active.Content, found {fill.Count}");
+        Assert.True(
+            clear[0].SpanStart < fill[0].SpanStart,
+            "Clear the leaving presenter first: a UIElement cannot be in two of them at once.");
+    }
+
+    /// <summary>
+    /// The horizontal presenter's cell runs to the footer's right edge, which
+    /// is the window's, so without the inset it draws under the OS caption
+    /// buttons. The vertical row's presenter is cleared by the caption column
+    /// it sits ahead of and needs no equivalent.
+    /// </summary>
+    [Fact]
+    public void The_caption_inset_sync_moves_the_horizontal_host()
+    {
+        var sync = ShellSource.Load(TitleBarSource).Method("SyncCaptionInset");
+        var call = sync.Call("_horizontalTabHost.SyncSponsorOverlayInset");
+
+        // The same number the drag region's MinWidth is set from. A second
+        // source for it is a second thing that can disagree with the caption
+        // lane, which is the defect the inset column was consolidated to fix.
+        Assert.Equal("dip", call.Arg(0));
+
+        // And the captionless (quake) window zeroes it: there are no buttons
+        // there, so the XAML default would hold an empty lane open.
+        var captionless = ShellSource.Load(TitleBarSource).Method("SetCaptionless");
+        Assert.Equal("0", captionless.Call("_horizontalTabHost.SyncSponsorOverlayInset").Arg(0));
+    }
+
+    private static XElement Parse(string logicalName)
+    {
+        var asm = Assembly.GetExecutingAssembly();
+        using var stream = asm.GetManifestResourceStream(logicalName);
+        Assert.True(stream is not null, $"embedded resource '{logicalName}' is missing");
+        using var reader = new StreamReader(stream!);
+        return XDocument.Parse(reader.ReadToEnd()).Root!;
+    }
+
+    private static XElement? Named(XElement root, string name) =>
+        root.DescendantsAndSelf().SingleOrDefault(e => NameOf(e) == name);
+
+    private static string? NameOf(XElement element) => (string?)element.Attribute(Xaml + "Name");
+}

--- a/windows/Ghostty.Tests/Wiring/ToastRegistrationWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/ToastRegistrationWiringTests.cs
@@ -1,0 +1,176 @@
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// Where the toast-registration self-heal sits in startup.
+///
+/// The decision itself is pure and tested outright in
+/// <c>ToastRegistrationTests</c>. What a parse adds is the ORDER, which no
+/// test of the decision can see and which is the whole reason the repair
+/// works: the removal has to run BEFORE <c>Register()</c>, because Register()
+/// is what writes the key back and a removal that runs after it costs this
+/// launch its notifications instead of fixing the next one. The rewrite has
+/// to run AFTER, because the two values it corrects are ones Register()
+/// derives from the process image and writes itself.
+///
+/// <c>App</c> lives in the WinUI project, which this assembly cannot
+/// reference, so this parses the source the way the other wiring guards do.
+/// </summary>
+public class ToastRegistrationWiringTests
+{
+    private const string ShellFile = "App.xaml.cs";
+    private const string Read = "Ghostty.Core.Windows.ToastRegistration.Read";
+    private const string Diagnose = "Ghostty.Core.Windows.ToastRegistration.Diagnose";
+    private const string Remove = "Ghostty.Core.Windows.ToastRegistration.Remove";
+    private const string Apply = "Ghostty.Core.Windows.ToastRegistration.Apply";
+    private const string Register =
+        "Microsoft.Windows.AppNotifications.AppNotificationManager.Default.Register";
+
+    private static BlockSyntax Launched() =>
+        ShellSource.Load(ShellFile).Method("OnLaunched").Body!;
+
+    private static int IndexOf(BlockSyntax body, string call) =>
+        body.Statements.ToList().FindIndex(s => s.Calls(call).Count > 0);
+
+    private static int LastIndexOf(BlockSyntax body, string call) =>
+        body.Statements.ToList().FindLastIndex(s => s.Calls(call).Count > 0);
+
+    [Fact]
+    public void Startup_repairs_a_stale_registration_before_registering()
+    {
+        var body = Launched();
+
+        var register = IndexOf(body, Register);
+        var remove = IndexOf(body, Remove);
+
+        Assert.True(register >= 0, "OnLaunched no longer registers for toast notifications");
+        Assert.True(
+            remove >= 0,
+            "OnLaunched no longer removes a registration whose activator points at a departed "
+            + "install; nothing else ever rewrites LocalServer32, so toast clicks stay dead.");
+        Assert.True(
+            remove < register,
+            $"the removal is at statement {remove}, at or below Register() at {register}. "
+                + "Register() is what writes the key back, so the removal has to precede it or "
+                + "this launch loses its registration instead of repairing it.");
+    }
+
+    [Fact]
+    public void The_shown_values_are_rewritten_after_registering()
+    {
+        var body = Launched();
+
+        var register = IndexOf(body, Register);
+        var apply = IndexOf(body, Apply);
+
+        Assert.True(
+            apply >= 0,
+            "OnLaunched no longer rewrites the registration's DisplayName / IconUri.");
+        Assert.True(
+            apply > register,
+            $"the rewrite is at statement {apply}, at or above Register() at {register}. "
+                + "Register() derives those two from the process image and writes them itself, "
+                + "so a rewrite before it is overwritten by it.");
+    }
+
+    /// <summary>
+    /// Both halves read the registry again rather than reusing one snapshot.
+    /// Register() runs between them and changes what is on the machine, so the
+    /// rewrite's decision has to be made against what Register() left.
+    /// </summary>
+    [Fact]
+    public void Each_half_diagnoses_against_a_fresh_read()
+    {
+        var body = Launched();
+
+        Assert.Equal(2, body.Calls(Read).Count);
+        Assert.Equal(2, body.Calls(Diagnose).Count);
+
+        var register = IndexOf(body, Register);
+        Assert.True(IndexOf(body, Read) < register, "the first read must precede Register()");
+        Assert.True(LastIndexOf(body, Read) > register, "the second read must follow Register()");
+    }
+
+    /// <summary>
+    /// The identity all four calls act on is the one the process was given,
+    /// read from the same local rather than spelled a second time. A name that
+    /// drifts here deletes a key that belongs to something else.
+    /// </summary>
+    [Fact]
+    public void Every_call_names_the_identity_the_process_set()
+    {
+        var body = Launched();
+
+        var identity = body.Call(
+            "Windows.Win32.PInvoke.SetCurrentProcessExplicitAppUserModelID").Arg(0);
+
+        foreach (var call in body.Calls(Read))
+            Assert.Equal(identity, call.Arg(0));
+        Assert.Equal(identity, body.Call(Remove).Arg(0));
+        Assert.Equal(identity, body.Call(Apply).Arg(0));
+    }
+
+    /// <summary>
+    /// The failure line carries the reason. A WinRT HRESULT arriving through a
+    /// projected interface leaves frames that name the method and nothing that
+    /// names the fault, which is how "Failed to register for toast
+    /// notifications" stood in the log for a whole rehearsal saying nothing
+    /// (deblasis/wintty-release#656).
+    /// </summary>
+    [Fact]
+    public void The_registration_failure_logs_the_exception_message()
+    {
+        var source = ShellSource.Load(ShellFile);
+
+        var template = source.Root.DescendantNodes()
+            .OfType<AttributeSyntax>()
+            .Where(a => a.Name.ToString() == "LoggerMessage")
+            .SelectMany(a => a.ArgumentList?.Arguments ?? default)
+            .Where(arg => arg.NameEquals?.Name.Identifier.ValueText == "Message")
+            .Select(arg => arg.Expression.ToString())
+            .SingleOrDefault(t => t.Contains(
+                "Failed to register for toast notifications", System.StringComparison.Ordinal));
+
+        Assert.True(template is not null, "the toast-registration failure message is gone");
+        Assert.Contains("{Reason}", template!, System.StringComparison.Ordinal);
+
+        foreach (var call in source.Root.Calls("Ghostty.Logging.StaticLoggers.App.LogToastRegisterFailed"))
+        {
+            Assert.Equal(2, call.ArgumentList.Arguments.Count);
+            Assert.Equal("ex.Message", call.Arg(1));
+        }
+    }
+
+    /// <summary>
+    /// A refused removal is loud. Remove() swallows by contract, which is
+    /// exactly why the call site has to say what was refused: without this
+    /// line a refused delete left the launch half-repaired, the key still
+    /// stale, and the next click still dead with nothing in the log.
+    /// </summary>
+    [Fact]
+    public void A_refused_removal_is_logged_with_the_key_and_the_reason()
+    {
+        var source = ShellSource.Load(ShellFile);
+
+        var call = source.Root.Calls(
+            "Ghostty.Logging.StaticLoggers.App.LogToastRegistrationRemoveRefused")
+            .SingleOrDefault();
+        Assert.True(
+            call is not null,
+            "OnLaunched no longer logs a refused toast-registration removal; "
+            + "Remove() never throws, so the call site is the only place a "
+            + "half-repaired launch says so.");
+
+        var identity = Launched().Call(
+            "Windows.Win32.PInvoke.SetCurrentProcessExplicitAppUserModelID").Arg(0);
+        Assert.Equal(identity, call!.Arg(0));
+        // The reason argument is the removal's out reason, not a constant:
+        // the argument is the local (with its null fallback spelled beside
+        // it), and a literal here would log the same reason for every
+        // refusal.
+        Assert.StartsWith("toastRemoveRefusal", call.Arg(1), System.StringComparison.Ordinal);
+    }
+}

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -658,7 +658,53 @@ public partial class App : Application
         }
         catch (System.Exception ex)
         {
-            Ghostty.Logging.StaticLoggers.App.LogToastRegisterFailed(ex);
+            Ghostty.Logging.StaticLoggers.App.LogToastRegisterFailed(ex, ex.Message);
+        }
+
+        // Register() writes this identity's registration once and then leaves
+        // whatever it finds alone, so on a machine that has had an earlier
+        // install the values it re-registers against are that install's. Two
+        // of them are wrong forever and nothing else ever corrects them: the
+        // CustomActivator's LocalServer32 still names an exe that may not
+        // exist, so a toast click launches nothing, and DisplayName still
+        // reads whatever that install called itself. Show() keeps working
+        // either way, which is why this went unseen. See ToastRegistration.
+        //
+        // Before Register(), for the same reason the superseded sweep above
+        // runs first: Register() is what writes the key back, so a removal
+        // that runs first is recoverable within this launch and one that runs
+        // after costs every toast until the next one.
+        // The qualified names stay unbroken: the wiring guard matches the
+        // callee as source text, and a name wrapped mid-way stops matching.
+        // Arguments may wrap freely.
+        //
+        // wantIconUri is null because nothing in this repository declares a
+        // toast icon, so Register()'s own choice (extracted from the process
+        // image) stands and the rewrite below leaves IconUri alone. A build
+        // tier that ships one passes it here and gets it written.
+        var toastRegistration = Ghostty.Core.Windows.ToastRegistration.Read(AppUserModelId);
+        var toastRepair = Ghostty.Core.Windows.ToastRegistration.Diagnose(
+            toastRegistration,
+            System.Environment.ProcessPath,
+            Ghostty.Core.AppIdentity.ProductName,
+            wantIconUri: null);
+        string? toastRemoveRefusal = null;
+        if (toastRepair.Recreate
+            && Ghostty.Core.Windows.ToastRegistration.Remove(
+                AppUserModelId, toastRegistration.ActivatorClsid, out toastRemoveRefusal))
+        {
+            Ghostty.Logging.StaticLoggers.App.LogToastRegistrationRecreated(
+                toastRegistration.ActivatorServer ?? "(no activator server)");
+        }
+        else if (toastRepair.Recreate)
+        {
+            // A refusal used to be completely silent: Remove() swallows by
+            // contract, the key stayed, and the launch went on looking
+            // repaired while the next toast click was still dead. Still no
+            // control flow - the launch continues either way - but the line
+            // now names the key and carries the OS message.
+            Ghostty.Logging.StaticLoggers.App.LogToastRegistrationRemoveRefused(
+                AppUserModelId, toastRemoveRefusal ?? "the registration was not removed");
         }
 
         // Exactly one Register() call may exist in the process.
@@ -668,7 +714,27 @@ public partial class App : Application
         }
         catch (System.Exception ex)
         {
-            Ghostty.Logging.StaticLoggers.App.LogToastRegisterFailed(ex);
+            // The message, not just the generic line: the HRESULT behind this
+            // is the only thing that tells a stale registration apart from a
+            // platform refusal, and the stack alone names neither.
+            Ghostty.Logging.StaticLoggers.App.LogToastRegisterFailed(ex, ex.Message);
+        }
+
+        // The two values Register() derives from the process image rather than
+        // from anything this build declares. Written straight onto the key it
+        // has just settled, because a delete-and-re-register would only make
+        // it derive the same values again: a disagreement Register() would
+        // reproduce is a delete on every launch, forever.
+        var toastSettled = Ghostty.Core.Windows.ToastRegistration.Read(AppUserModelId);
+        var toastRewrite = Ghostty.Core.Windows.ToastRegistration.Diagnose(
+            toastSettled,
+            System.Environment.ProcessPath,
+            Ghostty.Core.AppIdentity.ProductName,
+            wantIconUri: null);
+        if (Ghostty.Core.Windows.ToastRegistration.Apply(
+                AppUserModelId, toastRewrite, Ghostty.Core.AppIdentity.ProductName, iconUri: null))
+        {
+            Ghostty.Logging.StaticLoggers.App.LogToastRegistrationRewritten(Ghostty.Core.AppIdentity.ProductName);
         }
 
         // Read the activation this process was started for, before the
@@ -2346,11 +2412,34 @@ internal static partial class AppLogExtensions
     internal static partial void LogJumpListFailed(
         this ILogger<App> logger, System.Exception ex);
 
+    // The reason is spelled into the message rather than left to the
+    // exception: this is a WinRT HRESULT arriving through a projected
+    // interface, and the frames alone say only which method threw. Whoever
+    // reads this line is trying to tell a stale registration apart from a
+    // platform refusal, and that difference lives entirely in the message.
     [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Startup.ToastRegisterFailed,
                    Level = LogLevel.Warning,
-                   Message = "Failed to register for toast notifications")]
+                   Message = "Failed to register for toast notifications: {Reason}")]
     internal static partial void LogToastRegisterFailed(
-        this ILogger<App> logger, System.Exception ex);
+        this ILogger<App> logger, System.Exception ex, string reason);
+
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Startup.ToastRegistrationRecreated,
+                   Level = LogLevel.Information,
+                   Message = "Removed a toast registration whose activator pointed at {StaleServer}")]
+    internal static partial void LogToastRegistrationRecreated(
+        this ILogger<App> logger, string staleServer);
+
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Startup.ToastRegistrationRemoveRefused,
+                   Level = LogLevel.Warning,
+                   Message = "Could not remove the stale toast registration for {Aumid}: {Reason}")]
+    internal static partial void LogToastRegistrationRemoveRefused(
+        this ILogger<App> logger, string aumid, string reason);
+
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Startup.ToastRegistrationRewritten,
+                   Level = LogLevel.Information,
+                   Message = "Rewrote the toast registration's display name to {DisplayName}")]
+    internal static partial void LogToastRegistrationRewritten(
+        this ILogger<App> logger, string displayName);
 
     [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Startup.ConfigOpenFailed,
                    Level = LogLevel.Warning,

--- a/windows/Ghostty/Logging/LogEvents.cs
+++ b/windows/Ghostty/Logging/LogEvents.cs
@@ -16,6 +16,9 @@ internal static class LogEvents
         public const int StaleAumidRemoved   = 2004;
         public const int ConfigOpenFailed    = 2005;
         public const int QuakeWindowFailed   = 2006;
+        public const int ToastRegistrationRecreated = 2007;
+        public const int ToastRegistrationRewritten = 2008;
+        public const int ToastRegistrationRemoveRefused = 2009;
     }
 
     // 2100-2199: Clipboard

--- a/windows/Ghostty/MainWindow.xaml
+++ b/windows/Ghostty/MainWindow.xaml
@@ -57,16 +57,16 @@
         </Grid.ColumnDefinitions>
 
         <!--
-            Vertical-mode title bar. Three columns:
+            Vertical-mode title bar. Four columns:
             Col 0 mirrors StripColumn so the drag region starts after
             the tab strip, avoiding a Z-order fight with the chevron
             button inside VerticalTabHost. Col 1 is the draggable
-            area with the window title. Col 2 reserves room for the
-            OS caption buttons.
+            area with the window title. Col 2 is the sponsor pill's
+            own cell. Col 3 reserves room for the OS caption buttons.
 
             Col 0 uses a non-hit-testable fill so the strip-lane band
             can match the tab bar while clicks still reach the icon /
-            chevron in VerticalTabHost below. Fills for all three
+            chevron in VerticalTabHost below. Fills for all four
             columns come from ApplyVerticalTitleBarChrome, which leaves
             them transparent unless window-theme=wintty is painting the
             row. The default row is the window backdrop.
@@ -84,6 +84,7 @@
             <Grid.ColumnDefinitions>
                 <ColumnDefinition x:Name="TitleBarStripMirror" Width="0"/>
                 <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition x:Name="VerticalCaptionInset" Width="146"/>
             </Grid.ColumnDefinitions>
 
@@ -112,10 +113,34 @@
                            IsHitTestVisible="False"/>
             </Grid>
 
+            <!--
+                Sponsor overlay host for the vertical title row. One of
+                TWO presenters; the other is SponsorOverlayHostHorizontal
+                in TabHost's strip footer. Read the contract on
+                MainWindow.SponsorOverlayContent before touching either:
+                each presenter lives in the title row its own layout
+                hides, so the shell moves the content between them and a
+                lookup of one name alone only ever renders in one layout
+                (deblasis/wintty-release#655).
+
+                In its own cell BETWEEN the drag region and the caption
+                column, never inside the drag region, on the same terms
+                as the horizontal strip's new-tab control:
+                SetTitleBar(VerticalTitleDragRegion) makes that element
+                and everything under it caption input to the OS, so a
+                pill inside it would render but could not take a click.
+                The 8 here is the gap to the caption column; the column
+                itself clears the OS buttons.
+            -->
+            <ContentPresenter x:Name="SponsorOverlayHost"
+                              Grid.Column="2"
+                              VerticalAlignment="Center"
+                              Margin="0,0,8,0"/>
+
             <!-- Caption-button column: same fill as the drag region, so
                  the two never disagree across the row. -->
             <Border x:Name="VerticalTitleCaptionFill"
-                    Grid.Column="2"
+                    Grid.Column="3"
                     IsHitTestVisible="False"/>
 
             <!-- There is no caption seam cover here any more, and that is

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1605,6 +1605,82 @@ public sealed partial class MainWindow : Window
         AnimateTabLayoutTo(vertical);
     }
 
+    // --- Sponsor overlay host contract -------------------------------
+    //
+    // A downstream build tier (wintty-release's sponsor-update overlay)
+    // renders an update pill in the title row. This shell owns where that
+    // pill lives; the overlay owns what it is.
+    //
+    // There are TWO presenters, because there are two title rows and each
+    // one is inside the row its own layout hides: SponsorOverlayHost in
+    // MainWindow.xaml's VerticalTitleBar, and SponsorOverlayHostHorizontal
+    // in TabHost's strip footer. Whichever row is on screen is the one
+    // holding the content, and this shell moves it across on every layout
+    // switch, so the overlay assigns once and never thinks about layout
+    // again:
+    //
+    //     if (window is MainWindow main) main.SponsorOverlayContent = pill;
+    //
+    // Both sit in a cell of their own BESIDE their row's drag region,
+    // never inside it: VerticalTitleDragRegion and CustomDragRegion are
+    // what SetTitleBar binds, and the SetTitleBar element's subtree is
+    // caption input to the OS, so a pill under it could render but never
+    // take a click. The new-tab control outside TabHost's drag region is
+    // the same rule; SponsorOverlayHostWiringTests holds both doors shut.
+    //
+    // A FindName("SponsorOverlayHost") on the window content resolves to
+    // the VERTICAL presenter only, and that presenter is Collapsed with the
+    // row that carries it unless vertical-tabs is on. That is exactly the
+    // bug in deblasis/wintty-release#655: with the default horizontal
+    // layout no update state was ever visible. A caller that wants the pill
+    // in both layouts uses the property below, not the name.
+    private object? _sponsorOverlayContent;
+
+    /// <summary>
+    /// What the sponsor overlay wants rendered in the title row, in
+    /// whichever layout is on screen. Null clears both presenters. See the
+    /// contract above this property.
+    /// </summary>
+    internal object? SponsorOverlayContent
+    {
+        get => _sponsorOverlayContent;
+        set
+        {
+            _sponsorOverlayContent = value;
+            ReHomeSponsorOverlay();
+        }
+    }
+
+    /// <summary>
+    /// The presenter that is inside the title row currently on screen, or
+    /// null before the tab hosts are built. Exposed for the overlay's own
+    /// measurement and teleport work; assign through
+    /// <see cref="SponsorOverlayContent"/> rather than to this.
+    /// </summary>
+    internal ContentPresenter? ActiveSponsorOverlayHost =>
+        _verticalTabsVisible ? SponsorOverlayHost : _horizontalTabHost?.SponsorOverlayHost;
+
+    /// <summary>
+    /// Put the overlay content in the presenter belonging to the layout on
+    /// screen, and take it out of the other one.
+    /// </summary>
+    /// <remarks>
+    /// The idle presenter is cleared FIRST and unconditionally. The content
+    /// is a live UIElement and a UIElement has exactly one parent, so
+    /// assigning it to the incoming presenter while the outgoing one still
+    /// holds it throws rather than moving it. Clearing an already-empty
+    /// presenter costs nothing, which is why there is no guard.
+    /// </remarks>
+    private void ReHomeSponsorOverlay()
+    {
+        var horizontal = _horizontalTabHost?.SponsorOverlayHost;
+        var active = _verticalTabsVisible ? SponsorOverlayHost : horizontal;
+        var idle = _verticalTabsVisible ? horizontal : SponsorOverlayHost;
+
+        if (idle is not null) idle.Content = null;
+        if (active is not null) active.Content = _sponsorOverlayContent;
+    }
+
     private void AnimateTabLayoutTo(bool vertical)
     {
         if (_layout.IsSwitching)
@@ -1620,6 +1696,10 @@ public sealed partial class MainWindow : Window
         _pendingLayoutTarget = null;
         _verticalTabsVisible = vertical;
         _tabHost = vertical ? _verticalTabHost : _horizontalTabHost;
+        // Before the cross-fade, not after: the row that is arriving is made
+        // Visible at the start of the switch, so the pill travels with it
+        // instead of popping in at the landing. Reads the flag just set.
+        ReHomeSponsorOverlay();
         // The seam covers are gated on the flag just set, and the strip that
         // is coming back may not raise anything on its own (a switch does not
         // resize it or move its selection). Ask both for a fresh placement so

--- a/windows/Ghostty/Shell/TitleBarCoordinator.cs
+++ b/windows/Ghostty/Shell/TitleBarCoordinator.cs
@@ -144,6 +144,13 @@ internal sealed class TitleBarCoordinator
                 _captionInset.Width = new GridLength(dip);
                 if (_horizontalTabHost.DragRegion is FrameworkElement drag)
                     drag.MinWidth = dip;
+                // The horizontal sponsor overlay host's own cell sits at
+                // the footer's right edge, which is the window's, so it
+                // needs this number as a margin or the pill draws under
+                // the caption buttons. The vertical row's presenter sits
+                // in its own cell ahead of the inset column, which clears
+                // it for free.
+                _horizontalTabHost.SyncSponsorOverlayInset(dip);
                 CaptionInsetChanged?.Invoke();
             }
         }
@@ -166,6 +173,10 @@ internal sealed class TitleBarCoordinator
         _captionInset.Width = new GridLength(0);
         if (_horizontalTabHost.DragRegion is FrameworkElement dragRegion)
             dragRegion.MinWidth = 0;
+        // No buttons to clear on a borderless window, so the overlay host
+        // keeps only its gap. Left to the XAML default it would hold 146 DIP
+        // of empty lane open on the one layout that has nothing there.
+        _horizontalTabHost.SyncSponsorOverlayInset(0);
         _verticalTitleText.Visibility = Visibility.Collapsed;
     }
 

--- a/windows/Ghostty/Tabs/TabHost.xaml
+++ b/windows/Ghostty/Tabs/TabHost.xaml
@@ -64,9 +64,10 @@
                 <branding:AppIconBadge x:Name="IconBadgeHost" />
             </controls:TabView.TabStripHeader>
             <!--
-                TabStripFooter is a two-cell row. Cell 0 holds the
-                NewTabSplitButton (not inside the drag region so clicks
-                land on the button). Cell 1 is the drag-only spacer
+                TabStripFooter is a three-cell row. Cells 0 and 2 hold the
+                two interactive residents, the NewTabSplitButton and the
+                sponsor overlay host, both OUTSIDE the drag region so
+                clicks land on them. Cell 1 is the drag-only spacer
                 named CustomDragRegion; MainWindow calls
                 SetTitleBar(CustomDragRegion) so the empty strip area
                 still drags the window.
@@ -76,6 +77,7 @@
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
                     <!-- Cell 0: composite new-tab control. NOT inside the
                          drag region; clicks reach the SplitButton. -->
@@ -91,6 +93,29 @@
                           Grid.Column="1"
                           MinWidth="146"
                           Background="Transparent"/>
+                    <!-- Cell 2: sponsor overlay host for the horizontal
+                         strip: the twin of MainWindow's SponsorOverlayHost,
+                         and the half that did not exist, which is why the
+                         update pill only ever rendered under
+                         vertical-tabs (deblasis/wintty-release#655). Read
+                         the contract on MainWindow.SponsorOverlayContent.
+
+                         In its own cell BESIDE the drag region, never
+                         inside it, on the same terms as the new-tab control
+                         in cell 0: SetTitleBar(CustomDragRegion) makes that
+                         element and everything under it caption input to
+                         the OS, so a pill inside it would render but could
+                         not take a click, and the pill IS a click target.
+                         Right margin is the caption inset, so the pill
+                         stops where the OS buttons begin: the 154 here is
+                         the 100%-scale fallback (146 inset + the 8 gap the
+                         vertical row keeps) and SyncSponsorOverlayInset
+                         overwrites it from the live inset, exactly as
+                         MinWidth above. -->
+                    <ContentPresenter x:Name="SponsorOverlayHostHorizontal"
+                                      Grid.Column="2"
+                                      VerticalAlignment="Center"
+                                      Margin="0,0,154,0"/>
                 </Grid>
             </controls:TabView.TabStripFooter>
         </controls:TabView>

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -226,6 +226,41 @@ internal sealed partial class TabHost : UserControl, ITabHost
     /// </summary>
     public UIElement DragRegion => CustomDragRegion;
 
+    /// <summary>
+    /// This layout's half of the sponsor overlay host pair. See the contract
+    /// on <see cref="MainWindow.SponsorOverlayContent"/>: the shell owns
+    /// which of the two presenters holds the content; this only says where
+    /// the horizontal one is.
+    /// </summary>
+    public ContentPresenter SponsorOverlayHost => SponsorOverlayHostHorizontal;
+
+    /// <summary>
+    /// The gap kept between the overlay host and the caption buttons. The
+    /// same one the vertical title row's presenter carries in its margin, so
+    /// the pill sits in the same place in both layouts.
+    /// </summary>
+    private const double SponsorOverlayCaptionGap = 8;
+
+    /// <summary>
+    /// Keep the overlay host clear of the OS caption buttons.
+    /// <paramref name="captionInsetDip"/> is the live
+    /// <c>AppWindow.TitleBar.RightInset</c> in DIP, the same number
+    /// <see cref="DragRegion"/>'s MinWidth is set from; called from
+    /// <c>TitleBarCoordinator</c> so the two cannot disagree.
+    ///
+    /// Without it the host's cell runs to the footer's right edge, which
+    /// is the window's, and the pill renders underneath the buttons.
+    /// A zero inset is the captionless (quake) window, where there are no
+    /// buttons to clear and only the gap is left.
+    /// </summary>
+    public void SyncSponsorOverlayInset(double captionInsetDip)
+    {
+        var right = captionInsetDip > 0
+            ? captionInsetDip + SponsorOverlayCaptionGap
+            : SponsorOverlayCaptionGap;
+        SponsorOverlayHostHorizontal.Margin = new Thickness(0, 0, right, 0);
+    }
+
     public TabHost(TabManager manager, PaneActionRouter router, DialogTracker dialogs)
     {
         InitializeComponent();


### PR DESCRIPTION
Two app-code fixes reported against the installed builds. Separate commits, one per issue; they touch disjoint code and can be read independently.

## 1. Update pill only existed in the vertical-tabs layout

`SponsorOverlayHost` was one `ContentPresenter`, inside `VerticalTitleBar`, which is `Collapsed` unless `vertical-tabs` is on. On the default layout the pill rendered in no state at all.

There is no single place a presenter can sit and be inside both title rows, so there are two, separately named:

- `SponsorOverlayHost`, unchanged, in `MainWindow.xaml`'s `VerticalTitleDragRegion`
- `SponsorOverlayHostHorizontal`, new, in `TabHost`'s strip footer

`MainWindow.SponsorOverlayContent` is the contract: assign the pill once and the shell puts it in whichever row is on screen and moves it on every layout switch (`AnimateTabLayoutTo`). The move clears the leaving presenter first, because a UIElement has one parent.

Both presenters sit OUTSIDE their row's drag region, in their own auto-sized cells, because interactive content inside a `SetTitleBar` drag region cannot receive pointer input and the repo's own precedent says so (the new-tab SplitButton's cell-0 comment, `TitleBarPassthroughTests`). The horizontal host takes a new auto cell beside the strip footer's drag region; the vertical one a new auto column between the drag region and the caption fill. `SyncCaptionInset` still feeds the caption inset as the host's margin from the same number it already uses for that region's `MinWidth`; `SetCaptionless` zeroes it for the quake window. `MainWindow.xaml` is consumed from the embed windows already ships (`Ghostty.Tests.MainWindow.xaml`), so this PR no longer touches the test csproj at all.

## 2. Toast registration was never refreshed

`Register()` writes the AUMID key once and re-registers into whatever an earlier install left: a `CustomActivator` whose `LocalServer32` names an exe that may be gone, and a `DisplayName` that is the other install's. `Show()` keeps working, so only the click is dead and nothing says so.

New `Ghostty.Core.Windows.ToastRegistration`. `Diagnose` is the whole decision and is pure. Because a `Recreate` deletes registry keys unattended, every rule is a positive disagreement between two known values: a missing key asks for nothing, an unknown `ProcessPath` is not evidence, a caller with no opinion leaves the shown values alone.

Order is the point:

- the removal runs **before** `Register()` (which is what writes the key back), and takes the activator's CLSID key with it
- the `DisplayName` / `IconUri` rewrite runs **after**, as a direct write, because `Register()` derives those from the process image and a delete on a disagreement it reproduces would be a delete on every launch

The failure line now carries the exception message. `AppIdentity.ProductName` is what this build wants for `DisplayName`; downstream that resolves to `BuildInfo.DisplayName`, so the pro and enterprise names land on the key without a tier-side change.

## Tests

New:

- `windows/Ghostty.Tests/Wiring/SponsorOverlayHostWiringTests.cs` (5)
- `windows/Ghostty.Tests/Notifications/ToastRegistrationTests.cs` (23 incl. theory cases)
- `windows/Ghostty.Tests/Wiring/ToastRegistrationWiringTests.cs` (5)

`MainWindow.xaml` is now embedded in the test assembly: which title row a presenter sits in is a fact only the XAML carries.

Solution-level narrow run, everything green:

```
dotnet test Ghostty.sln /p:Platform=x64 --filter "...SponsorOverlayHostWiringTests|...ToastRegistrationTests|...ToastRegistrationWiringTests|...StaleAppUserModelWiringTests|...LogEventsUniquenessTests|...TabStripSyncWiringTests|...WindowTeardownWiringTests|...TabLayoutSwitchWiringTests"
Passed!  - Failed: 0, Passed: 102, Skipped: 0, Total: 102
```

The new guards can fail. Under a deliberate mutation pass (presenter deleted from `TabHost.xaml`, vertical presenter renamed, `ReHomeSponsorOverlay` call dropped, clear/fill order swapped, inset argument replaced with a literal, the repair blocks removed from `OnLaunched`, `ex.Message` replaced, and four inverted rules in `Diagnose`):

```
Failed!  - Failed: 13, Passed: 23, Skipped: 0, Total: 36
```

plus a second, narrower mutation moving the removal out of its slot:

```
Failed Ghostty.Tests.Wiring.ToastRegistrationWiringTests.Startup_repairs_a_stale_registration_before_registering
Failed!  - Failed: 1, Passed: 0, Skipped: 0, Total: 1
```

All 14 reds are in the new classes and cover both issues. Files restored afterwards; the green run above is post-revert.

## Follow-ups, not in this PR

- **Release-side follow-up, required for the pill fix to actually reach a user.** The overlay's `SponsorOverlayBootstrapper.Wire` still does `root.FindName("SponsorOverlayHost")`, which resolves to the vertical presenter only. It needs to assign `MainWindow.SponsorOverlayContent` instead, and the sponsor overlay patch needs its own `SponsorOverlayHost` hunk dropped, since this branch now declares it. A tier that does neither behaves exactly as it does today, not worse.
- The three toast-registration log lines are written before `StaticLoggers.Initialize`, so they are dropped in this repository the way the AUMID and jump-list warnings above them already are. Making early startup records survive is its own change.
- `PowerSaverIcon` already right-aligns to the same spot in row 0 and would overlap the pill in either layout. Pre-existing in vertical, now also possible in horizontal; left alone as unrelated chrome work.

## Review follow-up (same PR)

- The pill hosts moved OUTSIDE the drag regions as above (review finding: the original inside-the-region placement made the clickable pill dead input; no passthrough mechanism exists in the repo).
- A refused removal is no longer silent: `Remove` hands back each refusal with the key and the OS message and `OnLaunched` logs it at Warning (`ToastRegistrationRemoveRefused`, EventId 2009); control flow unchanged.
- `ToastRegistrationTests` now also executes the registry halves against real HKCU under per-instance GUID keys: the `DeleteSubKeyTree`-on-an-open-key hazard the `IsPlainAumid` doc names, and `Remove` deleting only the AUMID key plus the one CLSID it names. The file executes 27 cases (10 facts + 17 theory rows), not 23 as first written.
