### PR TITLE
shell: notices dock in their own row so the terminal resizes instead of being covered

### DIFF
--- a/windows/Ghostty.Core/Notifications/Notice.cs
+++ b/windows/Ghostty.Core/Notifications/Notice.cs
@@ -48,4 +48,18 @@ public sealed class Notice
     /// action that dismisses, or <see cref="INotificationService.Dismiss"/>.
     /// </summary>
     public Action? OnDismiss { get; init; }
+
+    /// <summary>
+    /// When set, the host dismisses the notice on its own after this long.
+    /// Null (the default) is a sticky notice that waits for the user.
+    /// </summary>
+    public TimeSpan? AutoDismissAfter { get; init; }
+
+    /// <summary>
+    /// When true, the host focuses the bar as it appears so Enter or Space
+    /// dismisses it, and hands focus back to the terminal when it leaves.
+    /// For notices raised from a command the user just ran (the palette
+    /// already held focus); leave false for notices that arrive on their own.
+    /// </summary>
+    public bool FocusOnShow { get; init; }
 }

--- a/windows/Ghostty.Tests/Ghostty.Tests.csproj
+++ b/windows/Ghostty.Tests/Ghostty.Tests.csproj
@@ -203,6 +203,13 @@
                       Link="Tabs\VerticalTabHost.xaml"
                       LogicalName="Ghostty.Tests.Tabs.VerticalTabHost.xaml" />
     <!--
+      MainWindow.xaml, for BottomDockWiringTests: the notice dock must live
+      in its own grid row, which only the XAML can show.
+    -->
+    <EmbeddedResource Include="..\Ghostty\MainWindow.xaml"
+                      Link="MainWindow.xaml"
+                      LogicalName="Ghostty.Tests.MainWindow.xaml" />
+    <!--
       The shell project file, for LaunchIconAssetsTests. It carries the one
       copy of the launch-icon ladder that no C# type can share: an explicit
       <Content Include> list of the generated PNG rungs.

--- a/windows/Ghostty.Tests/Notifications/NoticeTests.cs
+++ b/windows/Ghostty.Tests/Notifications/NoticeTests.cs
@@ -1,0 +1,24 @@
+using System;
+using Ghostty.Core.Notifications;
+using Xunit;
+
+namespace Ghostty.Tests.Notifications;
+
+public class NoticeTests
+{
+    [Fact]
+    public void Defaults_AreSticky_AndUnfocused()
+    {
+        var n = new Notice { Title = "t" };
+        Assert.Null(n.AutoDismissAfter);
+        Assert.False(n.FocusOnShow);
+    }
+
+    [Fact]
+    public void Transient_CarriesItsTimeout()
+    {
+        var n = new Notice { Title = "t", AutoDismissAfter = TimeSpan.FromSeconds(4), FocusOnShow = true };
+        Assert.Equal(TimeSpan.FromSeconds(4), n.AutoDismissAfter);
+        Assert.True(n.FocusOnShow);
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/BottomDockWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/BottomDockWiringTests.cs
@@ -1,0 +1,61 @@
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Xml.Linq;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// The notice surface gets a row of its own under the terminal. Sharing the
+/// terminal's cell put a translucent InfoBar over the swapchain (report 3,
+/// 2026-09-08); a reserved Auto row makes the terminal shrink instead.
+/// </summary>
+public sealed class BottomDockWiringTests
+{
+    private static readonly XNamespace X = "http://schemas.microsoft.com/winfx/2006/xaml";
+
+    private static XDocument MainWindowXaml()
+    {
+        using var s = Assembly.GetExecutingAssembly().GetManifestResourceStream("Ghostty.Tests.MainWindow.xaml")!;
+        return XDocument.Load(s);
+    }
+
+    private static XElement Named(XDocument doc, string name) =>
+        doc.Descendants().Single(e => (string?)e.Attribute(X + "Name") == name);
+
+    [Fact]
+    public void RootGrid_HasThreeRows_TerminalStar_DockAuto()
+    {
+        var root = Named(MainWindowXaml(), "RootGrid");
+        var rows = root.Elements().Single(e => e.Name.LocalName == "Grid.RowDefinitions")
+            .Elements().Select(r => (string?)r.Attribute("Height")).ToList();
+        Assert.Equal(["Auto", "*", "Auto"], rows);
+    }
+
+    [Fact]
+    public void PaneHostContainer_StaysInTheStarRow()
+    {
+        Assert.Equal("1", (string?)Named(MainWindowXaml(), "PaneHostContainer").Attribute("Grid.Row"));
+    }
+
+    [Fact]
+    public void NotificationHost_OwnsTheDockRow_NotAnOverlay()
+    {
+        var host = Named(MainWindowXaml(), "NotificationHost");
+        Assert.Equal("2", (string?)host.Attribute("Grid.Row"));
+        Assert.Equal("1", (string?)host.Attribute("Grid.Column"));
+        Assert.Null(host.Attribute("VerticalAlignment"));
+    }
+
+    [Fact]
+    public void EveryRowSpanningOverlay_SpansAllThreeRows()
+    {
+        var spans = MainWindowXaml().Descendants()
+            .Where(e => e.Attribute("Grid.RowSpan") is not null)
+            .Select(e => ((string?)e.Attribute(X + "Name") ?? e.Name.LocalName, (string?)e.Attribute("Grid.RowSpan")))
+            .ToList();
+        Assert.NotEmpty(spans);
+        Assert.All(spans, s => Assert.Equal("3", s.Item2));
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/BottomDockWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/BottomDockWiringTests.cs
@@ -58,4 +58,14 @@ public sealed class BottomDockWiringTests
         Assert.NotEmpty(spans);
         Assert.All(spans, s => Assert.Equal("3", s.Item2));
     }
+
+    [Fact]
+    public void DockSizeChange_NotesALayoutSwitch_OnVisibleTerminals()
+    {
+        var src = ShellSource.Load("MainWindow.xaml.cs");
+        var handler = src.Method("OnNotificationDockSizeChanged");
+        var calls = handler.DescendantNodes().OfType<Microsoft.CodeAnalysis.CSharp.Syntax.InvocationExpressionSyntax>()
+            .Select(i => i.Expression.ToString()).ToList();
+        Assert.Contains(calls, c => c.EndsWith("NoteLayoutSwitch"));
+    }
 }

--- a/windows/Ghostty.Tests/Wiring/BottomDockWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/BottomDockWiringTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -60,12 +61,55 @@ public sealed class BottomDockWiringTests
     }
 
     [Fact]
-    public void DockSizeChange_NotesALayoutSwitch_OnVisibleTerminals()
+    public void DockSizeChange_NotesALayoutSwitch_OnEveryTab()
     {
         var src = ShellSource.Load("MainWindow.xaml.cs");
         var handler = src.Method("OnNotificationDockSizeChanged");
         var calls = handler.DescendantNodes().OfType<Microsoft.CodeAnalysis.CSharp.Syntax.InvocationExpressionSyntax>()
             .Select(i => i.Expression.ToString()).ToList();
-        Assert.Contains(calls, c => c.EndsWith("NoteLayoutSwitch"));
+        // Every tab, the same reach NoteLayoutSwitchToSurfaces already uses
+        // for an actual tab-layout switch: a background tab's PaneHost is
+        // never laid out while hidden, so it would otherwise flash the
+        // cols x rows pill the moment the user switches to it after a dock
+        // resize, not at the moment the dock actually resized (fix round 1,
+        // finding 6).
+        Assert.Contains(calls, c => c.EndsWith("NoteLayoutSwitchToSurfaces"));
+    }
+
+    /// <summary>
+    /// EveryRowSpanningOverlay_SpansAllThreeRows above reads MainWindow.xaml
+    /// and structurally cannot see anything assigned in code-behind. Two
+    /// RootGrid children, _verticalTabHost and _verticalSeamCover, get their
+    /// span from Grid.SetRowSpan in MainWindow.xaml.cs instead, and both were
+    /// missed by the XAML-only sweep when the dock row was added (fix round
+    /// 1, finding 3). This reads the code-behind directly so that class of
+    /// bug cannot recur.
+    ///
+    /// Scoped to MainWindow.xaml.cs, where RootGrid's own children are added:
+    /// a RowSpan set on a grid a control builds for ITSELF -- e.g.
+    /// TabSwitcherPopup's per-cell field/end-bar spans inside its own local
+    /// "slot" Grid, or GradientTintVisual's overlay canvas inside its own
+    /// host -- is a different grid entirely and lives outside this file, so
+    /// it is out of scope by construction rather than by an exemption here.
+    /// _demoOverlay is the one legitimate exception inside this file: 99 is
+    /// a deliberate "cover any row/column count" value, not a stale "two
+    /// rows" left behind by this change.
+    /// </summary>
+    [Fact]
+    public void EveryCodeBehindRowSpanOnRootGrid_SpansAllThreeRows()
+    {
+        var exempt = new HashSet<string> { "_demoOverlay" };
+
+        var src = ShellSource.Load("MainWindow.xaml.cs");
+        var spans = src.Root.Calls("Grid.SetRowSpan")
+            .Concat(src.Root.Calls("Microsoft.UI.Xaml.Controls.Grid.SetRowSpan"))
+            .Select(call => (
+                Target: call.ArgumentList.Arguments[0].ToString(),
+                Span: call.ArgumentList.Arguments[1].ToString()))
+            .Where(x => !exempt.Contains(x.Target))
+            .ToList();
+
+        Assert.NotEmpty(spans);
+        Assert.All(spans, s => Assert.Equal("3", s.Span));
     }
 }

