### PR TITLE
panes: the startup glow ends on the prompt, not on the first paint

### DIFF
--- a/windows/Ghostty.Core/Panes/PaneStartupGlowState.cs
+++ b/windows/Ghostty.Core/Panes/PaneStartupGlowState.cs
@@ -27,7 +27,9 @@ public sealed class PaneStartupGlowState : IDisposable
     private readonly ISchedulerTimer _timer;
     private readonly TimeSpan _cap;
     private readonly TimeSpan _fade;
+    private readonly TimeSpan _renderGrace;
     private bool _disposed;
+    private bool _renderSeen;
 
     public Phase Current { get; private set; } = Phase.Idle;
 
@@ -36,12 +38,13 @@ public sealed class PaneStartupGlowState : IDisposable
     /// UI must marshal onto the dispatcher.</summary>
     public event Action<Phase>? StateChanged;
 
-    public PaneStartupGlowState(ISchedulerTimer timer, TimeSpan cap, TimeSpan fade)
+    public PaneStartupGlowState(ISchedulerTimer timer, TimeSpan cap, TimeSpan fade, TimeSpan renderGrace)
     {
         ArgumentNullException.ThrowIfNull(timer);
         _timer = timer;
         _cap = cap;
         _fade = fade;
+        _renderGrace = renderGrace;
         _timer.Callback = OnTimerFired;
     }
 
@@ -61,11 +64,27 @@ public sealed class PaneStartupGlowState : IDisposable
         Raise(changed);
     }
 
-    /// <summary>The surface produced its first render: end the glow early.
+    /// <summary>The surface painted something. That is not readiness: on a
+    /// daemon-attached pane the first paint is the attach resize repainting
+    /// blank cells, seconds before the prompt. Arm a short grace so a shell
+    /// with no prompt signal still ends the glow soon after it paints,
+    /// while <see cref="NotifyReady"/> can still cut in earlier. No-op
+    /// unless Glowing, and once per glow: the second paint never re-arms.</summary>
+    public void NotifyFirstRender()
+    {
+        lock (_gate)
+        {
+            if (_disposed || Current != Phase.Glowing || _renderSeen) return;
+            _renderSeen = true;
+            _timer.Schedule(_renderGrace);
+        }
+    }
+
+    /// <summary>The shell is ready (prompt up): end the glow now.
     /// No-op unless currently <see cref="Phase.Glowing"/> (Idle/FadingOut/
     /// disposed all ignore it). The fade timer supersedes the pending cap