--- a/windows/Ghostty.Tests/Wiring/NotificationHostWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/NotificationHostWiringTests.cs
@@ -13,6 +13,68 @@ public sealed class NotificationHostWiringTests
 {
     private static ShellSource Host() => ShellSource.Load("Controls.Notifications.NotificationHost.xaml.cs");
 
+    /// <summary>
+    /// WinUI folds a StackPanel's own Margin into its DesiredSize even with
+    /// zero children, so leaving the host Visible while empty would keep the
+    /// Auto dock row -- and the host's own opaque background -- permanently
+    /// open (fix round 1, finding 1). Starting Collapsed is what makes "no
+    /// notices" actually mean zero height.
+    /// </summary>
+    [Fact]
+    public void Constructor_StartsCollapsed()
+    {
+        var ctor = Host().Root.DescendantNodes().OfType<ConstructorDeclarationSyntax>()
+            .Single(c => c.Identifier.ValueText == "NotificationHost");
+        var setsCollapsed = ctor.Body!.Statements
+            .OfType<ExpressionStatementSyntax>()
+            .Any(s => s.Expression is AssignmentExpressionSyntax
+            {
+                Left: IdentifierNameSyntax { Identifier.ValueText: "Visibility" },
+            } assignment && assignment.Right.ToString() == "Visibility.Collapsed");
+        Assert.True(
+            setsCollapsed,
+            "the constructor must start the host Collapsed, or an empty StackPanel's own Margin "
+            + "keeps the Auto dock row permanently open");
+    }
+
+    /// <summary>
+    /// Every path that changes <see cref="_bars"/> -- adding a notice,
+    /// removing one, and the two bulk-clear paths -- has to agree on the
+    /// same collapse-when-empty decision, found by shape (a method that sets
+    /// Visibility from _bars.Count) rather than by a hardcoded name, so this
+    /// does not just re-assert one method's name back at it.
+    /// </summary>
+    [Fact]
+    public void VisibilityTracksWhetherAnyBarIsActive()
+    {
+        var src = Host();
+
+        // Not restricted to block-bodied methods: UpdateVisibility itself is
+        // an expression-bodied one, whose assignment lives under
+        // ExpressionBody rather than Body -- a Body-only search would find
+        // zero methods and fail this fact for a reason that has nothing to
+        // do with what it is meant to pin.
+        var updater = src.Root.DescendantNodes().OfType<MethodDeclarationSyntax>()
+            .Where(m => m.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+                .Any(a => a.Left is IdentifierNameSyntax { Identifier.ValueText: "Visibility" }
+                    && a.Right.ToString().Contains("_bars.Count")))
+            .ToList();
+        Assert.True(
+            updater.Count == 1,
+            $"expected exactly one method that sets Visibility from _bars.Count, found {updater.Count}");
+        var helperName = updater[0].Identifier.ValueText;
+
+        foreach (var caller in new[] { "AddBar", "RemoveBar", "OnUnloaded", "OnActiveChanged" })
+        {
+            var calls = src.Method(caller).Body!.DescendantNodes()
+                .OfType<InvocationExpressionSyntax>()
+                .Select(i => i.Expression.ToString());
+            Assert.Contains(
+                calls,
+                c => c == helperName);
+        }
+    }
+
     [Fact]
     public void AddBar_ArmsTheAutoDismissTimer_WhenTheNoticeAsksForOne()
     {

--- a/windows/Ghostty.Tests/Wiring/NotificationHostWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/NotificationHostWiringTests.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Xunit;
 
@@ -75,28 +76,140 @@ public sealed class NotificationHostWiringTests
         }
     }
 
+    /// <summary>
+    /// Tightened from a substring census (fix round 1, finding 7): the old
+    /// version accepted "AutoDismissAfter" and "CreateTimer" appearing
+    /// anywhere in AddBar's text, which a timer that is created and stored
+    /// but never started would still satisfy. This pins the actual call:
+    /// the local the AutoDismissAfter branch creates via CreateTimer() must
+    /// itself be the receiver of a .Start() in that same branch.
+    /// </summary>
     [Fact]
-    public void AddBar_ArmsTheAutoDismissTimer_WhenTheNoticeAsksForOne()
+    public void AddBar_ArmsAndStartsTheAutoDismissTimer_WhenTheNoticeAsksForOne()
     {
-        var body = Host().Method("AddBar").Body!.ToString();
-        Assert.Contains("AutoDismissAfter", body);
-        Assert.Contains("CreateTimer", body);
+        var body = Host().Method("AddBar").Body!;
+        var guard = body.Statements.OfType<IfStatementSyntax>()
+            .Where(i => i.Condition.ToString().Contains("AutoDismissAfter"))
+            .ToList();
+        Assert.True(
+            guard.Count == 1,
+            $"expected exactly one AutoDismissAfter guard in AddBar, found {guard.Count}");
+        var block = Assert.IsType<BlockSyntax>(guard[0].Statement);
+
+        var timerVar = block.Statements
+            .OfType<LocalDeclarationStatementSyntax>()
+            .SelectMany(d => d.Declaration.Variables)
+            .FirstOrDefault(v => v.Initializer?.Value is InvocationExpressionSyntax inv
+                && inv.Expression.ToString().EndsWith("CreateTimer"));
+        Assert.True(
+            timerVar is not null,
+            "expected AddBar's AutoDismissAfter branch to create a timer via CreateTimer()");
+
+        var started = block.Statements
+            .OfType<ExpressionStatementSyntax>()
+            .Any(s => s.Expression is InvocationExpressionSyntax inv
+                && inv.Expression.ToString() == timerVar!.Identifier.ValueText + ".Start");
+        Assert.True(
+            started,
+            "the timer AddBar creates for AutoDismissAfter must actually be started: a bare "
+            + "Contains(\"CreateTimer\") check would still pass an armed-but-never-started timer, "
+            + "and a transient notice that never starts its timer never dismisses itself");
     }
 
+    /// <summary>
+    /// Tightened from a substring census (fix round 1, finding 7): the old
+    /// version accepted "VirtualKey.Enter", "VirtualKey.Space" and
+    /// "FocusOnShow" appearing anywhere in AddBar's text, which a handler
+    /// that sets e.Handled and does nothing else would still satisfy. This
+    /// pins that the Enter-or-Space branch inside the FocusOnShow guard's
+    /// KeyDown handler actually calls Dismiss.
+    /// </summary>
     [Fact]
-    public void AddBar_HandlesEnterAndSpace()
+    public void AddBar_EnterOrSpace_ActuallyDismissesTheFocusedNotice()
     {
-        var body = Host().Method("AddBar").Body!.ToString();
-        Assert.Contains("VirtualKey.Enter", body);
-        Assert.Contains("VirtualKey.Space", body);
-        Assert.Contains("FocusOnShow", body);
+        var body = Host().Method("AddBar").Body!;
+        var guard = body.Statements.OfType<IfStatementSyntax>()
+            .Where(i => i.Condition.ToString().Contains("FocusOnShow"))
+            .ToList();
+        Assert.True(
+            guard.Count == 1,
+            $"expected exactly one FocusOnShow guard in AddBar, found {guard.Count}");
+
+        var keyDownHandlers = guard[0].DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.IsKind(SyntaxKind.AddAssignmentExpression) && a.Left.ToString().EndsWith("KeyDown"))
+            .Select(a => a.Right)
+            .ToList();
+        Assert.True(
+            keyDownHandlers.Count == 1,
+            $"expected exactly one KeyDown += inside the FocusOnShow branch, found {keyDownHandlers.Count}");
+
+        var keyGuard = keyDownHandlers[0].DescendantNodes().OfType<IfStatementSyntax>()
+            .Where(i => i.Condition.ToString().Contains("VirtualKey.Enter")
+                && i.Condition.ToString().Contains("VirtualKey.Space"))
+            .ToList();
+        Assert.True(keyGuard.Count == 1, "expected one Enter-or-Space guard inside the KeyDown handler");
+
+        var dismisses = keyGuard[0].DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Any(i => i.Expression.ToString().EndsWith(".Dismiss"));
+        Assert.True(
+            dismisses,
+            "the Enter/Space branch must actually call Dismiss on the notice: a handler that only "
+            + "sets e.Handled = true would still contain every token this fact used to look for");
     }
 
+    /// <summary>
+    /// Tightened from a substring census (fix round 1, finding 7): the old
+    /// version accepted "Stop()" and "FocusReturn" appearing anywhere in
+    /// RemoveBar's text, which an unconditional FocusReturn?.Invoke() --
+    /// stealing focus away on every dismissal, including a notice that was
+    /// never focused or one the user has since focused elsewhere -- would
+    /// still satisfy. This pins that the call sits behind an `if` whose
+    /// condition is exactly the local that reads notice.FocusOnShow.
+    /// </summary>
     [Fact]
-    public void RemoveBar_StopsTheTimer_AndReturnsFocus()
+    public void RemoveBar_StopsTheTimer_AndReturnsFocusOnlyWhenTheBarStillHasIt()
     {
-        var body = Host().Method("RemoveBar").Body!.ToString();
-        Assert.Contains("Stop()", body);
-        Assert.Contains("FocusReturn", body);
+        var body = Host().Method("RemoveBar").Body!;
+        var removeIf = body.Statements.OfType<IfStatementSyntax>()
+            .Where(i => i.Condition.ToString().Contains("_bars.Remove"))
+            .ToList();
+        Assert.True(
+            removeIf.Count == 1,
+            $"expected exactly one `_bars.Remove` guard in RemoveBar, found {removeIf.Count}");
+        var block = Assert.IsType<BlockSyntax>(removeIf[0].Statement);
+
+        var stopped = block.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Any(i => i.Expression.ToString().EndsWith(".Stop"));
+        Assert.True(stopped, "RemoveBar must stop the notice's timer, if it had one");
+
+        // The decision that gates FocusReturn, wherever it is declared and
+        // whatever it is named: it has to actually read notice.FocusOnShow,
+        // not merely exist as a bool that happens to be true whenever a bar
+        // had one.
+        var decision = block.Statements.OfType<LocalDeclarationStatementSyntax>()
+            .SelectMany(d => d.Declaration.Variables)
+            .FirstOrDefault(v => v.Initializer is not null
+                && v.Initializer.Value.ToString().Contains("FocusOnShow"));
+        Assert.True(
+            decision is not null,
+            "expected a local in RemoveBar that reads notice.FocusOnShow to decide whether focus returns");
+
+        // FocusReturn?.Invoke() is a conditional-access expression: the
+        // receiver ("FocusReturn") belongs to the ConditionalAccessExpression,
+        // not to the nested InvocationExpression (whose own Expression is
+        // just the bound ".Invoke"), so the receiver has to be matched at
+        // that outer node.
+        var focusCall = block.Statements.OfType<IfStatementSyntax>()
+            .Where(i => i.DescendantNodes().OfType<ConditionalAccessExpressionSyntax>()
+                .Any(c => c.Expression.ToString() == "FocusReturn"
+                    && c.WhenNotNull is InvocationExpressionSyntax invoke
+                    && invoke.Expression.ToString() == ".Invoke"))
+            .ToList();
+        Assert.True(
+            focusCall.Count == 1,
+            "expected exactly one `if (...) FocusReturn?.Invoke();` in RemoveBar");
+        Assert.Equal(
+            decision!.Identifier.ValueText,
+            focusCall[0].Condition.ToString());
     }
 }