-    /// (last-schedule-wins), so the cap is the fallback only for surfaces
-    /// that never render.</summary>
+    /// or grace (last-schedule-wins), so the cap is the fallback only for
+    /// surfaces that never render and never report a prompt.</summary>
     public void NotifyReady()
     {
         Phase? changed = null;
@@ -86,6 +105,7 @@ public sealed class PaneStartupGlowState : IDisposable
         {
             if (_disposed) return;
             _timer.Cancel();
+            _renderSeen = false;
             if (Current != Phase.Idle)
             {
                 Current = Phase.Idle;

--- a/windows/Ghostty.Tests/Panes/PaneStartupGlowStateTests.cs
+++ b/windows/Ghostty.Tests/Panes/PaneStartupGlowStateTests.cs
@@ -25,11 +25,12 @@ public class PaneStartupGlowStateTests
 
     private static readonly TimeSpan Cap = TimeSpan.FromMilliseconds(10000);
     private static readonly TimeSpan Fade = TimeSpan.FromMilliseconds(250);
+    private static readonly TimeSpan Grace = TimeSpan.FromMilliseconds(2000);
 
     private static (PaneStartupGlowState s, FakeTimer t, List<PaneStartupGlowState.Phase> log) Make()
     {
         var t = new FakeTimer();
-        var s = new PaneStartupGlowState(t, Cap, Fade);
+        var s = new PaneStartupGlowState(t, Cap, Fade, Grace);
         var log = new List<PaneStartupGlowState.Phase>();
         s.StateChanged += p => log.Add(p);
         return (s, t, log);
@@ -121,10 +122,76 @@ public class PaneStartupGlowStateTests
     }
 
     [Fact]
+    public void FirstRender_arms_the_grace_not_the_fade()
+    {
+        var (s, t, _) = Make();
+        s.Start();
+        s.NotifyFirstRender();
+        Assert.Equal(PaneStartupGlowState.Phase.Glowing, s.Current);
+        Assert.Equal(Grace, t.LastScheduled);
+    }
+
+    [Fact]
+    public void Grace_elapsing_fades()
+    {
+        var (s, t, log) = Make();
+        s.Start();
+        s.NotifyFirstRender();
+        t.Fire();
+        Assert.Equal(PaneStartupGlowState.Phase.FadingOut, s.Current);
+        Assert.Equal(Fade, t.LastScheduled);
+        Assert.Equal([PaneStartupGlowState.Phase.Glowing, PaneStartupGlowState.Phase.FadingOut], log);
+    }
+
+    [Fact]
+    public void Ready_during_the_grace_fades_at_once()
+    {
+        var (s, t, _) = Make();
+        s.Start();
+        s.NotifyFirstRender();
+        s.NotifyReady();
+        Assert.Equal(PaneStartupGlowState.Phase.FadingOut, s.Current);
+        Assert.Equal(Fade, t.LastScheduled);
+    }
+
+    [Fact]
+    public void Ready_before_any_render_fades_at_once()
+    {
+        var (s, t, _) = Make();
+        s.Start();
+        s.NotifyReady();
+        Assert.Equal(PaneStartupGlowState.Phase.FadingOut, s.Current);
+        Assert.Equal(Fade, t.LastScheduled);
+    }
+
+    [Fact]
+    public void A_second_FirstRender_does_not_rearm()
+    {
+        var (s, t, _) = Make();
+        s.Start();
+        s.NotifyFirstRender();
+        s.NotifyFirstRender();
+        Assert.Equal(2, t.ScheduleCount); // cap, then grace, nothing more
+    }
+
+    [Fact]
+    public void FirstRender_when_idle_or_fading_is_ignored()
+    {
+        var (s, t, _) = Make();
+        s.NotifyFirstRender();
+        Assert.Equal(0, t.ScheduleCount);
+        s.Start();
+        s.NotifyReady();
+        s.NotifyFirstRender();
+        Assert.Equal(PaneStartupGlowState.Phase.FadingOut, s.Current);
+        Assert.Equal(Fade, t.LastScheduled);
+    }
+
+    [Fact]
     public void Dispose_disposes_timer()
     {
         var t = new FakeTimer();
-        var s = new PaneStartupGlowState(t, Cap, Fade);
+        var s = new PaneStartupGlowState(t, Cap, Fade, Grace);
         s.Dispose();
         Assert.Equal(1, t.DisposeCount);
     }
@@ -169,7 +236,7 @@ public class PaneStartupGlowStateTests
     public void Dispose_twice_disposes_the_timer_once()
     {
         var t = new FakeTimer();
-        var s = new PaneStartupGlowState(t, Cap, Fade);
+        var s = new PaneStartupGlowState(t, Cap, Fade, Grace);
         s.Dispose();
         s.Dispose();
         Assert.Equal(1, t.DisposeCount);

--- a/windows/Ghostty.Tests/Wiring/PaneStartupGlowWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/PaneStartupGlowWiringTests.cs
@@ -69,23 +69,39 @@ public class PaneStartupGlowWiringTests
     }
 
     /// <summary>
-    /// Start on the surface spawn, end on the first render, both wired where
-    /// every leaf's control is born. Wiring one of them somewhere else (a
-    /// focus handler, a Loaded handler) would silently skip splits and
-    /// restored panes, which are the panes a glow is most useful on.
+    /// Start on the surface spawn, the grace on the first render, ready on
+    /// the prompt, all three wired where every leaf's control is born.
+    /// Wiring one of them somewhere else (a focus handler, a Loaded handler)
+    /// would silently skip splits and restored panes, which are the panes a
+    /// glow is most useful on.
     /// </summary>
     [Fact]
-    public void CreateTerminal_WiresSpawnToStart_AndFirstRenderToEnd()
+    public void CreateTerminal_WiresSpawnToStart_FirstRenderToGrace_AndPromptToEnd()
     {
         var body = Host().Method("CreateTerminal").Body!.Statements;
 
         var wired = body.SelectMany(s => s.DescendantNodesAndSelf())
             .OfType<AssignmentExpressionSyntax>()
-            .Where(a => a.Right.ToString() is "OnLeafSurfaceSpawned" or "OnLeafFirstRender")
+            .Where(a => a.Right.ToString() is "OnLeafSurfaceSpawned" or "OnLeafFirstRender" or "OnLeafPromptReady")
             .Select(a => a.Left.ToString())
             .ToList();
 
-        Assert.Equal(["t.SurfaceSpawned", "t.FirstRender"], wired);
+        Assert.Equal(["t.SurfaceSpawned", "t.FirstRender", "t.PromptReady"], wired);
+    }
+
+    /// <summary>
+    /// The first paint is not readiness: on a daemon-attached pane it is the
+    /// attach resize repainting blank cells, seconds before the prompt. It
+    /// only arms the grace; the prompt is what ends the glow.
+    /// </summary>
+    [Fact]
+    public void FirstRender_ArmsTheGrace_PromptReady_EndsTheGlow()
+    {
+        var first = Host().Method("OnLeafFirstRender").Body!.ToString();
+        Assert.Contains("NotifyFirstRender()", first);
+        Assert.DoesNotContain("NotifyReady()", first);
+        var prompt = Host().Method("OnLeafPromptReady").Body!.ToString();
+        Assert.Contains("NotifyReady()", prompt);
     }
 
     /// <summary>

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -121,6 +121,11 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     // genuinely stuck, and a glow that never leaves is worse than none).
     private static readonly TimeSpan GlowCapDuration = TimeSpan.FromMilliseconds(10000);
     private static readonly TimeSpan GlowFadeDuration = TimeSpan.FromMilliseconds(250);
+    // After the first paint, how long the glow keeps going for a shell that
+    // never reports a prompt. Long enough to outlive the launch splash's
+    // dismissal (which rides the same first paint), short enough that a
+    // cmd.exe with no integration does not glow for the whole cap.
+    private static readonly TimeSpan GlowRenderGrace = TimeSpan.FromMilliseconds(2000);
 
     // Top-right "restore" affordance shown only while a pane is zoomed,
     // styled like the quake pin button. Clicking it unzooms. The resting
@@ -1228,7 +1233,8 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
                 Microsoft.Extensions.Logging.Abstractions.NullLogger<
                     Ghostty.Core.Config.SystemSchedulerTimer>.Instance),
             cap: GlowCapDuration,
-            fade: GlowFadeDuration);
+            fade: GlowFadeDuration,
+            renderGrace: GlowRenderGrace);
         // The timer callback runs on a threadpool thread; the visual tree
         // only moves on the dispatcher thread.
         state.StateChanged += phase => DispatcherQueue.TryEnqueue(() => OnGlowPhase(terminal, phase));