--- a/windows/Ghostty.Tests/Wiring/NotificationHostWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/NotificationHostWiringTests.cs
@@ -1,0 +1,40 @@
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// A transient notice must actually leave on its own, and Enter or Space
+/// must dismiss a focused one; both live in AddBar, the only place a bar is
+/// born.
+/// </summary>
+public sealed class NotificationHostWiringTests
+{
+    private static ShellSource Host() => ShellSource.Load("Controls.Notifications.NotificationHost.xaml.cs");
+
+    [Fact]
+    public void AddBar_ArmsTheAutoDismissTimer_WhenTheNoticeAsksForOne()
+    {
+        var body = Host().Method("AddBar").Body!.ToString();
+        Assert.Contains("AutoDismissAfter", body);
+        Assert.Contains("CreateTimer", body);
+    }
+
+    [Fact]
+    public void AddBar_HandlesEnterAndSpace()
+    {
+        var body = Host().Method("AddBar").Body!.ToString();
+        Assert.Contains("VirtualKey.Enter", body);
+        Assert.Contains("VirtualKey.Space", body);
+        Assert.Contains("FocusOnShow", body);
+    }
+
+    [Fact]
+    public void RemoveBar_StopsTheTimer_AndReturnsFocus()
+    {
+        var body = Host().Method("RemoveBar").Body!.ToString();
+        Assert.Contains("Stop()", body);
+        Assert.Contains("FocusReturn", body);
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/NotificationHostWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/NotificationHostWiringTests.cs
@@ -51,15 +51,16 @@ public sealed class NotificationHostWiringTests
     {
         var src = Host();
 
-        // Not restricted to block-bodied methods: UpdateVisibility itself is
-        // an expression-bodied one, whose assignment lives under
-        // ExpressionBody rather than Body -- a Body-only search would find
-        // zero methods and fail this fact for a reason that has nothing to
-        // do with what it is meant to pin.
+        // Not restricted to block-bodied methods, and not matched on the
+        // assignment's right-hand side: the updater computes the next value
+        // into a local first (so it can compare against the current one and
+        // announce a real flip), which leaves the assignment reading
+        // `Visibility = next`. Match the method that both assigns Visibility
+        // and consults _bars.Count.
         var updater = src.Root.DescendantNodes().OfType<MethodDeclarationSyntax>()
             .Where(m => m.DescendantNodes().OfType<AssignmentExpressionSyntax>()
-                .Any(a => a.Left is IdentifierNameSyntax { Identifier.ValueText: "Visibility" }
-                    && a.Right.ToString().Contains("_bars.Count")))
+                    .Any(a => a.Left is IdentifierNameSyntax { Identifier.ValueText: "Visibility" })
+                && m.ToString().Contains("_bars.Count"))
             .ToList();
         Assert.True(
             updater.Count == 1,
@@ -75,6 +76,46 @@ public sealed class NotificationHostWiringTests
                 calls,
                 c => c == helperName);
         }
+
+        // The flip is announced at the source, before the layout pass it
+        // causes. It cannot be carried by the host's own SizeChanged: a
+        // collapsed element is skipped by Measure and Arrange, so the
+        // leaving transition raises no size event at all, and the arriving
+        // one arranges the terminal first. Losing this puts the cols x rows
+        // pill back on exactly the transitions the dock is meant to be
+        // quiet through, which no rendering test in this repo would catch.
+        // CalleeText, not Expression: a null-conditional call parses with the
+        // receiver hoisted out, so the invocation's own expression reads as
+        // ".Invoke" and a match on it finds nothing.
+        var body = updater[0].Body!;
+        Assert.Single(body.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(i => i.CalleeText() == "DockOccupancyChanged?.Invoke"));
+
+        // Only on a real change: announcing every call would stamp a layout
+        // switch on notices that come and go while the dock stays visible,
+        // which the window's SizeChanged handler already covers.
+        Assert.Contains(
+            body.DescendantNodes().OfType<IfStatementSyntax>(),
+            s => s.Condition.ToString().Contains("Visibility ==")
+                 && s.Statement.ToString().Contains("return"));
+    }
+
+    [Fact]
+    public void TheWindowWiresOccupancyToTheLayoutSwitchStamp_AndDropsItOnTeardown()
+    {
+        var window = ShellSource.Load("MainWindow.xaml.cs");
+
+        var assignments = window.Root.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.Left.ToString() == "NotificationHost.DockOccupancyChanged")
+            .ToList();
+
+        // One wire-up and one teardown. The hook is invoked from
+        // UpdateVisibility, which a late auto-dismiss timer can still reach
+        // while the tree is coming down, so leaving it attached calls back
+        // into a window that is already disposing.
+        Assert.Equal(2, assignments.Count);
+        Assert.Contains(assignments, a => a.Right.ToString() == "NoteLayoutSwitchToSurfaces");
+        Assert.Contains(assignments, a => a.Right.ToString() == "null");
     }
 
     /// <summary>

--- a/windows/Ghostty.Tests/Wiring/NotificationHostWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/NotificationHostWiringTests.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Xunit;

--- a/windows/Ghostty/Controls/Notifications/NotificationHost.xaml
+++ b/windows/Ghostty/Controls/Notifications/NotificationHost.xaml
@@ -1,15 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
     NotificationHost: the app's generic in-window notice surface. Renders one
-    InfoBar per active Notice from INotificationService, stacked at the BOTTOM
-    of the terminal content area so banners never fight the tab strip, the
-    prompt, or the OS caption buttons (mirrors macOS Ghostty's bottom-anchored
-    UpdateOverlay).
+    InfoBar per active Notice from INotificationService, docked in its own
+    row under the terminal (MainWindow.xaml RootGrid row 2) so banners never
+    fight the tab strip, the prompt, or the OS caption buttons, and never
+    composite over the terminal's DX12 swapchain.
 
-    The inner StackPanel is bottom-aligned and only as tall as its content, so
-    when there are no notices it occupies nothing and passes all pointer events
-    through to the terminal underneath. MainWindow calls Attach() once to bind
-    the shared service.
+    The inner StackPanel is only as tall as its content, so when there are no
+    notices the row is zero height and the terminal has the whole star row.
+    MainWindow calls Attach() once to bind the shared service.
 -->
 <UserControl
     x:Class="Ghostty.Controls.Notifications.NotificationHost"
@@ -17,12 +16,13 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d">
+    mc:Ignorable="d"
+    Background="#0C0C0C">
 
     <StackPanel x:Name="Stack"
                 Orientation="Vertical"
                 Spacing="4"
                 VerticalAlignment="Bottom"
                 HorizontalAlignment="Stretch"
-                Margin="8,0,8,8"/>
+                Margin="8,8,8,8"/>
 </UserControl>

--- a/windows/Ghostty/Controls/Notifications/NotificationHost.xaml
+++ b/windows/Ghostty/Controls/Notifications/NotificationHost.xaml
@@ -6,9 +6,13 @@
     fight the tab strip, the prompt, or the OS caption buttons, and never
     composite over the terminal's DX12 swapchain.
 
-    The inner StackPanel is only as tall as its content, so when there are no
-    notices the row is zero height and the terminal has the whole star row.
-    MainWindow calls Attach() once to bind the shared service.
+    The control collapses itself (Visibility.Collapsed, in code-behind) when
+    it has no active bars. A Collapsed element reports (0,0) DesiredSize
+    regardless of its content's Margin -- unlike merely emptying the inner
+    StackPanel, whose own Margin is folded into DesiredSize even with zero
+    children and would otherwise keep the Auto row, and this control's
+    opaque background, permanently ~16px tall. MainWindow calls Attach()
+    once to bind the shared service.
 -->
 <UserControl
     x:Class="Ghostty.Controls.Notifications.NotificationHost"

--- a/windows/Ghostty/Controls/Notifications/NotificationHost.xaml.cs
+++ b/windows/Ghostty/Controls/Notifications/NotificationHost.xaml.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using Ghostty.Core.Notifications;
@@ -25,6 +26,11 @@ public sealed partial class NotificationHost : UserControl
     private INotificationService? _service;
     private bool _subscribed;
     private readonly Dictionary<Notice, InfoBar> _bars = new();
+    private readonly Dictionary<Notice, Microsoft.UI.Dispatching.DispatcherQueueTimer> _timers = new();
+
+    /// <summary>Set by the window: returns focus to the active terminal after
+    /// a focused bar leaves. Null in tests and before Attach.</summary>
+    public Action? FocusReturn { get; set; }
 
     public NotificationHost()
     {
@@ -68,6 +74,7 @@ public sealed partial class NotificationHost : UserControl
         _subscribed = false;
         Stack.Children.Clear();
         _bars.Clear();
+        StopAllTimers();
     }
 
     private void OnActiveChanged(object? sender, NotifyCollectionChangedEventArgs e)
@@ -83,8 +90,21 @@ public sealed partial class NotificationHost : UserControl
             case NotifyCollectionChangedAction.Reset:
                 Stack.Children.Clear();
                 _bars.Clear();
+                StopAllTimers();
                 break;
         }
+    }
+
+    /// <summary>
+    /// Stop every armed auto-dismiss timer without dismissing the notices
+    /// they belong to. Used by the two paths that clear <see cref="_bars"/>
+    /// out from under the timers instead of going through
+    /// <see cref="RemoveBar"/> one notice at a time.
+    /// </summary>
+    private void StopAllTimers()
+    {
+        foreach (var timer in _timers.Values) timer.Stop();
+        _timers.Clear();
     }
 
     private void AddBar(Notice notice)
@@ -135,6 +155,36 @@ public sealed partial class NotificationHost : UserControl
         // drives RemoveBar).
         bar.CloseButtonClick += (_, _) => _service?.Dismiss(notice);
 
+        // A transient notice dismisses itself after its own timeout: the
+        // caller does not have to hold a reference or race the dispatcher.
+        if (notice.AutoDismissAfter is { } after)
+        {
+            var timer = DispatcherQueue.CreateTimer();
+            timer.Interval = after;
+            timer.IsRepeating = false;
+            timer.Tick += (_, _) => _service?.Dismiss(notice);
+            _timers[notice] = timer;
+            timer.Start();
+        }
+
+        // A notice raised from a command the user just ran already has the
+        // user's attention, so the bar takes focus and Enter or Space acts
+        // as its dismiss; a notice that arrives on its own leaves focus
+        // wherever it was.
+        if (notice.FocusOnShow)
+        {
+            bar.IsTabStop = true;
+            bar.KeyDown += (_, e) =>
+            {
+                if (e.Key is Windows.System.VirtualKey.Enter or Windows.System.VirtualKey.Space)
+                {
+                    e.Handled = true;
+                    _service?.Dismiss(notice);
+                }
+            };
+            bar.Loaded += (s, _) => ((Control)s).Focus(FocusState.Programmatic);
+        }
+
         _bars[notice] = bar;
         Stack.Children.Add(bar);
     }
@@ -144,7 +194,10 @@ public sealed partial class NotificationHost : UserControl
         if (_bars.Remove(notice, out var bar))
         {
             bar.IsOpen = false;
+            if (_timers.Remove(notice, out var timer)) timer.Stop();
+            var hadFocus = notice.FocusOnShow;
             Stack.Children.Remove(bar);
+            if (hadFocus) FocusReturn?.Invoke();
         }
     }
 

--- a/windows/Ghostty/Controls/Notifications/NotificationHost.xaml.cs
+++ b/windows/Ghostty/Controls/Notifications/NotificationHost.xaml.cs
@@ -35,6 +35,13 @@ public sealed partial class NotificationHost : UserControl
     public NotificationHost()
     {
         InitializeComponent();
+        // WinUI folds Margin into DesiredSize even when Stack has zero
+        // children, so an empty host would still report the StackPanel's own
+        // ~16px and keep the Auto dock row -- and this control's opaque
+        // background -- permanently open. A Collapsed element reports (0,0)
+        // DesiredSize regardless of its content's Margin, which is what "no
+        // notices, no row" actually needs. See UpdateVisibility.
+        Visibility = Visibility.Collapsed;
     }
 
     /// <summary>
@@ -75,6 +82,7 @@ public sealed partial class NotificationHost : UserControl
         Stack.Children.Clear();
         _bars.Clear();
         StopAllTimers();
+        UpdateVisibility();
     }
 
     private void OnActiveChanged(object? sender, NotifyCollectionChangedEventArgs e)
@@ -91,9 +99,19 @@ public sealed partial class NotificationHost : UserControl
                 Stack.Children.Clear();
                 _bars.Clear();
                 StopAllTimers();
+                UpdateVisibility();
                 break;
         }
     }