@@ -1245,17 +1251,24 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     private void OnLeafFirstRender(object? sender, EventArgs e)
     {
         if (sender is not TerminalControl terminal) return;
-        // The pane produced renderable content for the first time: end this
-        // leaf's glow now rather than waiting out the cap. NotifyReady is a
-        // no-op if the glow already faded or never started, so a late or
-        // duplicate signal is harmless. FirstRender is raised on the UI
-        // thread, and the state machine is thread-safe regardless.
+        // The pane painted something. On a daemon-attached pane that is the
+        // attach resize repainting blank cells, well before the prompt, so
+        // this only arms the grace; the prompt ends the glow.
         if (_glowStates.TryGetValue(terminal, out var state))
-            state.NotifyReady();
+            state.NotifyFirstRender();
         // The same sign tells the tab it is no longer starting. Raised
         // outside the glow lookup: a pane too small to glow still paints,
         // and a tab stuck reading as "starting" is worse than a missing glow.
         RaiseFirstRendered();
+    }
+
+    private void OnLeafPromptReady(object? sender, EventArgs e)
+    {
+        if (sender is not TerminalControl terminal) return;
+        // The shell drew its prompt: the pane is usable, end the glow now.
+        // NotifyReady is a no-op if the glow already faded or never started.
+        if (_glowStates.TryGetValue(terminal, out var state))
+            state.NotifyReady();
     }
 
     // A surface that never paints -- a command that fails to spawn, a
@@ -1781,14 +1794,17 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         t.CloseRequested += OnTerminalCloseRequested;
         t.ContextMenuRequested += OnTerminalContextMenuRequested;
         t.PwdChanged += OnTerminalPwdChanged;
-        // Startup glow: begin the orbit when this leaf's surface spawns; end
-        // it on the FIRST of first_render (the pane produced renderable
-        // content, shell-agnostic) or the cap timer as the fallback. We use
-        // first_render rather than OSC 133 prompt-ready: prompt-ready depends
-        // on shell integration loading and varies per shell
-        // (cmd/pwsh/wsl/...), whereas first_render is universal.
+        // Startup glow: begin the orbit when this leaf's surface spawns.
+        // first_render only arms a short grace, not the end -- on a
+        // daemon-attached pane it is the attach resize repainting blank
+        // cells, seconds before the prompt is actually up, and on a cold
+        // start it is also what dismisses the launch splash, so ending the
+        // glow there would end it while the splash still covers it.
+        // PromptReady (OSC 133;B) ends the glow for real; the render grace
+        // and the cap remain the fallback for a shell that never reports one.
         t.SurfaceSpawned += OnLeafSurfaceSpawned;
         t.FirstRender += OnLeafFirstRender;
+        t.PromptReady += OnLeafPromptReady;
         return t;
     }
 


### PR DESCRIPTION
The pane startup glow ended too early, and did not appear at all on a cold start when the daemon was not yet running.

The glow was ended by the first paint. A shell prints something long before it is usable, so the first `SPACE` paint stopped the glow while the pane was still starting.

The first paint now only starts a grace period; the prompt is what ends the glow.

Scope: this is the fork half. Daemon-backed panes need the pro tier's `PwdChanged` wiring to signal the prompt, which is gated on a pin bump. Until that lands, those panes fall back to the bounded grace rather than the prompt signal.

Test plan: unit tests over the glow state machine and a wiring census that the prompt path ends the glow while the paint path only starts the grace.

Cross-repo: this reaches no shipped tier until the release pins advance past it. The remaining pro-side `PwdChanged` wiring is a release-side change that can only be written after that bump, so daemon panes keep the bounded grace until then.