+
+    /// <summary>
+    /// The dock row is genuinely zero height, and this control paints
+    /// nothing, exactly when there is nothing to show. Called from every
+    /// path that changes <see cref="_bars"/>, so all of them agree on what
+    /// "collapse" means rather than each reaching for Visibility by hand.
+    /// </summary>
+    private void UpdateVisibility() =>
+        Visibility = _bars.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
 
     /// <summary>
     /// Stop every armed auto-dismiss timer without dismissing the notices
@@ -187,6 +205,7 @@ public sealed partial class NotificationHost : UserControl
 
         _bars[notice] = bar;
         Stack.Children.Add(bar);
+        UpdateVisibility();
     }
 
     private void RemoveBar(Notice notice)
@@ -197,6 +216,7 @@ public sealed partial class NotificationHost : UserControl
             if (_timers.Remove(notice, out var timer)) timer.Stop();
             var hadFocus = notice.FocusOnShow;
             Stack.Children.Remove(bar);
+            UpdateVisibility();
             if (hadFocus) FocusReturn?.Invoke();
         }
     }

--- a/windows/Ghostty/Controls/Notifications/NotificationHost.xaml.cs
+++ b/windows/Ghostty/Controls/Notifications/NotificationHost.xaml.cs
@@ -34,6 +34,17 @@ public sealed partial class NotificationHost : UserControl
     /// a focused bar leaves. Null in tests and before Attach.</summary>
     public Action? FocusReturn { get; set; }
 
+    /// <summary>
+    /// Set by the window: raised when the dock actually appears or
+    /// disappears, before the layout pass that resizes the terminal. The
+    /// window uses it to mark the coming resize as a layout switch so the
+    /// cols x rows pill stays quiet. Deliberately NOT the host's
+    /// SizeChanged: a collapsed element never arranges, so the leaving
+    /// transition raises no size event to hang this on. Null in tests and
+    /// before Attach.
+    /// </summary>
+    public Action? DockOccupancyChanged { get; set; }
+
     public NotificationHost()
     {
         InitializeComponent();
@@ -112,8 +123,25 @@ public sealed partial class NotificationHost : UserControl
     /// path that changes <see cref="_bars"/>, so all of them agree on what
     /// "collapse" means rather than each reaching for Visibility by hand.
     /// </summary>
-    private void UpdateVisibility() =>
-        Visibility = _bars.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
+    private void UpdateVisibility()
+    {
+        var next = _bars.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
+        if (Visibility == next) return;
+        Visibility = next;
+
+        // Announce the flip HERE, before the layout pass it triggers, rather
+        // than leaving the host's own SizeChanged to carry it. A collapsed
+        // element is skipped by Measure and Arrange, so on the way OUT this
+        // host never arranges and its SizeChanged never fires at all: the
+        // stamp meant to mark the terminal's growth as a layout switch would
+        // never land, and the cols x rows pill would pulse on exactly the
+        // transition it is supposed to stay quiet through. On the way IN the
+        // host arranges after the terminal, since it is declared later in
+        // the grid, so the stamp would land after the resize it must
+        // precede. Announcing at the source matches how the tab-switch path
+        // notes a switch at the start rather than at the result.
+        DockOccupancyChanged?.Invoke();
+    }
 
     /// <summary>
     /// Stop every armed auto-dismiss timer without dismissing the notices

--- a/windows/Ghostty/Controls/Notifications/NotificationHost.xaml.cs
+++ b/windows/Ghostty/Controls/Notifications/NotificationHost.xaml.cs
@@ -5,6 +5,8 @@ using Ghostty.Core.Notifications;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
 
 namespace Ghostty.Controls.Notifications;
 
@@ -200,7 +202,18 @@ public sealed partial class NotificationHost : UserControl
                     _service?.Dismiss(notice);
                 }
             };
-            bar.Loaded += (s, _) => ((Control)s).Focus(FocusState.Programmatic);
+            // Loaded is not one-shot: WinUI can refire it on a reparent or a
+            // monitor move, the same thing Attach's own doc comment notes
+            // for this host. Left subscribed, a refire while the bar is
+            // still up would grab focus back a second time regardless of
+            // where the user has since moved it, so the handler detaches
+            // itself the first time it runs.
+            void FocusOnce(object sender, RoutedEventArgs args)
+            {
+                bar.Loaded -= FocusOnce;
+                bar.Focus(FocusState.Programmatic);
+            }
+            bar.Loaded += FocusOnce;
         }
 
         _bars[notice] = bar;
@@ -214,11 +227,34 @@ public sealed partial class NotificationHost : UserControl
         {
             bar.IsOpen = false;
             if (_timers.Remove(notice, out var timer)) timer.Stop();
-            var hadFocus = notice.FocusOnShow;
+            // Read before the bar leaves the tree: FocusManager answers a
+            // different question once its element is gone. Gated on the bar
+            // (or something inside it) actually holding focus right now, not
+            // merely on FocusOnShow, so an auto-dismiss timer -- or any other
+            // removal path -- firing after the user has since clicked into a
+            // pane, opened Settings, or started renaming a tab does not yank
+            // focus back out from under them.
+            var returnFocus = notice.FocusOnShow && BarHasFocus(bar);
             Stack.Children.Remove(bar);
             UpdateVisibility();
-            if (hadFocus) FocusReturn?.Invoke();
+            if (returnFocus) FocusReturn?.Invoke();
         }
+    }
+
+    /// <summary>
+    /// Whether <paramref name="bar"/>, or something inside it, currently
+    /// holds keyboard focus. Same walk-up-from-FocusManager idiom as
+    /// MainWindow.FocusedTerminal and PaneHost.TestSeamFocusedLeafIndex.
+    /// </summary>
+    private static bool BarHasFocus(InfoBar bar)
+    {
+        if (bar.XamlRoot is null) return false;
+        var node = FocusManager.GetFocusedElement(bar.XamlRoot) as DependencyObject;
+        for (; node is not null; node = VisualTreeHelper.GetParent(node))
+        {
+            if (ReferenceEquals(node, bar)) return true;
+        }
+        return false;
     }
 
     private Button MakeButton(Notice notice, NoticeAction action)

--- a/windows/Ghostty/MainWindow.xaml
+++ b/windows/Ghostty/MainWindow.xaml
@@ -49,6 +49,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition x:Name="StripColumn" Width="0"/>
@@ -163,7 +164,7 @@
             header lane and the sidebar rail in one coordinate space.
         -->
         <Canvas x:Name="TabMorphLayer"
-                Grid.Row="0" Grid.RowSpan="2"
+                Grid.Row="0" Grid.RowSpan="3"
                 Grid.Column="0" Grid.ColumnSpan="2"
                 IsHitTestVisible="False"/>
 
@@ -171,7 +172,7 @@
         <Popup x:Name="CommandPalettePopup"
                IsLightDismissEnabled="True"
                ShouldConstrainToRootBounds="True"
-               Grid.Row="0" Grid.RowSpan="2"
+               Grid.Row="0" Grid.RowSpan="3"
                Grid.Column="0" Grid.ColumnSpan="2">
             <cmdpalette:CommandPaletteControl x:Name="CommandPaletteUI"/>
         </Popup>
@@ -179,7 +180,7 @@
         <!-- Tab switcher MRU cycle popup -->
         <Popup x:Name="TabSwitcherPopupHost"
                ShouldConstrainToRootBounds="True"
-               Grid.Row="0" Grid.RowSpan="2"
+               Grid.Row="0" Grid.RowSpan="3"
                Grid.Column="0" Grid.ColumnSpan="2">
             <tabs:TabSwitcherPopup x:Name="TabSwitcherPopupUI"/>
         </Popup>
@@ -187,7 +188,7 @@
         <!-- Tab overview grid -->
         <Popup x:Name="TabOverviewHost"
                ShouldConstrainToRootBounds="True"
-               Grid.Row="0" Grid.RowSpan="2"
+               Grid.Row="0" Grid.RowSpan="3"
                Grid.Column="0" Grid.ColumnSpan="2">
             <tabs:TabOverviewControl x:Name="TabOverviewUI"/>
         </Popup>
@@ -213,15 +214,16 @@
                   ToolTipService.ToolTip="Power saving mode active."/>
 
         <!--
-            Generic in-window notice surface. Bottom-anchored in the terminal
-            content area (Row 1, Col 1 — clear of both tab strips and the OS
-            caption buttons), overlaying only the terminal so it never covers
-            chrome. Renders one InfoBar per active Notice (NO_COLOR is its first
-            customer). Attached to App.NotificationService in code-behind.
+            Generic in-window notice surface. Docked in its own row under the
+            terminal (Row 2, Col 1: clear of both tab strips and the OS caption
+            buttons). The row is Auto, so with no notice it is zero height and
+            the terminal has the whole star row; with one, the terminal shrinks
+            and libghostty resizes, nothing composites over the swapchain.
+            Renders one InfoBar per active Notice. Attached to
+            App.NotificationService in code-behind.
         -->
         <notifications:NotificationHost x:Name="NotificationHost"
-                                        Grid.Row="1" Grid.Column="1"
-                                        VerticalAlignment="Bottom"
+                                        Grid.Row="2" Grid.Column="1"
                                         HorizontalAlignment="Stretch"/>
 
         <!--
@@ -234,7 +236,7 @@
             where the OS caption buttons used to be.
         -->
         <ToggleButton x:Name="QuakePinButton"
-                      Grid.Row="0" Grid.RowSpan="2"
+                      Grid.Row="0" Grid.RowSpan="3"
                       Grid.Column="0" Grid.ColumnSpan="2"
                       HorizontalAlignment="Right"
                       VerticalAlignment="Top"

--- a/windows/Ghostty/MainWindow.xaml
+++ b/windows/Ghostty/MainWindow.xaml
@@ -216,9 +216,10 @@
         <!--
             Generic in-window notice surface. Docked in its own row under the
             terminal (Row 2, Col 1: clear of both tab strips and the OS caption
-            buttons). The row is Auto, so with no notice it is zero height and
-            the terminal has the whole star row; with one, the terminal shrinks
-            and libghostty resizes, nothing composites over the swapchain.
+            buttons). The host collapses itself whenever it has no active
+            notice, so the Auto row is genuinely zero height and the terminal
+            has the whole star row; with one, the terminal shrinks and
+            libghostty resizes, nothing composites over the swapchain.
             Renders one InfoBar per active Notice. Attached to
             App.NotificationService in code-behind.
         -->

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -899,7 +899,12 @@ public sealed partial class MainWindow : Window
 
         Grid.SetRow(_verticalTabHost, 0);
         Grid.SetColumn(_verticalTabHost, 0);
-        Grid.SetRowSpan(_verticalTabHost, 2);
+        // Three rows, matching every RowSpan="2"->"3" bump the dock row's
+        // XAML-declared spanning overlays got: left at 2, the strip stopped
+        // at the old row-1 boundary while the notice dock (row 2, column 1)
+        // extended below it, leaving row 2/column 0 bare RootGrid background
+        // instead of continuing the sidebar under a notice.
+        Grid.SetRowSpan(_verticalTabHost, 3);
         Canvas.SetZIndex(_verticalTabHost, -1);
         RootGrid.Children.Add(_verticalTabHost);
 
@@ -957,7 +962,10 @@ public sealed partial class MainWindow : Window
             Width = VerticalSeamOverlap + Core.Panes.PaneChrome.SurfaceInset,
         };
         Grid.SetRow(_verticalSeamCover, 0);
-        Grid.SetRowSpan(_verticalSeamCover, 2);
+        // Same three-row correction as _verticalTabHost just above: this
+        // cover rides along the strip it seams, so it has to span exactly
+        // what the strip spans.
+        Grid.SetRowSpan(_verticalSeamCover, 3);
         Grid.SetColumn(_verticalSeamCover, 0);
         Grid.SetColumnSpan(_verticalSeamCover, 2);
         RootGrid.Children.Add(_verticalSeamCover);
@@ -1690,19 +1698,22 @@ public sealed partial class MainWindow : Window
     /// <summary>
     /// The notice dock's own row changes height as notices come and go
     /// (report 3), which resizes the star row and everything visible in it.
-    /// That is a layout switch on the active tab's terminals, the same
-    /// suppression <see cref="NoteLayoutSwitchToSurfaces"/> gives an actual
-    /// tab-layout switch, so the cols x rows resize pill stays quiet.
+    /// That is a layout switch, the same suppression
+    /// <see cref="NoteLayoutSwitchToSurfaces"/> gives an actual tab-layout
+    /// switch, so the cols x rows resize pill stays quiet.
     ///
-    /// Only the active tab: a background tab's PaneHost is not laid out, so
-    /// its terminals never see the resize that would trip the pill.
+    /// Every tab, not just the active one, for the same reason
+    /// <see cref="NoteLayoutSwitchToSurfaces"/> already walks every tab: a
+    /// background tab's PaneHost is not laid out while hidden, so it never
+    /// sees the resize at the moment the dock changes height, only the
+    /// deferred one WinUI does the moment the user switches to it -- and by
+    /// then the transient notice that caused it may be long gone, with
+    /// nothing narrating the resize the pill would flash for.
     /// </summary>
     private void OnNotificationDockSizeChanged(object sender, SizeChangedEventArgs e)
     {
         if (e.NewSize.Height == e.PreviousSize.Height) return;
-        if (_tabManager.ActiveTab?.PaneHost is not Panes.PaneHost host) return;
-        foreach (var leaf in PaneTree.Leaves(host.RootNode))
-            leaf.Terminal().NoteLayoutSwitch();
+        NoteLayoutSwitchToSurfaces();
     }
 
     /// <summary>
@@ -2149,6 +2160,13 @@ public sealed partial class MainWindow : Window
         // that can still land after the tree starts coming down.
         _horizontalTabHost.SelectedTabSeamChanged -= OnSelectedTabSeamChanged;
         _verticalTabHost.SelectionRowChanged -= OnVerticalSeamChanged;
+        // Same reasoning as the two above: NotificationHost is this window's
+        // own XAML element, so leaving this attached would leak nothing by
+        // itself, but the handler is raised from a layout callback -- one of
+        // the ones that can still land after the tree starts coming down --
+        // so it is detached here rather than left to the census to wave
+        // through as an assumption nobody wrote down.
+        NotificationHost.SizeChanged -= OnNotificationDockSizeChanged;
         // UISettings is an OS object and calls back on a thread-pool thread.
         // Left attached, an OS light/dark flip, accent change or high-contrast
         // toggle during teardown puts AppSetColorScheme through the app
@@ -3600,7 +3618,7 @@ public sealed partial class MainWindow : Window
         // is a bar of terminal colour drawn across the pane at a height with
         // no tab beside it.
         //
-        // The list, not the host: the host is Row 0 with RowSpan 2, so it
+        // The list, not the host: the host is Row 0 with RowSpan 3, so it
         // covers the whole window and clamping to it does nothing at all.
         if (_verticalTabHost.SelectionViewport(RootGrid) is { } viewport)
         {

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -986,6 +986,16 @@ public sealed partial class MainWindow : Window
         // A notice appearing or leaving resizes the star row, and with it every
         // visible surface; that is a layout switch, not a user drag, so the
         // cols x rows pill stays quiet.
+        //
+        // Two hooks, because one cannot cover both cases. The occupancy hook
+        // fires when the dock flips visible or collapsed, at the source and
+        // before the layout pass: the collapsing transition raises no
+        // SizeChanged at all, since a collapsed element is skipped by
+        // Measure and Arrange, and the appearing one arranges the terminal
+        // first because it is declared earlier in the grid. SizeChanged then
+        // covers what occupancy cannot: a height change while the dock stays
+        // visible, such as two bars becoming one.
+        NotificationHost.DockOccupancyChanged = NoteLayoutSwitchToSurfaces;
         NotificationHost.SizeChanged += OnNotificationDockSizeChanged;
         // A focused notice (FocusOnShow) takes keyboard focus while it is up;
         // when it leaves, hand focus back to the active terminal the same way
@@ -2167,6 +2177,11 @@ public sealed partial class MainWindow : Window
         // so it is detached here rather than left to the census to wave
         // through as an assumption nobody wrote down.
         NotificationHost.SizeChanged -= OnNotificationDockSizeChanged;
+        // Same reasoning for the occupancy hook: it is invoked from
+        // UpdateVisibility, which a late auto-dismiss timer can still reach
+        // while the tree is coming down, and it calls back into this window.
+        NotificationHost.DockOccupancyChanged = null;
+        NotificationHost.FocusReturn = null;
         // UISettings is an OS object and calls back on a thread-pool thread.
         // Left attached, an OS light/dark flip, accent change or high-contrast
         // toggle during teardown puts AppSetColorScheme through the app

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -975,6 +975,10 @@ public sealed partial class MainWindow : Window
         // harmless and it stays hidden until summoned.
         if (Ghostty.App.NotificationService is { } notifications)
             NotificationHost.Attach(notifications);
+        // A notice appearing or leaving resizes the star row, and with it every
+        // visible surface; that is a layout switch, not a user drag, so the
+        // cols x rows pill stays quiet.
+        NotificationHost.SizeChanged += OnNotificationDockSizeChanged;
 
         // Parent every existing and future PaneHost into the shared
         // container declared in MainWindow.xaml. This is the single
@@ -1677,6 +1681,24 @@ public sealed partial class MainWindow : Window
             foreach (var leaf in PaneTree.Leaves(host.RootNode))
                 leaf.Terminal().NoteLayoutSwitch();
         }
+    }
+
+    /// <summary>
+    /// The notice dock's own row changes height as notices come and go
+    /// (report 3), which resizes the star row and everything visible in it.
+    /// That is a layout switch on the active tab's terminals, the same
+    /// suppression <see cref="NoteLayoutSwitchToSurfaces"/> gives an actual
+    /// tab-layout switch, so the cols x rows resize pill stays quiet.
+    ///
+    /// Only the active tab: a background tab's PaneHost is not laid out, so
+    /// its terminals never see the resize that would trip the pill.
+    /// </summary>
+    private void OnNotificationDockSizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        if (e.NewSize.Height == e.PreviousSize.Height) return;
+        if (_tabManager.ActiveTab?.PaneHost is not Panes.PaneHost host) return;
+        foreach (var leaf in PaneTree.Leaves(host.RootNode))
+            leaf.Terminal().NoteLayoutSwitch();
     }
 
     /// <summary>

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -979,6 +979,10 @@ public sealed partial class MainWindow : Window
         // visible surface; that is a layout switch, not a user drag, so the
         // cols x rows pill stays quiet.
         NotificationHost.SizeChanged += OnNotificationDockSizeChanged;
+        // A focused notice (FocusOnShow) takes keyboard focus while it is up;
+        // when it leaves, hand focus back to the active terminal the same way
+        // the command palette does on close.
+        NotificationHost.FocusReturn = FocusActiveLeaf;
 
         // Parent every existing and future PaneHost into the shared
         // container declared in MainWindow.xaml. This is the single


### PR DESCRIPTION
The `agents: monitor` overlay was transparent and sat on top of the terminal, hiding output. The same applied to every notice rendered that way.

The notice surface now docks in its own grid row beneath the terminal, so showing a notice is a layout change and the terminal resizes to make room instead of being covered.

The host collapses to zero height when there are no notices. A margin left on the host would have kept the `Auto` row from ever collapsing, leaving a permanent band that shrinks the terminal forever, so the margin moves inside.

`Notice` also gains `AutoDismissAfter` and `FocusOnShow`, so a notice can be transient and can take Enter or Space. Focus is returned to the terminal only when the bar actually held it.

Test plan: full suite 3824 passed and 0 failed. Censuses cover the dock row and its span in `MainWindow.xaml`, that a dock resize is a layout switch for visible terminals, and that the size handler is detached on close.

Cross-repo: this reaches no shipped tier until the release pins advance past it. The release-side half needs the `AutoDismissAfter` and `FocusOnShow` added here to finish, and is written to work without them until the bump.

