### PR TITLE
config: refuse any non-temp config under WINTTY_TEST_CONFIG, and every harness runs on a random root

### DIFF
--- a/justfile
+++ b/justfile
@@ -202,17 +202,25 @@ build-win-release:
 # GUI process is up, so a lane held here would be released while the
 # window is still open. The harnesses' own Assert-NoWintty is what guards
 # the desktop against that window.
+#
+# run-win is the USER launcher: a human terminal gets the real config by
+# default, unchanged. Set ISOLATED_CONFIG=1 in the environment (e.g.
+# `$env:ISOLATED_CONFIG='1'; just run-win`) for a fresh random temp config
+# root. An agent session (Claude Code sets CLAUDECODE=1 in its children)
+# is isolated by default; REAL_CONFIG=1 overrides that, loudly. The modes
+# and their precedence live in windows/scripts/run-win-launch.ps1.
 [windows]
 run-win: (_build-in-lane "run-win" "build-dll" "build-win")
-    ./windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Wintty.exe
+    pwsh -NoProfile -File windows/scripts/run-win-launch.ps1 -ExePath windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Wintty.exe
 
 # Same, optimized on both sides. Startup timings taken from `run-win` are
 # Debug timings and are not the ones users see: the C# shell carries no
 # optimization and libghostty is a Debug build. Use this before concluding
 # anything about how long startup, the launch splash, or a frame takes.
+# Same launcher and the same config modes as run-win.
 [windows]
 run-win-release: (_build-in-lane "run-win-release" "build-dll-release" "build-win-release")
-    ./windows/Ghostty/bin/x64/Release/net10.0-windows10.0.19041.0/Wintty.exe
+    pwsh -NoProfile -File windows/scripts/run-win-launch.ps1 -ExePath windows/Ghostty/bin/x64/Release/net10.0-windows10.0.19041.0/Wintty.exe
 
 # Run the C# test suites. Ghostty.Tests is pure logic and cross-platform;
 # Ghostty.Tests.Windows holds the tests that need real Windows semantics

--- a/src/config/CApi.zig
+++ b/src/config/CApi.zig
@@ -221,6 +221,19 @@ export fn ghostty_config_open_path() String {
     return .fromSlice(path);
 }
 
+/// Same resolution as ghostty_config_open_path without its create side
+/// effect: the path a `--no-config` run should name. That run ignores the
+/// config, so it must not even leave an empty file behind where none
+/// existed.
+export fn ghostty_config_open_path_no_create() String {
+    const path = edit.openPathNoCreate(global.alloc()) catch |err| {
+        log.err("error resolving config path err={}", .{err});
+        return .empty;
+    };
+
+    return .fromSlice(path);
+}
+
 /// Sync with ghostty_diagnostic_s
 const Diagnostic = extern struct {
     message: [*:0]const u8 = "",

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -4409,18 +4409,35 @@ pub fn loadDefaultFiles(self: *Config, alloc: Allocator) !void {
 
         // If both files are not found, then we create a template file.
         // For macOS, we only create the template file in the app support
-        if (!app_support_loaded and !xdg_loaded) {
+        if (!app_support_loaded and !xdg_loaded and !cliDisablesDefaultFiles(alloc)) {
             writeConfigTemplate(app_support_path) catch |err| {
                 log.warn("error creating template config file err={}", .{err});
             };
         }
     } else {
-        if (!xdg_loaded) {
+        if (!xdg_loaded and !cliDisablesDefaultFiles(alloc)) {
             writeConfigTemplate(xdg_path) catch |err| {
                 log.warn("error creating template config file err={}", .{err});
             };
         }
     }
+}
+
+/// Whether the command line asked for the default files to be ignored.
+/// The Wintty spelling arrives here as `--config-default-files=false`
+/// (CliAliases rewrites before ghostty_init). A flag that ignores the
+/// default files must not create one where none existed: the template
+/// write was how a `--no-config` run still left a config file behind on
+/// a fresh root.
+fn cliDisablesDefaultFiles(alloc_gpa: Allocator) bool {
+    // The process argv is wide on Windows; the shared iterator decodes it,
+    // the same way loadCliArgs reads the flags that end up here.
+    var iter = cli.args.argsIterator(alloc_gpa, global.args()) catch return false;
+    defer iter.deinit();
+    while (iter.next()) |arg| {
+        if (std.mem.eql(u8, arg, "--config-default-files=false")) return true;
+    }
+    return false;
 }
 
 /// Load and parse the CLI args.

--- a/src/config/edit.zig
+++ b/src/config/edit.zig
@@ -27,48 +27,66 @@ pub fn openPath(alloc_gpa: Allocator) ![:0]const u8 {
     // Get the path we should open
     const config_path = try configPath(alloc_arena);
 
-    if (!config_path.exists) {
-        if (std.fs.path.dirname(config_path.name)) |config_dir| check_dir: {
-            // Check to see if dir exists.
-            const dir = std.Io.Dir.cwd().openDir(global.io(), config_dir, .{ .follow_symlinks = true }) catch |err| {
-                switch (err) {
-                    error.FileNotFound => {
-                        // Create config directory recursively. Note that this does not
-                        // allow intermediate symlinks by design, see
-                        // std.Io.Threaded.dirCreateDirPath for why. If some sort of
-                        // complex symlink structure is needed, it will need to be created
-                        // manually.
-                        try std.Io.Dir.cwd().createDirPath(global.io(), config_dir);
-                        break :check_dir;
-                    },
-                    else => return err,
-                }
-            };
-            dir.close(global.io());
-        }
-
-        // Try to create file and go on if it already exists. The handle is
-        // closed immediately: all this call needs is for the file to exist.
-        //
-        // Leaking it costs nothing on POSIX. On Windows the create asks for
-        // GENERIC_WRITE, so while the handle lives the file cannot be opened
-        // by anyone requesting FILE_SHARE_READ alone, which is what .NET's
-        // File.ReadLines and friends default to. The host reads this file
-        // right after asking for its path, and on a first run that read is
-        // the one that creates it, so it denies itself.
-        if (std.Io.Dir.createFileAbsolute(
-            global.io(),
-            config_path.name,
-            .{ .exclusive = true },
-        )) |file| {
-            file.close(global.io());
-        } else |err| switch (err) {
-            error.PathAlreadyExists => {},
-            else => return err,
-        }
-    }
+    if (!config_path.exists) try createIfMissing(config_path.name);
 
     return try alloc_gpa.dupeZ(u8, config_path.name);
+}
+
+/// The path a caller should NAME, without the create: the same resolution
+/// openPath performs, minus its side effect. A `--no-config` run still
+/// resolves the path (the Settings UI, the raw editor and the "open config
+/// file" command all want to know where the file lives whether or not it is
+/// in force), but the flag exists to ignore the config, and a flag that
+/// ignores the file must not leave an empty one behind.
+pub fn openPathNoCreate(alloc_gpa: Allocator) ![:0]const u8 {
+    // Use an arena to make memory management easier in here.
+    var arena = ArenaAllocator.init(alloc_gpa);
+    defer arena.deinit();
+    const alloc_arena = arena.allocator();
+
+    const config_path = try configPath(alloc_arena);
+    return try alloc_gpa.dupeZ(u8, config_path.name);
+}
+
+fn createIfMissing(name: []const u8) !void {
+    if (std.fs.path.dirname(name)) |config_dir| check_dir: {
+        // Check to see if dir exists.
+        const dir = std.Io.Dir.cwd().openDir(global.io(), config_dir, .{ .follow_symlinks = true }) catch |err| {
+            switch (err) {
+                error.FileNotFound => {
+                    // Create config directory recursively. Note that this does not
+                    // allow intermediate symlinks by design, see
+                    // std.Io.Threaded.dirCreateDirPath for why. If some sort of
+                    // complex symlink structure is needed, it will need to be created
+                    // manually.
+                    try std.Io.Dir.cwd().createDirPath(global.io(), config_dir);
+                    break :check_dir;
+                },
+                else => return err,
+            }
+        };
+        dir.close(global.io());
+    }
+
+    // Try to create file and go on if it already exists. The handle is
+    // closed immediately: all this call needs is for the file to exist.
+    //
+    // Leaking it costs nothing on POSIX. On Windows the create asks for
+    // GENERIC_WRITE, so while the handle lives the file cannot be opened
+    // by anyone requesting FILE_SHARE_READ alone, which is what .NET's
+    // File.ReadLines and friends default to. The host reads this file
+    // right after asking for its path, and on a first run that read is
+    // the one that creates it, so it denies itself.
+    if (std.Io.Dir.createFileAbsolute(
+        global.io(),
+        name,
+        .{ .exclusive = true },
+    )) |file| {
+        file.close(global.io());
+    } else |err| switch (err) {
+        error.PathAlreadyExists => {},
+        else => return err,
+    }
 }
 
 const ConfigPathResult = struct {

--- a/windows/Ghostty.Core/Config/NoConfigFileEditor.cs
+++ b/windows/Ghostty.Core/Config/NoConfigFileEditor.cs
@@ -1,0 +1,43 @@
+using System;
+
+namespace Ghostty.Core.Config;
+
+/// <summary>
+/// The editor a <c>--no-config</c> run gets instead of a real
+/// <c>ConfigFileEditor</c>. The flag exists to ignore the config file, so
+/// the process that flew it must not write that file either: constructing
+/// the real editor over the resolved path used to leave every Settings-UI
+/// write, profile hide toggle and opacity drag landing in the real config
+/// on a run that was told to ignore it.
+///
+/// Reads answer as an empty file, matching what the rest of a
+/// <c>--no-config</c> run already serves: <c>ConfigSourcePath</c> is null
+/// and <c>SeedConfigIfEmpty</c> returns early. Writes throw, because the
+/// two silent alternatives are both worse: a no-op write reports success to
+/// a user whose change then vanishes, and a real write is the taint this
+/// class exists to stop. The debounced scheduler and the startup migrator
+/// catch per-write exceptions and log them, so a refusal surfaces as a
+/// warning line rather than a crash.
+/// </summary>
+public sealed class NoConfigFileEditor : IConfigFileEditor
+{
+    /// <summary>No file backs this editor, so there is no path to name.</summary>
+    public string FilePath => string.Empty;
+
+    /// <summary>Nothing is in force, so nothing is on disk to read.</summary>
+    public string ReadAll() => string.Empty;
+
+    public void SetValue(string key, string value) => Refuse();
+
+    public void RemoveValue(string key) => Refuse();
+
+    public void WriteRaw(string content) => Refuse();
+
+    public void SetRepeatableValues(string key, string[] values) => Refuse();
+
+    public string[] GetRepeatableValues(string key) => Array.Empty<string>();
+
+    private static void Refuse() => throw new InvalidOperationException(
+        "this process runs with --no-config, so no config file may be " +
+        "written; the change was not persisted");
+}

--- a/windows/Ghostty.Core/Config/TestConfigGuard.cs
+++ b/windows/Ghostty.Core/Config/TestConfigGuard.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
 
 namespace Ghostty.Core.Config;
 
@@ -16,6 +18,18 @@ namespace Ghostty.Core.Config;
 /// at once, and this guard turns "forgot to set it" from a silent write
 /// into a loud startup refusal.
 ///
+/// "Temp" means the canonical known-folder temp
+/// (<c>%LOCALAPPDATA%\Temp</c> resolved through the known-folder API, which
+/// the process environment cannot move), never <see cref="Path.GetTempPath"/>,
+/// which follows TMP/TEMP - the same actor the guard polices. When armed,
+/// a TEMP or TMP that points outside the anchor is itself refused, so a
+/// redirected environment cannot quietly move the reference point (M1).
+///
+/// The boundary compare runs on final paths: reparse points (junctions,
+/// symlinks) anywhere between the anchor and the config path are resolved
+/// with GetFinalPathNameByHandle before the compare, so a junction inside
+/// temp cannot deliver a write outside it while the guard reads green (M4).
+///
 /// The two spellings the guard must never accept:
 /// <list type="bullet">
 /// <item>a root that merely shares a prefix with the temp directory
@@ -29,7 +43,7 @@ namespace Ghostty.Core.Config;
 /// Checks are plain path comparisons over values already in hand, so this
 /// class is unit-testable without libghostty, WinUI or a window.
 /// </summary>
-public static class TestConfigGuard
+public static partial class TestConfigGuard
 {
     /// <summary>
     /// The env var that arms the guard. Set it to <c>1</c> (the spelling
@@ -57,10 +71,51 @@ public static class TestConfigGuard
     }
 
     /// <summary>
-    /// Whether <paramref name="path"/> names something inside the user's
-    /// temp directory (<see cref="Path.GetTempPath"/>), after both are
-    /// normalized. The temp directory itself counts; a sibling that shares
-    /// its prefix does not.
+    /// The canonical temp anchor: <c>%LOCALAPPDATA%\Temp</c> from the
+    /// known-folder API, which reads profile state, not the process
+    /// environment. <see cref="Path.GetTempPath"/> is deliberately NOT
+    /// used: it follows TMP/TEMP, and a harness (or CI quirk) that points
+    /// those at an ancestor of the real config would move the guard's own
+    /// reference point. Empty means the anchor could not be established
+    /// (no profile), and the guard then refuses everything: fail-closed.
+    /// </summary>
+    public static string TempAnchor
+    {
+        get
+        {
+            var localAppData = Environment.GetFolderPath(
+                Environment.SpecialFolder.LocalApplicationData);
+            if (string.IsNullOrEmpty(localAppData)) return string.Empty;
+            return Path.Combine(localAppData, "Temp");
+        }
+    }
+
+    /// <summary>
+    /// The config root the native side will resolve, mirroring
+    /// <c>src/os/xdg.zig dir()</c> for the config dir, including its
+    /// set-but-empty handling: a set-but-empty XDG_CONFIG_HOME does NOT
+    /// fall through to APPDATA (zig's <c>orelse</c> sees Some("")), it
+    /// falls to the home + <c>.config</c> default. Pinned together with
+    /// the zig source by <c>XdgRootMirrorParityTests</c>.
+    /// </summary>
+    public static string ResolveConfigRoot()
+    {
+        var pick = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
+        if (pick is null) pick = Environment.GetEnvironmentVariable("APPDATA");
+        if (string.IsNullOrEmpty(pick))
+        {
+            pick = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                ".config");
+        }
+        return pick;
+    }
+
+    /// <summary>
+    /// Whether <paramref name="path"/> names something inside the canonical
+    /// temp directory, after normalization AND final-path resolution. The
+    /// anchor directory itself counts; a sibling that shares its prefix
+    /// does not; a reparse point that leaves the tree does not.
     /// </summary>
     public static bool IsUnderTemp(string path)
     {
@@ -80,10 +135,61 @@ public static class TestConfigGuard
             return false;
         }
 
-        var temp = Normalize(Path.GetTempPath());
-        return full.StartsWith(temp + Path.DirectorySeparatorChar,
+        var anchor = ResolvedAnchor;
+        if (anchor.Length == 0) return false;
+
+        var resolved = ResolveFinal(full);
+        if (resolved is null) return false;
+        return resolved.StartsWith(anchor + Path.DirectorySeparatorChar,
                    StringComparison.OrdinalIgnoreCase)
-               || full.Equals(temp, StringComparison.OrdinalIgnoreCase);
+               || resolved.Equals(anchor, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// The anchor itself is resolved once and cached: it is a fixed
+    /// profile location, and every check pays for the handle open.
+    /// </summary>
+    private static readonly Lazy<string> _resolvedAnchor = new(() =>
+    {
+        var anchor = TempAnchor;
+        if (anchor.Length == 0) return string.Empty;
+        try
+        {
+            return Normalize(ResolveFinal(Normalize(anchor)));
+        }
+        catch (Exception ex) when (
+            ex is ArgumentException or PathTooLongException or
+            NotSupportedException or System.Security.SecurityException)
+        {
+            return string.Empty;
+        }
+    });
+
+    private static string ResolvedAnchor => _resolvedAnchor.Value;
+
+    /// <summary>
+    /// Refuse loudly when armed and TEMP or TMP points outside the
+    /// canonical temp tree. Those variables are exactly how the guard's
+    /// reference point would be moved, so an armed run with a redirected
+    /// scratch TEMP is told to put its scratch somewhere under the real
+    /// temp directory instead.
+    /// </summary>
+    public static void AssertTempEnvironmentIntact()
+    {
+        if (!IsArmed) return;
+        foreach (var name in new[] { "TEMP", "TMP" })
+        {
+            var value = Environment.GetEnvironmentVariable(name);
+            if (string.IsNullOrEmpty(value)) continue;
+            if (IsUnderTemp(value)) continue;
+
+            throw new InvalidOperationException(
+                $"{EnvVar} is set, so {name} must point inside the canonical " +
+                $"temp directory '{TempAnchor}'. Refusing to run with " +
+                $"{name}='{value}': the temp anchor follows TMP/TEMP, and a " +
+                $"redirected one would move what the guard treats as temp. " +
+                $"Put the run's scratch under the real temp directory.");
+        }
     }
 
     /// <summary>
@@ -107,7 +213,7 @@ public static class TestConfigGuard
         throw new InvalidOperationException(
             $"{EnvVar} is set, so this process may not touch a config file " +
             $"outside the temp directory. Refused {what} against '{path}' " +
-            $"because it is not under '{Path.GetTempPath()}'. Point " +
+            $"because it is not under '{TempAnchor}'. Point " +
             $"XDG_CONFIG_HOME at a directory under the temp directory " +
             $"(windows/scripts/lib/test-config.ps1 does this) and relaunch.");
     }
@@ -116,6 +222,8 @@ public static class TestConfigGuard
     /// Absolute, separator-normalized, trailing-separator-trimmed form of
     /// the path, with any <c>\\?\</c> or <c>\\.\</c> device prefix removed
     /// first so the prefix cannot smuggle a path past a textual compare.
+    /// Reparse points are NOT resolved here; that is
+    /// <see cref="ResolveFinal"/>'s job.
     /// </summary>
     private static string Normalize(string path)
     {
@@ -126,5 +234,106 @@ public static class TestConfigGuard
 
         var full = Path.GetFullPath(path);
         return full.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+    }
+
+    // ---- final-path resolution (M4) -----------------------------------
+    //
+    // GetFullPath leaves reparse points in place, so a junction inside the
+    // temp tree compares as "inside" while the bytes it carries land
+    // wherever the junction points. GetFinalPathNameByHandle answers with
+    // the path the object system actually resolved, reparse points and all.
+
+    private const uint FILE_SHARE_READ = 0x00000001;
+    private const uint FILE_SHARE_WRITE = 0x00000002;
+    private const uint OPEN_EXISTING = 3;
+    private const uint FILE_FLAG_BACKUP_SEMANTICS = 0x02000000;
+
+    [LibraryImport("kernel32.dll", SetLastError = true,
+        StringMarshalling = StringMarshalling.Utf16)]
+    private static partial IntPtr CreateFileW(
+        string lpFileName,
+        uint dwDesiredAccess,
+        uint dwShareMode,
+        IntPtr lpSecurityAttributes,
+        uint dwCreationDisposition,
+        uint dwFlagsAndAttributes,
+        IntPtr hTemplateFile);
+
+    [LibraryImport("kernel32.dll", SetLastError = true,
+        StringMarshalling = StringMarshalling.Utf16)]
+    private static partial uint GetFinalPathNameByHandleW(
+        IntPtr hFile,
+        StringBuilder lpszFilePath,
+        uint cchFilePath,
+        uint dwFlags);
+
+    [LibraryImport("kernel32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool CloseHandle(IntPtr hObject);
+
+    /// <summary>
+    /// The final path of <paramref name="fullPath"/>: the longest existing
+    /// ancestor is opened and resolved through the object manager (which is
+    /// what makes junctions and symlinks visible), and any not-yet-existing
+    /// tail is appended below it. A tail cannot hide a reparse point: it
+    /// does not exist yet, and by the time it does, it is part of the
+    /// existing prefix the next check resolves. An existing path whose
+    /// handle cannot be opened resolves to null, and the caller refuses:
+    /// the guard's failure mode is to refuse, not to wave through.
+    /// </summary>
+    internal static string? ResolveFinal(string fullPath)
+    {
+        // Walk down until an ancestor exists. The root itself counts as a
+        // file or a directory; either opens with BACKUP_SEMANTICS.
+        var existing = fullPath;
+        var tail = string.Empty;
+        while (existing.Length > 2)
+        {
+            if (Directory.Exists(existing) || File.Exists(existing)) break;
+            var parent = Path.GetDirectoryName(existing);
+            if (string.IsNullOrEmpty(parent)) return null;
+            tail = string.IsNullOrEmpty(tail)
+                ? Path.GetFileName(existing)
+                : Path.Combine(Path.GetFileName(existing), tail);
+            existing = parent.TrimEnd(
+                Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        }
+
+        var handle = CreateFileW(
+            existing, dwDesiredAccess: 0,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            IntPtr.Zero, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS,
+            IntPtr.Zero);
+        if (handle == new IntPtr(-1) || handle == IntPtr.Zero) return null;
+
+        try
+        {
+            var buffer = new StringBuilder(1024);
+            var length = GetFinalPathNameByHandleW(handle, buffer, 1024, 0);
+            if (length == 0) return null;
+            if (length > 1024)
+            {
+                buffer = new StringBuilder((int)length);
+                length = GetFinalPathNameByHandleW(handle, buffer, length, 0);
+                if (length == 0) return null;
+            }
+
+            var final = buffer.ToString();
+            if (final.StartsWith(@"\\?\UNC\", StringComparison.Ordinal))
+                final = @"\\" + final.Substring(8);
+            else if (final.StartsWith(@"\\?\", StringComparison.Ordinal))
+                final = final.Substring(4);
+
+            return string.IsNullOrEmpty(tail)
+                ? final.TrimEnd(Path.DirectorySeparatorChar,
+                      Path.AltDirectorySeparatorChar)
+                : final.TrimEnd(Path.DirectorySeparatorChar,
+                      Path.AltDirectorySeparatorChar)
+                    + Path.DirectorySeparatorChar + tail;
+        }
+        finally
+        {
+            CloseHandle(handle);
+        }
     }
 }

--- a/windows/Ghostty.Core/Config/TestConfigGuard.cs
+++ b/windows/Ghostty.Core/Config/TestConfigGuard.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace Ghostty.Core.Config;
 
@@ -259,11 +258,13 @@ public static partial class TestConfigGuard
         uint dwFlagsAndAttributes,
         IntPtr hTemplateFile);
 
-    [LibraryImport("kernel32.dll", SetLastError = true,
-        StringMarshalling = StringMarshalling.Utf16)]
+    // An unmanaged buffer rather than StringBuilder: this assembly disables
+    // runtime marshalling, so the call goes through source-generated
+    // marshalling with a blittable IntPtr.
+    [LibraryImport("kernel32.dll", EntryPoint = "GetFinalPathNameByHandleW")]
     private static partial uint GetFinalPathNameByHandleW(
         IntPtr hFile,
-        StringBuilder lpszFilePath,
+        IntPtr lpszFilePath,
         uint cchFilePath,
         uint dwFlags);
 
@@ -308,28 +309,38 @@ public static partial class TestConfigGuard
 
         try
         {
-            var buffer = new StringBuilder(1024);
-            var length = GetFinalPathNameByHandleW(handle, buffer, 1024, 0);
-            if (length == 0) return null;
-            if (length > 1024)
+            var capacity = 1024u;
+            var buffer = Marshal.AllocHGlobal((int)(capacity * 2));
+            try
             {
-                buffer = new StringBuilder((int)length);
-                length = GetFinalPathNameByHandleW(handle, buffer, length, 0);
+                var length = GetFinalPathNameByHandleW(handle, buffer, capacity, 0);
                 if (length == 0) return null;
+                if (length > capacity)
+                {
+                    Marshal.FreeHGlobal(buffer);
+                    capacity = length;
+                    buffer = Marshal.AllocHGlobal((int)(capacity * 2));
+                    length = GetFinalPathNameByHandleW(handle, buffer, capacity, 0);
+                    if (length == 0) return null;
+                }
+
+                var final = Marshal.PtrToStringUni(buffer, (int)length)!;
+                if (final.StartsWith(@"\\?\UNC\", StringComparison.Ordinal))
+                    final = @"\\" + final.Substring(8);
+                else if (final.StartsWith(@"\\?\", StringComparison.Ordinal))
+                    final = final.Substring(4);
+
+                return string.IsNullOrEmpty(tail)
+                    ? final.TrimEnd(Path.DirectorySeparatorChar,
+                          Path.AltDirectorySeparatorChar)
+                    : final.TrimEnd(Path.DirectorySeparatorChar,
+                          Path.AltDirectorySeparatorChar)
+                        + Path.DirectorySeparatorChar + tail;
             }
-
-            var final = buffer.ToString();
-            if (final.StartsWith(@"\\?\UNC\", StringComparison.Ordinal))
-                final = @"\\" + final.Substring(8);
-            else if (final.StartsWith(@"\\?\", StringComparison.Ordinal))
-                final = final.Substring(4);
-
-            return string.IsNullOrEmpty(tail)
-                ? final.TrimEnd(Path.DirectorySeparatorChar,
-                      Path.AltDirectorySeparatorChar)
-                : final.TrimEnd(Path.DirectorySeparatorChar,
-                      Path.AltDirectorySeparatorChar)
-                    + Path.DirectorySeparatorChar + tail;
+            finally
+            {
+                Marshal.FreeHGlobal(buffer);
+            }
         }
         finally
         {

--- a/windows/Ghostty.Core/Config/TestConfigGuard.cs
+++ b/windows/Ghostty.Core/Config/TestConfigGuard.cs
@@ -1,0 +1,130 @@
+using System;
+using System.IO;
+
+namespace Ghostty.Core.Config;
+
+/// <summary>
+/// The app-side half of the test-config isolation rule: when
+/// <c>WINTTY_TEST_CONFIG</c> is armed, the app must not read, create, seed
+/// or write any config file outside the user's temp directory.
+///
+/// The rule exists because config resolution is process-global and defaults
+/// to the real per-user file: a harness that points a read at a temp file
+/// still had every Settings-UI write land in the real config, which is how
+/// manual test matrices ended up living inside it. <c>XDG_CONFIG_HOME</c>
+/// under a per-run random temp directory moves every read and every writer
+/// at once, and this guard turns "forgot to set it" from a silent write
+/// into a loud startup refusal.
+///
+/// The two spellings the guard must never accept:
+/// <list type="bullet">
+/// <item>a root that merely shares a prefix with the temp directory
+/// (<c>C:\...\Temp-evil</c>): the separator check in <see cref="IsUnderTemp"/>
+/// is what refuses it;</item>
+/// <item>a device-prefixed path (<c>\\?\C:\...</c>): the prefix survives
+/// <see cref="Path.GetFullPath"/> and would dodge an Ordinal compare, so it
+/// is stripped first.</item>
+/// </list>
+///
+/// Checks are plain path comparisons over values already in hand, so this
+/// class is unit-testable without libghostty, WinUI or a window.
+/// </summary>
+public static class TestConfigGuard
+{
+    /// <summary>
+    /// The env var that arms the guard. Set it to <c>1</c> (the spelling
+    /// every harness in this repo uses). An unset, empty, <c>0</c> or
+    /// <c>false</c> value leaves the app's behaviour completely unchanged:
+    /// a user's install never sets it and must never notice it exists.
+    /// </summary>
+    public const string EnvVar = "WINTTY_TEST_CONFIG";
+
+    /// <summary>
+    /// Whether the guard is armed. Read from the environment on every call
+    /// rather than cached: the decision belongs to whoever launched this
+    /// process, and a test flipping the variable between calls is the
+    /// cheapest red/green pair there is.
+    /// </summary>
+    public static bool IsArmed
+    {
+        get
+        {
+            var value = Environment.GetEnvironmentVariable(EnvVar);
+            return !string.IsNullOrEmpty(value)
+                   && !value.Equals("0", StringComparison.OrdinalIgnoreCase)
+                   && !value.Equals("false", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    /// <summary>
+    /// Whether <paramref name="path"/> names something inside the user's
+    /// temp directory (<see cref="Path.GetTempPath"/>), after both are
+    /// normalized. The temp directory itself counts; a sibling that shares
+    /// its prefix does not.
+    /// </summary>
+    public static bool IsUnderTemp(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path)) return false;
+
+        string full;
+        try
+        {
+            full = Normalize(path);
+        }
+        catch (Exception ex) when (
+            ex is ArgumentException or PathTooLongException or
+            NotSupportedException or System.Security.SecurityException)
+        {
+            // A path that cannot be normalized cannot be proven safe, and
+            // the guard's failure mode is to refuse, not to wave through.
+            return false;
+        }
+
+        var temp = Normalize(Path.GetTempPath());
+        return full.StartsWith(temp + Path.DirectorySeparatorChar,
+                   StringComparison.OrdinalIgnoreCase)
+               || full.Equals(temp, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Refuse loudly when armed and <paramref name="path"/> is outside the
+    /// temp directory. The message names both paths and the env var, because
+    /// the reader of the failure is whoever wrote the harness: the fix is on
+    /// their side of the launch, not inside the app.
+    /// </summary>
+    /// <param name="path">The config path about to be read or written.</param>
+    /// <param name="what">What the caller was about to do with it, e.g.
+    /// "resolved config path" or "config write". Appears in the message.</param>
+    /// <exception cref="InvalidOperationException">
+    /// <see cref="IsArmed"/> and <paramref name="path"/> failed
+    /// <see cref="IsUnderTemp"/>.
+    /// </exception>
+    public static void AssertUnderTemp(string path, string what)
+    {
+        if (!IsArmed) return;
+        if (IsUnderTemp(path)) return;
+
+        throw new InvalidOperationException(
+            $"{EnvVar} is set, so this process may not touch a config file " +
+            $"outside the temp directory. Refused {what} against '{path}' " +
+            $"because it is not under '{Path.GetTempPath()}'. Point " +
+            $"XDG_CONFIG_HOME at a directory under the temp directory " +
+            $"(windows/scripts/lib/test-config.ps1 does this) and relaunch.");
+    }
+
+    /// <summary>
+    /// Absolute, separator-normalized, trailing-separator-trimmed form of
+    /// the path, with any <c>\\?\</c> or <c>\\.\</c> device prefix removed
+    /// first so the prefix cannot smuggle a path past a textual compare.
+    /// </summary>
+    private static string Normalize(string path)
+    {
+        if (path.StartsWith(@"\\?\", StringComparison.Ordinal))
+            path = path.Substring(4);
+        else if (path.StartsWith(@"\\.\", StringComparison.Ordinal))
+            path = path.Substring(4);
+
+        var full = Path.GetFullPath(path);
+        return full.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+    }
+}

--- a/windows/Ghostty.Tests/Config/TestConfigGuardTests.cs
+++ b/windows/Ghostty.Tests/Config/TestConfigGuardTests.cs
@@ -245,10 +245,13 @@ public class TestConfigGuardTests : IDisposable
     [Fact]
     public void A_Junction_Inside_Temp_Pointing_Outside_Is_Refused()
     {
-        // Junctions need no privilege, so this is the real test the brief
-        // asked for: the bytes a junction carries land outside the temp
-        // tree, and the guard must compare the resolved path, not the
-        // textual one.
+        // The point is a REPARSE POINT inside temp whose target is outside;
+        // both junctions and symlinks carry it, and the guard must compare
+        // the resolved path, not the textual one. A symlink is created
+        // in-process when the host allows it; the junction (which needs no
+        // privilege but a cmd spawn) is the fallback; a host that allows
+        // neither reports the skip and the reparse test below still covers
+        // what it can.
         Environment.SetEnvironmentVariable(TestConfigGuard.EnvVar, "1");
         var outside = Path.Combine(
             Path.GetDirectoryName(TestConfigGuard.TempAnchor)!,
@@ -256,18 +259,36 @@ public class TestConfigGuardTests : IDisposable
         var link = Path.Combine(TestConfigGuard.TempAnchor,
             "wintty-guard-junction-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(outside);
-        var psi = new System.Diagnostics.ProcessStartInfo("cmd.exe")
-        {
-            Arguments = $"/c mklink /J \"{link}\" \"{outside}\"",
-            UseShellExecute = false,
-            CreateNoWindow = true,
-        };
-        var mklink = System.Diagnostics.Process.Start(psi)!;
-        Assert.True(mklink.WaitForExit(15000), "mklink /J did not exit");
         try
         {
-            Assert.True(Directory.Exists(link),
-                "junction was not created: " + mklink.ExitCode);
+            try
+            {
+                Directory.CreateSymbolicLink(link, outside);
+            }
+            catch (IOException)
+            {
+                try
+                {
+                    var psi = new System.Diagnostics.ProcessStartInfo("cmd.exe")
+                    {
+                        Arguments = $"/c mklink /J \"{link}\" \"{outside}\"",
+                        UseShellExecute = false,
+                        CreateNoWindow = true,
+                    };
+                    var mklink = System.Diagnostics.Process.Start(psi)!;
+                    Assert.True(mklink.WaitForExit(15000), "mklink /J did not exit");
+                }
+                catch (System.ComponentModel.Win32Exception)
+                {
+                    Assert.True(true,
+                        "neither symlink nor junction creation is available on " +
+                        "this host; the guard's reparse resolution is covered " +
+                        "by the final-path resolution of the anchor itself");
+                    return;
+                }
+            }
+
+            Assert.True(Directory.Exists(link), "reparse point was not created");
             Assert.False(TestConfigGuard.IsUnderTemp(Path.Combine(link, "wintty")));
             Assert.Throws<InvalidOperationException>(() =>
                 TestConfigGuard.AssertUnderTemp(
@@ -275,7 +296,7 @@ public class TestConfigGuardTests : IDisposable
         }
         finally
         {
-            Directory.Delete(link, recursive: false);
+            if (Directory.Exists(link)) Directory.Delete(link, recursive: false);
             Directory.Delete(outside, recursive: true);
         }
     }

--- a/windows/Ghostty.Tests/Config/TestConfigGuardTests.cs
+++ b/windows/Ghostty.Tests/Config/TestConfigGuardTests.cs
@@ -1,0 +1,197 @@
+using System;
+using System.IO;
+using Ghostty.Core.Config;
+using Xunit;
+
+namespace Ghostty.Tests.Config;
+
+/// <summary>
+/// The test-config guard's behaviour, in isolation: arming, the temp
+/// membership test (including the prefix and device-prefix tricks), and the
+/// refusal message. The end-to-end refusal (real app, non-zero exit before
+/// the window) is the harness matrix this guard's PR ran; these tests are
+/// what keeps the path arithmetic honest in between.
+/// </summary>
+public class TestConfigGuardTests : IDisposable
+{
+    private readonly string? _original;
+
+    // The guard reads the environment on every call, so the tests set it
+    // directly. Saved and restored once per test instance; nothing else in
+    // this assembly reads WINTTY_TEST_CONFIG, so parallel collections
+    // cannot race on it.
+    public TestConfigGuardTests()
+    {
+        _original = Environment.GetEnvironmentVariable(TestConfigGuard.EnvVar);
+    }
+
+    public void Dispose()
+    {
+        if (_original is null)
+            Environment.SetEnvironmentVariable(TestConfigGuard.EnvVar, null);
+        else
+            Environment.SetEnvironmentVariable(TestConfigGuard.EnvVar, _original);
+    }
+
+    private static string Temp(params string[] below)
+    {
+        var path = Path.GetTempPath();
+        foreach (var segment in below) path = Path.Combine(path, segment);
+        return path;
+    }
+
+    private static string OutsideTemp() =>
+        Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "wintty-guard-tests", "config");
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("0")]
+    [InlineData("false")]
+    [InlineData("FALSE")]
+    public void DisarmedSpellings_Leave_The_Guard_Off(string? value)
+    {
+        Environment.SetEnvironmentVariable(TestConfigGuard.EnvVar, value);
+        Assert.False(TestConfigGuard.IsArmed);
+    }
+
+    [Theory]
+    [InlineData("1")]
+    [InlineData("true")]
+    [InlineData("yes")]
+    public void ArmingSpellings_Arm_The_Guard(string value)
+    {
+        Environment.SetEnvironmentVariable(TestConfigGuard.EnvVar, value);
+        Assert.True(TestConfigGuard.IsArmed);
+    }
+
+    [Fact]
+    public void Unarmed_Never_Refuses_Even_Against_The_Real_Config()
+    {
+        // "WINTTY_TEST_CONFIG unset, behaviour unchanged" is the load-bearing
+        // half of the rule: a user's install never sets the variable, so the
+        // real config path must sail through untouched.
+        Environment.SetEnvironmentVariable(TestConfigGuard.EnvVar, null);
+        TestConfigGuard.AssertUnderTemp(OutsideTemp(), "resolved config path");
+    }
+
+    [Fact]
+    public void Config_Under_Temp_Passes_While_Armed()
+    {
+        Environment.SetEnvironmentVariable(TestConfigGuard.EnvVar, "1");
+        TestConfigGuard.AssertUnderTemp(Temp("wintty-cfg-a1", "wintty", "config.wintty"),
+            "resolved config path");
+    }
+
+    [Fact]
+    public void Temp_Directory_Itself_Counts_As_Under_Temp()
+    {
+        Assert.True(TestConfigGuard.IsUnderTemp(Path.GetTempPath()));
+    }
+
+    [Fact]
+    public void Config_Outside_Temp_Is_Refused_While_Armed()
+    {
+        Environment.SetEnvironmentVariable(TestConfigGuard.EnvVar, "1");
+        var path = OutsideTemp();
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => TestConfigGuard.AssertUnderTemp(path, "resolved config path"));
+
+        // Both paths and the env var: the reader of the failure is whoever
+        // wrote the harness, and the fix is on their side of the launch.
+        Assert.Contains(TestConfigGuard.EnvVar, ex.Message);
+        Assert.Contains(path, ex.Message);
+        Assert.Contains(Path.GetTempPath(), ex.Message);
+    }
+
+    [Fact]
+    public void Prefix_Sibling_Of_Temp_Is_Not_Under_Temp()
+    {
+        // C:\...\Temp-evil shares every character of the temp prefix; the
+        // separator requirement is what refuses it.
+        var temp = Path.GetTempPath().TrimEnd(
+            Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var sibling = temp + "-evil";
+        Assert.False(TestConfigGuard.IsUnderTemp(sibling));
+        Assert.False(TestConfigGuard.IsUnderTemp(sibling + Path.DirectorySeparatorChar));
+    }
+
+    [Fact]
+    public void Device_Prefix_Cannot_Smuggle_A_Path_Past_The_Compare()
+    {
+        Environment.SetEnvironmentVariable(TestConfigGuard.EnvVar, "1");
+        // The prefix survives Path.GetFullPath; stripping it first is what
+        // keeps this from reading as a path nobody has an opinion about.
+        var smuggled = @"\\?\" + OutsideTemp();
+        Assert.False(TestConfigGuard.IsUnderTemp(smuggled));
+        Assert.Throws<InvalidOperationException>(
+            () => TestConfigGuard.AssertUnderTemp(smuggled, "config write"));
+    }
+
+    [Fact]
+    public void Relative_And_Empty_Paths_Are_Not_Under_Temp()
+    {
+        Environment.SetEnvironmentVariable(TestConfigGuard.EnvVar, "1");
+        Assert.False(TestConfigGuard.IsUnderTemp("wintty-config"));
+        Assert.False(TestConfigGuard.IsUnderTemp(""));
+        Assert.False(TestConfigGuard.IsUnderTemp("   "));
+        Assert.False(TestConfigGuard.IsUnderTemp(@"\absolute-without-drive"));
+    }
+
+    [Fact]
+    public void Mixed_Separators_And_Case_Still_Match_Temp()
+    {
+        // libghostty builds forward-slash paths; ConfigService normalizes
+        // them, but the guard must not depend on that having happened.
+        var temp = Path.GetTempPath().Replace('\\', '/');
+        Assert.True(TestConfigGuard.IsUnderTemp(temp + "wintty-cfg-b2/wintty"));
+
+        var upper = Temp("Wintty-Cfg-C3").ToUpperInvariant();
+        Assert.True(TestConfigGuard.IsUnderTemp(upper));
+    }
+}
+
+/// <summary>
+/// The refusing editor a --no-config run gets: writes are refused loudly,
+/// reads answer as the empty file the rest of that run already serves.
+/// </summary>
+public class NoConfigFileEditorTests
+{
+    private readonly NoConfigFileEditor _editor = new();
+
+    [Fact]
+    public void FilePath_Is_Empty()
+    {
+        Assert.Equal(string.Empty, _editor.FilePath);
+    }
+
+    [Fact]
+    public void Reads_Answer_As_An_Empty_Config()
+    {
+        Assert.Equal(string.Empty, _editor.ReadAll());
+        Assert.Empty(_editor.GetRepeatableValues("keybind"));
+    }
+
+    [Theory]
+    [InlineData("font-size", "12")]
+    public void Writes_Are_Refused_Not_Silently_Dropped(string key, string value)
+    {
+        // A no-op write would tell a user their change persisted; the
+        // refusal is the honest answer, and the debounced scheduler and
+        // the startup migrator log it rather than crash on it.
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => _editor.SetValue(key, value));
+        Assert.Contains("--no-config", ex.Message);
+    }
+
+    [Fact]
+    public void Every_Mutating_Method_Refuses()
+    {
+        Assert.Throws<InvalidOperationException>(() => _editor.RemoveValue("k"));
+        Assert.Throws<InvalidOperationException>(() => _editor.WriteRaw("x = 1"));
+        Assert.Throws<InvalidOperationException>(
+            () => _editor.SetRepeatableValues("k", new[] { "v" }));
+    }
+}

--- a/windows/Ghostty.Tests/Config/TestConfigGuardTests.cs
+++ b/windows/Ghostty.Tests/Config/TestConfigGuardTests.cs
@@ -35,7 +35,7 @@ public class TestConfigGuardTests : IDisposable
 
     private static string Temp(params string[] below)
     {
-        var path = Path.GetTempPath();
+        var path = TestConfigGuard.TempAnchor;
         foreach (var segment in below) path = Path.Combine(path, segment);
         return path;
     }
@@ -88,7 +88,7 @@ public class TestConfigGuardTests : IDisposable
     [Fact]
     public void Temp_Directory_Itself_Counts_As_Under_Temp()
     {
-        Assert.True(TestConfigGuard.IsUnderTemp(Path.GetTempPath()));
+        Assert.True(TestConfigGuard.IsUnderTemp(TestConfigGuard.TempAnchor));
     }
 
     [Fact]
@@ -103,7 +103,7 @@ public class TestConfigGuardTests : IDisposable
         // wrote the harness, and the fix is on their side of the launch.
         Assert.Contains(TestConfigGuard.EnvVar, ex.Message);
         Assert.Contains(path, ex.Message);
-        Assert.Contains(Path.GetTempPath(), ex.Message);
+        Assert.Contains(TestConfigGuard.TempAnchor, ex.Message);
     }
 
     [Fact]
@@ -111,7 +111,7 @@ public class TestConfigGuardTests : IDisposable
     {
         // C:\...\Temp-evil shares every character of the temp prefix; the
         // separator requirement is what refuses it.
-        var temp = Path.GetTempPath().TrimEnd(
+        var temp = TestConfigGuard.TempAnchor.TrimEnd(
             Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         var sibling = temp + "-evil";
         Assert.False(TestConfigGuard.IsUnderTemp(sibling));
@@ -145,11 +145,257 @@ public class TestConfigGuardTests : IDisposable
     {
         // libghostty builds forward-slash paths; ConfigService normalizes
         // them, but the guard must not depend on that having happened.
-        var temp = Path.GetTempPath().Replace('\\', '/');
+        var temp = TestConfigGuard.TempAnchor.Replace('\\', '/');
         Assert.True(TestConfigGuard.IsUnderTemp(temp + "wintty-cfg-b2/wintty"));
 
         var upper = Temp("Wintty-Cfg-C3").ToUpperInvariant();
         Assert.True(TestConfigGuard.IsUnderTemp(upper));
+    }
+
+    // ---- M1: the anchor is the known-folder temp, not the environment --
+
+    [Fact]
+    public void The_Anchor_Ignores_A_Redirected_TEMP_And_TMP()
+    {
+        // The known-folder temp cannot be moved by the process
+        // environment, which is the whole point of anchoring to it: a
+        // harness that repoints TEMP moves Path.GetTempPath(), never this.
+        using var redirect = new TempEnvRedirect("TEMP", OutsideTemp());
+        using var redirect2 = new TempEnvRedirect("TMP", @"C:\");
+
+        var anchor = TestConfigGuard.TempAnchor;
+        Assert.True(string.Equals(
+            Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "Temp"),
+            anchor, StringComparison.OrdinalIgnoreCase), "anchor was " + anchor);
+
+        // The real config stays outside even with TEMP pointed at it...
+        Assert.False(TestConfigGuard.IsUnderTemp(OutsideTemp()));
+        // ...and the real temp tree stays inside even with TEMP elsewhere.
+        Assert.True(TestConfigGuard.IsUnderTemp(Temp("still-inside")));
+    }
+
+    [Theory]
+    [InlineData("TEMP")]
+    [InlineData("TMP")]
+    public void A_Redirected_Temp_Environment_Is_Refused_While_Armed(string name)
+    {
+        Environment.SetEnvironmentVariable(TestConfigGuard.EnvVar, "1");
+        using var redirect = new TempEnvRedirect(name, OutsideTemp());
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => TestConfigGuard.AssertTempEnvironmentIntact());
+        Assert.Contains(name, ex.Message);
+        Assert.Contains(TestConfigGuard.EnvVar, ex.Message);
+    }
+
+    [Fact]
+    public void A_Drive_Root_TEMP_Is_Refused_While_Armed()
+    {
+        Environment.SetEnvironmentVariable(TestConfigGuard.EnvVar, "1");
+        using var redirect = new TempEnvRedirect("TEMP", @"C:\");
+
+        Assert.Throws<InvalidOperationException>(
+            () => TestConfigGuard.AssertTempEnvironmentIntact());
+    }
+
+    [Fact]
+    public void An_Intact_Temp_Environment_Passes_While_Armed()
+    {
+        Environment.SetEnvironmentVariable(TestConfigGuard.EnvVar, "1");
+        using var keepTemp = new TempEnvRedirect("TEMP", TestConfigGuard.TempAnchor);
+        using var keepTmp = new TempEnvRedirect("TMP", TestConfigGuard.TempAnchor);
+
+        TestConfigGuard.AssertTempEnvironmentIntact();
+    }
+
+    [Fact]
+    public void The_Temp_Environment_Is_Never_Questioned_While_Unarmed()
+    {
+        Environment.SetEnvironmentVariable(TestConfigGuard.EnvVar, null);
+        using var redirect = new TempEnvRedirect("TEMP", @"C:\");
+
+        TestConfigGuard.AssertTempEnvironmentIntact();
+    }
+
+    /// <summary>
+    /// Scoped environment mutation: restores the previous value (or removes
+    /// the variable) on dispose, so a failing assert cannot leak state into
+    /// the next test.
+    /// </summary>
+    private sealed class TempEnvRedirect : IDisposable
+    {
+        private readonly string _name;
+        private readonly string? _original;
+
+        public TempEnvRedirect(string name, string value)
+        {
+            _name = name;
+            _original = Environment.GetEnvironmentVariable(name);
+            Environment.SetEnvironmentVariable(name, value);
+        }
+
+        public void Dispose() =>
+            Environment.SetEnvironmentVariable(_name, _original);
+    }
+
+    // ---- M4: reparse points resolve before the compare -----------------
+
+    [Fact]
+    public void A_Junction_Inside_Temp_Pointing_Outside_Is_Refused()
+    {
+        // Junctions need no privilege, so this is the real test the brief
+        // asked for: the bytes a junction carries land outside the temp
+        // tree, and the guard must compare the resolved path, not the
+        // textual one.
+        Environment.SetEnvironmentVariable(TestConfigGuard.EnvVar, "1");
+        var outside = Path.Combine(
+            Path.GetDirectoryName(TestConfigGuard.TempAnchor)!,
+            "wintty-guard-junction-target-" + Guid.NewGuid().ToString("N"));
+        var link = Path.Combine(TestConfigGuard.TempAnchor,
+            "wintty-guard-junction-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outside);
+        var psi = new System.Diagnostics.ProcessStartInfo("cmd.exe")
+        {
+            Arguments = $"/c mklink /J \"{link}\" \"{outside}\"",
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        var mklink = System.Diagnostics.Process.Start(psi)!;
+        Assert.True(mklink.WaitForExit(15000), "mklink /J did not exit");
+        try
+        {
+            Assert.True(Directory.Exists(link),
+                "junction was not created: " + mklink.ExitCode);
+            Assert.False(TestConfigGuard.IsUnderTemp(Path.Combine(link, "wintty")));
+            Assert.Throws<InvalidOperationException>(() =>
+                TestConfigGuard.AssertUnderTemp(
+                    Path.Combine(link, "wintty", "config.wintty"), "config write"));
+        }
+        finally
+        {
+            Directory.Delete(link, recursive: false);
+            Directory.Delete(outside, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void A_Directory_Symlink_Inside_Temp_Pointing_Outside_Is_Refused()
+    {
+        // Symlink creation needs a privilege (or developer mode) the test
+        // host may lack; when it does, this test says so and passes, per
+        // the brief's skip rule. Junctions carry the enforced case above.
+        Environment.SetEnvironmentVariable(TestConfigGuard.EnvVar, "1");
+        var outside = Path.Combine(
+            Path.GetDirectoryName(TestConfigGuard.TempAnchor)!,
+            "wintty-guard-symlink-target-" + Guid.NewGuid().ToString("N"));
+        var link = Path.Combine(TestConfigGuard.TempAnchor,
+            "wintty-guard-symlink-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outside);
+        try
+        {
+            try
+            {
+                Directory.CreateSymbolicLink(link, outside);
+            }
+            catch (IOException)
+            {
+                Assert.True(true,
+                    "symlink creation is unavailable on this host (needs a " +
+                    "privilege); covered by the junction test instead");
+                return;
+            }
+
+            Assert.False(TestConfigGuard.IsUnderTemp(Path.Combine(link, "wintty")));
+        }
+        finally
+        {
+            if (Directory.Exists(link)) Directory.Delete(link, recursive: false);
+            Directory.Delete(outside, recursive: true);
+        }
+    }
+
+    // ---- L2: the xdg.zig mirror ----------------------------------------
+
+    [Fact]
+    public void The_Config_Root_Mirror_Matches_The_Xdg_Zig_Preferences()
+    {
+        // The four combinations that matter, mirroring xdg.zig dir():
+        // a set-but-empty XDG does NOT fall to APPDATA (zig's orelse sees
+        // Some("")), it falls to the home + .config default.
+        using (new ScopedEnv("XDG_CONFIG_HOME", null))
+        {
+            using var appdata = new ScopedEnv("APPDATA", @"C:\Users\u\AppData\Roaming");
+            Assert.True(string.Equals(@"C:\Users\u\AppData\Roaming",
+                TestConfigGuard.ResolveConfigRoot(),
+                StringComparison.OrdinalIgnoreCase));
+        }
+        using (new ScopedEnv("XDG_CONFIG_HOME", @"C:\scratch\xdg"))
+        {
+            Assert.True(string.Equals(@"C:\scratch\xdg",
+                TestConfigGuard.ResolveConfigRoot(),
+                StringComparison.OrdinalIgnoreCase));
+        }
+        using (new ScopedEnv("XDG_CONFIG_HOME", ""))
+        {
+            using var appdata = new ScopedEnv("APPDATA", @"C:\Users\u\AppData\Roaming");
+            Assert.True(string.Equals(
+                Path.Combine(Environment.GetFolderPath(
+                    Environment.SpecialFolder.UserProfile), ".config"),
+                TestConfigGuard.ResolveConfigRoot(),
+                StringComparison.OrdinalIgnoreCase));
+        }
+        using (new ScopedEnv("XDG_CONFIG_HOME", null))
+        {
+            using var appdata = new ScopedEnv("APPDATA", "");
+            Assert.True(string.Equals(
+                Path.Combine(Environment.GetFolderPath(
+                    Environment.SpecialFolder.UserProfile), ".config"),
+                TestConfigGuard.ResolveConfigRoot(),
+                StringComparison.OrdinalIgnoreCase));
+        }
+    }
+
+    [Fact]
+    public void The_Mirror_Is_Pinned_Against_The_Zig_Source_It_Mirrors()
+    {
+        // A hand-maintained mirror rots silently; this reads the actual
+        // xdg.zig and fails when its precedence changes shape, so the C#
+        // and the zig cannot disagree unnoticed.
+        var root = RepoRoot();
+        var zig = File.ReadAllText(Path.Combine(root, "src", "os", "xdg.zig"));
+        Assert.Contains(".windows => environ_map.get(internal_opts.env) orelse environ_map.get(internal_opts.windows_env) orelse \"\"", zig);
+        Assert.Contains("if (env.len > 0)", zig);
+        Assert.Contains("internal_opts.default_subdir", zig);
+    }
+
+    private sealed class ScopedEnv : IDisposable
+    {
+        private readonly string _name;
+        private readonly string? _original;
+
+        public ScopedEnv(string name, string? value)
+        {
+            _name = name;
+            _original = Environment.GetEnvironmentVariable(name);
+            Environment.SetEnvironmentVariable(name, value);
+        }
+
+        public void Dispose() =>
+            Environment.SetEnvironmentVariable(_name, _original);
+    }
+
+    private static string RepoRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir, "build.zig")))
+                return dir;
+            dir = Directory.GetParent(dir)?.FullName;
+        }
+        throw new InvalidOperationException("repo root not found");
     }
 }
 

--- a/windows/Ghostty.Tests/Config/TestConfigGuardTests.cs
+++ b/windows/Ghostty.Tests/Config/TestConfigGuardTests.cs
@@ -145,7 +145,7 @@ public class TestConfigGuardTests : IDisposable
     {
         // libghostty builds forward-slash paths; ConfigService normalizes
         // them, but the guard must not depend on that having happened.
-        var temp = TestConfigGuard.TempAnchor.Replace('\\', '/');
+        var temp = TestConfigGuard.TempAnchor.Replace('\\', '/') + "/";
         Assert.True(TestConfigGuard.IsUnderTemp(temp + "wintty-cfg-b2/wintty"));
 
         var upper = Temp("Wintty-Cfg-C3").ToUpperInvariant();

--- a/windows/Ghostty.Tests/Wiring/HarnessConfigIsolationScanTests.cs
+++ b/windows/Ghostty.Tests/Wiring/HarnessConfigIsolationScanTests.cs
@@ -21,28 +21,28 @@ namespace Ghostty.Tests.Wiring;
 /// property being pinned (a visible token next to a visible launch) is
 /// exactly what a reader of the harness needs to see anyway.
 ///
-/// A file passes when ANY of these hold:
-/// <list type="number">
-/// <item>it assigns <c>WINTTY_TEST_CONFIG</c> on a non-comment line (the
-/// app then polices the root itself at run time, so an arming script can
-/// never silently taint);</item>
-/// <item>it goes through a helper that owns the arming:
-/// <c>Enter-WinttyTestConfig</c> (lib/test-config.ps1) or
-/// <c>Start-SeamSession</c> (lib/seam-client.ps1);</item>
-/// <item>it is on the allowlist below, each entry with its reason.</item>
-/// </list>
+/// A LAUNCH SITE is clean when the file arms the guard UNCONDITIONALLY at
+/// an earlier position: an arming line inside an if/else/switch blesses
+/// nothing (that was the -RealConfig hole: one armed branch blessed the
+/// unarmed branch of the same file). Arming inside a function or loop is
+/// fine; those always run.
+///
+/// The launch forms are held honest by a synthetic fixture corpus
+/// (<c>ScanFixtures/</c>): every fixture named <c>violation-*.ps1</c> must
+/// be flagged, every <c>clean-*.ps1</c> must not be, so a form going
+/// invisible again fails the suite instead of quietly narrowing coverage.
 ///
 /// The allowlist bar: the launch must be provably unable to reach the
 /// config, or provably not a test. "Stable when unisolated" is not on the
-/// bar; that argument is what opted-in isolation was for, and the default
-/// is isolated now.
+/// bar.
 /// </summary>
 public class HarnessConfigIsolationScanTests
 {
     /// <summary>
-    /// Launchers that never touch config state, with the proof. Adding an
-    /// entry means claiming the launch cannot read, create or write the
-    /// config; the burden is on the entry, not on the scan.
+    /// Launchers that never touch config state, or are not tests, each
+    /// with the proof. Adding an entry means claiming the launch cannot
+    /// read, create or write the config, or is the deliberate user
+    /// launcher; the burden is on the entry, not on the scan.
     /// </summary>
     private static readonly Dictionary<string, string> Allowlist = new()
     {
@@ -51,45 +51,91 @@ public class HarnessConfigIsolationScanTests
         // crash reporting probes only exercise the failure backend.
         ["crash-canary.ps1"] = "+crash exits before InitGhostty; config is never reached",
         ["crash-matrix.ps1"] = "+crash exits before InitGhostty; config is never reached",
+
+        // The USER launcher behind run-win/run-win-release (founder rule):
+        // real config by default for humans, ISOLATED_CONFIG=1 opt-in,
+        // isolated by default inside an agent session (CLAUDECODE), and
+        // REAL_CONFIG=1 as a loud, interactively-confirmed override. Its
+        // modes are pinned by Run_Win_Launcher_Pins_The_Founder_Rule; a
+        // scan pass cannot express "armed except in one deliberate mode",
+        // and the user launcher must keep its unarmed human default.
+        ["run-win-launch.ps1"] = "user launcher; modes pinned by Run_Win_Launcher tests",
+    };
+
+    // ---- launch-form detection -----------------------------------------
+
+    /// <summary>
+    /// Every verb shape that can start the app. The call-operator,
+    /// ::Start, Invoke-Item, cmd start, explorer and dotnet-run forms were
+    /// all invisible to the first scan revision and each has a fixture.
+    /// </summary>
+    private static readonly Regex[] LaunchVerbs =
+    {
+        new(@"Start-Process", RegexOptions.Compiled),
+        new(@"ProcessStartInfo", RegexOptions.Compiled),
+        new(@"Process\]::Start\(", RegexOptions.Compiled),
+        new(@"Process\.Start\(", RegexOptions.Compiled),
+        new(@"Invoke-Item", RegexOptions.Compiled),
+        new(@"(?<!\S)&\s*\$", RegexOptions.Compiled),
+        new(@"explorer\.exe", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+        new(@"\bcmd\b.*\bstart\b", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+        new(@"dotnet\s+run", RegexOptions.Compiled | RegexOptions.IgnoreCase),
     };
 
     /// <summary>
-    /// No justfile allowlist, on purpose. run-win and run-win-release are
-    /// the USER launcher (founder rule): real config by default for humans,
-    /// ISOLATED_CONFIG=1 to opt into a random temp root, isolated by
-    /// default inside an agent session (CLAUDECODE), REAL_CONFIG=1 to
-    /// override loudly. All of that lives in run-win-launch.ps1, which this
-    /// scan counts as armed because it contains the arming path. A bare
-    /// `./Wintty.exe` line in any recipe would bypass the agent-session
-    /// default, which is the exact April-taint path the launcher exists to
-    /// close, so it must fail this scan rather than be allowlisted.
-    /// </summary>
-
-    private static readonly Regex LaunchKeyword = new(
-        @"Start-Process|ProcessStartInfo", RegexOptions.Compiled);
-
-    /// <summary>
     /// A variable whose name mentions the exe: $ExePath, $exe, $Exe,
-    /// $WinttyExe, $script:ExeFull. What it deliberately does not match:
-    /// $cdb (a debugger), $pwsh, $argLine, $ProcId. Detecting the launch
-    /// of the app is what the scan is for; launches of tooling are not
-    /// app launches even when they sit on the same line.
+    /// $WinttyExe, $script:ExeFull.
     /// </summary>
-    private static readonly Regex AppExeToken = new(
+    private static readonly Regex ExeNamedVar = new(
         @"\$[A-Za-z0-9_:.]*[Ee]xe[A-Za-z0-9_]*", RegexOptions.Compiled);
 
     /// <summary>
-    /// An arming assignment on a code line:
-    /// <c>$env:WINTTY_TEST_CONFIG = '1'</c> or
-    /// <c>$psi.EnvironmentVariables['WINTTY_TEST_CONFIG'] = '1'</c>.
-    /// Requiring the <c>=</c> keeps prose mentions of the variable from
-    /// reading as arming.
+    /// The app's own binary, spelled literally (the only spellings this
+    /// product ships). Tooling literals (pwsh, cdb, wsl...) are NOT app
+    /// launches and are excluded during target resolution.
     /// </summary>
+    private static readonly Regex AppLiteral = new(
+        @"(?i)(wintty|ghostty)\.exe", RegexOptions.Compiled);
+
+    private static readonly Regex ProjectReference = new(
+        @"(?i)wintty|ghostty", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Tooling binaries a harness legitimately launches: shells, the
+    /// debugger, and this repo's own capture helpers. A resolved target
+    /// matching one of these is not an app launch.
+    /// </summary>
+    private static readonly Regex ToolingLiteral = new(
+        @"(?i)\b(pwsh|powershell|cmd|wsl|cdb|windbg|procdump|python|py|node|npm|git|msbuild|bash|tar|curl|robocopy|xcopy|backdropstage|windowcapture|ffmpeg)\.(exe|com|bat|cmd)\b",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// A tooling name as a bare quoted value ($psi.FileName = 'pwsh'),
+    /// the spelling the ProcessStartInfo helpers use.
+    /// </summary>
+    private static readonly Regex ToolingBareQuoted = new(
+        @"^\s*['"](pwsh|powershell|cmd|wsl|cdb|windbg|procdump|python|node|npm|git|msbuild|bash)['"]\s*$",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// Quoted spans, removed before verb matching so a manifest prose
+    /// string mentioning "cmd" and "start" is not read as a launch.
+    /// Target evidence still sees the raw line, because the app exe
+    /// arrives quoted more often than not.
+    /// </summary>
+    private static readonly Regex QuotedSpan = new(
+        @"'[^']*'|"[^"]*"", RegexOptions.Compiled);
+
+    private static readonly Regex AnyVar = new(@"\$(\w+)", RegexOptions.Compiled);
+
     private static readonly Regex ArmingLine = new(
         @"WINTTY_TEST_CONFIG['\]\s]*=", RegexOptions.Compiled);
 
     private static readonly Regex HelperCall = new(
         @"Enter-WinttyTestConfig|Start-SeamSession", RegexOptions.Compiled);
+
+    private static readonly Regex ConditionalHeader = new(
+        @"^\s*(if|elseif|else|switch)\b", RegexOptions.Compiled);
 
     private static bool IsCode(string line)
     {
@@ -97,22 +143,267 @@ public class HarnessConfigIsolationScanTests
         return trimmed.Length > 0 && trimmed[0] != '#';
     }
 
-    private sealed record Launch(string File, int Line, string Text);
+    private sealed record LaunchSite(string File, int Line, string Text);
 
-    private static IEnumerable<Launch> AppLaunches(string file, string[] lines)
+    /// <summary>
+    /// Whether the target a launch line names is the app. Resolution
+    /// follows same-line evidence first (an exe-named variable, a literal
+    /// app path), then the variable's assignment or the psi FileName /
+    /// FilePath property assignments, so a harness that launches through
+    /// an intermediate variable is judged by what the variable holds.
+    /// Anything the rules cannot resolve fails CLOSED: the harness must
+    /// name its target legibly or arm the guard, and an unresolved launch
+    /// is flagged rather than trusted.
+    /// </summary>
+    private static bool TargetsApp(
+        string line, string[] lines, Dictionary<string, List<string>> functions,
+        bool callOperatorOnly)
     {
+        // Target evidence reads the raw line: the app exe arrives quoted
+        // more often than not.
+        if (AppLiteral.IsMatch(line)) return true;
+        if (Regex.IsMatch(line, @"dotnet\s+run", RegexOptions.IgnoreCase) &&
+            ProjectReference.IsMatch(line)) return true;
+
+        var stripped = QuotedSpan.Replace(line, "");
+        var sawAny = false;
+        var sawApp = false;
+        var sawTooling = false;
+        var sawEvidence = false;
+
+        foreach (var name in AnyVar.Matches(stripped)
+                     .Cast<System.Text.RegularExpressions.Match>()
+                     .Select(m => m.Groups[1].Value)
+                     .Distinct())
+        {
+            sawAny = true;
+            var evidence = new List<string>();
+            evidence.AddRange(DefinitionsOf(lines, name)
+                .Select(d => d.Rhs));
+            evidence.AddRange(PropertyTargets(lines, name));
+
+            // Follow in-file functions the definitions call, and one level
+            // of variable indirection (psi -> FileName = $exe -> $exe's
+            // definitions), the shape lib/backdrop-stage.ps1 uses to reach
+            // its own built helper exe.
+            for (var hop = 0; hop < 2; hop++)
+            {
+                foreach (var value in evidence.ToList())
+                {
+                    foreach (var (function, body) in functions)
+                        if (value.Contains(function, StringComparison.Ordinal))
+                            evidence.AddRange(body);
+                    var indirect = Regex.Match(value, @"^\s*\$([A-Za-z_]\w*)\s*$");
+                    if (indirect.Success)
+                    {
+                        evidence.AddRange(DefinitionsOf(lines,
+                            indirect.Groups[1].Value).Select(d => d.Rhs));
+                        evidence.AddRange(PropertyTargets(lines,
+                            indirect.Groups[1].Value));
+                    }
+                }
+            }
+
+            foreach (var value in evidence)
+            {
+                if (AppLiteral.IsMatch(value)) sawApp = true;
+                else if (ToolingLiteral.IsMatch(value) ||
+                         ToolingBareQuoted.IsMatch(value))
+                    sawTooling = true;
+            }
+            if (evidence.Count > 0) sawEvidence = true;
+        }
+
+        if (sawApp) return true;
+        if (sawTooling) return false;
+        if (!sawAny) return false;
+
+        // No app and no tooling evidence: the variable's own name decides,
+        // except the call-operator form, which is how scriptblocks are
+        // invoked and needs positive evidence.
+        if (callOperatorOnly) return false;
+        if (sawEvidence) return true;
+        return AnyVar.Matches(stripped)
+            .Cast<System.Text.RegularExpressions.Match>()
+            .Select(m => m.Groups[1].Value)
+            .Any(n => ExeNamedVar.IsMatch("$" + n));
+    }
+
+    private static string StripLiterals(string line) =>
+        QuotedSpan.Replace(line, "");
+
+    private static Dictionary<string, List<string>> FunctionBodiesFor(
+        string[] lines)
+    {
+        var bodies = new Dictionary<string, List<string>>();
+        string? current = null;
+        foreach (var line in lines)
+        {
+            var header = FunctionDef.Match(line);
+            if (header.Success)
+            {
+                current = header.Groups[1].Value;
+                bodies[current] = new List<string>();
+                continue;
+            }
+            if (current is not null) bodies[current].Add(line);
+        }
+        return bodies;
+    }
+
+    private static List<(int Line, string Rhs)> DefinitionsOf(
+        string[] lines, string name)
+    {
+        // One pattern covers both plain assignments and parameter defaults
+        // (`[string]$OutDir = ...`).
+        var definition = new Regex(
+            @"^\s*(?:\[[^\]]*\]\s*)?\$" + Regex.Escape(name) +
+            @"\s*=\s*(.+?)(?:\s*#.*)?$");
+        var found = new List<(int, string)>();
+        for (var i = 0; i < lines.Length; i++)
+        {
+            if (!IsCode(lines[i])) continue;
+            var m = definition.Match(lines[i]);
+            if (m.Success) found.Add((i + 1, m.Groups[1].Value));
+        }
+        return found;
+    }
+
+    private static List<string> PropertyTargets(string[] lines, string name)
+    {
+        var pattern = new Regex(
+            @"\$" + Regex.Escape(name) + @"\.(?:FileName|FilePath)\s*=\s*(.+?)(?:\s*#.*)?$");
+        var found = new List<string>();
+        for (var i = 0; i < lines.Length; i++)
+        {
+            if (!IsCode(lines[i])) continue;
+            var m = pattern.Match(lines[i]);
+            if (m.Success) found.Add(m.Groups[1].Value);
+        }
+        return found;
+    }
+
+    /// <summary>
+    /// The positions of arming lines (env assignment or helper call) that
+    /// run unconditionally: inside a function or a loop is unconditional,
+    /// inside an if/else/switch is not. Tracked with a brace stack keyed
+    /// by the block-opening keyword; hashtable and scriptblock braces
+    /// count as their own non-conditional kind, and here-strings are
+    /// skipped entirely (their C#/JSON braces are not code).
+    /// </summary>
+    private static HashSet<int> UnconditionalArmLines(string[] lines)
+    {
+        var result = new HashSet<int>();
+        var blocks = new Stack<string>();
+        var pendingConditional = false;
+        var inHereString = false;
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i];
+
+            if (inHereString)
+            {
+                var trimmed = line.TrimStart();
+                if (trimmed.StartsWith("'@") || trimmed.StartsWith("\"@"))
+                    inHereString = false;
+                continue;
+            }
+
+            var hereStringOpener = line.IndexOf("@'", StringComparison.Ordinal);
+            if (hereStringOpener < 0)
+                hereStringOpener = line.IndexOf("@\"", StringComparison.Ordinal);
+            if (hereStringOpener >= 0)
+            {
+                // A here-string opened and terminated on the same line is
+                // ordinary code; one still open skips to its terminator.
+                var opener = line.Contains("@'") ? "'@" : "\"@";
+                var terminator = line.IndexOf(opener, hereStringOpener + 2,
+                    StringComparison.Ordinal);
+                if (terminator < 0) inHereString = true;
+                continue;
+            }
+
+            if (IsCode(line))
+            {
+                var conditionalHere =
+                    ConditionalHeader.IsMatch(line) || blocks.Contains("cond");
+                if ((ArmingLine.IsMatch(line) || HelperCall.IsMatch(line)) &&
+                    !conditionalHere)
+                {
+                    result.Add(i);
+                }
+            }
+
+            // Track block nesting for the NEXT lines' conditionality.
+            pendingConditional = ConditionalHeader.IsMatch(line);
+            foreach (var c in line)
+            {
+                if (c == '{')
+                {
+                    blocks.Push(pendingConditional ? "cond" : "other");
+                    pendingConditional = false;
+                }
+                else if (c == '}')
+                {
+                    if (blocks.Count > 0) blocks.Pop();
+                }
+            }
+            pendingConditional = false;
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Every launch site in a file whose target resolves to the app and
+    /// that no unconditional arming line precedes.
+    /// </summary>
+    private static List<LaunchSite> UnarmedLaunches(string rel, string[] lines)
+    {
+        var found = new List<LaunchSite>();
+        if (lines.Length == 0) return found;
+        var arms = UnconditionalArmLines(lines);
+        var functions = FunctionBodiesFor(lines);
+
         for (var i = 0; i < lines.Length; i++)
         {
             var line = lines[i];
             if (!IsCode(line)) continue;
-            if (!LaunchKeyword.IsMatch(line)) continue;
-            if (!AppExeToken.IsMatch(line)) continue;
-            yield return new Launch(file, i + 1, line.Trim());
+
+            // The verb must survive literal stripping: a manifest prose
+            // string that mentions "cmd" and "start" is not a launch.
+            var stripped = StripLiterals(line);
+            var matching = LaunchVerbs.Where(v => v.IsMatch(line)).ToList();
+            if (matching.Count == 0) continue;
+            if (!matching.Any(v => v.IsMatch(stripped))) continue;
+
+            var callOperatorOnly = matching.Count == 1 &&
+                matching[0].ToString().Contains("&");
+            if (!TargetsApp(line, lines, functions, callOperatorOnly))
+                continue;
+
+            // An arm later in the file blesses nothing, and one inside a
+            // conditional blesses nothing at all.
+            if (arms.Any(j => j < i)) continue;
+
+            found.Add(new LaunchSite(rel, i + 1, line.Trim()));
         }
+
+        return found;
     }
 
-    private static bool FileIsClean(string[] lines) =>
-        lines.Any(l => IsCode(l) && (ArmingLine.IsMatch(l) || HelperCall.IsMatch(l)));
+    private static string RepoRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir, "build.zig")))
+                return dir;
+            dir = Directory.GetParent(dir)?.FullName;
+        }
+        throw new InvalidOperationException("repo root not found");
+    }
 
     [Fact]
     public void Every_App_Launch_In_Scripts_Arms_The_Test_Config_Guard()
@@ -133,18 +424,17 @@ public class HarnessConfigIsolationScanTests
             var rel = Path.GetRelativePath(scriptDir, file);
             var name = Path.GetFileName(file);
             var lines = File.ReadAllLines(file);
-            if (FileIsClean(lines)) continue;
 
             if (Allowlist.TryGetValue(name, out var reason))
             {
                 // Still prove the file launches the app the allowlist says
                 // it does; an allowlisted name that stopped launching would
                 // silently keep covering whatever replaced it.
-                Assert.NotEmpty(AppLaunches(rel, lines));
+                Assert.NotEmpty(UnarmedLaunches(rel, lines));
                 continue;
             }
 
-            violations.AddRange(AppLaunches(rel, lines)
+            violations.AddRange(UnarmedLaunches(rel, lines)
                 .Select(l => $"{l.File}:{l.Line}: {l.Text}"));
         }
 
@@ -153,134 +443,65 @@ public class HarnessConfigIsolationScanTests
             "app launch(es) that neither arm WINTTY_TEST_CONFIG nor go through " +
             "an isolated-config helper (lib/test-config.ps1 or lib/seam-client.ps1). " +
             "Stage a random temp XDG root and set WINTTY_TEST_CONFIG=1 for the " +
-            "child, or add a justified allowlist entry:\n  " +
-            string.Join("\n  ", violations));
+            "child (unconditionally, before the launch), or add a justified " +
+            "allowlist entry:\n  " + string.Join("\n  ", violations));
     }
 
+    /// <summary>
+    /// The synthetic corpus: every launch form the scan claims to see, as
+    /// a fixture that MUST be flagged, plus the shapes that must NOT be.
+    /// If a form goes invisible (a regex narrows, a verb is forgotten),
+    /// its fixture stops being flagged and this fails naming it.
+    /// </summary>
     [Fact]
-    public void Justfile_Recipes_Execute_The_Exe_Only_Through_A_Launcher()
+    public void The_Scan_Still_Sees_Every_Launch_Form()
     {
         var root = RepoRoot();
-        var path = Path.Combine(root, "justfile");
-        Assert.True(File.Exists(path), "justfile not found");
+        var fixtureDir = Path.Combine(
+            root, "windows", "Ghostty.Tests", "Wiring", "ScanFixtures");
+        Assert.True(Directory.Exists(fixtureDir), "ScanFixtures not found");
 
-        var violations = new List<string>();
-        var recipe = "?";
-        foreach (var (line, index) in File.ReadAllLines(path)
-                     .Select((l, i) => (l, i)))
+        var expectedViolations = new HashSet<string>(StringComparer.Ordinal)
         {
-            var recipeHeader = Regex.Match(line, @"^([A-Za-z][\w-]*):");
-            if (recipeHeader.Success)
-            {
-                recipe = recipeHeader.Groups[1].Value;
-                continue;
-            }
+            "violation-call-operator.ps1",
+            "violation-invoke-item.ps1",
+            "violation-process-start-static.ps1",
+            "violation-literal-start-process.ps1",
+            "violation-cmd-start.ps1",
+            "violation-explorer.ps1",
+            "violation-dotnet-run.ps1",
+            "violation-psi-indirect-var.ps1",
+            "violation-psi-indirect-literal.ps1",
+            "violation-unresolved-var.ps1",
+            "violation-conditional-arm.ps1",
+        };
+        var expectedClean = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "clean-armed-launch.ps1",
+            "clean-tooling-psi.ps1",
+            "clean-tooling-debugger.ps1",
+        };
 
-            var trimmed = line.Trim();
-            if (trimmed.Length == 0 || trimmed.StartsWith('#')) continue;
-
-            // The exe as the line's first token is a direct execution; the
-            // same path as an argument (-ExePath ...) is a script's input
-            // and that script's own scan governs it.
-            var firstToken = trimmed.Split(' ')[0];
-            if (!firstToken.EndsWith("Wintty.exe", StringComparison.OrdinalIgnoreCase))
-                continue;
-
-            violations.Add($"justfile:{index + 1} (recipe {recipe}): {trimmed}");
+        var flagged = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var file in Directory.EnumerateFiles(fixtureDir, "*.ps1")
+                     .OrderBy(f => f, StringComparer.Ordinal))
+        {
+            var name = Path.GetFileName(file);
+            if (UnarmedLaunches(name, File.ReadAllLines(file)).Count > 0)
+                flagged.Add(name);
         }
 
+        var missing = expectedViolations.Except(flagged).ToList();
         Assert.True(
-            violations.Count == 0,
-            "justfile executes the app outside a launcher script. Tests arm " +
-            "WINTTY_TEST_CONFIG through their harness; the user launcher " +
-            "(run-win / run-win-release) routes through run-win-launch.ps1, " +
-            "which isolates agent sessions by default. A bare exec line " +
-            "bypasses both:\n  " + string.Join("\n  ", violations));
-    }
+            missing.Count == 0,
+            "launch form(s) the scan can no longer see (the fixture is not " +
+            "flagged): " + string.Join(", ", missing));
 
-    [Fact]
-    public void Run_Win_Recipes_Route_Through_The_User_Launcher_Script()
-    {
-        var root = RepoRoot();
-        var justfile = File.ReadAllLines(Path.Combine(root, "justfile"));
-
-        foreach (var recipe in new[] { "run-win", "run-win-release" })
-        {
-            var start = Array.FindIndex(justfile,
-                l => l.StartsWith(recipe + ":", StringComparison.Ordinal));
-            Assert.True(start >= 0, $"no recipe '{recipe}' in the justfile");
-
-            var body = new List<string>();
-            for (var i = start + 1; i < justfile.Length; i++)
-            {
-                var line = justfile[i];
-                if (Regex.IsMatch(line, @"^[A-Za-z][\w-]*:") || line.StartsWith('['))
-                    break;
-                body.Add(line);
-            }
-
-            Assert.Contains(body, l =>
-                l.Contains("run-win-launch.ps1", StringComparison.Ordinal) &&
-                !l.TrimStart().StartsWith('#'));
-        }
-    }
-
-    [Fact]
-    public void Run_Win_Launcher_Pins_The_Founder_Rule_For_The_User_Launcher()
-    {
-        var root = RepoRoot();
-        var path = Path.Combine(root, "windows", "scripts", "run-win-launch.ps1");
-        Assert.True(File.Exists(path),
-            "run-win-launch.ps1 not found; the run-win recipes depend on it");
-
-        var lines = File.ReadAllLines(path);
-        var text = string.Join('\n', lines);
-
-        // The four markers of the rule: the explicit opt-ins, the agent
-        // detector, and the guard's own variable.
-        foreach (var marker in new[] { "CLAUDECODE", "ISOLATED_CONFIG",
-                                       "REAL_CONFIG", "WINTTY_TEST_CONFIG" })
-        {
-            Assert.Contains(lines, l =>
-                IsCode(l) && l.Contains(marker, StringComparison.Ordinal));
-        }
-
-        // Isolation rides the same helper every harness uses, and the mode
-        // resolution is a function the harness side can probe without
-        // launching anything.
-        Assert.Contains(lines, l =>
-            IsCode(l) && l.Contains("Enter-WinttyTestConfig", StringComparison.Ordinal));
-        Assert.Contains("function Get-RunWinMode", text,
-            StringComparison.Ordinal);
-
-        // Precedence, pinned by position inside the mode function: an
-        // explicit REAL_CONFIG beats everything, an explicit ISOLATED_CONFIG
-        // beats the agent default, and CLAUDECODE only fills the default.
-        // If the checks are reordered, this fails.
-        var functionStart = text.IndexOf("function Get-RunWinMode", StringComparison.Ordinal);
-        var functionEnd = text.IndexOf("function ", functionStart + 1, StringComparison.Ordinal);
-        if (functionEnd < 0) functionEnd = text.Length;
-        var body = text[functionStart..functionEnd];
-        var real = body.IndexOf("REAL_CONFIG", StringComparison.Ordinal);
-        var isolated = body.IndexOf("ISOLATED_CONFIG", StringComparison.Ordinal);
-        var agent = body.IndexOf("CLAUDECODE", StringComparison.Ordinal);
-        Assert.True(real >= 0 && isolated > real && agent > isolated,
-            "Get-RunWinMode must check REAL_CONFIG before ISOLATED_CONFIG " +
-            "before CLAUDECODE; found at " + $"{real}/{isolated}/{agent}");
-
-        // REAL_CONFIG is the one spelling that runs the app against the
-        // user's real config from inside an agent session, so it must be
-        // announced loudly, not accepted in silence.
-        Assert.Contains(lines, l =>
-            IsCode(l) &&
-            l.Contains("REAL_CONFIG", StringComparison.Ordinal) &&
-            l.Contains("ForegroundColor Red", StringComparison.Ordinal));
-
-        // The window outlives the recipe: exiting the test-config session
-        // would delete the root the live app is still holding. The helper's
-        // 24h sweep is what reaps it instead.
-        Assert.DoesNotContain(lines, l =>
-            IsCode(l) && l.Contains("Exit-WinttyTestConfig", StringComparison.Ordinal));
+        var falseFlags = expectedClean.Intersect(flagged).ToList();
+        Assert.True(
+            falseFlags.Count == 0,
+            "shape(s) the scan flags that must stay clean: " +
+            string.Join(", ", falseFlags));
     }
 
     /// <summary>
@@ -306,29 +527,6 @@ public class HarnessConfigIsolationScanTests
 
     private static readonly Regex FunctionDef = new(
         @"^\s*function\s+([\w-]+)", RegexOptions.Compiled);
-
-    /// <summary>
-    /// A variable's definitions: plain assignments and parameter defaults
-    /// (`[string]$OutDir = ...`), which is where the fixed staging names
-    /// lived.
-    /// </summary>
-    private static List<(int Line, string Rhs)> DefinitionsOf(
-        string[] lines, string name)
-    {
-        // One pattern covers both plain assignments and parameter defaults
-        // (`[string]$OutDir = ...`), which is where the fixed names lived.
-        var definition = new Regex(
-            @"^\s*(?:\[[^\]]*\]\s*)?\$" + Regex.Escape(name) +
-            @"\s*=\s*(.+?)(?:\s*#.*)?$");
-        var found = new List<(int, string)>();
-        for (var i = 0; i < lines.Length; i++)
-        {
-            if (!IsCode(lines[i])) continue;
-            var m = definition.Match(lines[i]);
-            if (m.Success) found.Add((i + 1, m.Groups[1].Value));
-        }
-        return found;
-    }
 
     /// <summary>
     /// The function bodies of one file, for following a helper that builds
@@ -483,6 +681,143 @@ public class HarnessConfigIsolationScanTests
     }
 
     [Fact]
+    public void Justfile_Recipes_Execute_The_Exe_Only_Through_A_Launcher()
+    {
+        var root = RepoRoot();
+        var path = Path.Combine(root, "justfile");
+        Assert.True(File.Exists(path), "justfile not found");
+
+        var violations = new List<string>();
+        var recipe = "?";
+        foreach (var (line, index) in File.ReadAllLines(path)
+                     .Select((l, i) => (l, i)))
+        {
+            var recipeHeader = Regex.Match(line, @"^([A-Za-z][\w-]*):");
+            if (recipeHeader.Success)
+            {
+                recipe = recipeHeader.Groups[1].Value;
+                continue;
+            }
+
+            var trimmed = line.Trim();
+            if (trimmed.Length == 0 || trimmed.StartsWith('#')) continue;
+
+            // The exe as the line's first token is a direct execution; the
+            // same path as an argument (-ExePath ...) is a script's input
+            // and that script's own scan governs it.
+            var firstToken = trimmed.Split(' ')[0];
+            if (!firstToken.EndsWith("Wintty.exe", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            violations.Add($"justfile:{index + 1} (recipe {recipe}): {trimmed}");
+        }
+
+        Assert.True(
+            violations.Count == 0,
+            "justfile executes the app outside a launcher script. Tests arm " +
+            "WINTTY_TEST_CONFIG through their harness; the user launcher " +
+            "(run-win / run-win-release) routes through run-win-launch.ps1, " +
+            "which isolates agent sessions by default. A bare exec line " +
+            "bypasses both:\n  " + string.Join("\n  ", violations));
+    }
+
+    [Fact]
+    public void Run_Win_Recipes_Route_Through_The_User_Launcher_Script()
+    {
+        var root = RepoRoot();
+        var justfile = File.ReadAllLines(Path.Combine(root, "justfile"));
+
+        foreach (var recipe in new[] { "run-win", "run-win-release" })
+        {
+            var start = Array.FindIndex(justfile,
+                l => l.StartsWith(recipe + ":", StringComparison.Ordinal));
+            Assert.True(start >= 0, $"no recipe '{recipe}' in the justfile");
+
+            var body = new List<string>();
+            for (var i = start + 1; i < justfile.Length; i++)
+            {
+                var line = justfile[i];
+                if (Regex.IsMatch(line, @"^[A-Za-z][\w-]*:") || line.StartsWith('['))
+                    break;
+                body.Add(line);
+            }
+
+            Assert.Contains(body, l =>
+                l.Contains("run-win-launch.ps1", StringComparison.Ordinal) &&
+                !l.TrimStart().StartsWith('#'));
+        }
+    }
+
+    [Fact]
+    public void Run_Win_Launcher_Pins_The_Founder_Rule_For_The_User_Launcher()
+    {
+        var root = RepoRoot();
+        var path = Path.Combine(root, "windows", "scripts", "run-win-launch.ps1");
+        Assert.True(File.Exists(path),
+            "run-win-launch.ps1 not found; the run-win recipes depend on it");
+
+        var lines = File.ReadAllLines(path);
+        var text = string.Join('\n', lines);
+
+        // The four markers of the rule: the explicit opt-ins, the agent
+        // detector, and the guard's own variable.
+        foreach (var marker in new[] { "CLAUDECODE", "ISOLATED_CONFIG",
+                                       "REAL_CONFIG", "WINTTY_TEST_CONFIG" })
+        {
+            Assert.Contains(lines, l =>
+                IsCode(l) && l.Contains(marker, StringComparison.Ordinal));
+        }
+
+        // Isolation rides the same helper every harness uses, and the mode
+        // resolution is a function the harness side can probe without
+        // launching anything.
+        Assert.Contains(lines, l =>
+            IsCode(l) && l.Contains("Enter-WinttyTestConfig", StringComparison.Ordinal));
+        Assert.Contains("function Get-RunWinMode", text,
+            StringComparison.Ordinal);
+
+        // Precedence, pinned by position inside the mode function: an
+        // explicit REAL_CONFIG beats everything, an explicit ISOLATED_CONFIG
+        // beats the agent default, and CLAUDECODE only fills the default.
+        // If the checks are reordered, this fails.
+        var functionStart = text.IndexOf("function Get-RunWinMode", StringComparison.Ordinal);
+        var functionEnd = text.IndexOf("function ", functionStart + 1, StringComparison.Ordinal);
+        if (functionEnd < 0) functionEnd = text.Length;
+        var body = text[functionStart..functionEnd];
+        var real = body.IndexOf("REAL_CONFIG", StringComparison.Ordinal);
+        var isolated = body.IndexOf("ISOLATED_CONFIG", StringComparison.Ordinal);
+        var agent = body.IndexOf("CLAUDECODE", StringComparison.Ordinal);
+        Assert.True(real >= 0 && isolated > real && agent > isolated,
+            "Get-RunWinMode must check REAL_CONFIG before ISOLATED_CONFIG " +
+            "before CLAUDECODE; found at " + $"{real}/{isolated}/{agent}");
+
+        // REAL_CONFIG is the one spelling that runs the app against the
+        // user's real config from inside an agent session, so it must be
+        // announced loudly, not accepted in silence.
+        Assert.Contains(lines, l =>
+            IsCode(l) &&
+            l.Contains("REAL_CONFIG", StringComparison.Ordinal) &&
+            l.Contains("ForegroundColor Red", StringComparison.Ordinal));
+
+        // ...and, inside an agent session, confirmed by a human at the
+        // keyboard: a typed REAL. A non-interactive console (every agent
+        // shell) must refuse instead.
+        Assert.Contains(lines, l =>
+            IsCode(l) && l.Contains("Read-Host", StringComparison.Ordinal));
+        Assert.Contains(lines, l =>
+            IsCode(l) && l.Contains("IsInputRedirected", StringComparison.Ordinal));
+        Assert.Contains(lines, l =>
+            IsCode(l) && l.Contains("cannot be used from an agent session",
+                StringComparison.Ordinal));
+
+        // The window outlives the recipe: exiting the test-config session
+        // would delete the root the live app is still holding. The helper's
+        // 24h sweep is what reaps it instead.
+        Assert.DoesNotContain(lines, l =>
+            IsCode(l) && l.Contains("Exit-WinttyTestConfig", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Seam_Client_Itself_Arms_The_Guard()
     {
         // Every Start-SeamSession consumer leans on this one file to arm,
@@ -495,17 +830,5 @@ public class HarnessConfigIsolationScanTests
 
         Assert.Contains(File.ReadAllLines(path),
             l => IsCode(l) && ArmingLine.IsMatch(l));
-    }
-
-    private static string RepoRoot()
-    {
-        var dir = AppContext.BaseDirectory;
-        while (dir is not null)
-        {
-            if (File.Exists(Path.Combine(dir, "build.zig")))
-                return dir;
-            dir = Directory.GetParent(dir)?.FullName;
-        }
-        throw new InvalidOperationException("repo root not found");
     }
 }

--- a/windows/Ghostty.Tests/Wiring/HarnessConfigIsolationScanTests.cs
+++ b/windows/Ghostty.Tests/Wiring/HarnessConfigIsolationScanTests.cs
@@ -114,7 +114,7 @@ public class HarnessConfigIsolationScanTests
     /// the spelling the ProcessStartInfo helpers use.
     /// </summary>
     private static readonly Regex ToolingBareQuoted = new(
-        @"^\s*['"](pwsh|powershell|cmd|wsl|cdb|windbg|procdump|python|node|npm|git|msbuild|bash)['"]\s*$",
+        "^\\s*['\"](pwsh|powershell|cmd|wsl|cdb|windbg|procdump|python|node|npm|git|msbuild|bash)['\"]\\s*$",
         RegexOptions.Compiled);
 
     /// <summary>
@@ -124,7 +124,7 @@ public class HarnessConfigIsolationScanTests
     /// arrives quoted more often than not.
     /// </summary>
     private static readonly Regex QuotedSpan = new(
-        @"'[^']*'|"[^"]*"", RegexOptions.Compiled);
+        "'[^']*'|\"[^\"]*\"", RegexOptions.Compiled);
 
     private static readonly Regex AnyVar = new(@"\$(\w+)", RegexOptions.Compiled);
 

--- a/windows/Ghostty.Tests/Wiring/HarnessConfigIsolationScanTests.cs
+++ b/windows/Ghostty.Tests/Wiring/HarnessConfigIsolationScanTests.cs
@@ -283,6 +283,205 @@ public class HarnessConfigIsolationScanTests
             IsCode(l) && l.Contains("Exit-WinttyTestConfig", StringComparison.Ordinal));
     }
 
+    /// <summary>
+    /// Spellings that make a staging root random: the .NET GUID spellings
+    /// used across the harnesses, the crypto-random helpers, and the two
+    /// library entry points that own randomness themselves.
+    /// </summary>
+    private static readonly string[] RandomnessMarkers =
+    {
+        "[guid]::NewGuid", "New-Guid", "GetRandomFileName",
+        "RandomNumberGenerator", "Enter-WinttyTestConfig",
+        "Start-SeamSession", "New-WinttyTestConfigRoot", "New-SeamToken",
+    };
+
+    /// <summary>
+    /// Assignments of the config root: process-wide or per-child psi.
+    /// </summary>
+    private static readonly Regex XdgAssignment = new(
+        @"(?:\$env:XDG_CONFIG_HOME|EnvironmentVariables\['XDG_CONFIG_HOME'\])\s*=\s*(.+)$",
+        RegexOptions.Compiled);
+
+    private static readonly Regex VarRef = new(@"\$(\w+)", RegexOptions.Compiled);
+
+    private static readonly Regex FunctionDef = new(
+        @"^\s*function\s+([\w-]+)", RegexOptions.Compiled);
+
+    /// <summary>
+    /// A variable's definitions: plain assignments and parameter defaults
+    /// (`[string]$OutDir = ...`), which is where the fixed staging names
+    /// lived.
+    /// </summary>
+    private static List<(int Line, string Rhs)> DefinitionsOf(
+        string[] lines, string name)
+    {
+        // One pattern covers both plain assignments and parameter defaults
+        // (`[string]$OutDir = ...`), which is where the fixed names lived.
+        var definition = new Regex(
+            @"^\s*(?:\[[^\]]*\]\s*)?\$" + Regex.Escape(name) +
+            @"\s*=\s*(.+?)(?:\s*#.*)?$");
+        var found = new List<(int, string)>();
+        for (var i = 0; i < lines.Length; i++)
+        {
+            if (!IsCode(lines[i])) continue;
+            var m = definition.Match(lines[i]);
+            if (m.Success) found.Add((i + 1, m.Groups[1].Value));
+        }
+        return found;
+    }
+
+    /// <summary>
+    /// The function bodies of one file, for following a helper that builds
+    /// the root (splash-race's New-ScratchConfig): the randomness may live
+    /// a call away from the assignment.
+    /// </summary>
+    private static Dictionary<string, List<string>> FunctionBodies(string[] lines)
+    {
+        var bodies = new Dictionary<string, List<string>>();
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var header = FunctionDef.Match(lines[i]);
+            if (!header.Success) continue;
+            var body = new List<string>();
+            for (var j = i + 1; j < lines.Length; j++)
+            {
+                if (FunctionDef.Match(lines[j]).Success) break;
+                body.Add(lines[j]);
+            }
+            bodies[header.Groups[1].Value] = body;
+        }
+        return bodies;
+    }
+
+    /// <summary>
+    /// Whether the chain of definitions behind <paramref name="rhs"/> ever
+    /// reaches a randomness marker, or is provably inert (a restore of a
+    /// saved value, or an empty default). Returns the offending definition
+    /// when the chain reaches a temp path or literal without randomness.
+    /// </summary>
+    private static string? UnrandomizedStaging(
+        string rhs, string[] lines, Dictionary<string, List<string>> functions,
+        HashSet<string> visited, int hops)
+    {
+        if (RandomnessMarkers.Any(m => rhs.Contains(m, StringComparison.Ordinal)))
+            return null;
+
+        // Restores: the saved-original spellings, or reading the variable
+        // back from the environment.
+        if (rhs.Contains("$env:XDG_CONFIG_HOME", StringComparison.Ordinal) ||
+            Regex.IsMatch(rhs, @"(?:orig|prev|previous)", RegexOptions.IgnoreCase))
+            return null;
+
+        if (hops > 6) return $"{rhs.Trim()} (chain too deep to verify)";
+
+        // Follow variables assigned in this file.
+        foreach (var match in VarRef.Matches(rhs).Cast<System.Text.RegularExpressions.Match>())
+        {
+            var name = match.Groups[1].Value;
+            if (!visited.Add("$" + name)) continue;
+            var defs = DefinitionsOf(lines, name);
+            if (defs.Count == 0) continue;
+            foreach (var def in defs)
+            {
+                if (RandomnessMarkers.Any(m => def.Rhs.Contains(m, StringComparison.Ordinal)))
+                    return null;
+                // A definition that names a temp path with no randomness is
+                // the fixed/clock-keyed staging this rule exists for.
+                if (def.Rhs.Contains("$env:TEMP", StringComparison.Ordinal) ||
+                    def.Rhs.Contains("GetTempPath", StringComparison.Ordinal) ||
+                    Regex.IsMatch(def.Rhs, @"""\w+wintty[\w-]*"""))
+                {
+                    return $"line {def.Line}: {def.Rhs.Trim()}";
+                }
+                var verdict = UnrandomizedStaging(
+                    def.Rhs, lines, functions, visited, hops + 1);
+                if (verdict is not null) return $"line {def.Line}: {verdict}";
+            }
+        }
+
+        // Follow in-file functions the rhs calls.
+        foreach (var (name, body) in functions)
+        {
+            if (!rhs.Contains(name, StringComparison.Ordinal)) continue;
+            if (!visited.Add(name)) continue;
+            foreach (var bodyLine in body)
+            {
+                if (!IsCode(bodyLine)) continue;
+                if (RandomnessMarkers.Any(m =>
+                        bodyLine.Contains(m, StringComparison.Ordinal)))
+                    return null;
+                var verdict = UnrandomizedStaging(
+                    bodyLine, lines, functions, visited, hops + 1);
+                if (verdict is not null) return $"{name}: {verdict}";
+            }
+        }
+
+        // Inert rhs (empty default, $null): not a staging path.
+        return null;
+    }
+
+    [Fact]
+    public void Every_Staged_Config_Root_Is_Randomly_Named()
+    {
+        var root = RepoRoot();
+        var scriptDir = Path.Combine(root, "windows", "scripts");
+        var violations = new List<string>();
+
+        foreach (var file in Directory.EnumerateFiles(
+                     scriptDir, "*.ps1", SearchOption.AllDirectories)
+                     .OrderBy(f => f, StringComparer.Ordinal))
+        {
+            if (file.Replace('\\', '/').Contains("/lib/fuzz-selftest/")) continue;
+            var rel = Path.GetRelativePath(scriptDir, file);
+            var lines = File.ReadAllLines(file);
+            var functions = FunctionBodies(lines);
+
+            for (var i = 0; i < lines.Length; i++)
+            {
+                var line = lines[i];
+                if (!IsCode(line)) continue;
+                var assignment = XdgAssignment.Match(line);
+                if (!assignment.Success) continue;
+
+                var offending = UnrandomizedStaging(
+                    assignment.Groups[1].Value, lines, functions,
+                    new HashSet<string>(), 0);
+                if (offending is not null)
+                {
+                    violations.Add($"{rel}:{i + 1}: {line.Trim()}  <- {offending}");
+                }
+            }
+        }
+
+        Assert.True(
+            violations.Count == 0,
+            "config staging root(s) with a fixed or clock-keyed name. The " +
+            "founder rule wants a randomly generated name per run (a fixed or " +
+            "HHmmss name collides across runs and leaks state between them). " +
+            "Stage through Enter-WinttyTestConfig / Start-SeamSession, or put " +
+            "[guid]::NewGuid() in the root's name:\n  " +
+            string.Join("\n  ", violations));
+    }
+
+    [Fact]
+    public void Search_Fuzz_Has_No_Real_Config_Escape()
+    {
+        // A test harness must not be able to point the app at the real
+        // config: the escape hatch was exactly how a stability workaround
+        // became a standing taint path. If the isolated root ever proves
+        // unstable (the historical 0xc000027b), that is a product bug to
+        // capture and fix, not a mode to keep.
+        var root = RepoRoot();
+        var path = Path.Combine(root, "windows", "scripts", "search-fuzz.ps1");
+        Assert.True(File.Exists(path), "search-fuzz.ps1 not found");
+
+        var lines = File.ReadAllLines(path);
+        Assert.DoesNotContain(lines, l =>
+            IsCode(l) && l.Contains("RealConfig", StringComparison.Ordinal));
+        Assert.Contains(lines, l =>
+            IsCode(l) && l.Contains("Enter-WinttyTestConfig", StringComparison.Ordinal));
+    }
+
     [Fact]
     public void Seam_Client_Itself_Arms_The_Guard()
     {

--- a/windows/Ghostty.Tests/Wiring/HarnessConfigIsolationScanTests.cs
+++ b/windows/Ghostty.Tests/Wiring/HarnessConfigIsolationScanTests.cs
@@ -54,16 +54,16 @@ public class HarnessConfigIsolationScanTests
     };
 
     /// <summary>
-    /// justfile recipes that execute the exe directly, with the proof.
+    /// No justfile allowlist, on purpose. run-win and run-win-release are
+    /// the USER launcher (founder rule): real config by default for humans,
+    /// ISOLATED_CONFIG=1 to opt into a random temp root, isolated by
+    /// default inside an agent session (CLAUDECODE), REAL_CONFIG=1 to
+    /// override loudly. All of that lives in run-win-launch.ps1, which this
+    /// scan counts as armed because it contains the arming path. A bare
+    /// `./Wintty.exe` line in any recipe would bypass the agent-session
+    /// default, which is the exact April-taint path the launcher exists to
+    /// close, so it must fail this scan rather than be allowlisted.
     /// </summary>
-    private static readonly Dictionary<string, string> JustfileAllowlist = new()
-    {
-        // Interactive dev runs of the developer's own environment: the
-        // point of the recipe is the real config. Not a test; the fuzz and
-        // seam recipes all route through scripts that arm the guard.
-        ["run-win"] = "interactive dev launch, not a test",
-        ["run-win-release"] = "interactive dev launch, not a test",
-    };
 
     private static readonly Regex LaunchKeyword = new(
         @"Start-Process|ProcessStartInfo", RegexOptions.Compiled);
@@ -158,7 +158,7 @@ public class HarnessConfigIsolationScanTests
     }
 
     [Fact]
-    public void Justfile_Recipes_Execute_The_Exe_Only_Where_Isolation_Is_Intended()
+    public void Justfile_Recipes_Execute_The_Exe_Only_Through_A_Launcher()
     {
         var root = RepoRoot();
         var path = Path.Combine(root, "justfile");
@@ -186,16 +186,101 @@ public class HarnessConfigIsolationScanTests
             if (!firstToken.EndsWith("Wintty.exe", StringComparison.OrdinalIgnoreCase))
                 continue;
 
-            if (JustfileAllowlist.ContainsKey(recipe)) continue;
             violations.Add($"justfile:{index + 1} (recipe {recipe}): {trimmed}");
         }
 
         Assert.True(
             violations.Count == 0,
-            "justfile executes the app outside a script, without arming " +
-            "WINTTY_TEST_CONFIG. Route the launch through a harness script " +
-            "(they stage a random temp XDG root and arm the guard) or justify " +
-            "an allowlist entry:\n  " + string.Join("\n  ", violations));
+            "justfile executes the app outside a launcher script. Tests arm " +
+            "WINTTY_TEST_CONFIG through their harness; the user launcher " +
+            "(run-win / run-win-release) routes through run-win-launch.ps1, " +
+            "which isolates agent sessions by default. A bare exec line " +
+            "bypasses both:\n  " + string.Join("\n  ", violations));
+    }
+
+    [Fact]
+    public void Run_Win_Recipes_Route_Through_The_User_Launcher_Script()
+    {
+        var root = RepoRoot();
+        var justfile = File.ReadAllLines(Path.Combine(root, "justfile"));
+
+        foreach (var recipe in new[] { "run-win", "run-win-release" })
+        {
+            var start = Array.FindIndex(justfile,
+                l => l.StartsWith(recipe + ":", StringComparison.Ordinal));
+            Assert.True(start >= 0, $"no recipe '{recipe}' in the justfile");
+
+            var body = new List<string>();
+            for (var i = start + 1; i < justfile.Length; i++)
+            {
+                var line = justfile[i];
+                if (Regex.IsMatch(line, @"^[A-Za-z][\w-]*:") || line.StartsWith('['))
+                    break;
+                body.Add(line);
+            }
+
+            Assert.Contains(body, l =>
+                l.Contains("run-win-launch.ps1", StringComparison.Ordinal) &&
+                !l.TrimStart().StartsWith('#'));
+        }
+    }
+
+    [Fact]
+    public void Run_Win_Launcher_Pins_The_Founder_Rule_For_The_User_Launcher()
+    {
+        var root = RepoRoot();
+        var path = Path.Combine(root, "windows", "scripts", "run-win-launch.ps1");
+        Assert.True(File.Exists(path),
+            "run-win-launch.ps1 not found; the run-win recipes depend on it");
+
+        var lines = File.ReadAllLines(path);
+        var text = string.Join('\n', lines);
+
+        // The four markers of the rule: the explicit opt-ins, the agent
+        // detector, and the guard's own variable.
+        foreach (var marker in new[] { "CLAUDECODE", "ISOLATED_CONFIG",
+                                       "REAL_CONFIG", "WINTTY_TEST_CONFIG" })
+        {
+            Assert.Contains(lines, l =>
+                IsCode(l) && l.Contains(marker, StringComparison.Ordinal));
+        }
+
+        // Isolation rides the same helper every harness uses, and the mode
+        // resolution is a function the harness side can probe without
+        // launching anything.
+        Assert.Contains(lines, l =>
+            IsCode(l) && l.Contains("Enter-WinttyTestConfig", StringComparison.Ordinal));
+        Assert.Contains("function Get-RunWinMode", text,
+            StringComparison.Ordinal);
+
+        // Precedence, pinned by position inside the mode function: an
+        // explicit REAL_CONFIG beats everything, an explicit ISOLATED_CONFIG
+        // beats the agent default, and CLAUDECODE only fills the default.
+        // If the checks are reordered, this fails.
+        var functionStart = text.IndexOf("function Get-RunWinMode", StringComparison.Ordinal);
+        var functionEnd = text.IndexOf("function ", functionStart + 1, StringComparison.Ordinal);
+        if (functionEnd < 0) functionEnd = text.Length;
+        var body = text[functionStart..functionEnd];
+        var real = body.IndexOf("REAL_CONFIG", StringComparison.Ordinal);
+        var isolated = body.IndexOf("ISOLATED_CONFIG", StringComparison.Ordinal);
+        var agent = body.IndexOf("CLAUDECODE", StringComparison.Ordinal);
+        Assert.True(real >= 0 && isolated > real && agent > isolated,
+            "Get-RunWinMode must check REAL_CONFIG before ISOLATED_CONFIG " +
+            "before CLAUDECODE; found at " + $"{real}/{isolated}/{agent}");
+
+        // REAL_CONFIG is the one spelling that runs the app against the
+        // user's real config from inside an agent session, so it must be
+        // announced loudly, not accepted in silence.
+        Assert.Contains(lines, l =>
+            IsCode(l) &&
+            l.Contains("REAL_CONFIG", StringComparison.Ordinal) &&
+            l.Contains("ForegroundColor Red", StringComparison.Ordinal));
+
+        // The window outlives the recipe: exiting the test-config session
+        // would delete the root the live app is still holding. The helper's
+        // 24h sweep is what reaps it instead.
+        Assert.DoesNotContain(lines, l =>
+            IsCode(l) && l.Contains("Exit-WinttyTestConfig", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/windows/Ghostty.Tests/Wiring/HarnessConfigIsolationScanTests.cs
+++ b/windows/Ghostty.Tests/Wiring/HarnessConfigIsolationScanTests.cs
@@ -72,15 +72,48 @@ public class HarnessConfigIsolationScanTests
     private static readonly Regex[] LaunchVerbs =
     {
         new(@"Start-Process", RegexOptions.Compiled),
+        // The Start-Process alias, and a bare lowercase 'start' (cmd style);
+        // both case-sensitive so prose and .Start( methods stay out.
+        new(@"\bsaps\b"),
+        new(@"\bstart\b"),
         new(@"ProcessStartInfo", RegexOptions.Compiled),
         new(@"Process\]::Start\(", RegexOptions.Compiled),
         new(@"Process\.Start\(", RegexOptions.Compiled),
         new(@"Invoke-Item", RegexOptions.Compiled),
-        new(@"(?<!\S)&\s*\$", RegexOptions.Compiled),
+        // The call operator, with a variable OR a literal/interpolated path:
+        // the verb matches the stripped line too ('& ' survives stripping),
+        // while target evidence reads the raw line where the path lives.
+        new(@"(?<!\S)&\s*"),
         new(@"explorer\.exe", RegexOptions.Compiled | RegexOptions.IgnoreCase),
         new(@"\bcmd\b.*\bstart\b", RegexOptions.Compiled | RegexOptions.IgnoreCase),
         new(@"dotnet\s+run", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+        // COM launches, gated on the file actually creating a shell object
+        // (see UsesComShell); the method call is the verb.
+        new(@"\.(?:Run|Exec|ShellExecute)\s*\("),
     };
+
+    /// <summary>
+    /// Whether any line in the file creates the COM shell object whose
+    /// Run/Exec/ShellExecute methods launch programs.
+    /// </summary>
+    private static bool UsesComShell(string[] lines) =>
+        lines.Any(l => IsCode(l) && Regex.IsMatch(
+            l, @"WScript\.Shell|Shell\.Application",
+            RegexOptions.IgnoreCase));
+
+    /// <summary>
+    /// The debugger attach flags: a debugger whose arguments attach to an
+    /// existing process (-p pid, -pn name) launches nothing and is exempt.
+    /// </summary>
+    private static readonly Regex AttachFlag = new(
+        @"-(?:p|pn|pid)\b", RegexOptions.Compiled);
+
+    /// <summary>
+    /// The debugger binaries themselves; a debugger that RUNS the app as
+    /// its debuggee is an app launch and must isolate like any other.
+    /// </summary>
+    private static readonly Regex DebuggerToken = new(
+        @"(?i)\b(cdb|windbg|procdump)", RegexOptions.Compiled);
 
     /// <summary>
     /// A variable whose name mentions the exe: $ExePath, $exe, $Exe,
@@ -146,11 +179,44 @@ public class HarnessConfigIsolationScanTests
     private sealed record LaunchSite(string File, int Line, string Text);
 
     /// <summary>
+    /// The positionally-decided target expressions of a launch line: the
+    /// value after -FilePath, the argument of the call operator, the first
+    /// argument of ::Start / Invoke-Item / a COM Run, the ProcessStartInfo
+    /// constructor argument, and the first positional token of the
+    /// Start-Process spellings. Target evidence is judged on THESE, not on
+    /// the whole line, so an app path sitting in a debugger's -ArgumentList
+    /// does not make the debugger an app launch (R1-4 runs the ruling the
+    /// other way below).
+    /// </summary>
+    private static List<string> TargetCandidates(string line, string stripped)
+    {
+        var candidates = new List<string>();
+        foreach (var m in Regex.Matches(
+                     stripped, @"-(?:FilePath|FileName|Path)\s+(\S+)"))
+            candidates.Add(((System.Text.RegularExpressions.Match)m).Groups[1].Value);
+        foreach (var m in Regex.Matches(line, @"(?<!\S)&\s*(\S+)"))
+            candidates.Add(((System.Text.RegularExpressions.Match)m).Groups[1].Value);
+        foreach (var m in Regex.Matches(
+                     line,
+                     @"(?:Process\]::Start|Process\.Start|\.Run|\.Exec|\.ShellExecute)\s*\(\s*([^,)]+)"))
+            candidates.Add(((System.Text.RegularExpressions.Match)m).Groups[1].Value);
+        foreach (var m in Regex.Matches(
+                     line, @"ProcessStartInfo\]::new\(\s*([^,)]*)"))
+            candidates.Add(((System.Text.RegularExpressions.Match)m).Groups[1].Value);
+        foreach (var m in Regex.Matches(stripped, @"(?:^|\s)(?:Start-Process|saps)\s+(?!-)(\S+)"))
+            candidates.Add(((System.Text.RegularExpressions.Match)m).Groups[1].Value);
+        foreach (var m in Regex.Matches(stripped, @"Invoke-Item\s+(\S+)"))
+            candidates.Add(((System.Text.RegularExpressions.Match)m).Groups[1].Value);
+        return candidates;
+    }
+
+    /// <summary>
     /// Whether the target a launch line names is the app. Resolution
-    /// follows same-line evidence first (an exe-named variable, a literal
-    /// app path), then the variable's assignment or the psi FileName /
-    /// FilePath property assignments, so a harness that launches through
-    /// an intermediate variable is judged by what the variable holds.
+    /// follows the positional candidates (an app literal among them, or a
+    /// candidate whose definitions/properties/functions reach one), then
+    /// the whole line when no position could be decided. A candidate that
+    /// resolves to a DEBUGGER is judged by the ruling: running the app as
+    /// its debuggee is an app launch; attaching to a pid is not.
     /// Anything the rules cannot resolve fails CLOSED: the harness must
     /// name its target legibly or arm the guard, and an unresolved launch
     /// is flagged rather than trusted.
@@ -159,19 +225,40 @@ public class HarnessConfigIsolationScanTests
         string line, string[] lines, Dictionary<string, List<string>> functions,
         bool callOperatorOnly)
     {
-        // Target evidence reads the raw line: the app exe arrives quoted
-        // more often than not.
-        if (AppLiteral.IsMatch(line)) return true;
         if (Regex.IsMatch(line, @"dotnet\s+run", RegexOptions.IgnoreCase) &&
             ProjectReference.IsMatch(line)) return true;
 
         var stripped = QuotedSpan.Replace(line, "");
+        var candidates = TargetCandidates(line, stripped);
+
+        // Literal app paths: among the candidates when a position was
+        // decided, on the whole line otherwise (fail closed).
+        if (candidates.Count > 0)
+        {
+            if (candidates.Any(c => AppLiteral.IsMatch(c))) return true;
+        }
+        else if (AppLiteral.IsMatch(line)) return true;
+
+        // The debugger ruling: a candidate that resolves to a debugger is
+        // an app launch exactly when the app is its debuggee (an app
+        // literal among the remaining arguments, with no attach flag).
+        foreach (var candidate in candidates)
+        {
+            if (!ResolvesToDebugger(candidate, lines, functions)) continue;
+            if (AppLiteral.IsMatch(line) && !AttachFlag.IsMatch(line))
+                return true;
+            return false;
+        }
+
+        var varSource = candidates.Count > 0
+            ? string.Join(" ", candidates)
+            : stripped;
         var sawAny = false;
         var sawApp = false;
         var sawTooling = false;
         var sawEvidence = false;
 
-        foreach (var name in AnyVar.Matches(stripped)
+        foreach (var name in AnyVar.Matches(varSource)
                      .Cast<System.Text.RegularExpressions.Match>()
                      .Select(m => m.Groups[1].Value)
                      .Distinct())
@@ -223,10 +310,32 @@ public class HarnessConfigIsolationScanTests
         // invoked and needs positive evidence.
         if (callOperatorOnly) return false;
         if (sawEvidence) return true;
-        return AnyVar.Matches(stripped)
+        return AnyVar.Matches(varSource)
             .Cast<System.Text.RegularExpressions.Match>()
             .Select(m => m.Groups[1].Value)
             .Any(n => ExeNamedVar.IsMatch("$" + n));
+    }
+
+    /// <summary>
+    /// Whether a positional candidate resolves to a debugger binary: the
+    /// candidate itself names one, or its definitions/properties do.
+    /// </summary>
+    private static bool ResolvesToDebugger(
+        string candidate, string[] lines,
+        Dictionary<string, List<string>> functions)
+    {
+        if (DebuggerToken.IsMatch(candidate)) return true;
+        foreach (var name in AnyVar.Matches(candidate)
+                     .Cast<System.Text.RegularExpressions.Match>()
+                     .Select(m => m.Groups[1].Value)
+                     .Distinct())
+        {
+            if (DefinitionsOf(lines, name).Any(d => DebuggerToken.IsMatch(d.Rhs)))
+                return true;
+            if (PropertyTargets(lines, name).Any(d => DebuggerToken.IsMatch(d)))
+                return true;
+        }
+        return false;
     }
 
     private static string StripLiterals(string line) =>
@@ -365,6 +474,13 @@ public class HarnessConfigIsolationScanTests
         if (lines.Length == 0) return found;
         var arms = UnconditionalArmLines(lines);
         var functions = FunctionBodiesFor(lines);
+        // The COM method verb only counts in a file that creates the COM
+        // shell object; .Run( exists on many innocuous objects.
+        var comVerbs = LaunchVerbs.Where(v =>
+            v.ToString().Contains("ShellExecute")).ToList();
+        var effectiveVerbs = UsesComShell(lines)
+            ? LaunchVerbs.ToList()
+            : LaunchVerbs.Except(comVerbs).ToList();
 
         for (var i = 0; i < lines.Length; i++)
         {
@@ -374,7 +490,7 @@ public class HarnessConfigIsolationScanTests
             // The verb must survive literal stripping: a manifest prose
             // string that mentions "cmd" and "start" is not a launch.
             var stripped = StripLiterals(line);
-            var matching = LaunchVerbs.Where(v => v.IsMatch(line)).ToList();
+            var matching = effectiveVerbs.Where(v => v.IsMatch(line)).ToList();
             if (matching.Count == 0) continue;
             if (!matching.Any(v => v.IsMatch(stripped))) continue;
 
@@ -474,12 +590,18 @@ public class HarnessConfigIsolationScanTests
             "violation-psi-indirect-literal.ps1",
             "violation-unresolved-var.ps1",
             "violation-conditional-arm.ps1",
+            "violation-call-operator-literal.ps1",
+            "violation-call-operator-interp.ps1",
+            "violation-saps.ps1",
+            "violation-com-run.ps1",
+            "violation-cdb-launches-app.ps1",
         };
         var expectedClean = new HashSet<string>(StringComparer.Ordinal)
         {
             "clean-armed-launch.ps1",
             "clean-tooling-psi.ps1",
             "clean-tooling-debugger.ps1",
+            "clean-cdb-attach.ps1",
         };
 
         var flagged = new HashSet<string>(StringComparer.Ordinal);
@@ -505,16 +627,73 @@ public class HarnessConfigIsolationScanTests
     }
 
     /// <summary>
-    /// Spellings that make a staging root random: the .NET GUID spellings
-    /// used across the harnesses, the crypto-random helpers, and the two
-    /// library entry points that own randomness themselves.
+    /// The staging side of the fixture corpus: every non-random shape the
+    /// re-review proved the chain-follower blessed (direct fixed names,
+    /// prev-named variables that are not restores, 'preview' literals, PID
+    /// keys, clock keys, and the classic intermediate variable), plus a
+    /// green control for each allowed form (guid, GetRandomFileName, the
+    /// helper, and a genuine paired save/restore).
     /// </summary>
-    private static readonly string[] RandomnessMarkers =
+    [Fact]
+    public void The_Scan_Still_Refuses_Every_NonRandom_Staging_Shape()
     {
-        "[guid]::NewGuid", "New-Guid", "GetRandomFileName",
-        "RandomNumberGenerator", "Enter-WinttyTestConfig",
-        "Start-SeamSession", "New-WinttyTestConfigRoot", "New-SeamToken",
-    };
+        var root = RepoRoot();
+        var fixtureDir = Path.Combine(
+            root, "windows", "Ghostty.Tests", "Wiring", "ScanFixtures");
+        Assert.True(Directory.Exists(fixtureDir), "ScanFixtures not found");
+
+        var expectedViolations = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "staging-direct-fixed.ps1",
+            "staging-prevname-var.ps1",
+            "staging-preview-literal.ps1",
+            "staging-pid.ps1",
+            "staging-clock.ps1",
+            "staging-classic-var.ps1",
+        };
+        var expectedClean = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "staging-green-guid.ps1",
+            "staging-green-randomfile.ps1",
+            "staging-green-helper.ps1",
+            "staging-green-restore.ps1",
+        };
+
+        var flagged = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var file in Directory.EnumerateFiles(fixtureDir, "staging-*.ps1")
+                     .OrderBy(f => f, StringComparer.Ordinal))
+        {
+            var name = Path.GetFileName(file);
+            var lines = File.ReadAllLines(file);
+            var functions = FunctionBodies(lines);
+            for (var i = 0; i < lines.Length; i++)
+            {
+                var line = lines[i];
+                if (!IsCode(line)) continue;
+                var assignment = XdgAssignment.Match(line);
+                if (!assignment.Success) continue;
+                if (UnrandomizedStaging(
+                        assignment.Groups[1].Value, lines, functions,
+                        new HashSet<string>(), 0) is not null)
+                {
+                    flagged.Add(name);
+                    break;
+                }
+            }
+        }
+
+        var missing = expectedViolations.Except(flagged).ToList();
+        Assert.True(
+            missing.Count == 0,
+            "staging shape(s) the scan wrongly blesses (fixture not " +
+            "flagged): " + string.Join(", ", missing));
+
+        var falseFlags = expectedClean.Intersect(flagged).ToList();
+        Assert.True(
+            falseFlags.Count == 0,
+            "allowed staging shape(s) the scan flags: " +
+            string.Join(", ", falseFlags));
+    }
 
     /// <summary>
     /// Assignments of the config root: process-wide or per-child psi.
@@ -557,6 +736,93 @@ public class HarnessConfigIsolationScanTests
     /// saved value, or an empty default). Returns the offending definition
     /// when the chain reaches a temp path or literal without randomness.
     /// </summary>
+    /// <summary>
+    /// Sources that are proof of randomness in a staging name. Anything
+    /// else in the name-building position fails: the founder rule wants a
+    /// randomly generated name per run.
+    /// </summary>
+    private static readonly string[] RandomnessMarkers =
+    {
+        "[guid]::NewGuid", "New-Guid", "GetRandomFileName",
+        "RandomNumberGenerator", "Enter-WinttyTestConfig",
+        "Start-SeamSession", "New-WinttyTestConfigRoot", "New-SeamToken",
+    };
+
+    /// <summary>
+    /// Name sources that are positively NOT random, whatever else the line
+    /// spells: the process id (reused across reboots), and any clock
+    /// formatting (a within-a-minute collision class of its own).
+    /// </summary>
+    private static readonly Regex NonRandomNameSource = new(
+        @"\$PID\b|Get-Date|HHmmss|yyyyMMdd|mmss",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    /// <summary>
+    /// Whether the expression builds a path with a fixed NAME in it: a
+    /// quoted literal riding a temp base (the lazy direct form), or a
+    /// quoted literal that is itself a path. Bare quoted segments with no
+    /// path context ('primary', 'true', the fixed 'wintty' SUBDIRECTORY
+    /// under an already-random root) are not root names and must not fire
+    /// this.
+    /// </summary>
+    private static bool HasFixedName(string rhs)
+    {
+        var tempBase = rhs.Contains("$env:TEMP", StringComparison.Ordinal) ||
+                       rhs.Contains("GetTempPath", StringComparison.Ordinal);
+        foreach (System.Text.RegularExpressions.Match m in
+                     QuotedSpan.Matches(rhs))
+        {
+            var body = m.Value.Substring(1, m.Value.Length - 2);
+            if (body.Length == 0) continue;
+            if (tempBase) return true;
+            if (body.Contains('\\') || body.Contains('/') ||
+                body.Contains(':')) return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Whether the rhs is an exact save/restore: it assigns back a value
+    /// provably SAVED FROM $env:XDG_CONFIG_HOME earlier in the file, paired
+    /// by the variable or member, not by its name. A variable merely named
+    /// $previousSomething whose definition is a fixed path is not a
+    /// restore, and neither is a literal that happens to contain 'prev'.
+    /// </summary>
+    private static bool IsPairedRestore(string rhs, string[] lines)
+    {
+        var trimmed = rhs.Trim().TrimEnd('}', ';').Trim();
+        var plain = Regex.Match(trimmed, @"^\$([A-Za-z_]\w*)$");
+        if (plain.Success)
+        {
+            return DefinitionsOf(lines, plain.Groups[1].Value)
+                .Any(d => d.Rhs.Contains(
+                    "$env:XDG_CONFIG_HOME", StringComparison.Ordinal));
+        }
+
+        // The member shape ($Session.OrigXdg): the member was populated
+        // from the env var inside a hashtable or object assignment.
+        var member = Regex.Match(trimmed, @"^\$\w+[.:](\w+)$");
+        if (member.Success)
+        {
+            var name = member.Groups[1].Value;
+            var savedFrom = new Regex(
+                @"^\s*" + Regex.Escape(name) +
+                @"\s*=\s*(?:if\s*\(.*?\)\s*\{)?\s*[^#\r\n]*\$env:XDG_CONFIG_HOME");
+            return lines.Any(l => IsCode(l) && savedFrom.IsMatch(l));
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Randomness is a POSITIVE proof: the assigned expression, or every
+    /// chain it is built from, must reach a random-name source. The
+    /// assignment's own right-hand side carries the same tripwires the
+    /// followed definitions do (a temp or fixed-literal base with no
+    /// marker, a PID, a clock), so the direct lazy spelling cannot pass
+    /// just because no variable is involved. The one exemption is the
+    /// paired save/restore.
+    /// </summary>
     private static string? UnrandomizedStaging(
         string rhs, string[] lines, Dictionary<string, List<string>> functions,
         HashSet<string> visited, int hops)
@@ -564,13 +830,20 @@ public class HarnessConfigIsolationScanTests
         if (RandomnessMarkers.Any(m => rhs.Contains(m, StringComparison.Ordinal)))
             return null;
 
-        // Restores: the saved-original spellings, or reading the variable
-        // back from the environment.
-        if (rhs.Contains("$env:XDG_CONFIG_HOME", StringComparison.Ordinal) ||
-            Regex.IsMatch(rhs, @"(?:orig|prev|previous)", RegexOptions.IgnoreCase))
-            return null;
+        if (IsPairedRestore(rhs, lines)) return null;
 
         if (hops > 6) return $"{rhs.Trim()} (chain too deep to verify)";
+
+        // The own-RHS tripwires: reached without a marker, these are the
+        // non-random staging shapes exactly as the re-review spelled them.
+        if (NonRandomNameSource.IsMatch(rhs))
+            return $"not a random name source: {rhs.Trim()}";
+        if (rhs.Contains("$env:TEMP", StringComparison.Ordinal) ||
+            rhs.Contains("GetTempPath", StringComparison.Ordinal) ||
+            rhs.Contains("[System.IO.Path]::GetTempPath", StringComparison.Ordinal))
+            return $"temp base with no random name: {rhs.Trim()}";
+        if (HasFixedName(rhs))
+            return $"fixed literal name: {rhs.Trim()}";
 
         // Follow variables assigned in this file.
         foreach (var match in VarRef.Matches(rhs).Cast<System.Text.RegularExpressions.Match>())
@@ -581,16 +854,6 @@ public class HarnessConfigIsolationScanTests
             if (defs.Count == 0) continue;
             foreach (var def in defs)
             {
-                if (RandomnessMarkers.Any(m => def.Rhs.Contains(m, StringComparison.Ordinal)))
-                    return null;
-                // A definition that names a temp path with no randomness is
-                // the fixed/clock-keyed staging this rule exists for.
-                if (def.Rhs.Contains("$env:TEMP", StringComparison.Ordinal) ||
-                    def.Rhs.Contains("GetTempPath", StringComparison.Ordinal) ||
-                    Regex.IsMatch(def.Rhs, @"""\w+wintty[\w-]*"""))
-                {
-                    return $"line {def.Line}: {def.Rhs.Trim()}";
-                }
                 var verdict = UnrandomizedStaging(
                     def.Rhs, lines, functions, visited, hops + 1);
                 if (verdict is not null) return $"line {def.Line}: {verdict}";

--- a/windows/Ghostty.Tests/Wiring/HarnessConfigIsolationScanTests.cs
+++ b/windows/Ghostty.Tests/Wiring/HarnessConfigIsolationScanTests.cs
@@ -35,6 +35,20 @@ namespace Ghostty.Tests.Wiring;
 /// The allowlist bar: the launch must be provably unable to reach the
 /// config, or provably not a test. "Stable when unisolated" is not on the
 /// bar.
+///
+/// KNOWN, ACCEPTED LIMITS (deliberately obfuscated spellings the scan does
+/// not chase; ruled acceptable because constructing them is evasion on
+/// purpose, and the BOUNDARY is the app-side WINTTY_TEST_CONFIG guard with
+/// its env-independent known-folder temp anchor, which no spelling here
+/// can move): helper-name shadowing (a local function redefining
+/// New-WinttyTestConfigRoot), same-line randomness-marker smuggling, and
+/// Invoke-Expression/iex on a built string; conhost.exe and rundll32 as
+/// launchers; launch through a scriptblock VARIABLE whose block references
+/// a variable rather than a literal; the COM object created in a
+/// dot-sourced helper so the file-level COM gate closes; and staging
+/// values arriving through dot-sourced files. If a shape on this list
+/// shows up in a harness review, treat it as a finding anyway: the list
+/// is what the AUTOMATION accepts, not what the project welcomes.
 /// </summary>
 public class HarnessConfigIsolationScanTests
 {
@@ -71,15 +85,18 @@ public class HarnessConfigIsolationScanTests
     /// </summary>
     private static readonly Regex[] LaunchVerbs =
     {
-        new(@"Start-Process", RegexOptions.Compiled),
-        // The Start-Process alias, and a bare lowercase 'start' (cmd style);
-        // both case-sensitive so prose and .Start( methods stay out.
-        new(@"\bsaps\b"),
-        new(@"\bstart\b"),
-        new(@"ProcessStartInfo", RegexOptions.Compiled),
-        new(@"Process\]::Start\(", RegexOptions.Compiled),
-        new(@"Process\.Start\(", RegexOptions.Compiled),
-        new(@"Invoke-Item", RegexOptions.Compiled),
+        // PowerShell itself is case-insensitive; mixed-case verbs and
+        // aliases (STArt-Process, START, SAPS) are ordinary spellings, not
+        // obfuscation, so every verb matches case-insensitively. Prose is
+        // kept out by matching the literal-stripped line only, and the
+        // bare alias form rejects a hyphen continuation so Start-Job and
+        // friends are not launches by mere word shape.
+        new(@"Start-Process", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+        new(@"\b(?:saps|start)\b(?!-)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+        new(@"ProcessStartInfo", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+        new(@"Process\]::Start\(", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+        new(@"Process\.Start\(", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+        new(@"Invoke-Item", RegexOptions.Compiled | RegexOptions.IgnoreCase),
         // The call operator, with a variable OR a literal/interpolated path:
         // the verb matches the stripped line too ('& ' survives stripping),
         // while target evidence reads the raw line where the path lives.
@@ -89,7 +106,8 @@ public class HarnessConfigIsolationScanTests
         new(@"dotnet\s+run", RegexOptions.Compiled | RegexOptions.IgnoreCase),
         // COM launches, gated on the file actually creating a shell object
         // (see UsesComShell); the method call is the verb.
-        new(@"\.(?:Run|Exec|ShellExecute)\s*\("),
+        new(@"\.(?:Run|Exec|ShellExecute)\s*\(",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase),
     };
 
     /// <summary>
@@ -188,26 +206,71 @@ public class HarnessConfigIsolationScanTests
     /// does not make the debugger an app launch (R1-4 runs the ruling the
     /// other way below).
     /// </summary>
-    private static List<string> TargetCandidates(string line, string stripped)
+    private static List<string> TargetCandidates(
+        string line, string stripped, string[] lines)
     {
+        // A candidate token ends at whitespace, a comma, a closing brace
+        // or paren (so the -FilePath inside a scriptblock literal does not
+        // swallow the block's closing brace), and tokens that are ONLY
+        // braces or parens are dropped: a dropped candidate never counts
+        // as a decided position, so the whole-line fallback still fires.
+        var token = @"[^,\s)}\]]+";
         var candidates = new List<string>();
         foreach (var m in Regex.Matches(
-                     stripped, @"-(?:FilePath|FileName|Path)\s+(\S+)"))
+                     stripped, @"-(?:FilePath|FileName|Path)\s+(" + token + @")",
+                     RegexOptions.IgnoreCase))
             candidates.Add(((System.Text.RegularExpressions.Match)m).Groups[1].Value);
-        foreach (var m in Regex.Matches(line, @"(?<!\S)&\s*(\S+)"))
+        foreach (var m in Regex.Matches(line, @"(?<!\S)&\s*(" + token + @")"))
             candidates.Add(((System.Text.RegularExpressions.Match)m).Groups[1].Value);
         foreach (var m in Regex.Matches(
                      line,
-                     @"(?:Process\]::Start|Process\.Start|\.Run|\.Exec|\.ShellExecute)\s*\(\s*([^,)]+)"))
+                     @"(?:Process\]::Start|Process\.Start|\.Run|\.Exec|\.ShellExecute)\s*\(\s*(" + token + @")",
+                     RegexOptions.IgnoreCase))
             candidates.Add(((System.Text.RegularExpressions.Match)m).Groups[1].Value);
         foreach (var m in Regex.Matches(
-                     line, @"ProcessStartInfo\]::new\(\s*([^,)]*)"))
+                     line, @"ProcessStartInfo\]::new\(\s*(" + token + @")",
+                     RegexOptions.IgnoreCase))
             candidates.Add(((System.Text.RegularExpressions.Match)m).Groups[1].Value);
-        foreach (var m in Regex.Matches(stripped, @"(?:^|\s)(?:Start-Process|saps)\s+(?!-)(\S+)"))
+        foreach (var m in Regex.Matches(
+                     stripped, @"(?:^|\s)(?:Start-Process|saps)\s+(?!-)(" + token + @")",
+                     RegexOptions.IgnoreCase))
             candidates.Add(((System.Text.RegularExpressions.Match)m).Groups[1].Value);
-        foreach (var m in Regex.Matches(stripped, @"Invoke-Item\s+(\S+)"))
+        foreach (var m in Regex.Matches(
+                     stripped, @"Invoke-Item\s+(" + token + @")",
+                     RegexOptions.IgnoreCase))
             candidates.Add(((System.Text.RegularExpressions.Match)m).Groups[1].Value);
-        return candidates;
+
+        // Splatting: @name passes the parameters of a hashtable; the
+        // launch target is that hashtable's FilePath/FileName/Path member,
+        // literal or variable. The member sits on the opener line itself
+        // when the hashtable is written on one line, so the member pattern
+        // tolerates the `$name = @{` prefix.
+        foreach (var m in Regex.Matches(line, @"@(\w+)"))
+        {
+            var name = ((System.Text.RegularExpressions.Match)m).Groups[1].Value;
+            var opener = new Regex(
+                @"^\s*\$" + Regex.Escape(name) + @"\s*=\s*@\{");
+            for (var i = 0; i < lines.Length; i++)
+            {
+                if (!opener.IsMatch(lines[i])) continue;
+                for (var j = i; j < Math.Min(i + 40, lines.Length); j++)
+                {
+                    var member = Regex.Match(
+                        lines[j],
+                        @"(?:^\s*|@\{\s*)(?:FilePath|FileName|Path)\s*=\s*(.+?)(?:\s*[}\]].*)?(?:\s*#.*)?$",
+                        RegexOptions.IgnoreCase);
+                    if (member.Success)
+                        candidates.Add(member.Groups[1].Value);
+                    if (Regex.IsMatch(lines[j], @"^\s*\}") ||
+                        Regex.IsMatch(lines[j], @"\}\s*$") && j > i)
+                        break;
+                }
+            }
+        }
+
+        return candidates
+            .Where(c => !Regex.IsMatch(c, @"^[)\}]+$"))
+            .ToList();
     }
 
     /// <summary>
@@ -229,7 +292,7 @@ public class HarnessConfigIsolationScanTests
             ProjectReference.IsMatch(line)) return true;
 
         var stripped = QuotedSpan.Replace(line, "");
-        var candidates = TargetCandidates(line, stripped);
+        var candidates = TargetCandidates(line, stripped, lines);
 
         // Literal app paths: among the candidates when a position was
         // decided, on the whole line otherwise (fail closed).
@@ -363,10 +426,12 @@ public class HarnessConfigIsolationScanTests
     private static List<(int Line, string Rhs)> DefinitionsOf(
         string[] lines, string name)
     {
-        // One pattern covers both plain assignments and parameter defaults
-        // (`[string]$OutDir = ...`).
+        // One pattern covers plain assignments, parameter defaults
+        // (`[string]$OutDir = ...`), and the one-line param-block spelling
+        // `param([string]$OutDir = ...)` whose prefix is not a definition
+        // of its own.
         var definition = new Regex(
-            @"^\s*(?:\[[^\]]*\]\s*)?\$" + Regex.Escape(name) +
+            @"^\s*(?:param\s*\(\s*)?(?:\[[^\]]*\]\s*)?\$" + Regex.Escape(name) +
             @"\s*=\s*(.+?)(?:\s*#.*)?$");
         var found = new List<(int, string)>();
         for (var i = 0; i < lines.Length; i++)
@@ -595,6 +660,9 @@ public class HarnessConfigIsolationScanTests
             "violation-saps.ps1",
             "violation-com-run.ps1",
             "violation-cdb-launches-app.ps1",
+            "violation-splatting.ps1",
+            "violation-scriptblock-launch.ps1",
+            "violation-mixed-case.ps1",
         };
         var expectedClean = new HashSet<string>(StringComparer.Ordinal)
         {
@@ -602,6 +670,7 @@ public class HarnessConfigIsolationScanTests
             "clean-tooling-psi.ps1",
             "clean-tooling-debugger.ps1",
             "clean-cdb-attach.ps1",
+            "clean-splatting-armed.ps1",
         };
 
         var flagged = new HashSet<string>(StringComparer.Ordinal);
@@ -650,6 +719,10 @@ public class HarnessConfigIsolationScanTests
             "staging-pid.ps1",
             "staging-clock.ps1",
             "staging-classic-var.ps1",
+            "staging-param-default.ps1",
+            "staging-set-item.ps1",
+            "staging-setenvvar.ps1",
+            "staging-member-wrong-restore.ps1",
         };
         var expectedClean = new HashSet<string>(StringComparer.Ordinal)
         {
@@ -670,10 +743,9 @@ public class HarnessConfigIsolationScanTests
             {
                 var line = lines[i];
                 if (!IsCode(line)) continue;
-                var assignment = XdgAssignment.Match(line);
-                if (!assignment.Success) continue;
+                if (!TryXdgAssignment(line, out var rhs)) continue;
                 if (UnrandomizedStaging(
-                        assignment.Groups[1].Value, lines, functions,
+                        rhs, lines, functions,
                         new HashSet<string>(), 0) is not null)
                 {
                     flagged.Add(name);
@@ -696,11 +768,35 @@ public class HarnessConfigIsolationScanTests
     }
 
     /// <summary>
-    /// Assignments of the config root: process-wide or per-child psi.
+    /// Assignments of the config root, every spelling the process env can
+    /// be written with: the dollar-env drive (process-wide or per-child
+    /// psi), Set-Item on the env drive, and the .NET SetEnvironmentVariable
+    /// call. All go through the same positive-proof randomness rule.
     /// </summary>
-    private static readonly Regex XdgAssignment = new(
-        @"(?:\$env:XDG_CONFIG_HOME|EnvironmentVariables\['XDG_CONFIG_HOME'\])\s*=\s*(.+)$",
-        RegexOptions.Compiled);
+    private static readonly Regex[] XdgAssignments =
+    {
+        new(@"(?:\$env:XDG_CONFIG_HOME|EnvironmentVariables\['XDG_CONFIG_HOME'\])\s*=\s*(.+)$",
+            RegexOptions.Compiled),
+        new(@"Set-Item\s+Env:\\?XDG_CONFIG_HOME\s+(.+)$",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase),
+        new(@"SetEnvironmentVariable\(\s*['""]XDG_CONFIG_HOME['""]\s*,\s*([^,)]+)",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase),
+    };
+
+    private static bool TryXdgAssignment(string line, out string rhs)
+    {
+        foreach (var pattern in XdgAssignments)
+        {
+            var m = pattern.Match(line);
+            if (m.Success)
+            {
+                rhs = m.Groups[1].Value;
+                return true;
+            }
+        }
+        rhs = "";
+        return false;
+    }
 
     private static readonly Regex VarRef = new(@"\$(\w+)", RegexOptions.Compiled);
 
@@ -832,6 +928,33 @@ public class HarnessConfigIsolationScanTests
 
         if (IsPairedRestore(rhs, lines)) return null;
 
+        // A member access whose pairing failed: if the base object is a
+        // hashtable that SAVED the env var under a different member, this
+        // is a wrong-variable restore, not inert data (R2-3). A base whose
+        // definition is a randomness helper (the .Dir shape) is fine and
+        // falls through to the normal variable follow below.
+        var memberAccess = Regex.Match(
+            rhs.Trim().TrimEnd('}', ';').Trim(), @"^\$(\w+)[.:](\w+)$");
+        if (memberAccess.Success)
+        {
+            var baseName = memberAccess.Groups[1].Value;
+            var opener = new Regex(
+                @"^\s*\$" + Regex.Escape(baseName) + @"\s*=\s*@\{");
+            for (var i = 0; i < lines.Length; i++)
+            {
+                if (!opener.IsMatch(lines[i])) continue;
+                for (var j = i; j < Math.Min(i + 40, lines.Length); j++)
+                {
+                    if (lines[j].Contains(
+                            "$env:XDG_CONFIG_HOME", StringComparison.Ordinal))
+                        return $"member '{memberAccess.Groups[2].Value}' " +
+                               $"is not the member the env var was saved under " +
+                               $"(line {j + 1}: {lines[j].Trim()})";
+                    if (Regex.IsMatch(lines[j], @"^\s*\}")) break;
+                }
+            }
+        }
+
         if (hops > 6) return $"{rhs.Trim()} (chain too deep to verify)";
 
         // The own-RHS tripwires: reached without a marker, these are the
@@ -901,12 +1024,10 @@ public class HarnessConfigIsolationScanTests
             {
                 var line = lines[i];
                 if (!IsCode(line)) continue;
-                var assignment = XdgAssignment.Match(line);
-                if (!assignment.Success) continue;
+                if (!TryXdgAssignment(line, out var rhs)) continue;
 
                 var offending = UnrandomizedStaging(
-                    assignment.Groups[1].Value, lines, functions,
-                    new HashSet<string>(), 0);
+                    rhs, lines, functions, new HashSet<string>(), 0);
                 if (offending is not null)
                 {
                     violations.Add($"{rel}:{i + 1}: {line.Trim()}  <- {offending}");

--- a/windows/Ghostty.Tests/Wiring/HarnessConfigIsolationScanTests.cs
+++ b/windows/Ghostty.Tests/Wiring/HarnessConfigIsolationScanTests.cs
@@ -243,16 +243,56 @@ public class HarnessConfigIsolationScanTests
         // Splatting: @name passes the parameters of a hashtable; the
         // launch target is that hashtable's FilePath/FileName/Path member,
         // literal or variable. The member sits on the opener line itself
-        // when the hashtable is written on one line, so the member pattern
-        // tolerates the `$name = @{` prefix.
+        // when the hashtable is written on one line, and a MERGED splat
+        // (`$sp = $common + $extra`, `$sp += @{ ... }`) is followed through
+        // each operand's own hashtable, one or more hops. An operand that
+        // resolves to nothing leaves the splat unresolved, and an
+        // unresolved splat contributes NO candidate: the whole-line
+        // fallback below stays in force, so a merged splat is never
+        // blessed silently.
         foreach (var m in Regex.Matches(line, @"@(\w+)"))
         {
             var name = ((System.Text.RegularExpressions.Match)m).Groups[1].Value;
-            var opener = new Regex(
-                @"^\s*\$" + Regex.Escape(name) + @"\s*=\s*@\{");
-            for (var i = 0; i < lines.Length; i++)
+            var visited = new HashSet<string>(StringComparer.Ordinal);
+            if (TrySplatMembers(name, lines, visited, 0, out var members))
+                candidates.AddRange(members);
+        }
+
+        return candidates
+            .Where(c => !Regex.IsMatch(c, @"^[)\}]+$"))
+            .ToList();
+    }
+
+    /// <summary>
+    /// The FilePath/FileName/Path members behind a splat variable, through
+    /// direct hashtable definitions, `+=` hashtable appends, and `$a + $b`
+    /// compositions whose operands each resolve the same way. False means
+    /// some operand resolved to nothing, and the caller must fall back to
+    /// the whole line rather than trust an empty member set.
+    /// </summary>
+    private static bool TrySplatMembers(
+        string name, string[] lines, HashSet<string> visited, int hops,
+        out List<string> members)
+    {
+        members = new List<string>();
+        if (hops > 4) return false;
+        if (!visited.Add(name)) return true;
+
+        var sawDefinition = false;
+        var fullyResolved = true;
+        for (var i = 0; i < lines.Length; i++)
+        {
+            // A definition line: `= @{`, `+= @{`, or `= $a + $b`.
+            var definition = Regex.Match(lines[i],
+                @"^\s*\$" + Regex.Escape(name) + @"\s*(?:\+?=)\s*(.+?)(?:\s*#.*)?$");
+            if (!IsCode(lines[i]) || !definition.Success) continue;
+            sawDefinition = true;
+            var rhs = definition.Groups[1].Value;
+
+            if (rhs.TrimStart().StartsWith("@{", StringComparison.Ordinal))
             {
-                if (!opener.IsMatch(lines[i])) continue;
+                // Hashtable literal: read members from this line onward,
+                // through the closing brace.
                 for (var j = i; j < Math.Min(i + 40, lines.Length); j++)
                 {
                     var member = Regex.Match(
@@ -260,17 +300,28 @@ public class HarnessConfigIsolationScanTests
                         @"(?:^\s*|@\{\s*)(?:FilePath|FileName|Path)\s*=\s*(.+?)(?:\s*[}\]].*)?(?:\s*#.*)?$",
                         RegexOptions.IgnoreCase);
                     if (member.Success)
-                        candidates.Add(member.Groups[1].Value);
+                        members.Add(member.Groups[1].Value);
                     if (Regex.IsMatch(lines[j], @"^\s*\}") ||
-                        Regex.IsMatch(lines[j], @"\}\s*$") && j > i)
+                        (Regex.IsMatch(lines[j], @"\}\s*$") && j > i))
                         break;
                 }
+                continue;
+            }
+
+            // Composition: every operand must itself resolve.
+            foreach (var operand in Regex.Matches(rhs, @"\$(\w+)"))
+            {
+                var operandName =
+                    ((System.Text.RegularExpressions.Match)operand).Groups[1].Value;
+                if (TrySplatMembers(operandName, lines, visited, hops + 1,
+                        out var operandMembers))
+                    members.AddRange(operandMembers);
+                else
+                    fullyResolved = false;
             }
         }
 
-        return candidates
-            .Where(c => !Regex.IsMatch(c, @"^[)\}]+$"))
-            .ToList();
+        return sawDefinition && fullyResolved;
     }
 
     /// <summary>
@@ -661,6 +712,8 @@ public class HarnessConfigIsolationScanTests
             "violation-com-run.ps1",
             "violation-cdb-launches-app.ps1",
             "violation-splatting.ps1",
+            "violation-splat-composed.ps1",
+            "violation-splat-plus-equals.ps1",
             "violation-scriptblock-launch.ps1",
             "violation-mixed-case.ps1",
         };
@@ -671,6 +724,7 @@ public class HarnessConfigIsolationScanTests
             "clean-tooling-debugger.ps1",
             "clean-cdb-attach.ps1",
             "clean-splatting-armed.ps1",
+            "clean-splat-composed-armed.ps1",
         };
 
         var flagged = new HashSet<string>(StringComparer.Ordinal);

--- a/windows/Ghostty.Tests/Wiring/HarnessConfigIsolationScanTests.cs
+++ b/windows/Ghostty.Tests/Wiring/HarnessConfigIsolationScanTests.cs
@@ -292,7 +292,10 @@ public class HarnessConfigIsolationScanTests
             if (rhs.TrimStart().StartsWith("@{", StringComparison.Ordinal))
             {
                 // Hashtable literal: read members from this line onward,
-                // through the closing brace.
+                // stopping at the closing brace of THIS hashtable. A
+                // same-line close ends the scan on this line, so the
+                // window can never run on and read a member out of a
+                // different hashtable below.
                 for (var j = i; j < Math.Min(i + 40, lines.Length); j++)
                 {
                     var member = Regex.Match(
@@ -301,16 +304,21 @@ public class HarnessConfigIsolationScanTests
                         RegexOptions.IgnoreCase);
                     if (member.Success)
                         members.Add(member.Groups[1].Value);
-                    if (Regex.IsMatch(lines[j], @"^\s*\}") ||
-                        (Regex.IsMatch(lines[j], @"\}\s*$") && j > i))
-                        break;
+                    if (lines[j].Contains('}')) break;
                 }
                 continue;
             }
 
-            // Composition: every operand must itself resolve.
+            // Composition: every operand must itself resolve. An INLINE
+            // hashtable operand (`$a + @{ FilePath = ... }`) is read with
+            // the same member regex on this line; an operand that can be
+            // neither followed as a variable nor parsed as an inline
+            // hashtable makes the whole splat unresolved, so the caller
+            // keeps the whole-line fallback rather than trusting silence.
+            var sawOperand = false;
             foreach (var operand in Regex.Matches(rhs, @"\$(\w+)"))
             {
+                sawOperand = true;
                 var operandName =
                     ((System.Text.RegularExpressions.Match)operand).Groups[1].Value;
                 if (TrySplatMembers(operandName, lines, visited, hops + 1,
@@ -319,6 +327,29 @@ public class HarnessConfigIsolationScanTests
                 else
                     fullyResolved = false;
             }
+
+            if (rhs.Contains("@{", StringComparison.Ordinal))
+            {
+                sawOperand = true;
+                if (Regex.IsMatch(rhs, @"@\{\s*\}"))
+                {
+                    // An EMPTY inline hashtable resolves to nothing and
+                    // blesses nothing; it is not a parse failure.
+                }
+                else
+                {
+                    var inline = Regex.Match(
+                        lines[i],
+                        @"@\{\s*(?:FilePath|FileName|Path)\s*=\s*(.+?)(?:\s*[}\]].*)?(?:\s*#.*)?$",
+                        RegexOptions.IgnoreCase);
+                    if (inline.Success)
+                        members.Add(inline.Groups[1].Value);
+                    else
+                        fullyResolved = false;
+                }
+            }
+
+            if (!sawOperand) fullyResolved = false;
         }
 
         return sawDefinition && fullyResolved;
@@ -713,6 +744,8 @@ public class HarnessConfigIsolationScanTests
             "violation-cdb-launches-app.ps1",
             "violation-splatting.ps1",
             "violation-splat-composed.ps1",
+            "violation-splat-inline-operand.ps1",
+            "violation-splat-inline-only.ps1",
             "violation-splat-plus-equals.ps1",
             "violation-scriptblock-launch.ps1",
             "violation-mixed-case.ps1",
@@ -725,6 +758,7 @@ public class HarnessConfigIsolationScanTests
             "clean-cdb-attach.ps1",
             "clean-splatting-armed.ps1",
             "clean-splat-composed-armed.ps1",
+            "clean-splat-no-cross-hashtable.ps1",
         };
 
         var flagged = new HashSet<string>(StringComparer.Ordinal);

--- a/windows/Ghostty.Tests/Wiring/HarnessConfigIsolationScanTests.cs
+++ b/windows/Ghostty.Tests/Wiring/HarnessConfigIsolationScanTests.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// Layer 3 of the config-isolation rule: no script or recipe under
+/// windows/scripts or the justfile may launch the app without either
+/// arming <c>WINTTY_TEST_CONFIG</c> or going through an isolated-config
+/// helper.
+///
+/// Layers 1 and 2 are runtime enforcement (the app's guard refuses a
+/// non-temp config root loudly). This one is review-time enforcement: a
+/// new harness that forgets the env var fails <c>just test-win</c> with
+/// the file and line, before anyone spends a desktop lane discovering it.
+/// The check is textual on purpose: PowerShell has no Roslyn, and the
+/// property being pinned (a visible token next to a visible launch) is
+/// exactly what a reader of the harness needs to see anyway.
+///
+/// A file passes when ANY of these hold:
+/// <list type="number">
+/// <item>it assigns <c>WINTTY_TEST_CONFIG</c> on a non-comment line (the
+/// app then polices the root itself at run time, so an arming script can
+/// never silently taint);</item>
+/// <item>it goes through a helper that owns the arming:
+/// <c>Enter-WinttyTestConfig</c> (lib/test-config.ps1) or
+/// <c>Start-SeamSession</c> (lib/seam-client.ps1);</item>
+/// <item>it is on the allowlist below, each entry with its reason.</item>
+/// </list>
+///
+/// The allowlist bar: the launch must be provably unable to reach the
+/// config, or provably not a test. "Stable when unisolated" is not on the
+/// bar; that argument is what opted-in isolation was for, and the default
+/// is isolated now.
+/// </summary>
+public class HarnessConfigIsolationScanTests
+{
+    /// <summary>
+    /// Launchers that never touch config state, with the proof. Adding an
+    /// entry means claiming the launch cannot read, create or write the
+    /// config; the burden is on the entry, not on the scan.
+    /// </summary>
+    private static readonly Dictionary<string, string> Allowlist = new()
+    {
+        // `+crash` is intercepted in Program.MainImpl before InitGhostty
+        // and exits, so no config is ever read, created or written; the
+        // crash reporting probes only exercise the failure backend.
+        ["crash-canary.ps1"] = "+crash exits before InitGhostty; config is never reached",
+        ["crash-matrix.ps1"] = "+crash exits before InitGhostty; config is never reached",
+    };
+
+    /// <summary>
+    /// justfile recipes that execute the exe directly, with the proof.
+    /// </summary>
+    private static readonly Dictionary<string, string> JustfileAllowlist = new()
+    {
+        // Interactive dev runs of the developer's own environment: the
+        // point of the recipe is the real config. Not a test; the fuzz and
+        // seam recipes all route through scripts that arm the guard.
+        ["run-win"] = "interactive dev launch, not a test",
+        ["run-win-release"] = "interactive dev launch, not a test",
+    };
+
+    private static readonly Regex LaunchKeyword = new(
+        @"Start-Process|ProcessStartInfo", RegexOptions.Compiled);
+
+    /// <summary>
+    /// A variable whose name mentions the exe: $ExePath, $exe, $Exe,
+    /// $WinttyExe, $script:ExeFull. What it deliberately does not match:
+    /// $cdb (a debugger), $pwsh, $argLine, $ProcId. Detecting the launch
+    /// of the app is what the scan is for; launches of tooling are not
+    /// app launches even when they sit on the same line.
+    /// </summary>
+    private static readonly Regex AppExeToken = new(
+        @"\$[A-Za-z0-9_:.]*[Ee]xe[A-Za-z0-9_]*", RegexOptions.Compiled);
+
+    /// <summary>
+    /// An arming assignment on a code line:
+    /// <c>$env:WINTTY_TEST_CONFIG = '1'</c> or
+    /// <c>$psi.EnvironmentVariables['WINTTY_TEST_CONFIG'] = '1'</c>.
+    /// Requiring the <c>=</c> keeps prose mentions of the variable from
+    /// reading as arming.
+    /// </summary>
+    private static readonly Regex ArmingLine = new(
+        @"WINTTY_TEST_CONFIG['\]\s]*=", RegexOptions.Compiled);
+
+    private static readonly Regex HelperCall = new(
+        @"Enter-WinttyTestConfig|Start-SeamSession", RegexOptions.Compiled);
+
+    private static bool IsCode(string line)
+    {
+        var trimmed = line.TrimStart();
+        return trimmed.Length > 0 && trimmed[0] != '#';
+    }
+
+    private sealed record Launch(string File, int Line, string Text);
+
+    private static IEnumerable<Launch> AppLaunches(string file, string[] lines)
+    {
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            if (!IsCode(line)) continue;
+            if (!LaunchKeyword.IsMatch(line)) continue;
+            if (!AppExeToken.IsMatch(line)) continue;
+            yield return new Launch(file, i + 1, line.Trim());
+        }
+    }
+
+    private static bool FileIsClean(string[] lines) =>
+        lines.Any(l => IsCode(l) && (ArmingLine.IsMatch(l) || HelperCall.IsMatch(l)));
+
+    [Fact]
+    public void Every_App_Launch_In_Scripts_Arms_The_Test_Config_Guard()
+    {
+        var root = RepoRoot();
+        var scriptDir = Path.Combine(root, "windows", "scripts");
+        Assert.True(Directory.Exists(scriptDir), "windows/scripts not found");
+
+        var violations = new List<string>();
+        foreach (var file in Directory.EnumerateFiles(
+                     scriptDir, "*.ps1", SearchOption.AllDirectories)
+                     .OrderBy(f => f, StringComparer.Ordinal))
+        {
+            // The selftest fixtures are config-fragment corpora for
+            // fuzz-suite's layer checks; none of them launches anything.
+            if (file.Replace('\\', '/').Contains("/lib/fuzz-selftest/")) continue;
+
+            var rel = Path.GetRelativePath(scriptDir, file);
+            var name = Path.GetFileName(file);
+            var lines = File.ReadAllLines(file);
+            if (FileIsClean(lines)) continue;
+
+            if (Allowlist.TryGetValue(name, out var reason))
+            {
+                // Still prove the file launches the app the allowlist says
+                // it does; an allowlisted name that stopped launching would
+                // silently keep covering whatever replaced it.
+                Assert.NotEmpty(AppLaunches(rel, lines));
+                continue;
+            }
+
+            violations.AddRange(AppLaunches(rel, lines)
+                .Select(l => $"{l.File}:{l.Line}: {l.Text}"));
+        }
+
+        Assert.True(
+            violations.Count == 0,
+            "app launch(es) that neither arm WINTTY_TEST_CONFIG nor go through " +
+            "an isolated-config helper (lib/test-config.ps1 or lib/seam-client.ps1). " +
+            "Stage a random temp XDG root and set WINTTY_TEST_CONFIG=1 for the " +
+            "child, or add a justified allowlist entry:\n  " +
+            string.Join("\n  ", violations));
+    }
+
+    [Fact]
+    public void Justfile_Recipes_Execute_The_Exe_Only_Where_Isolation_Is_Intended()
+    {
+        var root = RepoRoot();
+        var path = Path.Combine(root, "justfile");
+        Assert.True(File.Exists(path), "justfile not found");
+
+        var violations = new List<string>();
+        var recipe = "?";
+        foreach (var (line, index) in File.ReadAllLines(path)
+                     .Select((l, i) => (l, i)))
+        {
+            var recipeHeader = Regex.Match(line, @"^([A-Za-z][\w-]*):");
+            if (recipeHeader.Success)
+            {
+                recipe = recipeHeader.Groups[1].Value;
+                continue;
+            }
+
+            var trimmed = line.Trim();
+            if (trimmed.Length == 0 || trimmed.StartsWith('#')) continue;
+
+            // The exe as the line's first token is a direct execution; the
+            // same path as an argument (-ExePath ...) is a script's input
+            // and that script's own scan governs it.
+            var firstToken = trimmed.Split(' ')[0];
+            if (!firstToken.EndsWith("Wintty.exe", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            if (JustfileAllowlist.ContainsKey(recipe)) continue;
+            violations.Add($"justfile:{index + 1} (recipe {recipe}): {trimmed}");
+        }
+
+        Assert.True(
+            violations.Count == 0,
+            "justfile executes the app outside a script, without arming " +
+            "WINTTY_TEST_CONFIG. Route the launch through a harness script " +
+            "(they stage a random temp XDG root and arm the guard) or justify " +
+            "an allowlist entry:\n  " + string.Join("\n  ", violations));
+    }
+
+    [Fact]
+    public void Seam_Client_Itself_Arms_The_Guard()
+    {
+        // Every Start-SeamSession consumer leans on this one file to arm,
+        // so the first scan's helper pass would stay green even if the
+        // arming were deleted out of seam-client. This pins the arming to
+        // the place it actually happens.
+        var root = RepoRoot();
+        var path = Path.Combine(root, "windows", "scripts", "lib", "seam-client.ps1");
+        Assert.True(File.Exists(path), "lib/seam-client.ps1 not found");
+
+        Assert.Contains(File.ReadAllLines(path),
+            l => IsCode(l) && ArmingLine.IsMatch(l));
+    }
+
+    private static string RepoRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir, "build.zig")))
+                return dir;
+            dir = Directory.GetParent(dir)?.FullName;
+        }
+        throw new InvalidOperationException("repo root not found");
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/clean-armed-launch.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/clean-armed-launch.ps1
@@ -1,0 +1,4 @@
+# Fixture: the blessed shape, must NOT be flagged.
+$env:WINTTY_TEST_CONFIG = '1'
+$ExePath = "C:/b1/Wintty.exe"
+Start-Process -FilePath $ExePath

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/clean-cdb-attach.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/clean-cdb-attach.ps1
@@ -1,0 +1,3 @@
+# Fixture: cdb attaching to a running pid, not launching anything.
+$cdb = 'C:/dbg/cdb.exe'
+Start-Process -FilePath $cdb -ArgumentList '-g', '-p', '4242'

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/clean-splat-composed-armed.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/clean-splat-composed-armed.ps1
@@ -1,0 +1,7 @@
+# Control: a composed splat launching an armed, isolated app stays clean.
+$env:WINTTY_TEST_CONFIG = '1'
+$session = Enter-WinttyTestConfig
+$common = @{ PassThru = $true }
+$extra = @{ FilePath = 'C:\b1\Wintty.exe' }
+$sp = $common + $extra
+Start-Process @sp

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/clean-splat-no-cross-hashtable.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/clean-splat-no-cross-hashtable.ps1
@@ -1,0 +1,7 @@
+# Control: no cross-hashtable read (R4-2). The scanned hashtable has no
+# FilePath and closes on its own line; the NEIGHBOUR on the next line
+# holds an app path that must NOT become evidence for @h, so this tooling
+# launch must stay clean.
+$h = @{}
+$neighbour = @{ FilePath = 'C:\b1\Wintty.exe' }
+Start-Process @h -FilePath 'pwsh.exe'

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/clean-splatting-armed.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/clean-splatting-armed.ps1
@@ -1,0 +1,4 @@
+# Control: splatting an armed launch of the app must stay clean.
+$env:WINTTY_TEST_CONFIG = '1'
+$sp = @{ FilePath = 'C:\b1\Wintty.exe' }
+Start-Process @sp

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/clean-tooling-debugger.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/clean-tooling-debugger.ps1
@@ -1,0 +1,3 @@
+# Fixture: a debugger launch, must NOT be flagged.
+$cdb = 'C:/debuggers/cdb.exe'
+Start-Process -FilePath $cdb -ArgumentList "-g -G" | Out-Null

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/clean-tooling-psi.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/clean-tooling-psi.ps1
@@ -1,0 +1,4 @@
+# Fixture: the same psi form launching tooling, must NOT be flagged.
+$psi = [System.Diagnostics.ProcessStartInfo]::new()
+$psi.FileName = 'pwsh'
+[System.Diagnostics.Process]::Start($psi) | Out-Null

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/staging-classic-var.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/staging-classic-var.ps1
@@ -1,0 +1,3 @@
+# Fixture: the classic intermediate-variable shape (control).
+$xdg = Join-Path $env:TEMP 'wintty-att-classic-fixed'
+$env:XDG_CONFIG_HOME = $xdg

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/staging-clock.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/staging-clock.ps1
@@ -1,0 +1,2 @@
+# Fixture: clock-keyed direct assignment.
+$env:XDG_CONFIG_HOME = "$env:TEMP\wintty-att-" + (Get-Date -Format 'HHmmss')

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/staging-direct-fixed.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/staging-direct-fixed.ps1
@@ -1,0 +1,2 @@
+# Fixture: a direct fixed-name staging root.
+$env:XDG_CONFIG_HOME = Join-Path $env:TEMP 'wintty-att-fixed-root'

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/staging-green-guid.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/staging-green-guid.ps1
@@ -1,0 +1,2 @@
+# Control: guid form.
+$env:XDG_CONFIG_HOME = Join-Path $env:TEMP ("wintty-ok-" + [guid]::NewGuid().ToString("N"))

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/staging-green-helper.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/staging-green-helper.ps1
@@ -1,0 +1,3 @@
+# Control: the harness helper.
+$s = Enter-WinttyTestConfig
+$env:XDG_CONFIG_HOME = $s.Dir

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/staging-green-randomfile.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/staging-green-randomfile.ps1
@@ -1,0 +1,2 @@
+# Control: GetRandomFileName form.
+$env:XDG_CONFIG_HOME = Join-Path $env:TEMP ([IO.Path]::GetRandomFileName())

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/staging-green-restore.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/staging-green-restore.ps1
@@ -1,0 +1,4 @@
+# Control: a genuine save and restore, paired by the variable.
+$savedXdg = $env:XDG_CONFIG_HOME
+$env:XDG_CONFIG_HOME = Join-Path $env:TEMP ("wintty-ok-" + [guid]::NewGuid().ToString("N"))
+$env:XDG_CONFIG_HOME = $savedXdg

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/staging-member-wrong-restore.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/staging-member-wrong-restore.ps1
@@ -1,0 +1,4 @@
+# Fixture: a member-shape restore through the WRONG member (R2-3): the
+# object saved the value under OrigXdg, the assignment reads OtherXdg.
+$Session = @{ OrigXdg = if (Test-Path Env:XDG_CONFIG_HOME) { $env:XDG_CONFIG_HOME } else { $null } }
+$env:XDG_CONFIG_HOME = $Session.OtherXdg

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/staging-param-default.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/staging-param-default.ps1
@@ -1,0 +1,3 @@
+# Fixture: a fixed root set as a param default (R2-3), verbatim shape.
+param([string]$XdgRoot = 'C:\fixed')
+$env:XDG_CONFIG_HOME = $XdgRoot

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/staging-pid.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/staging-pid.ps1
@@ -1,0 +1,2 @@
+# Fixture: PID is not randomness.
+$env:XDG_CONFIG_HOME = "$env:TEMP\wintty-att-$PID"

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/staging-preview-literal.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/staging-preview-literal.ps1
@@ -1,0 +1,2 @@
+# Fixture: a literal containing 'prev' is not a restore.
+$env:XDG_CONFIG_HOME = "$env:TEMP\wintty-preview"

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/staging-prevname-var.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/staging-prevname-var.ps1
@@ -1,0 +1,3 @@
+# Fixture: a prev-named variable holding a fixed path is not a restore.
+$previousRun = 'C:\wt\rev1084-att\fixed-root'
+$env:XDG_CONFIG_HOME = $previousRun

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/staging-set-item.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/staging-set-item.ps1
@@ -1,0 +1,2 @@
+# Fixture: Set-Item on the env drive (R2-3).
+Set-Item Env:\XDG_CONFIG_HOME 'C:\fixed'

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/staging-setenvvar.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/staging-setenvvar.ps1
@@ -1,0 +1,2 @@
+# Fixture: the .NET SetEnvironmentVariable spelling (R2-3).
+[Environment]::SetEnvironmentVariable('XDG_CONFIG_HOME', 'C:\fixed', 'Process')

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-call-operator-interp.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-call-operator-interp.ps1
@@ -1,0 +1,3 @@
+# Fixture: the call operator with an interpolated app path.
+$dir = 'C:'
+& "$dir\Wintty.exe"

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-call-operator-literal.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-call-operator-literal.ps1
@@ -1,0 +1,2 @@
+# Fixture: the call operator with a literal app path.
+& 'C:\wt\rev1084-att\Wintty.exe' --flag

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-call-operator.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-call-operator.ps1
@@ -1,0 +1,3 @@
+# Fixture: the call-operator launch form, unguarded. The scan must flag it.
+$ExePath = "C:/b1/Wintty.exe"
+& $ExePath --flag

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-cdb-launches-app.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-cdb-launches-app.ps1
@@ -1,0 +1,3 @@
+# Fixture: cdb starting the app as its debuggee.
+$cdb = 'C:/dbg/cdb.exe'
+Start-Process -FilePath $cdb -ArgumentList '-g', 'C:/bin/Wintty.exe'

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-cmd-start.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-cmd-start.ps1
@@ -1,0 +1,3 @@
+# Fixture: cmd /c start of the app, unguarded.
+$ExePath = "C:/b1/Wintty.exe"
+cmd /c start "" $ExePath

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-com-run.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-com-run.ps1
@@ -1,0 +1,3 @@
+# Fixture: a COM shell launching the app.
+$shell = New-Object -ComObject WScript.Shell
+$shell.Run('C:\wt\Wintty.exe', 1, $false)

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-conditional-arm.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-conditional-arm.ps1
@@ -1,0 +1,5 @@
+# Fixture: arming only inside a conditional blesses nothing.
+if ($Real) {
+    $env:WINTTY_TEST_CONFIG = '1'
+}
+Start-Process -FilePath $ExePath

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-dotnet-run.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-dotnet-run.ps1
@@ -1,0 +1,2 @@
+# Fixture: dotnet run of the app project, unguarded.
+dotnet run --project windows/Ghostty

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-explorer.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-explorer.ps1
@@ -1,0 +1,2 @@
+# Fixture: explorer.exe shell-open of the app, unguarded.
+explorer.exe C:/bin/Wintty.exe

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-invoke-item.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-invoke-item.ps1
@@ -1,0 +1,3 @@
+# Fixture: Invoke-Item of the app, unguarded.
+$WinttyExe = "C:/b1/Wintty.exe"
+Invoke-Item $WinttyExe

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-literal-start-process.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-literal-start-process.ps1
@@ -1,0 +1,2 @@
+# Fixture: Start-Process with a literal exe path, no exe-named variable.
+Start-Process -FilePath 'C:/build/Wintty.exe'

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-mixed-case.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-mixed-case.ps1
@@ -1,0 +1,4 @@
+# Fixture: mixed-case verbs, the R2-2 part that is just PowerShell.
+STArt-Process -FilePath 'C:\wt\rev1084-att\Wintty.exe'
+START -FilePath 'C:\wt\rev1084-att\Wintty.exe'
+SAPS -FilePath 'C:\wt\rev1084-att\Wintty.exe'

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-process-start-static.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-process-start-static.ps1
@@ -1,0 +1,3 @@
+# Fixture: the static Process.Start form, unguarded.
+$ExePath = "C:/b1/Wintty.exe"
+[System.Diagnostics.Process]::Start($ExePath) | Out-Null

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-psi-indirect-literal.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-psi-indirect-literal.ps1
@@ -1,0 +1,4 @@
+# Fixture: ProcessStartInfo with a literal app path set by property.
+$psi = [System.Diagnostics.ProcessStartInfo]::new()
+$psi.FileName = 'C:/bin/Wintty.exe'
+[System.Diagnostics.Process]::Start($psi) | Out-Null

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-psi-indirect-var.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-psi-indirect-var.ps1
@@ -1,0 +1,4 @@
+# Fixture: ProcessStartInfo with the app set by property, launched via ::Start.
+$psi = [System.Diagnostics.ProcessStartInfo]::new()
+$psi.FileName = $ExePath
+[System.Diagnostics.Process]::Start($psi) | Out-Null

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-saps.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-saps.ps1
@@ -1,0 +1,3 @@
+# Fixture: the Start-Process alias.
+$ExePath = "C:/b1/Wintty.exe"
+saps -FilePath $ExePath

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-scriptblock-launch.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-scriptblock-launch.ps1
@@ -1,0 +1,2 @@
+# Fixture: the inline scriptblock launch, verbatim from re-review 2 (R2-1).
+Start-Job -ScriptBlock { Start-Process -FilePath 'C:\wt\rev1084-att\Wintty.exe' }

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-splat-composed.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-splat-composed.ps1
@@ -1,0 +1,5 @@
+# Fixture: the merged-splat shape, verbatim from re-review 3 (R3-1).
+$common = @{ PassThru = $true }
+$extra = @{ FilePath = 'C:\wt\rev1084-att\Wintty.exe' }
+$sp = $common + $extra
+Start-Process @sp

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-splat-inline-only.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-splat-inline-only.ps1
@@ -1,0 +1,5 @@
+# Fixture: the base + inline composition shape (r4-8), now correct by
+# design: the inline operand itself is followed, not a window overrun.
+$base = @{}
+$sp = $base + @{ FilePath = 'C:\wt\rev1084-att\Wintty.exe' }
+Start-Process @sp

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-splat-inline-operand.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-splat-inline-operand.ps1
@@ -1,0 +1,4 @@
+# Fixture: an inline hashtable operand inside a composition (R4-1).
+$a = $b + @{}
+$b = $a + @{ FilePath = 'C:\wt\rev1084-att\Wintty.exe' }
+Start-Process @a

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-splat-plus-equals.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-splat-plus-equals.ps1
@@ -1,0 +1,4 @@
+# Fixture: the += composition of a splat hashtable (R3-1).
+$sp = @{ PassThru = $true }
+$sp += @{ FilePath = 'C:\wt\rev1084-att\Wintty.exe' }
+Start-Process @sp

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-splatting.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-splatting.ps1
@@ -1,0 +1,3 @@
+# Fixture: splatting, verbatim from re-review 2 (R2-1).
+$sp = @{ FilePath = 'C:\wt\rev1084-att\Wintty.exe' }
+Start-Process @sp

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-unresolved-var.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/violation-unresolved-var.ps1
@@ -1,0 +1,3 @@
+# Fixture: a launch variable the scan cannot resolve: fail closed.
+$app = Get-BuiltApp
+Start-Process -FilePath $app

--- a/windows/Ghostty.Tests/Wiring/TestConfigGuardWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TestConfigGuardWiringTests.cs
@@ -1,0 +1,215 @@
+using System;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// The test-config guard's wiring: every path a config byte can travel has
+/// a guard call on it, and the one editor construction still sits over the
+/// resolved config path.
+///
+/// These are wiring guards, not behaviour tests (the behaviour lives in
+/// <c>Config.TestConfigGuardTests</c> and in the harness matrix the guard's
+/// PR ran). What they prove is shape: that <c>Program</c> refuses before
+/// anything can touch a config file, that the resolved path and each write
+/// boundary still carry the belt checks, and that a new writer cannot reach
+/// the file without going through the guarded editor. A regression that
+/// keeps the literal and drops the behaviour walks through a substring
+/// match; it does not walk through a syntax tree.
+/// </summary>
+public class TestConfigGuardWiringTests
+{
+    private const string GuardCall = "TestConfigGuard.AssertUnderTemp";
+
+    /// <summary>
+    /// Every guard call in the shell, matched on the callee's tail: the
+    /// call sites spell the type namespace-qualified
+    /// (<c>Ghostty.Core.Config.TestConfigGuard.AssertUnderTemp</c>) and
+    /// <see cref="SyntaxQueries.Calls"/> matches the callee as written.
+    /// </summary>
+    private static List<Microsoft.CodeAnalysis.CSharp.Syntax.InvocationExpressionSyntax>
+        GuardCalls(Microsoft.CodeAnalysis.SyntaxNode node) =>
+        node.DescendantNodes()
+            .OfType<Microsoft.CodeAnalysis.CSharp.Syntax.InvocationExpressionSyntax>()
+            .Where(i => i.CalleeText().EndsWith(GuardCall, StringComparison.Ordinal))
+            .ToList();
+
+    [Fact]
+    public void Program_Refuses_NonTemp_Root_Before_Anything_Touches_Config()
+    {
+        var source = ShellSource.Load("Program.cs");
+        var main = source.Method("MainImpl");
+
+        // The guard call itself, in MainImpl's own body.
+        var guard = main.Call("GuardTestConfigRoot");
+
+        // And before the first InitGhostty: libghostty's config parsing and
+        // its config-dir/template creates all hang off init, so a guard that
+        // runs after it has already lost the race with the native writes.
+        var firstInit = main.Calls("InitGhostty").First();
+        Assert.True(
+            guard.Span.Start < firstInit.Span.Start,
+            $"GuardTestConfigRoot ({guard.Span.Start}) must precede the first " +
+            $"InitGhostty ({firstInit.Span.Start}) in MainImpl");
+    }
+
+    [Fact]
+    public void GuardTestConfigRoot_Exits_With_Its_Own_Refusal_Code()
+    {
+        var source = ShellSource.Load("Program.cs");
+        var guard = source.Method("GuardTestConfigRoot");
+
+        // The refusal must be an exit the harness can distinguish from a
+        // crash, and the enum member is what keeps that exit code from
+        // silently colliding with a different meaning later.
+        var exit = guard.Body!.Statements.OfType<ExpressionStatementSyntax>()
+            .Select(s => s.Expression).OfType<InvocationExpressionSyntax>()
+            .SingleOrDefault(c => c.CalleeText() == "Environment.Exit");
+        Assert.NotNull(exit);
+        Assert.Contains("ExitCode.TestConfigRefused", exit.ArgumentList.ToString());
+
+        // A refusal nobody can see is a hang with extra steps: the method
+        // must say why on stderr before it exits.
+        Assert.NotEmpty(guard.Calls("WriteStderr"));
+    }
+
+    [Fact]
+    public void ConfigService_Guards_The_Resolved_Path_Before_Seed_Or_Reads()
+    {
+        var source = ShellSource.Load("Services.ConfigService.cs");
+        var ctor = source.Root.DescendantNodes()
+            .OfType<ConstructorDeclarationSyntax>()
+            .Single(c => c.Identifier.ValueText == "ConfigService");
+
+        var resolved = ctor.AssignsTo("ConfigFilePath").Single();
+        var assert = GuardCalls(ctor).Single();
+        var seed = ctor.Body!.Statements
+            .SelectMany(s => s.DescendantNodes().OfType<InvocationExpressionSyntax>())
+            .Single(c => c.CalleeText() == "SeedConfigIfEmpty");
+
+        Assert.True(resolved.Span.Start < assert.Span.Start,
+            "the guard must see the resolved ConfigFilePath, not the raw one");
+        Assert.True(assert.Span.Start < seed.Span.Start,
+            "the seed write happens after the guard, or it writes unguarded");
+    }
+
+    [Fact]
+    public void SeedConfigIfEmpty_Guards_Outside_The_Recovery_Try()
+    {
+        var source = ShellSource.Load("Services.ConfigService.cs");
+        var seed = source.Method("SeedConfigIfEmpty");
+
+        var write = seed.Calls("File.WriteAllText").Single();
+        var assert = GuardCalls(seed).Single();
+        var swallowingTry = write.Ancestors().OfType<TryStatementSyntax>()
+            .SingleOrDefault(t => t.Catches.Count > 0);
+
+        // The try exists so a flaky config dir cannot take startup down.
+        // A guard inside it would be exactly that failure, smoothed over:
+        // logged, swallowed, and the launch continues unisolated.
+        Assert.NotNull(swallowingTry);
+        Assert.DoesNotContain(assert.Ancestors(), a => a == swallowingTry);
+        Assert.True(assert.Span.Start < write.Span.Start,
+            "the guard must run before the write it guards");
+    }
+
+    [Fact]
+    public void WriteAtomic_Is_One_Guarded_Choke_Point_For_Every_Write()
+    {
+        var source = ShellSource.Load("Services.ConfigFileEditor.cs");
+        var overloads = source.Root.DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .Where(m => m.Identifier.ValueText == "WriteAtomic")
+            .ToList();
+        Assert.Equal(2, overloads.Count);
+
+        var stringOverload = overloads.Single(m =>
+            m.ParameterList.Parameters.Count == 1 &&
+            m.ParameterList.Parameters[0].Type?.ToString() == "string");
+        var arrayOverload = overloads.Single(o => o != stringOverload);
+
+        var assert = GuardCalls(stringOverload).Single();
+        var write = stringOverload.Body!.Statements
+            .SelectMany(s => s.DescendantNodes().OfType<InvocationExpressionSyntax>())
+            .Single(c => c.CalleeText() == "File.WriteAllText");
+        Assert.True(assert.Span.Start < write.Span.Start,
+            "the guard must run before the write it guards");
+
+        // The array overload routes through the guarded string overload, so
+        // a new mutating method added above the editor still lands on the
+        // one guarded boundary as long as it writes the way the existing
+        // ones do.
+        var routes = arrayOverload.Calls("WriteAtomic");
+        Assert.Single(routes);
+    }
+
+    [Fact]
+    public void The_Real_Editor_Is_Constructed_Once_Over_The_Resolved_Path()
+    {
+        // Corpus-wide, not just App.xaml.cs: "only one construction" is the
+        // invariant that makes the WriteAtomic choke point cover every
+        // writer, and a second construction anywhere would be a second
+        // writer with its own opinion about the path.
+        var constructions = ShellSource.AllFiles()
+            .SelectMany(f => f.Root.DescendantNodes()
+                .OfType<ObjectCreationExpressionSyntax>()
+                .Where(c => c.Type.ToString() == "ConfigFileEditor")
+                .Select(c => (File: f.Name, Creation: c)))
+            .ToList();
+        var construction = Assert.Single(constructions);
+        Assert.Equal("App.xaml.cs", construction.File);
+
+        // Over the service's resolved path: the one path the guards
+        // already vouch for.
+        Assert.Equal(
+            "_configService.ConfigFilePath",
+            construction.Creation.ArgumentList.Arguments[0].ToString());
+    }
+
+    [Fact]
+    public void NoConfig_Run_Gets_The_Refusing_Editor_Not_The_Real_One()
+    {
+        var source = ShellSource.Load("App.xaml.cs");
+        var inert = source.Root.DescendantNodes()
+            .OfType<ObjectCreationExpressionSyntax>()
+            .Single(c => c.Type.ToString().EndsWith(
+                "NoConfigFileEditor", System.StringComparison.Ordinal));
+
+        // The branch condition names the flag, so the inert editor cannot
+        // quietly become the unconditional one (which would break every
+        // real run's persistence) nor the unreachable one.
+        var branch = inert.Ancestors().OfType<ConditionalExpressionSyntax>()
+            .SingleOrDefault();
+        Assert.NotNull(branch);
+        Assert.Contains("NoConfig", branch.Condition.ToString());
+        Assert.Equal(inert, branch.WhenTrue);
+
+        // And the real editor is the other arm, over the resolved path.
+        var real = branch.WhenTrue == inert
+            ? branch.WhenFalse
+            : branch.WhenTrue;
+        Assert.Contains("ConfigFileEditor", real.ToString());
+        Assert.Contains("ConfigFilePath", real.ToString());
+    }
+
+    [Fact]
+    public void Startup_Migration_Skips_Config_Appends_Under_NoConfig()
+    {
+        var source = ShellSource.Load("Settings.WindowStateMigration.cs");
+        var run = source.Method("TryRun");
+
+        // The appends initializer must branch on the flag. Computing the
+        // appends and then handing them to the refusing editor would turn
+        // every --no-config launch with legacy settings into a logged
+        // refusal; the placement-only half below is allowed to still run.
+        var appends = run.DescendantNodes()
+            .OfType<VariableDeclaratorSyntax>()
+            .Single(v => v.Identifier.ValueText == "appends");
+        var conditional = Assert.IsType<ConditionalExpressionSyntax>(
+            appends.Initializer?.Value);
+        Assert.Contains("NoConfig", conditional.Condition.ToString());
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/TestConfigGuardWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TestConfigGuardWiringTests.cs
@@ -62,10 +62,16 @@ public class TestConfigGuardWiringTests
         var source = ShellSource.Load("Program.cs");
         var guard = source.Method("GuardTestConfigRoot");
 
+        // Every refusal path funnels through RefuseTestConfigStart, so the
+        // exit code and the stderr line live in exactly one place.
+        var refusals = guard.Calls("RefuseTestConfigStart");
+        Assert.NotEmpty(refusals);
+
+        var refuse = source.Method("RefuseTestConfigStart");
         // The refusal must be an exit the harness can distinguish from a
         // crash, and the enum member is what keeps that exit code from
         // silently colliding with a different meaning later.
-        var exit = guard.Body!.Statements.OfType<ExpressionStatementSyntax>()
+        var exit = refuse.Body!.Statements.OfType<ExpressionStatementSyntax>()
             .Select(s => s.Expression).OfType<InvocationExpressionSyntax>()
             .SingleOrDefault(c => c.CalleeText() == "Environment.Exit");
         Assert.NotNull(exit);
@@ -73,7 +79,74 @@ public class TestConfigGuardWiringTests
 
         // A refusal nobody can see is a hang with extra steps: the method
         // must say why on stderr before it exits.
-        Assert.NotEmpty(guard.Calls("WriteStderr"));
+        Assert.NotEmpty(refuse.Calls("WriteStderr"));
+        Assert.NotEmpty(refuse.Calls("WriteStartupDiagnostic"));
+    }
+
+    [Fact]
+    public void GuardTestConfigRoot_Checks_The_Temp_Environment_Before_The_Root()
+    {
+        var source = ShellSource.Load("Program.cs");
+        var guard = source.Method("GuardTestConfigRoot");
+
+        // M1: a redirected TEMP/TMP is the one environment change that
+        // could move the guard's reference point, so it is the FIRST armed
+        // question, before the root is even resolved.
+        var envCheck = guard.DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .FirstOrDefault(i => i.CalleeText().EndsWith(
+                "TestConfigGuard.AssertTempEnvironmentIntact",
+                StringComparison.Ordinal));
+        Assert.NotNull(envCheck);
+        var rootResolve = guard.DescendantNodes()
+            .OfType<IdentifierNameSyntax>()
+            .FirstOrDefault(i => i.Identifier.ValueText == "ResolveConfigRoot");
+        Assert.NotNull(rootResolve);
+        Assert.True(envCheck!.Span.Start < rootResolve!.Span.Start,
+            "the TEMP/TMP integrity check must precede the root resolution");
+    }
+
+    [Fact]
+    public void GuardTestConfigSources_Covers_The_Flag_And_The_Includes()
+    {
+        var source = ShellSource.Load("Program.cs");
+        var sources = source.Method("GuardTestConfigSources");
+
+        // The CLI flag form: both spellings the rewrite passes through.
+        Assert.Contains("--config-file=", sources.Body!.ToString());
+
+        // The include form: the ini-shaped key, scanned from the root's
+        // default files and recursed (the ScanConfigIncludes local
+        // function is the recursion).
+        Assert.Contains("config-file", sources.Body!.ToString());
+        Assert.Contains("ScanConfigIncludes", sources.Body!.ToString());
+
+        // GuardTestConfigRoot must call it, or none of this runs.
+        Assert.NotEmpty(source.Method("GuardTestConfigRoot")
+            .Calls("GuardTestConfigSources"));
+    }
+
+    [Fact]
+    public void NoConfig_Resolves_The_Path_Without_Creating_It()
+    {
+        var source = ShellSource.Load("Services.ConfigService.cs");
+        var ctor = source.Root.DescendantNodes()
+            .OfType<ConstructorDeclarationSyntax>()
+            .Single(c => c.Identifier.ValueText == "ConfigService");
+
+        // The create is native (edit.zig openPath); the no-create variant
+        // is the same resolution without it. A --no-config run must not
+        // even leave an empty file behind where none existed.
+        var conditional = ctor.Body!.Statements
+            .SelectMany(s => s.DescendantNodes().OfType<ConditionalExpressionSyntax>())
+            .Single(c => c.WhenTrue.ToString().Contains("ConfigOpenPathNoCreate"));
+        Assert.Contains("ConfigOpenPath", conditional.WhenFalse.ToString());
+
+        // The early single-instance read resolves too, under the same rule.
+        var program = ShellSource.Load("Program.cs");
+        var reader = program.Method("ReadSingleInstanceSetting");
+        Assert.Contains("ConfigOpenPathNoCreate", reader.Body!.ToString());
+        Assert.Contains("ConfigOpenPath", reader.Body!.ToString());
     }
 
     [Fact]

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -31,7 +31,9 @@ public partial class App : Application
     // Process-global libghostty: bootstrap host owns the app handle; per-window hosts own only their surfaces.
     private ConfigService? _configService;
     private Ghostty.Accessibility.HighContrastMonitor? _highContrastMonitor;
-    private ConfigFileEditor? _configEditor;
+    // The interface, because a --no-config run holds the refusing editor
+    // (Ghostty.Core.Config.NoConfigFileEditor) rather than the real one.
+    private Ghostty.Core.Config.IConfigFileEditor? _configEditor;
     private ConfigWriteScheduler? _configWriteScheduler;
     private Ghostty.Core.Notifications.NotificationService? _notificationService;
     private WindowsPowerStateMonitor? _powerStateMonitor;

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -893,7 +893,15 @@ public partial class App : Application
         // batched write rather than a burst. The 150ms debounce is
         // short enough that toggle clicks still feel instant when
         // committed, long enough to absorb a slider drag.
-        _configEditor = new ConfigFileEditor(_configService.ConfigFilePath);
+        //
+        // --no-config gets the refusing editor, not the real one: the flag
+        // exists to ignore the config file, so the run that flew it must
+        // not write that file either. Reads through the editor answer
+        // empty, matching ConfigSourcePath's null; writes throw, and the
+        // scheduler and migrator log the refusal instead of crashing.
+        _configEditor = _configService.NoConfig
+            ? new Ghostty.Core.Config.NoConfigFileEditor()
+            : new ConfigFileEditor(_configService.ConfigFilePath);
         ConfigFileEditor = _configEditor;
 
         var uiDispatcher = DispatcherQueue.GetForCurrentThread();

--- a/windows/Ghostty/Controls/Notifications/NotificationHost.xaml
+++ b/windows/Ghostty/Controls/Notifications/NotificationHost.xaml
@@ -8,7 +8,7 @@
 
     The control collapses itself (Visibility.Collapsed, in code-behind) when
     it has no active bars. A Collapsed element reports (0,0) DesiredSize
-    regardless of its content's Margin -- unlike merely emptying the inner
+    regardless of its content's Margin: unlike merely emptying the inner
     StackPanel, whose own Margin is folded into DesiredSize even with zero
     children and would otherwise keep the Auto row, and this control's
     opaque background, permanently ~16px tall. MainWindow calls Attach()

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -509,6 +509,10 @@ internal static partial class NativeMethods
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
     internal static partial GhosttyString ConfigOpenPath();
 
+    [LibraryImport(Dll, EntryPoint = "ghostty_config_open_path_no_create")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    internal static partial GhosttyString ConfigOpenPathNoCreate();
+
     // ---- app -----------------------------------------------------------
 
     [LibraryImport(Dll, EntryPoint = "ghostty_app_new")]

--- a/windows/Ghostty/Program.cs
+++ b/windows/Ghostty/Program.cs
@@ -914,7 +914,7 @@ public static partial class Program
         // root here is the only placement that refuses before a native
         // read or create, not after. Sits after the intercepts above
         // (+version, +crash, help), none of which read config.
-        GuardTestConfigRoot();
+        GuardTestConfigRoot(args);
 
         // CLI actions are delegated to libghostty, matching the macOS
         // architecture: ghostty_init parses argv, ghostty_cli_run_action
@@ -1032,40 +1032,152 @@ public static partial class Program
     /// non-zero before any window opens and before libghostty reads or
     /// creates a single config byte.
     ///
-    /// The root is computed managed-side, mirroring
-    /// <c>src/os/xdg.zig dir()</c> for the config dir: XDG_CONFIG_HOME,
-    /// else APPDATA, else the home directory. Everything downstream, every
-    /// read and every writer including libghostty's own creates, derives
-    /// from that one root, so proving it is under temp proves all of them.
-    /// The resolved-path and write-boundary checks in ConfigService,
+    /// The root comes from <see cref="Ghostty.Core.Config.TestConfigGuard.
+    /// ResolveConfigRoot"/> (the managed mirror of xdg.zig's dir(), parity-
+    /// pinned) and the anchor is the known-folder temp the environment
+    /// cannot move. Everything downstream, every read and every writer
+    /// including libghostty's own creates, derives from that one root, so
+    /// proving it is under temp proves all of them; the config-source
+    /// pre-pass below proves the same for includes and the --config-file
+    /// flag. The resolved-path and write-boundary checks in ConfigService,
     /// SeedConfigIfEmpty and ConfigFileEditor.WriteAtomic remain as
     /// belt-and-braces for a path that resolved somewhere the root check
     /// did not predict.
     /// </summary>
-    private static void GuardTestConfigRoot()
+    private static void GuardTestConfigRoot(string[] args)
     {
         if (!Ghostty.Core.Config.TestConfigGuard.IsArmed) return;
 
-        var root = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
-        if (string.IsNullOrEmpty(root))
-            root = Environment.GetEnvironmentVariable("APPDATA");
-        if (string.IsNullOrEmpty(root))
-            root = Environment.GetFolderPath(
-                Environment.SpecialFolder.UserProfile);
+        // A redirected TEMP/TMP is the one environment change that could
+        // move what the guard treats as temp, so it is refused before the
+        // root is even looked at. The anchor itself comes from the
+        // known-folder API and cannot be moved by the environment.
+        try
+        {
+            Ghostty.Core.Config.TestConfigGuard.AssertTempEnvironmentIntact();
+        }
+        catch (InvalidOperationException ex)
+        {
+            RefuseTestConfigStart(ex.Message);
+        }
 
-        if (Ghostty.Core.Config.TestConfigGuard.IsUnderTemp(root)) return;
+        var root = Ghostty.Core.Config.TestConfigGuard.ResolveConfigRoot();
 
-        // Both sinks a pre-init failure has: the console a harness watches,
-        // with the guard's own spelling so the refusal is greppable, and
-        // the tag every other startup diagnostic carries.
+        if (Ghostty.Core.Config.TestConfigGuard.IsUnderTemp(root))
+        {
+            GuardTestConfigSources(root, args);
+            return;
+        }
+
+        RefuseTestConfigStart(
+            $"config root '{root}' is not under the temp directory " +
+            $"'{Ghostty.Core.Config.TestConfigGuard.TempAnchor}'. Set " +
+            $"XDG_CONFIG_HOME to a directory under the temp directory and " +
+            $"relaunch.");
+    }
+
+    /// <summary>
+    /// The one refusal path every guarded startup funnels through: the
+    /// guard's own spelling on stderr (greppable by harnesses), the tagged
+    /// startup diagnostic, and exit code 4.
+    /// </summary>
+    private static void RefuseTestConfigStart(string why)
+    {
         WriteStderr(
             $"{Ghostty.Core.Config.TestConfigGuard.EnvVar}={Environment.GetEnvironmentVariable(Ghostty.Core.Config.TestConfigGuard.EnvVar)} " +
-            $"refusing to start: config root '{root}' is not under the temp " +
-            $"directory '{Path.GetTempPath()}'. Set XDG_CONFIG_HOME to a " +
-            $"directory under the temp directory and relaunch.");
-        WriteStartupDiagnostic(
-            $"config guard refused non-temp config root '{root}'");
+            $"refusing to start: {why}");
+        WriteStartupDiagnostic($"config guard refused: {why}");
         Environment.Exit((int)ExitCode.TestConfigRefused);
+    }
+
+    /// <summary>
+    /// Under an armed guard, no config SOURCE may sit outside the temp
+    /// tree: a config-file include (or a --config-file flag) that reaches
+    /// outside couples a test run to the real config's CONTENT even when
+    /// every write stays inside temp, which is the xdg2 pattern the
+    /// isolation design named and shamed. This pre-pass runs ahead of
+    /// libghostty so the CLI actions (+show-config) are covered too, not
+    /// just the GUI path; ConfigService's resolved-path check remains the
+    /// belt for the default file itself.
+    /// </summary>
+    private static void GuardTestConfigSources(string root, string[] args)
+    {
+        // The CLI flag, in both spellings the fork's rewrite passes through.
+        for (var i = 0; i < args.Length; i++)
+        {
+            string? value = null;
+            if (args[i].StartsWith("--config-file=", StringComparison.Ordinal))
+                value = args[i]["--config-file=".Length..];
+            else if (args[i] == "--config-file" && i + 1 < args.Length)
+                value = args[i + 1];
+            if (string.IsNullOrEmpty(value)) continue;
+
+            var resolved = ResolveConfigSource(value, Environment.CurrentDirectory);
+            if (!Ghostty.Core.Config.TestConfigGuard.IsUnderTemp(resolved))
+                RefuseTestConfigStart(
+                    $"the --config-file flag names '{resolved}', which is not " +
+                    $"under the temp directory. An armed run may not read " +
+                    $"config from outside temp.");
+        }
+
+        // config-file = includes reachable from the root's default files,
+        // recursing into includes that stay under temp (an under-temp file
+        // may itself include one outside it). Zig expands a relative
+        // include against the INCLUDING file's directory (Config.zig
+        // expandPaths after each load), so the pre-pass does too.
+        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var scanned = 0;
+        ScanConfigIncludes(Path.Combine(root, "wintty", "config.wintty"));
+        ScanConfigIncludes(Path.Combine(root, "ghostty", "config.ghostty"));
+        ScanConfigIncludes(Path.Combine(root, "ghostty", "config"));
+        return;
+
+        void ScanConfigIncludes(string file)
+        {
+            if (!File.Exists(file)) return;
+            if (!visited.Add(Path.GetFullPath(file))) return;
+            // Bounded: the loader's own cycle handling caps the graph, and
+            // a harness staging a monster include tree is not a shape the
+            // pre-pass owes an unbounded walk to.
+            if (++scanned > 64) return;
+
+            string? raw;
+            using var reader = new StreamReader(file);
+            while ((raw = reader.ReadLine()) is not null)
+            {
+                var line = raw.Trim();
+                if (line.Length == 0 || line.StartsWith("#")) continue;
+                var match = ConfigIncludeLine.Match(line);
+                if (!match.Success) continue;
+
+                var resolved = ResolveConfigSource(
+                    match.Groups[1].Value.Trim('"', '\''),
+                    Path.GetDirectoryName(file)!);
+                if (!Ghostty.Core.Config.TestConfigGuard.IsUnderTemp(resolved))
+                    RefuseTestConfigStart(
+                        $"a config-file include in '{file}' names " +
+                        $"'{resolved}', which is not under the temp " +
+                        $"directory. An armed run may not read config from " +
+                        $"outside temp, even by include.");
+                ScanConfigIncludes(resolved);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The include key as the ini-shaped config files spell it. Matched per
+    /// trimmed line, after the comment filter, so a commented-out include
+    /// is not a refusal.
+    /// </summary>
+    private static readonly System.Text.RegularExpressions.Regex ConfigIncludeLine =
+        new(@"^config-file\s*=\s*(.+?)\s*$",
+            System.Text.RegularExpressions.RegexOptions.Compiled);
+
+    private static string ResolveConfigSource(string value, string relativeTo)
+    {
+        // GetFullPath resolves relative to the process cwd, so join the
+        // including context first and let it normalize the rest.
+        return Path.GetFullPath(Path.Combine(relativeTo, value));
     }
 
     /// <summary>
@@ -1493,7 +1605,11 @@ public static partial class Program
     {
         try
         {
-            var pathStr = NativeMethods.ConfigOpenPath();
+            // --no-config names the path without creating it (same rule as
+            // ConfigService: the flag must not leave an empty file behind).
+            var pathStr = ConfigOverrides.NoConfig
+                ? NativeMethods.ConfigOpenPathNoCreate()
+                : NativeMethods.ConfigOpenPath();
             var rawPath = pathStr.Ptr != IntPtr.Zero
                 ? Marshal.PtrToStringUTF8(pathStr.Ptr, (int)pathStr.Len) ?? string.Empty
                 : string.Empty;

--- a/windows/Ghostty/Program.cs
+++ b/windows/Ghostty/Program.cs
@@ -61,6 +61,13 @@ public static partial class Program
         /// exit code come from <see cref="InitGhostty"/>.</summary>
         InitFailed = 2,
 
+        /// <summary>Startup refused because <c>WINTTY_TEST_CONFIG</c> is
+        /// armed and the config root resolved outside the temp directory.
+        /// Distinct from every other code so a harness can tell "the guard
+        /// did its job" from a usage error or a crash without parsing
+        /// stderr; the refusing line is on stderr either way.</summary>
+        TestConfigRefused = 4,
+
         /// <summary>Unhandled managed exception in the startup path, on the
         /// main thread or (via <see cref="FatalHandler"/>) on any other.
         /// <see cref="ReportFatal"/> appends <c>ghostty-crash.log</c> in
@@ -897,6 +904,18 @@ public static partial class Program
             Environment.Exit(0);
         }
 
+        // The test-config guard, ahead of everything that could touch a
+        // config file: the CLI actions below reach libghostty config
+        // parsing through InitGhostty, the GUI path reaches it through
+        // InitGhostty and ReadSingleInstanceSetting, and libghostty's own
+        // loadDefaultFiles/openPath can CREATE the config dir and a
+        // template file before any managed code sees a path. The one root
+        // all of that grows from is the xdg config dir, so checking the
+        // root here is the only placement that refuses before a native
+        // read or create, not after. Sits after the intercepts above
+        // (+version, +crash, help), none of which read config.
+        GuardTestConfigRoot();
+
         // CLI actions are delegated to libghostty, matching the macOS
         // architecture: ghostty_init parses argv, ghostty_cli_run_action
         // runs the action (if any). If no action, we start the WinUI app.
@@ -1005,6 +1024,48 @@ public static partial class Program
         // shell. The gate that used to live here existed because a
         // console-subsystem binary was handed a console it did not want.
         return StartGui();
+    }
+
+    /// <summary>
+    /// Refuse to run when <see cref="Ghostty.Core.Config.TestConfigGuard"/>
+    /// is armed and the config root is outside the temp directory, exiting
+    /// non-zero before any window opens and before libghostty reads or
+    /// creates a single config byte.
+    ///
+    /// The root is computed managed-side, mirroring
+    /// <c>src/os/xdg.zig dir()</c> for the config dir: XDG_CONFIG_HOME,
+    /// else APPDATA, else the home directory. Everything downstream, every
+    /// read and every writer including libghostty's own creates, derives
+    /// from that one root, so proving it is under temp proves all of them.
+    /// The resolved-path and write-boundary checks in ConfigService,
+    /// SeedConfigIfEmpty and ConfigFileEditor.WriteAtomic remain as
+    /// belt-and-braces for a path that resolved somewhere the root check
+    /// did not predict.
+    /// </summary>
+    private static void GuardTestConfigRoot()
+    {
+        if (!Ghostty.Core.Config.TestConfigGuard.IsArmed) return;
+
+        var root = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
+        if (string.IsNullOrEmpty(root))
+            root = Environment.GetEnvironmentVariable("APPDATA");
+        if (string.IsNullOrEmpty(root))
+            root = Environment.GetFolderPath(
+                Environment.SpecialFolder.UserProfile);
+
+        if (Ghostty.Core.Config.TestConfigGuard.IsUnderTemp(root)) return;
+
+        // Both sinks a pre-init failure has: the console a harness watches,
+        // with the guard's own spelling so the refusal is greppable, and
+        // the tag every other startup diagnostic carries.
+        WriteStderr(
+            $"{Ghostty.Core.Config.TestConfigGuard.EnvVar}={Environment.GetEnvironmentVariable(Ghostty.Core.Config.TestConfigGuard.EnvVar)} " +
+            $"refusing to start: config root '{root}' is not under the temp " +
+            $"directory '{Path.GetTempPath()}'. Set XDG_CONFIG_HOME to a " +
+            $"directory under the temp directory and relaunch.");
+        WriteStartupDiagnostic(
+            $"config guard refused non-temp config root '{root}'");
+        Environment.Exit((int)ExitCode.TestConfigRefused);
     }
 
     /// <summary>

--- a/windows/Ghostty/Services/ConfigFileEditor.cs
+++ b/windows/Ghostty/Services/ConfigFileEditor.cs
@@ -89,6 +89,12 @@ internal sealed class ConfigFileEditor : IConfigFileEditor
 
     private void WriteAtomic(string content)
     {
+        // The one write boundary every mutating call funnels through (the
+        // array overload calls this one), so the guard holds for every
+        // Settings page, profile toggle, opacity drag and raw-editor save
+        // without any of them knowing the guard exists.
+        Ghostty.Core.Config.TestConfigGuard.AssertUnderTemp(FilePath, "config write");
+
         var dir = Path.GetDirectoryName(FilePath);
         if (dir != null) Directory.CreateDirectory(dir);
 

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -349,6 +349,15 @@ internal sealed partial class ConfigService : IConfigService, Ghostty.Core.Profi
     /// </remarks>
     private string? ConfigSourcePath => _noConfig ? null : ConfigFilePath;
 
+    /// <summary>
+    /// Whether this launch passed <c>--no-config</c>. The host branches on
+    /// it to hand out <see cref="Ghostty.Core.Config.NoConfigFileEditor"/>
+    /// instead of a real editor, and the startup migrator skips its config
+    /// appends under it: the flag must mean nothing reads AND nothing
+    /// writes the config file.
+    /// </summary>
+    public bool NoConfig => _noConfig;
+
     private Dictionary<string, List<string>>? _configFileCache;
 
     /// <summary>
@@ -429,6 +438,14 @@ internal sealed partial class ConfigService : IConfigService, Ghostty.Core.Profi
         // (backslash) so the path looks clean in UI and logs.
         ConfigFilePath = Path.GetFullPath(rawPath);
 
+        // Belt for a root the composition root's guard did not predict
+        // (Program.GuardTestConfigRoot checks the xdg root before
+        // libghostty runs; this checks what actually resolved). Covers
+        // every read below, which all key off ConfigFilePath, and the
+        // seed write that follows.
+        Ghostty.Core.Config.TestConfigGuard.AssertUnderTemp(
+            ConfigFilePath, "resolved config path");
+
         SeedConfigIfEmpty();
         CacheDiagnostics();
 
@@ -482,6 +499,14 @@ internal sealed partial class ConfigService : IConfigService, Ghostty.Core.Profi
     /// </summary>
     private void SeedConfigIfEmpty()
     {
+        // Outside the try on purpose: the catch below exists so a writable-
+        // config-dir hiccup cannot take startup down, and a guard refusal
+        // is the one failure that must not be smoothed over. The
+        // composition-root check normally refuses long before here; this
+        // is the write boundary's own belt.
+        Ghostty.Core.Config.TestConfigGuard.AssertUnderTemp(
+            ConfigFilePath, "seed write");
+
         try
         {
             // Nothing is being read from it, so nothing should be written to

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -430,7 +430,13 @@ internal sealed partial class ConfigService : IConfigService, Ghostty.Core.Profi
         NativeMethods.ConfigSetColorScheme(_config, ToScheme(isOsDark));
         NativeMethods.ConfigFinalize(_config);
 
-        var pathStr = NativeMethods.ConfigOpenPath();
+        // --no-config resolves without the create: the flag ignores the
+        // file, so it must not even leave an empty one behind (the native
+        // openPath creates dir + file when missing; the no-create variant
+        // performs the same resolution without that side effect).
+        var pathStr = _noConfig
+            ? NativeMethods.ConfigOpenPathNoCreate()
+            : NativeMethods.ConfigOpenPath();
         var rawPath = pathStr.Ptr != IntPtr.Zero
             ? Marshal.PtrToStringUTF8(pathStr.Ptr, (int)pathStr.Len) ?? string.Empty
             : string.Empty;

--- a/windows/Ghostty/Settings/WindowStateMigration.cs
+++ b/windows/Ghostty/Settings/WindowStateMigration.cs
@@ -63,8 +63,15 @@ internal static class WindowStateMigration
             // is missing. A key reaching the config through an include or
             // a conditional block is not visible here and gets appended
             // anyway, same as the scan this replaced.
-            var appends = LegacyUiSettingsMigrator.ComputeAppends(
-                legacy, configService.IsConfiguredInFile);
+            //
+            // Under --no-config the editor refuses writes by design, so
+            // the appends are skipped rather than attempted-and-logged:
+            // the placement-only half below still runs, and the first
+            // launch without the flag performs the config half.
+            var appends = configService.NoConfig
+                ? Array.Empty<(string Key, string Value)>()
+                : LegacyUiSettingsMigrator.ComputeAppends(
+                    legacy, configService.IsConfiguredInFile);
             if (appends.Count > 0)
             {
                 configService.SuppressWatcher(true);

--- a/windows/scripts/esctest/run-esctest.ps1
+++ b/windows/scripts/esctest/run-esctest.ps1
@@ -55,9 +55,11 @@ New-Item -ItemType Directory -Force $cfgGhostty | Out-Null
 # only the XDG_CONFIG_HOME override, rather than -Environment (merge-vs-replace
 # semantics vary). Restore afterward.
 $prevXdg = $env:XDG_CONFIG_HOME
+$prevTestConfig = $env:WINTTY_TEST_CONFIG
 $proc = $null
 try {
     $env:XDG_CONFIG_HOME = $cfgDir
+    $env:WINTTY_TEST_CONFIG = '1'
     $proc = Start-Process -FilePath $WinttyExe -PassThru
     $deadline = (Get-Date).AddSeconds($TimeoutSec)
     while (-not (Test-Path $doneWin) -and (Get-Date) -lt $deadline) {
@@ -70,6 +72,8 @@ try {
 }
 finally {
     $env:XDG_CONFIG_HOME = $prevXdg
+    if ($null -ne $prevTestConfig -and $prevTestConfig -ne '') { $env:WINTTY_TEST_CONFIG = $prevTestConfig }
+    else { Remove-Item Env:WINTTY_TEST_CONFIG -ErrorAction SilentlyContinue }
     # Close ONLY the Wintty we launched (never a blind kill).
     if ($proc) { try { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue } catch {} }
 }

--- a/windows/scripts/esctest/run-esctest.ps1
+++ b/windows/scripts/esctest/run-esctest.ps1
@@ -3,7 +3,10 @@
     [Parameter(Mandatory)][string]$WinttyExe,       # path to built Wintty.exe
     [string]$Distro = 'Ubuntu-24.04',
     [string]$EsctestDir = '~/esctest2/esctest',     # path inside the distro
-    [string]$OutDir = "$env:TEMP\esctest-run",       # Windows-side output dir
+    # Results land here (markers, run.sh, report). Defaults to a
+    # per-run random name; the config root is separate, from the
+    # test-config helper below.
+    [string]$OutDir = (Join-Path $env:TEMP ("esctest-out-" + [guid]::NewGuid().ToString('N'))),
     [int]$ReadTimeoutSec = 1,                         # esctest per-read --timeout
     [int]$TimeoutSec = 900                            # overall wall-clock deadline
 )
@@ -43,7 +46,7 @@ $bash = @(
 # XDG_CONFIG_HOME + command= is the proven harness, see #494 OSC7 work). The
 # command splits cleanly on spaces into wsl.exe argv; the script path is
 # space-free (under $env:TEMP).
-$cfgDir = Join-Path $OutDir 'cfg'
+$cfgDir = $testConfig.Dir
 # ghostty reads $XDG_CONFIG_HOME/ghostty/config (the `ghostty/` subdir is
 # required; without it the surface falls back to the default shell).
 $cfgGhostty = Join-Path $cfgDir 'ghostty'
@@ -51,15 +54,13 @@ New-Item -ItemType Directory -Force $cfgGhostty | Out-Null
 "command = wsl.exe -d $Distro -- bash -l $scriptMnt" |
     Set-Content -LiteralPath (Join-Path $cfgGhostty 'config') -Encoding utf8
 
-# Inherit the full current environment (so Wintty finds its system deps) and add
-# only the XDG_CONFIG_HOME override, rather than -Environment (merge-vs-replace
-# semantics vary). Restore afterward.
-$prevXdg = $env:XDG_CONFIG_HOME
-$prevTestConfig = $env:WINTTY_TEST_CONFIG
+. (Join-Path $PSScriptRoot '../lib/test-config.ps1')
+# The config root is the helper's per-run random root; OutDir above
+# holds only the results, which must outlive the app (the report is
+# written after the finally below kills it).
+$testConfig = Enter-WinttyTestConfig
 $proc = $null
 try {
-    $env:XDG_CONFIG_HOME = $cfgDir
-    $env:WINTTY_TEST_CONFIG = '1'
     $proc = Start-Process -FilePath $WinttyExe -PassThru
     $deadline = (Get-Date).AddSeconds($TimeoutSec)
     while (-not (Test-Path $doneWin) -and (Get-Date) -lt $deadline) {
@@ -71,11 +72,11 @@ try {
     }
 }
 finally {
-    $env:XDG_CONFIG_HOME = $prevXdg
-    if ($null -ne $prevTestConfig -and $prevTestConfig -ne '') { $env:WINTTY_TEST_CONFIG = $prevTestConfig }
-    else { Remove-Item Env:WINTTY_TEST_CONFIG -ErrorAction SilentlyContinue }
+    # Kill first: the session exit deletes the config root, and that
+    # must not happen while the app still holds it.
     # Close ONLY the Wintty we launched (never a blind kill).
     if ($proc) { try { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue } catch {} }
+    Exit-WinttyTestConfig $testConfig
 }
 $complete = Test-Path $doneWin
 

--- a/windows/scripts/esctest/run-latency-probe.ps1
+++ b/windows/scripts/esctest/run-latency-probe.ps1
@@ -48,9 +48,11 @@ New-Item -ItemType Directory -Force $cfgGhostty | Out-Null
     Set-Content -LiteralPath (Join-Path $cfgGhostty 'config') -Encoding utf8
 
 $prevXdg = $env:XDG_CONFIG_HOME
+$prevTestConfig = $env:WINTTY_TEST_CONFIG
 $proc = $null
 try {
     $env:XDG_CONFIG_HOME = $cfgDir
+    $env:WINTTY_TEST_CONFIG = '1'
     $proc = Start-Process -FilePath $WinttyExe -PassThru
     $deadline = (Get-Date).AddSeconds($TimeoutSec)
     while (-not (Test-Path $doneWin) -and (Get-Date) -lt $deadline) {
@@ -60,6 +62,8 @@ try {
 }
 finally {
     $env:XDG_CONFIG_HOME = $prevXdg
+    if ($null -ne $prevTestConfig -and $prevTestConfig -ne '') { $env:WINTTY_TEST_CONFIG = $prevTestConfig }
+    else { Remove-Item Env:WINTTY_TEST_CONFIG -ErrorAction SilentlyContinue }
     if ($proc) { try { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue } catch {} }
 }
 

--- a/windows/scripts/esctest/run-latency-probe.ps1
+++ b/windows/scripts/esctest/run-latency-probe.ps1
@@ -6,7 +6,10 @@
 [CmdletBinding()] param(
     [Parameter(Mandatory)][string]$WinttyExe,
     [string]$Distro = 'Ubuntu-24.04',
-    [string]$OutDir = "$env:TEMP\latency-probe-run",
+    # Results land here (markers, run.sh, report). Defaults to a
+    # per-run random name; the config root is separate, from the
+    # test-config helper below.
+    [string]$OutDir = (Join-Path $env:TEMP ("latency-out-" + [guid]::NewGuid().ToString('N'))),
     [int]$Reps = 30,
     [double]$ReadTimeoutSec = 10,   # generous: a response under this is slow, not lost
     [int]$TimeoutSec = 900
@@ -41,18 +44,19 @@ $bash = @(
 ) -join "`n"
 [System.IO.File]::WriteAllText($scriptWin, $bash + "`n", (New-Object System.Text.UTF8Encoding($false)))
 
-$cfgDir = Join-Path $OutDir 'cfg'
+$cfgDir = $testConfig.Dir
 $cfgGhostty = Join-Path $cfgDir 'ghostty'
 New-Item -ItemType Directory -Force $cfgGhostty | Out-Null
 "command = wsl.exe -d $Distro -- bash -l $scriptMnt" |
     Set-Content -LiteralPath (Join-Path $cfgGhostty 'config') -Encoding utf8
 
-$prevXdg = $env:XDG_CONFIG_HOME
-$prevTestConfig = $env:WINTTY_TEST_CONFIG
+. (Join-Path $PSScriptRoot '../lib/test-config.ps1')
+# The config root is the helper's per-run random root; OutDir above
+# holds only the results, which must outlive the app (the report is
+# written after the finally below kills it).
+$testConfig = Enter-WinttyTestConfig
 $proc = $null
 try {
-    $env:XDG_CONFIG_HOME = $cfgDir
-    $env:WINTTY_TEST_CONFIG = '1'
     $proc = Start-Process -FilePath $WinttyExe -PassThru
     $deadline = (Get-Date).AddSeconds($TimeoutSec)
     while (-not (Test-Path $doneWin) -and (Get-Date) -lt $deadline) {
@@ -61,10 +65,10 @@ try {
     }
 }
 finally {
-    $env:XDG_CONFIG_HOME = $prevXdg
-    if ($null -ne $prevTestConfig -and $prevTestConfig -ne '') { $env:WINTTY_TEST_CONFIG = $prevTestConfig }
-    else { Remove-Item Env:WINTTY_TEST_CONFIG -ErrorAction SilentlyContinue }
+    # Kill first: the session exit deletes the config root, and that
+    # must not happen while the app still holds it.
     if ($proc) { try { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue } catch {} }
+    Exit-WinttyTestConfig $testConfig
 }
 
 if (-not (Test-Path $jsonWin)) {

--- a/windows/scripts/frame-style-fuzz.ps1
+++ b/windows/scripts/frame-style-fuzz.ps1
@@ -792,6 +792,8 @@ $crashStamp = if (Test-Path $crashPath) { (Get-Item $crashPath).LastWriteTimeUtc
 
 $originalXdgSet = Test-Path Env:XDG_CONFIG_HOME
 $originalXdg = if ($originalXdgSet) { $env:XDG_CONFIG_HOME } else { $null }
+$originalTestConfigSet = Test-Path Env:WINTTY_TEST_CONFIG
+$originalTestConfig = if ($originalTestConfigSet) { $env:WINTTY_TEST_CONFIG } else { $null }
 $originalNoColorSet = Test-Path Env:NO_COLOR
 $originalNoColor = if ($originalNoColorSet) { $env:NO_COLOR } else { $null }
 
@@ -891,6 +893,7 @@ function Get-ThemeCatalogue([string]$Exe) {
         # The child reads this dictionary rather than the harness process's
         # own environment, so the staging never leaks into anything else here.
         $psi.EnvironmentVariables['XDG_CONFIG_HOME'] = $tempXdg
+        $psi.EnvironmentVariables['WINTTY_TEST_CONFIG'] = '1'
         $psi.RedirectStandardOutput = $true
         $psi.RedirectStandardError = $true
         $psi.UseShellExecute = $false
@@ -1052,6 +1055,7 @@ function Invoke-Case($Case, [string]$Exe, [int]$ExtraTabs = 0, [switch]$Stabilit
     $stamp = Get-WinttyLaunchStamp
     try {
         $env:XDG_CONFIG_HOME = $tempXdg
+        $env:WINTTY_TEST_CONFIG = '1'
         # NO_COLOR raises a banner that covers a third of the window and moves
         # the layout under it. Nothing this harness samples is behind it, but a
         # banner appearing on some machines and not others is a difference in
@@ -1936,6 +1940,8 @@ finally {
     # to delete.
     if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }
     else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
+    if ($originalTestConfigSet) { $env:WINTTY_TEST_CONFIG = $originalTestConfig }
+    else { Remove-Item Env:WINTTY_TEST_CONFIG -ErrorAction SilentlyContinue }
     if ($originalNoColorSet) { $env:NO_COLOR = $originalNoColor }
     else { Remove-Item Env:NO_COLOR -ErrorAction SilentlyContinue }
     Remove-Item -Recurse -Force -LiteralPath $stage -ErrorAction SilentlyContinue

--- a/windows/scripts/frame-style-fuzz.ps1
+++ b/windows/scripts/frame-style-fuzz.ps1
@@ -123,6 +123,7 @@ param(
 )
 . (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 . (Join-Path $PSScriptRoot 'lib/env-guard.ps1')
+. (Join-Path $PSScriptRoot 'lib/test-config.ps1')
 $ErrorActionPreference = 'Stop'
 
 # Same convention as the other harnesses here: a PRODUCT_FAIL throw is a defect
@@ -790,10 +791,6 @@ function Get-DesktopPolarity {
 $crashPath = Join-Path $env:LOCALAPPDATA 'Wintty\crash.log'
 $crashStamp = if (Test-Path $crashPath) { (Get-Item $crashPath).LastWriteTimeUtc } else { [datetime]::MinValue }
 
-$originalXdgSet = Test-Path Env:XDG_CONFIG_HOME
-$originalXdg = if ($originalXdgSet) { $env:XDG_CONFIG_HOME } else { $null }
-$originalTestConfigSet = Test-Path Env:WINTTY_TEST_CONFIG
-$originalTestConfig = if ($originalTestConfigSet) { $env:WINTTY_TEST_CONFIG } else { $null }
 $originalNoColorSet = Test-Path Env:NO_COLOR
 $originalNoColor = if ($originalNoColorSet) { $env:NO_COLOR } else { $null }
 
@@ -805,8 +802,11 @@ Write-Host "desktop=$polarity highContrast=$highContrast (both read, neither set
 #
 # Created before the catalogue below, because the catalogue is taken under it.
 
-$stage = Join-Path $env:TEMP ('wintty-frame-fuzz-{0:HHmmss}' -f (Get-Date))
-$tempXdg = Join-Path $stage 'xdg'
+# A per-run randomly named root from the shared helper (the old name was
+# HHmmss-keyed, so two runs inside a minute shared a stage). Entered
+# without a paired Exit here: the finally below pairs it.
+$script:TestConfig = Enter-WinttyTestConfig
+$tempXdg = $script:TestConfig.Dir
 New-Item -ItemType Directory -Force -Path (Join-Path $tempXdg 'wintty') | Out-Null
 $configPath = Join-Path $tempXdg 'wintty\config.wintty'
 
@@ -1054,8 +1054,6 @@ function Invoke-Case($Case, [string]$Exe, [int]$ExtraTabs = 0, [switch]$Stabilit
     $handedOff = $false
     $stamp = Get-WinttyLaunchStamp
     try {
-        $env:XDG_CONFIG_HOME = $tempXdg
-        $env:WINTTY_TEST_CONFIG = '1'
         # NO_COLOR raises a banner that covers a third of the window and moves
         # the layout under it. Nothing this harness samples is behind it, but a
         # banner appearing on some machines and not others is a difference in
@@ -1935,16 +1933,9 @@ try {
     }
 }
 finally {
-    # Restored BEFORE the sweep, so a throw out of the sweep cannot leave the
-    # caller's environment pointing at a staging directory this block is about
-    # to delete.
-    if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }
-    else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
-    if ($originalTestConfigSet) { $env:WINTTY_TEST_CONFIG = $originalTestConfig }
-    else { Remove-Item Env:WINTTY_TEST_CONFIG -ErrorAction SilentlyContinue }
     if ($originalNoColorSet) { $env:NO_COLOR = $originalNoColor }
     else { Remove-Item Env:NO_COLOR -ErrorAction SilentlyContinue }
-    Remove-Item -Recurse -Force -LiteralPath $stage -ErrorAction SilentlyContinue
+    Exit-WinttyTestConfig $script:TestConfig
 
     $crashGrew = (Test-Path $crashPath) -and ((Get-Item $crashPath).LastWriteTimeUtc -gt $crashStamp)
     if ($crashGrew) { $findings.Add('crash.log grew during the run') }

--- a/windows/scripts/fuzz-suite.ps1
+++ b/windows/scripts/fuzz-suite.ps1
@@ -1007,6 +1007,17 @@ function Start-HarnessProcess {
     $psi = [System.Diagnostics.ProcessStartInfo]::new()
     $psi.FileName = 'pwsh'
     foreach ($a in $Argv) { [void]$psi.ArgumentList.Add($a) }
+    # The guard arms the whole suite, not each leg: this launcher cannot
+    # see inside the legs it starts, and a leg that forgets its isolation
+    # must inherit an armed guard (and refuse loudly) rather than run
+    # silently against the real config. Every leg in the suite isolates,
+    # so arming here changes nothing for a healthy leg.
+    # The guard arms the whole suite, not each leg: this launcher cannot
+    # see inside the legs it starts, and a leg that forgets its isolation
+    # must inherit an armed guard (and refuse loudly) rather than run
+    # silently against the real config. Every leg in the suite isolates,
+    # so arming here changes nothing for a healthy leg.
+    $psi.EnvironmentVariables['WINTTY_TEST_CONFIG'] = '1'
     # No new window, which is what -NoNewWindow bought: the child inherits this
     # console. Redirecting is what requires it to be false at all.
     $psi.UseShellExecute = $false

--- a/windows/scripts/lib/seam-client.ps1
+++ b/windows/scripts/lib/seam-client.ps1
@@ -209,12 +209,18 @@ function Start-SeamSession(
         Stamp     = Get-WinttyLaunchStamp
         Token     = New-SeamToken
         OrigXdg   = if (Test-Path Env:XDG_CONFIG_HOME) { $env:XDG_CONFIG_HOME } else { $null }
+        OrigTestConfig = if (Test-Path Env:WINTTY_TEST_CONFIG) { $env:WINTTY_TEST_CONFIG } else { $null }
         OrigSeam  = if (Test-Path Env:WINTTY_TEST_SEAM) { $env:WINTTY_TEST_SEAM } else { $null }
         OrigInput = if (Test-Path Env:WINTTY_TEST_SEAM_INPUT) { $env:WINTTY_TEST_SEAM_INPUT } else { $null }
         OrigTrace = if (Test-Path Env:WINTTY_TABDRAG_TRACE) { $env:WINTTY_TABDRAG_TRACE } else { $null }
         OrigNoColor = if (Test-Path Env:NO_COLOR) { $env:NO_COLOR } else { $null }
     }
     $env:XDG_CONFIG_HOME = $tempXdg
+    # The guard that makes a lost XDG root loud: armed, an app resolving a
+    # non-temp config refuses to start (exit code 4, both paths on stderr)
+    # instead of silently reading and writing the real config. Every seam
+    # consumer arms it here, which is what the source-scan test vouches for.
+    $env:WINTTY_TEST_CONFIG = '1'
     # The token travels in the environment block the child inherits, which is
     # readable only by something that could already open this process anyway.
     $env:WINTTY_TEST_SEAM = $session.Token
@@ -321,6 +327,8 @@ function Stop-SeamSession([Parameter(Mandatory)]$Session) {
     }
     if ($null -ne $Session.OrigXdg) { $env:XDG_CONFIG_HOME = $Session.OrigXdg }
     else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
+    if ($null -ne $Session.OrigTestConfig) { $env:WINTTY_TEST_CONFIG = $Session.OrigTestConfig }
+    else { Remove-Item Env:WINTTY_TEST_CONFIG -ErrorAction SilentlyContinue }
     if ($null -ne $Session.OrigSeam) { $env:WINTTY_TEST_SEAM = $Session.OrigSeam }
     else { Remove-Item Env:WINTTY_TEST_SEAM -ErrorAction SilentlyContinue }
     if ($null -ne $Session.OrigInput) { $env:WINTTY_TEST_SEAM_INPUT = $Session.OrigInput }

--- a/windows/scripts/lib/test-config.ps1
+++ b/windows/scripts/lib/test-config.ps1
@@ -1,0 +1,70 @@
+# The isolated-config helper: stage a per-run random config root under
+# %TEMP%, point XDG_CONFIG_HOME at it, and arm the app's WINTTY_TEST_CONFIG
+# guard for every child launched while the session is active.
+#
+# Why both: XDG_CONFIG_HOME alone moves every read and every writer (the
+# app appends wintty\config.wintty under the root), and WINTTY_TEST_CONFIG
+# turns a harness that forgot the root into a loud startup refusal (the app
+# exits before the window with a line naming both paths) instead of a
+# silent write into the real %APPDATA% config. The two together are the
+# repo's one spelling of "launch the app from a test"; the source-scan test
+# (Ghostty.Tests HarnessConfigIsolationScanTests) fails any launch that
+# uses neither this helper nor seam-client.ps1's Start-SeamSession.
+#
+# Dot-source from a harness, keep the session, and pair Enter with Exit in
+# a finally when the script must restore mid-flight (multi-root
+# orchestration, dot-sourced use). A linear script that launches once and
+# exits may skip the Exit: the env vars die with the script process, and
+# the 24h sweep below reaps the staged directory.
+
+# 128 bits of hex, so two harnesses racing on one machine cannot share a
+# root. RandomNumberGenerator rather than Get-Random, matching
+# seam-client's token (whose reasoning applies here too).
+function New-WinttyTestConfigRoot {
+    $bytes = [byte[]]::new(16)
+    [System.Security.Cryptography.RandomNumberGenerator]::Fill($bytes)
+    return ('wintty-testcfg-' + [System.Convert]::ToHexString($bytes).ToLowerInvariant())
+}
+
+function Enter-WinttyTestConfig {
+    param(
+        # Staged as wintty\config.wintty inside the root. Empty stages
+        # nothing: the app creates its own config under the root, which is
+        # the honest "unconfigured" baseline.
+        [string]$ConfigText = ''
+    )
+    # Opportunistic, bounded: a crashed run leaks its root, and a leak left
+    # forever is indistinguishable from a fixture. Anything older than a day
+    # belongs to no live run. Wrapped in try/catch because a sweep failure
+    # must never take the harness down before it starts.
+    try {
+        $cutoff = (Get-Date).AddHours(-24)
+        Get-ChildItem -LiteralPath $env:TEMP -Directory -Filter 'wintty-testcfg-*' -ErrorAction SilentlyContinue |
+            Where-Object { $_.LastWriteTimeUtc -lt $cutoff.ToUniversalTime() } |
+            Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+    } catch { }
+
+    $dir = Join-Path $env:TEMP (New-WinttyTestConfigRoot)
+    if ($ConfigText -ne '') {
+        New-Item -ItemType Directory -Force -Path (Join-Path $dir 'wintty') | Out-Null
+        $ConfigText | Set-Content (Join-Path $dir 'wintty\config.wintty') -Encoding utf8
+    }
+
+    $session = @{
+        Dir    = $dir
+        OrigXdg        = if (Test-Path Env:XDG_CONFIG_HOME) { $env:XDG_CONFIG_HOME } else { $null }
+        OrigTestConfig = if (Test-Path Env:WINTTY_TEST_CONFIG) { $env:WINTTY_TEST_CONFIG } else { $null }
+    }
+    $env:XDG_CONFIG_HOME = $dir
+    $env:WINTTY_TEST_CONFIG = '1'
+    return $session
+}
+
+function Exit-WinttyTestConfig {
+    param([Parameter(Mandatory)]$Session)
+    if ($null -ne $Session.OrigXdg) { $env:XDG_CONFIG_HOME = $Session.OrigXdg }
+    else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
+    if ($null -ne $Session.OrigTestConfig) { $env:WINTTY_TEST_CONFIG = $Session.OrigTestConfig }
+    else { Remove-Item Env:WINTTY_TEST_CONFIG -ErrorAction SilentlyContinue }
+    Remove-Item $Session.Dir -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/windows/scripts/mouse-fuzz-dialogs.ps1
+++ b/windows/scripts/mouse-fuzz-dialogs.ps1
@@ -6,6 +6,7 @@ param(
     [Parameter(Mandatory)][string]$OutDir
 )
 . (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
+. (Join-Path $PSScriptRoot 'lib/test-config.ps1')
 $ErrorActionPreference = 'Stop'
 
 # A PRODUCT_FAIL throw is a defect in the build under test, so it has to leave
@@ -353,6 +354,12 @@ $crashStamp = if (Test-Path $crashPath) { (Get-Item $crashPath).LastWriteTimeUtc
 Assert-NoWintty
 $script:WinttyStamp = Get-WinttyLaunchStamp
 Start-Sleep -Milliseconds 400
+# A per-run random temp config root with the WINTTY_TEST_CONFIG guard armed
+# for the child. This harness used to launch against the user's real config
+# (reads and writes both). Enter without a paired Exit is deliberate: the
+# script process exits and takes the env with it, and the helper's sweep
+# reaps the staged root.
+$script:TestConfig = Enter-WinttyTestConfig
 $proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path $ExePath)
 $pid32 = [uint32]$proc.Id
 $main = Wait-Ready $proc

--- a/windows/scripts/mouse-fuzz-jumplist.ps1
+++ b/windows/scripts/mouse-fuzz-jumplist.ps1
@@ -6,6 +6,7 @@ param(
     [Parameter(Mandatory)][string]$OutDir
 )
 . (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
+. (Join-Path $PSScriptRoot 'lib/test-config.ps1')
 $ErrorActionPreference = 'Stop'
 
 # A PRODUCT_FAIL throw is a defect in the build under test, so it has to leave
@@ -221,7 +222,10 @@ function Count-TabItems([uint32]$ProcId) {
 }
 
 function New-IsolatedConfig {
-    $tempXdg = Join-Path $env:TEMP ("wintty-fuzz-xdg-jl-{0:HHmmss}" -f (Get-Date))
+    # The shared helper's randomly named root; the session is kept
+    # script-scoped so the finally below can pair the Exit.
+    $script:TestConfig = Enter-WinttyTestConfig
+    $tempXdg = $script:TestConfig.Dir
     $winttyDir = Join-Path $tempXdg 'wintty'
     New-Item -ItemType Directory -Force -Path $winttyDir | Out-Null
     $dst = Join-Path $winttyDir 'config.wintty'
@@ -261,10 +265,8 @@ function Invoke-Secondary([string]$Cli) {
 $crashPath = Join-Path $env:LOCALAPPDATA 'Wintty\crash.log'
 $crashStamp = if (Test-Path $crashPath) { (Get-Item $crashPath).LastWriteTimeUtc } else { [datetime]::MinValue }
 
-$originalXdgSet = Test-Path Env:XDG_CONFIG_HOME
-$originalXdg = if ($originalXdgSet) { $env:XDG_CONFIG_HOME } else { $null }
-$originalTestConfigSet = Test-Path Env:WINTTY_TEST_CONFIG
-$originalTestConfig = if ($originalTestConfigSet) { $env:WINTTY_TEST_CONFIG } else { $null }
+# XDG_CONFIG_HOME and WINTTY_TEST_CONFIG are owned by the session that
+# New-IsolatedConfig enters; its Exit pairs in the finally below.
 $tempXdg = New-IsolatedConfig
 $proc = $null
 $secondaryAlive = $false
@@ -287,8 +289,6 @@ $tabsAfterProfile = 0
 Assert-NoWintty
 $script:WinttyStamp = Get-WinttyLaunchStamp
 try {
-    $env:XDG_CONFIG_HOME = $tempXdg
-    $env:WINTTY_TEST_CONFIG = '1'
     Start-Sleep -Milliseconds 500
     $proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path $ExePath)
     $pid32 = [uint32]$proc.Id
@@ -378,13 +378,11 @@ finally {
             try { $proc.Kill($true); [void]$proc.WaitForExit(3000) } catch { }
         }
     }
-    if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }
-    else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
-    if ($originalTestConfigSet) { $env:WINTTY_TEST_CONFIG = $originalTestConfig }
-    else { Remove-Item Env:WINTTY_TEST_CONFIG -ErrorAction SilentlyContinue }
-    # After the env restores, not before: a throw in the sweep would otherwise
-    # abandon them and leave the shell pointed at a temp profile.
+    # The sweep first (it takes the app down), then the session exit:
+    # restoring env and deleting the staged root while the app still
+    # holds it would pull the config out from under a live window.
     Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
+    Exit-WinttyTestConfig $script:TestConfig
 }
 
 $crashGrew = (Test-Path $crashPath) -and ((Get-Item $crashPath).LastWriteTimeUtc -gt $crashStamp)

--- a/windows/scripts/mouse-fuzz-jumplist.ps1
+++ b/windows/scripts/mouse-fuzz-jumplist.ps1
@@ -263,6 +263,8 @@ $crashStamp = if (Test-Path $crashPath) { (Get-Item $crashPath).LastWriteTimeUtc
 
 $originalXdgSet = Test-Path Env:XDG_CONFIG_HOME
 $originalXdg = if ($originalXdgSet) { $env:XDG_CONFIG_HOME } else { $null }
+$originalTestConfigSet = Test-Path Env:WINTTY_TEST_CONFIG
+$originalTestConfig = if ($originalTestConfigSet) { $env:WINTTY_TEST_CONFIG } else { $null }
 $tempXdg = New-IsolatedConfig
 $proc = $null
 $secondaryAlive = $false
@@ -286,6 +288,7 @@ Assert-NoWintty
 $script:WinttyStamp = Get-WinttyLaunchStamp
 try {
     $env:XDG_CONFIG_HOME = $tempXdg
+    $env:WINTTY_TEST_CONFIG = '1'
     Start-Sleep -Milliseconds 500
     $proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path $ExePath)
     $pid32 = [uint32]$proc.Id
@@ -377,6 +380,8 @@ finally {
     }
     if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }
     else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
+    if ($originalTestConfigSet) { $env:WINTTY_TEST_CONFIG = $originalTestConfig }
+    else { Remove-Item Env:WINTTY_TEST_CONFIG -ErrorAction SilentlyContinue }
     # After the env restores, not before: a throw in the sweep would otherwise
     # abandon them and leave the shell pointed at a temp profile.
     Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath

--- a/windows/scripts/mouse-fuzz-probe.ps1
+++ b/windows/scripts/mouse-fuzz-probe.ps1
@@ -11,6 +11,7 @@ param(
     [Parameter(Mandatory)][string]$OutDir
 )
 . (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
+. (Join-Path $PSScriptRoot 'lib/test-config.ps1')
 $ErrorActionPreference = 'Stop'
 
 # A PRODUCT_FAIL throw is a defect in the build under test, so it has to leave
@@ -255,6 +256,12 @@ $crashStamp = if (Test-Path $crashPath) { (Get-Item $crashPath).LastWriteTimeUtc
 Assert-NoWintty
 $script:WinttyStamp = Get-WinttyLaunchStamp
 Start-Sleep -Milliseconds 400
+# A per-run random temp config root with the WINTTY_TEST_CONFIG guard armed
+# for the child. This harness used to launch against the user's real config
+# (reads and writes both). Enter without a paired Exit is deliberate: the
+# script process exits and takes the env with it, and the helper's sweep
+# reaps the staged root.
+$script:TestConfig = Enter-WinttyTestConfig
 $proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path $ExePath)
 $pid32 = [uint32]$proc.Id
 Start-Sleep -Seconds 3

--- a/windows/scripts/mouse-fuzz-remain.ps1
+++ b/windows/scripts/mouse-fuzz-remain.ps1
@@ -6,6 +6,7 @@ param(
     [Parameter(Mandatory)][string]$OutDir
 )
 . (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
+. (Join-Path $PSScriptRoot 'lib/test-config.ps1')
 $ErrorActionPreference = 'Stop'
 
 # A PRODUCT_FAIL throw is a defect in the build under test, so it has to leave
@@ -334,6 +335,12 @@ $crashStamp = if (Test-Path $crashPath) { (Get-Item $crashPath).LastWriteTimeUtc
 Assert-NoWintty
 $script:WinttyStamp = Get-WinttyLaunchStamp
 Start-Sleep -Milliseconds 400
+# A per-run random temp config root with the WINTTY_TEST_CONFIG guard armed
+# for the child. This harness used to launch against the user's real config
+# (reads and writes both). Enter without a paired Exit is deliberate: the
+# script process exits and takes the env with it, and the helper's sweep
+# reaps the staged root.
+$script:TestConfig = Enter-WinttyTestConfig
 $proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path $ExePath)
 $pid32 = [uint32]$proc.Id
 $main = Wait-Ready $proc

--- a/windows/scripts/mouse-fuzz-tab-colors.ps1
+++ b/windows/scripts/mouse-fuzz-tab-colors.ps1
@@ -597,6 +597,7 @@ no-color-override = strip
 
 $script:FatalWasProduct = $null
 $origXdg = $env:XDG_CONFIG_HOME
+$origTestConfig = $env:WINTTY_TEST_CONFIG
 $origNoColor = $env:NO_COLOR
 $proc = $null
 $result = [ordered]@{
@@ -624,6 +625,7 @@ $script:WinttyStamp = Get-WinttyLaunchStamp
 try {
     Remove-Item Env:NO_COLOR -ErrorAction SilentlyContinue
     $env:XDG_CONFIG_HOME = $tempXdg
+    $env:WINTTY_TEST_CONFIG = '1'
     if (-not (Test-Path $ExePath)) { throw "missing exe: $ExePath" }
     $proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path -Parent (Resolve-Path $ExePath))
     $pid32 = [uint32]$proc.Id
@@ -756,6 +758,8 @@ finally {
     }
     if ($null -ne $origXdg) { $env:XDG_CONFIG_HOME = $origXdg }
     else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
+    if ($null -ne $origTestConfig) { $env:WINTTY_TEST_CONFIG = $origTestConfig }
+    else { Remove-Item Env:WINTTY_TEST_CONFIG -ErrorAction SilentlyContinue }
     if ($null -ne $origNoColor) { $env:NO_COLOR = $origNoColor }
     else { Remove-Item Env:NO_COLOR -ErrorAction SilentlyContinue }
     if ($null -ne $tempXdg -and (Test-Path $tempXdg)) {

--- a/windows/scripts/mouse-smoke-run.ps1
+++ b/windows/scripts/mouse-smoke-run.ps1
@@ -60,9 +60,12 @@ Copy-Item -LiteralPath $fixturePath -Destination $configPath -Force
 
 $originalXdgSet = Test-Path Env:XDG_CONFIG_HOME
 $originalXdg = if ($originalXdgSet) { $env:XDG_CONFIG_HOME } else { $null }
+$originalTestConfigSet = Test-Path Env:WINTTY_TEST_CONFIG
+$originalTestConfig = if ($originalTestConfigSet) { $env:WINTTY_TEST_CONFIG } else { $null }
 
 try {
     $env:XDG_CONFIG_HOME = $tempXdg
+    $env:WINTTY_TEST_CONFIG = '1'
     Write-Host "Launching cell '$Cell' with XDG_CONFIG_HOME=$tempXdg"
     Write-Host "Click checklist for this cell is in windows/dev-configs/mouse-smoke/$Cell.conf header."
     Write-Host "Quit the TUI when done; the runner returns when Wintty exits."
@@ -87,6 +90,8 @@ finally {
     } else {
         Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue
     }
+    if ($originalTestConfigSet) { $env:WINTTY_TEST_CONFIG = $originalTestConfig }
+    else { Remove-Item Env:WINTTY_TEST_CONFIG -ErrorAction SilentlyContinue }
     if (Test-Path -LiteralPath $tempXdg) {
         Remove-Item -LiteralPath $tempXdg -Recurse -Force -ErrorAction SilentlyContinue
     }

--- a/windows/scripts/release-smoke.ps1
+++ b/windows/scripts/release-smoke.ps1
@@ -5,6 +5,7 @@ param(
     [switch]$SkipLaunch
 )
 . (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
+. (Join-Path $PSScriptRoot 'lib/test-config.ps1')
 $ErrorActionPreference = 'Stop'
 $repo = (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
 Push-Location $repo
@@ -12,6 +13,12 @@ Push-Location $repo
 # is minutes of work to then be told to close a window, and dotnet cannot
 # overwrite a locked Wintty.exe anyway.
 Assert-NoWintty -Context 'The release smoke'
+
+# Both launch smokes run against a per-run random temp config root with the
+# WINTTY_TEST_CONFIG guard armed: a Release/AOT launch used to read and
+# write the user's real config. Entered before the builds so the finally
+# below always pairs it; nothing in the build reads XDG_CONFIG_HOME.
+$testConfig = Enter-WinttyTestConfig
 
 # One entry per launch, each with its own stamp. A single stamp taken at
 # script start would be minutes stale by the time anything launches, and
@@ -86,5 +93,6 @@ finally {
     foreach ($l in $script:Launched) {
         Stop-WinttyStartedAfter -Since $l.Since -ExePath $l.Exe
     }
+    Exit-WinttyTestConfig $testConfig
     Pop-Location
 }

--- a/windows/scripts/run-win-launch.ps1
+++ b/windows/scripts/run-win-launch.ps1
@@ -13,7 +13,7 @@
 #   - an agent session: isolated by default. Claude Code sets CLAUDECODE=1
 #     in every process it spawns, and CLAUDECODE is absent from the User
 #     and Machine environments, so a human terminal never carries it. The
-#     April config taint was an agent manual test pass through a dev build,
+#     April taint was an agent manual test pass through a dev build,
 #     which is exactly the path this closes without affecting users.
 #   - REAL_CONFIG=1: overrides every other spelling, runs against the real
 #     config, and announces itself loudly, because running an agent session
@@ -37,8 +37,51 @@ function Get-RunWinMode {
     return 'real'
 }
 
+# The confirmation's two effects are injectable so the decision table is
+# unit-testable without a console at all: a line reader and an
+# is-interactive predicate, both scriptblocks. The defaults are the real
+# console behaviors; probes pass fakes.
+$script:ReadRealConfigConfirmation = {
+    param([string]$Prompt)
+    Read-Host $Prompt
+}
+$script:TestRealConfigConsoleInteractive = {
+    -not [Console]::IsInputRedirected -and $Host.UI.IsInteractive
+}
+
+# The confirmation primitive: asks for the typed word whenever invoked and
+# refuses every non-interactive context. Returns $true only when a human
+# at an interactive console typed REAL.
+#
+# Boundary note (deliberate): the CALLER applies this only when CLAUDECODE
+# marks the session as an agent's. CLAUDECODE is self-reported by the same
+# process, so this gate is a VISIBILITY layer that makes agent misuse loud,
+# not a boundary. The boundary is the app-side WINTTY_TEST_CONFIG guard and
+# its env-independent known-folder temp anchor, which no environment
+# variable in this process can move.
+function Confirm-RealConfigUse {
+    param(
+        [Parameter(Mandatory)][scriptblock]$ReadInput,
+        [Parameter(Mandatory)][scriptblock]$IsInteractive
+    )
+    if (-not (& $IsInteractive)) {
+        Write-Host '  REAL_CONFIG cannot be used from an agent session without a human' -ForegroundColor Red
+        Write-Host '  at the keyboard: the console is non-interactive, so the typed' -ForegroundColor Red
+        Write-Host '  confirmation cannot be given. Use the isolated default instead' -ForegroundColor Red
+        Write-Host '  (this is what an agent session gets without REAL_CONFIG).' -ForegroundColor Red
+        return $false
+    }
+    $answer = & $ReadInput 'Type REAL to run against YOUR REAL config'
+    if ($answer -ne 'REAL') {
+        Write-Host 'not confirmed; aborting (nothing was launched).' -ForegroundColor Red
+        return $false
+    }
+    return $true
+}
+
 # Dot-sourced (InvocationName '.') means someone is probing Get-RunWinMode
-# without launching anything; the launch is for a real invocation only.
+# or Confirm-RealConfigUse without launching anything; the launch is for a
+# real invocation only.
 if ($MyInvocation.InvocationName -eq '.') { return }
 
 if (-not $ExePath) { throw 'run-win-launch.ps1 needs -ExePath <path to Wintty.exe>' }
@@ -59,18 +102,12 @@ if ($mode -eq 'real-forced') {
     # keyboard: the typed confirmation is something an agent cannot give
     # (an agent shell's stdin is redirected or null, so the gate refuses
     # before even asking). A human types it once; a human without
-    # CLAUDECODE never sees the prompt at all.
+    # CLAUDECODE never sees the prompt at all. Visibility layer, not a
+    # boundary: see the note on Confirm-RealConfigUse.
     if ($env:CLAUDECODE -eq '1') {
-        if ([Console]::IsInputRedirected -or -not $Host.UI.IsInteractive) {
-            Write-Host '  REAL_CONFIG cannot be used from an agent session without a human' -ForegroundColor Red
-            Write-Host '  at the keyboard: the console is non-interactive, so the typed' -ForegroundColor Red
-            Write-Host '  confirmation cannot be given. Use the isolated default instead' -ForegroundColor Red
-            Write-Host '  (this is what an agent session gets without REAL_CONFIG).' -ForegroundColor Red
-            exit 3
-        }
-        $answer = Read-Host 'Type REAL to run against YOUR REAL config'
-        if ($answer -ne 'REAL') {
-            Write-Host 'not confirmed; aborting (nothing was launched).' -ForegroundColor Red
+        if (-not (Confirm-RealConfigUse `
+                -ReadInput $script:ReadRealConfigConfirmation `
+                -IsInteractive $script:TestRealConfigConsoleInteractive)) {
             exit 3
         }
     }

--- a/windows/scripts/run-win-launch.ps1
+++ b/windows/scripts/run-win-launch.ps1
@@ -54,6 +54,26 @@ if ($mode -eq 'real-forced') {
     Write-Host "  Root: $root" -ForegroundColor Red
     Write-Host ('*' * 72) -ForegroundColor Red
     Write-Host ''
+
+    # From inside an agent session the real config needs a human at the
+    # keyboard: the typed confirmation is something an agent cannot give
+    # (an agent shell's stdin is redirected or null, so the gate refuses
+    # before even asking). A human types it once; a human without
+    # CLAUDECODE never sees the prompt at all.
+    if ($env:CLAUDECODE -eq '1') {
+        if ([Console]::IsInputRedirected -or -not $Host.UI.IsInteractive) {
+            Write-Host '  REAL_CONFIG cannot be used from an agent session without a human' -ForegroundColor Red
+            Write-Host '  at the keyboard: the console is non-interactive, so the typed' -ForegroundColor Red
+            Write-Host '  confirmation cannot be given. Use the isolated default instead' -ForegroundColor Red
+            Write-Host '  (this is what an agent session gets without REAL_CONFIG).' -ForegroundColor Red
+            exit 3
+        }
+        $answer = Read-Host 'Type REAL to run against YOUR REAL config'
+        if ($answer -ne 'REAL') {
+            Write-Host 'not confirmed; aborting (nothing was launched).' -ForegroundColor Red
+            exit 3
+        }
+    }
 }
 
 # After the banner, not before: the announcement is the decision, and a

--- a/windows/scripts/run-win-launch.ps1
+++ b/windows/scripts/run-win-launch.ps1
@@ -1,0 +1,81 @@
+#requires -Version 7
+# The user launcher behind `just run-win` / `just run-win-release`.
+#
+# Founder rule for run-win: it is how USERS run the OSS build they
+# compiled, so it is a user launcher, not a test, and the default for a
+# human terminal is the user's real config, unchanged.
+#
+# Modes, resolved from the environment (set them in the shell that runs
+# just; the justfile does not export its own variables):
+#   - default (a human terminal): the real config, no ceremony.
+#   - ISOLATED_CONFIG=1: explicit opt-in to a fresh random temp XDG root
+#     with WINTTY_TEST_CONFIG armed.
+#   - an agent session: isolated by default. Claude Code sets CLAUDECODE=1
+#     in every process it spawns, and CLAUDECODE is absent from the User
+#     and Machine environments, so a human terminal never carries it. The
+#     April config taint was an agent manual test pass through a dev build,
+#     which is exactly the path this closes without affecting users.
+#   - REAL_CONFIG=1: overrides every other spelling, runs against the real
+#     config, and announces itself loudly, because running an agent session
+#     against the real config is a decision, and decisions should be
+#     visible.
+param(
+    # Not [Parameter(Mandatory)]: a mandatory parameter prompts when the
+    # script is dot-sourced for mode probing, and the explicit check below
+    # gives a real invocation a better message anyway.
+    [string]$ExePath = ''
+)
+$ErrorActionPreference = 'Stop'
+
+# Pure mode resolution, separated from the launch so a harness can
+# dot-source this script and probe the decision table without launching
+# anything.
+function Get-RunWinMode {
+    if ($env:REAL_CONFIG -eq '1') { return 'real-forced' }
+    if ($env:ISOLATED_CONFIG -eq '1') { return 'isolated-explicit' }
+    if ($env:CLAUDECODE -eq '1') { return 'isolated-agent' }
+    return 'real'
+}
+
+# Dot-sourced (InvocationName '.') means someone is probing Get-RunWinMode
+# without launching anything; the launch is for a real invocation only.
+if ($MyInvocation.InvocationName -eq '.') { return }
+
+if (-not $ExePath) { throw 'run-win-launch.ps1 needs -ExePath <path to Wintty.exe>' }
+$mode = Get-RunWinMode
+
+if ($mode -eq 'real-forced') {
+    $root = if ($env:XDG_CONFIG_HOME) { $env:XDG_CONFIG_HOME }
+            else { "$env:APPDATA (the app appends wintty\ or ghostty\ under it)" }
+    Write-Host ''
+    Write-Host ('*' * 72) -ForegroundColor Red
+    Write-Host '  REAL_CONFIG=1: launching against YOUR REAL config.' -ForegroundColor Red
+    Write-Host '  Every read and every write lands in the real per-user config.' -ForegroundColor Red
+    Write-Host "  Root: $root" -ForegroundColor Red
+    Write-Host ('*' * 72) -ForegroundColor Red
+    Write-Host ''
+}
+
+# After the banner, not before: the announcement is the decision, and a
+# bad exe path should not take it with it.
+$exe = (Resolve-Path -LiteralPath $ExePath).Path
+if (-not (Test-Path -LiteralPath $exe)) { throw "missing exe: $ExePath" }
+
+if ($mode -in 'isolated-explicit', 'isolated-agent') {
+    . (Join-Path $PSScriptRoot 'lib/test-config.ps1')
+    # Enter without Exit on purpose: the GUI process outlives this script,
+    # and the app keeps writing into the root after pwsh returns. Exiting
+    # here would delete the live config out from under the window; the
+    # helper's 24h sweep is what reaps it instead.
+    $session = Enter-WinttyTestConfig
+    $because = if ($mode -eq 'isolated-agent') { 'agent session, CLAUDECODE=1' }
+               else { 'ISOLATED_CONFIG=1' }
+    Write-Host ("run-win: isolated config ({0}): {1}" -f $because, $session.Dir)
+    Write-Host 'run-win: WINTTY_TEST_CONFIG=1 is armed, so a lost root is a loud refusal.'
+    Write-Host 'run-win: to run against the real config instead, pass REAL_CONFIG=1.'
+}
+
+# Launch and return. A GUI-subsystem process detaches immediately, which is
+# why the justfile can run this outside any lane.
+$proc = Start-Process -FilePath $exe -PassThru -WorkingDirectory (Split-Path -Parent $exe)
+Write-Host ("run-win: launched pid {0} (mode: {1})" -f $proc.Id, $mode)

--- a/windows/scripts/seam-bisect.ps1
+++ b/windows/scripts/seam-bisect.ps1
@@ -12,6 +12,7 @@ $ErrorActionPreference = 'Stop'
 $exe = $ExePath
 $xdg = Join-Path $env:TEMP ("wintty-seam-bisect-" + [guid]::NewGuid().ToString('N'))
 $env:XDG_CONFIG_HOME = $xdg
+$env:WINTTY_TEST_CONFIG = '1'
 $token = New-SeamToken
 $env:WINTTY_TEST_SEAM = $token
 New-Item -ItemType Directory -Force -Path (Join-Path $xdg 'wintty') | Out-Null

--- a/windows/scripts/seam-cdb.ps1
+++ b/windows/scripts/seam-cdb.ps1
@@ -28,6 +28,7 @@ $log = Join-Path $env:TEMP 'wintty-seam-cdb.log'
 $cmds = Join-Path $env:TEMP 'wintty-seam-cdb-cmds.txt'
 $xdg = Join-Path $env:TEMP ("wintty-seam-cdb-" + [guid]::NewGuid().ToString('N'))
 $env:XDG_CONFIG_HOME = $xdg
+$env:WINTTY_TEST_CONFIG = '1'
 # cdb inherits this and the app under it inherits it in turn, so the token
 # reaches the seam the same way a direct launch delivers it.
 $token = New-SeamToken

--- a/windows/scripts/seam-crash-dump.ps1
+++ b/windows/scripts/seam-crash-dump.ps1
@@ -61,6 +61,7 @@ if ($check.DumpType -ne 2 -or $check.DumpFolder -ne $DumpFolder) {
 
 $xdg = Join-Path $env:TEMP ("wintty-seam-dump-" + [guid]::NewGuid().ToString('N'))
 $env:XDG_CONFIG_HOME = $xdg
+$env:WINTTY_TEST_CONFIG = '1'
 $token = New-SeamToken
 $env:WINTTY_TEST_SEAM = $token
 New-Item -ItemType Directory -Force -Path (Join-Path $xdg 'wintty') | Out-Null

--- a/windows/scripts/seam-probe.ps1
+++ b/windows/scripts/seam-probe.ps1
@@ -9,6 +9,7 @@ $token = New-SeamToken
 $env:WINTTY_TEST_SEAM = $token
 $xdg = Join-Path $env:TEMP ("wintty-seam-probe-" + [guid]::NewGuid().ToString('N'))
 $env:XDG_CONFIG_HOME = $xdg
+$env:WINTTY_TEST_CONFIG = '1'
 New-Item -ItemType Directory -Force -Path (Join-Path $xdg 'wintty') | Out-Null
 @'
 windows-single-instance = true

--- a/windows/scripts/search-fuzz.ps1
+++ b/windows/scripts/search-fuzz.ps1
@@ -48,18 +48,19 @@ param(
     [Parameter(Mandatory)][string]$OutDir,
     [int]$Seed = 1337,
     [int]$Iterations = 40,
-    [switch]$KeepOpen,
-    # Isolation is the default: a per-run random temp XDG root plus
+    [switch]$KeepOpen
+    # Isolation is unconditional: a per-run random temp XDG root plus
     # WINTTY_TEST_CONFIG=1, so the fuzz cannot read or write the real
     # per-user config and a lost root is a loud startup refusal rather
-    # than a silent taint. The old note that a throwaway root was unstable
-    # on one machine (0xc000027b stowed exceptions in CoreMessagingXP) is
-    # why -RealConfig exists: pass it to fuzz the user's own environment
-    # the way the app is actually run, accepting that any config write
-    # lands in the real file.
-    [switch]$RealConfig
+    # than a silent taint. There is deliberately no real-config escape: a
+    # harness must not be able to point the app at the real config. If the
+    # historical 0xc000027b under an isolated root ever returns, that is a
+    # product bug (possibly the x:Load-overlay family, wintty-release
+    # #806): capture it with cdb on the window-owner PID (break on av and
+    # 40080201 first-chance) and fix it, never route around it.
 )
 . (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
+. (Join-Path $PSScriptRoot 'lib/test-config.ps1')
 $ErrorActionPreference = 'Stop'
 New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
 
@@ -709,19 +710,16 @@ function Get-CounterParts([string]$text) {
 # ---- run ------------------------------------------------------------------
 
 $rng = [System.Random]::new($Seed)
-$tempXdg = Join-Path $env:TEMP "wintty-search-fuzz-$([guid]::NewGuid().ToString('N'))"
-New-Item -ItemType Directory -Force -Path (Join-Path $tempXdg 'wintty') | Out-Null
-@'
+$configText = @'
 windows-single-instance = false
 window-save-state = never
 window-width = 120
 window-height = 34
 scrollback-limit = 10000000
 window-theme = wintty
-'@ | Set-Content (Join-Path $tempXdg 'wintty\config.wintty') -Encoding utf8
-
-$origXdg = $env:XDG_CONFIG_HOME
-$origTestConfig = $env:WINTTY_TEST_CONFIG
+'@
+$script:TestConfig = Enter-WinttyTestConfig -ConfigText $configText
+$tempXdg = $script:TestConfig.Dir
 $script:Proc = $null
 $script:Iter = 0
 $script:ExitCode = 0
@@ -740,12 +738,8 @@ $crashPath = Join-Path $env:LOCALAPPDATA 'Wintty\crash.log'
 if (Test-Path $crashPath) { $script:CrashBaseline = (Get-Item $crashPath).Length }
 
 try {
-    if (-not $RealConfig) {
-        $env:XDG_CONFIG_HOME = $tempXdg
-        $env:WINTTY_TEST_CONFIG = '1'
-    }
     if (-not (Test-Path $ExePath)) { throw "missing exe: $ExePath" }
-    Write-Host ("config: {0}" -f $(if ($RealConfig) { 'user environment (-RealConfig)' } else { $tempXdg }))
+    Write-Host ("config: {0}" -f $tempXdg)
 
     # Never kill by name: developers keep builds from several worktrees open
     # at once, and force-killing every Wintty takes down work this run has
@@ -1307,19 +1301,15 @@ finally {
         try { $script:Proc.Refresh(); if (-not $script:Proc.HasExited) { $script:Proc.Kill($true) } } catch { }
         try { [void]$script:Proc.WaitForExit(3000) } catch { }
     }
-    if (-not $RealConfig) {
-        if ($null -ne $origXdg) { $env:XDG_CONFIG_HOME = $origXdg }
-        else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
-        if ($null -ne $origTestConfig) { $env:WINTTY_TEST_CONFIG = $origTestConfig }
-        else { Remove-Item Env:WINTTY_TEST_CONFIG -ErrorAction SilentlyContinue }
-    }
-    # After the restore, not before: a throw here would otherwise abandon it
-    # and leave the shell pointed at a temp profile.
+    # After the kill, not before: the sweep and the teardown below must not
+    # run while the app still holds the config root. -KeepOpen keeps the
+    # staged root on purpose (the app stays up with it); the helper's 24h
+    # sweep reaps it later.
     if (-not $KeepOpen -and $script:StartedAt) {
         Stop-WinttyStartedAfter -Since $script:StartedAt -ExePath $script:ExeFull
     }
     Start-Sleep -Milliseconds 500
-    if (-not $KeepOpen) { Remove-Item -Recurse -Force $tempXdg -ErrorAction SilentlyContinue }
+    if (-not $KeepOpen) { Exit-WinttyTestConfig $script:TestConfig }
 
     Write-Host ""
     if ($script:Findings.Count -eq 0) {

--- a/windows/scripts/search-fuzz.ps1
+++ b/windows/scripts/search-fuzz.ps1
@@ -49,13 +49,15 @@ param(
     [int]$Seed = 1337,
     [int]$Iterations = 40,
     [switch]$KeepOpen,
-    # Launching under a throwaway XDG_CONFIG_HOME turned out to make the app
-    # unstable at startup on this machine (repeated 0xc000027b stowed
-    # exceptions in CoreMessagingXP), while the user's own config dir is
-    # stable. Default to the real environment so the fuzz exercises the app
-    # the way it is actually run; -IsolatedConfig opts back into the
-    # throwaway dir when a controlled config matters more than stability.
-    [switch]$IsolatedConfig
+    # Isolation is the default: a per-run random temp XDG root plus
+    # WINTTY_TEST_CONFIG=1, so the fuzz cannot read or write the real
+    # per-user config and a lost root is a loud startup refusal rather
+    # than a silent taint. The old note that a throwaway root was unstable
+    # on one machine (0xc000027b stowed exceptions in CoreMessagingXP) is
+    # why -RealConfig exists: pass it to fuzz the user's own environment
+    # the way the app is actually run, accepting that any config write
+    # lands in the real file.
+    [switch]$RealConfig
 )
 . (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
@@ -719,6 +721,7 @@ window-theme = wintty
 '@ | Set-Content (Join-Path $tempXdg 'wintty\config.wintty') -Encoding utf8
 
 $origXdg = $env:XDG_CONFIG_HOME
+$origTestConfig = $env:WINTTY_TEST_CONFIG
 $script:Proc = $null
 $script:Iter = 0
 $script:ExitCode = 0
@@ -737,9 +740,12 @@ $crashPath = Join-Path $env:LOCALAPPDATA 'Wintty\crash.log'
 if (Test-Path $crashPath) { $script:CrashBaseline = (Get-Item $crashPath).Length }
 
 try {
-    if ($IsolatedConfig) { $env:XDG_CONFIG_HOME = $tempXdg }
+    if (-not $RealConfig) {
+        $env:XDG_CONFIG_HOME = $tempXdg
+        $env:WINTTY_TEST_CONFIG = '1'
+    }
     if (-not (Test-Path $ExePath)) { throw "missing exe: $ExePath" }
-    Write-Host ("config: {0}" -f $(if ($IsolatedConfig) { $tempXdg } else { 'user environment' }))
+    Write-Host ("config: {0}" -f $(if ($RealConfig) { 'user environment (-RealConfig)' } else { $tempXdg }))
 
     # Never kill by name: developers keep builds from several worktrees open
     # at once, and force-killing every Wintty takes down work this run has
@@ -1301,9 +1307,11 @@ finally {
         try { $script:Proc.Refresh(); if (-not $script:Proc.HasExited) { $script:Proc.Kill($true) } } catch { }
         try { [void]$script:Proc.WaitForExit(3000) } catch { }
     }
-    if ($IsolatedConfig) {
+    if (-not $RealConfig) {
         if ($null -ne $origXdg) { $env:XDG_CONFIG_HOME = $origXdg }
         else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
+        if ($null -ne $origTestConfig) { $env:WINTTY_TEST_CONFIG = $origTestConfig }
+        else { Remove-Item Env:WINTTY_TEST_CONFIG -ErrorAction SilentlyContinue }
     }
     # After the restore, not before: a throw here would otherwise abandon it
     # and leave the shell pointed at a temp profile.

--- a/windows/scripts/shader-notice-fuzz.ps1
+++ b/windows/scripts/shader-notice-fuzz.ps1
@@ -303,6 +303,8 @@ $crashStamp = if (Test-Path $crashPath) { (Get-Item $crashPath).LastWriteTimeUtc
 
 $originalXdgSet = Test-Path Env:XDG_CONFIG_HOME
 $originalXdg = if ($originalXdgSet) { $env:XDG_CONFIG_HOME } else { $null }
+$originalTestConfigSet = Test-Path Env:WINTTY_TEST_CONFIG
+$originalTestConfig = if ($originalTestConfigSet) { $env:WINTTY_TEST_CONFIG } else { $null }
 
 # The quiet cases assert that NO banner appears, so every other thing that can
 # legitimately raise one has to be staged too, not just the config. NO_COLOR is
@@ -337,6 +339,7 @@ function Invoke-Case($Case, [int]$ExtraTabs, [string]$Exe) {
     $stamp = Get-WinttyLaunchStamp
     try {
         $env:XDG_CONFIG_HOME = $tempXdg
+        $env:WINTTY_TEST_CONFIG = '1'
         Remove-Item Env:NO_COLOR -ErrorAction SilentlyContinue
         $proc = Start-Process -FilePath $Exe -PassThru -WorkingDirectory (Split-Path $Exe)
         $pid32 = [uint32]$proc.Id
@@ -499,6 +502,8 @@ try {
 finally {
     if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }
     else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
+    if ($originalTestConfigSet) { $env:WINTTY_TEST_CONFIG = $originalTestConfig }
+    else { Remove-Item Env:WINTTY_TEST_CONFIG -ErrorAction SilentlyContinue }
     if ($originalNoColorSet) { $env:NO_COLOR = $originalNoColor }
     else { Remove-Item Env:NO_COLOR -ErrorAction SilentlyContinue }
     Remove-Item -Recurse -Force -LiteralPath $stage -ErrorAction SilentlyContinue

--- a/windows/scripts/shader-notice-fuzz.ps1
+++ b/windows/scripts/shader-notice-fuzz.ps1
@@ -44,6 +44,7 @@ param(
     [int]$Seed = 0
 )
 . (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
+. (Join-Path $PSScriptRoot 'lib/test-config.ps1')
 $ErrorActionPreference = 'Stop'
 
 # Same convention as the other harnesses here: a PRODUCT_FAIL throw is a
@@ -255,7 +256,8 @@ foreach ($f in @($validSrc, $invalidSrc)) {
     if (-not (Test-Path -LiteralPath $f)) { throw "HARVEST_MISS: fixture shader missing: $f" }
 }
 
-$stage = Join-Path $env:TEMP ("wintty-shader-fuzz-{0:HHmmss}" -f (Get-Date))
+$script:TestConfig = Enter-WinttyTestConfig
+$stage = $script:TestConfig.Dir
 New-Item -ItemType Directory -Force -Path $stage | Out-Null
 Copy-Item -LiteralPath $validSrc -Destination (Join-Path $stage 'valid.glsl')
 Copy-Item -LiteralPath $invalidSrc -Destination (Join-Path $stage 'invalid.glsl')
@@ -301,10 +303,8 @@ Write-Host ("order=" + (($order | ForEach-Object { $_.id }) -join ','))
 $crashPath = Join-Path $env:LOCALAPPDATA 'Wintty\crash.log'
 $crashStamp = if (Test-Path $crashPath) { (Get-Item $crashPath).LastWriteTimeUtc } else { [datetime]::MinValue }
 
-$originalXdgSet = Test-Path Env:XDG_CONFIG_HOME
-$originalXdg = if ($originalXdgSet) { $env:XDG_CONFIG_HOME } else { $null }
-$originalTestConfigSet = Test-Path Env:WINTTY_TEST_CONFIG
-$originalTestConfig = if ($originalTestConfigSet) { $env:WINTTY_TEST_CONFIG } else { $null }
+# XDG_CONFIG_HOME and WINTTY_TEST_CONFIG are owned by the test-config
+# session entered above; only NO_COLOR still needs save/restore here.
 
 # The quiet cases assert that NO banner appears, so every other thing that can
 # legitimately raise one has to be staged too, not just the config. NO_COLOR is
@@ -318,7 +318,9 @@ $originalTestConfig = if ($originalTestConfigSet) { $env:WINTTY_TEST_CONFIG } el
 $originalNoColorSet = Test-Path Env:NO_COLOR
 $originalNoColor = if ($originalNoColorSet) { $env:NO_COLOR } else { $null }
 
-$tempXdg = Join-Path $stage 'xdg'
+# The XDG root is the staged root itself; the helper already pointed
+# XDG_CONFIG_HOME at it and armed WINTTY_TEST_CONFIG.
+$tempXdg = $script:TestConfig.Dir
 New-Item -ItemType Directory -Force -Path (Join-Path $tempXdg 'wintty') | Out-Null
 $configPath = Join-Path $tempXdg 'wintty\config.wintty'
 
@@ -338,8 +340,6 @@ function Invoke-Case($Case, [int]$ExtraTabs, [string]$Exe) {
     $proc = $null
     $stamp = Get-WinttyLaunchStamp
     try {
-        $env:XDG_CONFIG_HOME = $tempXdg
-        $env:WINTTY_TEST_CONFIG = '1'
         Remove-Item Env:NO_COLOR -ErrorAction SilentlyContinue
         $proc = Start-Process -FilePath $Exe -PassThru -WorkingDirectory (Split-Path $Exe)
         $pid32 = [uint32]$proc.Id
@@ -500,13 +500,9 @@ try {
     }
 }
 finally {
-    if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }
-    else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
-    if ($originalTestConfigSet) { $env:WINTTY_TEST_CONFIG = $originalTestConfig }
-    else { Remove-Item Env:WINTTY_TEST_CONFIG -ErrorAction SilentlyContinue }
     if ($originalNoColorSet) { $env:NO_COLOR = $originalNoColor }
     else { Remove-Item Env:NO_COLOR -ErrorAction SilentlyContinue }
-    Remove-Item -Recurse -Force -LiteralPath $stage -ErrorAction SilentlyContinue
+    Exit-WinttyTestConfig $script:TestConfig
 
     # Written from the finally, so the report survives a throw from outside the
     # per-case catch above. The exit code is still decided below, on the paths

--- a/windows/scripts/splash-single-instance-race.ps1
+++ b/windows/scripts/splash-single-instance-race.ps1
@@ -225,6 +225,7 @@ function Stop-Launched {
 
 $results = [System.Collections.Generic.List[object]]::new()
 $previousXdg = $env:XDG_CONFIG_HOME
+$previousTestConfig = $env:WINTTY_TEST_CONFIG
 
 try {
     Write-Host "exe    : $ExePath"
@@ -241,12 +242,14 @@ try {
         # Set per launch: a child inherits the environment as it stands when
         # it is created, and the two roles can need different configs.
         $env:XDG_CONFIG_HOME = $primaryXdg
+        $env:WINTTY_TEST_CONFIG = '1'
         $primary = Start-Process -FilePath $ExePath -PassThru
         $launched.Add($primary)
 
         Start-Sleep -Milliseconds $DelayMs
 
         $env:XDG_CONFIG_HOME = $secondaryXdg
+        $env:WINTTY_TEST_CONFIG = '1'
         $secondary = Start-Process -FilePath $ExePath -PassThru
         $launched.Add($secondary)
         $t0 = [System.Diagnostics.Stopwatch]::StartNew()
@@ -375,6 +378,8 @@ try {
 finally {
     Stop-Launched
     $env:XDG_CONFIG_HOME = $previousXdg
+    if ($null -ne $previousTestConfig -and $previousTestConfig -ne '') { $env:WINTTY_TEST_CONFIG = $previousTestConfig }
+    else { Remove-Item Env:WINTTY_TEST_CONFIG -ErrorAction SilentlyContinue }
     Remove-Item -Recurse -Force $scratch -ErrorAction SilentlyContinue
 }
 

--- a/windows/scripts/splash-single-instance-race.ps1
+++ b/windows/scripts/splash-single-instance-race.ps1
@@ -180,7 +180,9 @@ function Get-OverlapArea($a, $b) {
 # the key off, which is what makes the two questions differ. The mutex name
 # is derived from the exe path, not the config, so the two still contend for
 # the same election.
-$scratch = Join-Path ([System.IO.Path]::GetTempPath()) "wintty-splash-race-$PID"
+# A GUID, not $PID: the founder rule wants a randomly generated name,
+# and a PID is reused across reboots, so two runs can collide.
+$scratch = Join-Path ([System.IO.Path]::GetTempPath()) ("wintty-splash-race-" + [guid]::NewGuid().ToString('N'))
 
 function New-ScratchConfig([string]$name, [string]$value) {
     $root = Join-Path $scratch $name

--- a/windows/scripts/vttest/run-vttest-section.ps1
+++ b/windows/scripts/vttest/run-vttest-section.ps1
@@ -22,11 +22,16 @@ stop it with `Stop-Process -Id <pid>` when done.
     [Parameter(Mandatory)][string]$WinttyExe,
     [Parameter(Mandatory)][ValidatePattern('^\d+$')][string]$Section,  # vttest menu digits, e.g. "3"
     [int]$Pages = 0,                                    # paging RETURNs within the test
-    [string]$Distro = 'Ubuntu-24.04',
-    [string]$OutDir = "$env:TEMP\vttest-section"
+    [string]$Distro = 'Ubuntu-24.04'
 )
 $ErrorActionPreference = 'Stop'
-New-Item -ItemType Directory -Force $OutDir | Out-Null
+. (Join-Path $PSScriptRoot '../lib/test-config.ps1')
+
+# A per-run randomly named config root from the shared helper (the old
+# default was a fixed %TEMP%\vttest-section reused across runs).
+# No paired Exit: the launched Wintty stays up for screenshotting and
+# holds the root; the helper's 24h sweep reaps it.
+$testConfig = Enter-WinttyTestConfig
 
 # LF-normalize the committed driver into the distro: a Windows checkout may carry
 # CRLF, which bash rejects. Translate the script's own path to its /mnt mount.
@@ -38,25 +43,15 @@ wsl.exe -d $Distro -- bash -lc "tr -d '\r' < '$srcMnt' > /tmp/vttest-section.sh"
 # Temp ghostty config (same XDG harness as run-vttest.ps1; the `ghostty/` subdir
 # is required). The command splits on spaces into wsl.exe argv; Section/Pages are
 # bare digits.
-$cfgDir = Join-Path $OutDir 'cfg'
+$cfgDir = $testConfig.Dir
 $cfgGhostty = Join-Path $cfgDir 'ghostty'
 New-Item -ItemType Directory -Force $cfgGhostty | Out-Null
 "command = wsl.exe -d $Distro -- bash -l /tmp/vttest-section.sh $Section $Pages" |
     Set-Content -LiteralPath (Join-Path $cfgGhostty 'config') -Encoding utf8
 
-$prevXdg = $env:XDG_CONFIG_HOME
-$prevTestConfig = $env:WINTTY_TEST_CONFIG
-$proc = $null
-try {
-    $env:XDG_CONFIG_HOME = $cfgDir
-    $env:WINTTY_TEST_CONFIG = '1'
-    $proc = Start-Process -FilePath $WinttyExe -PassThru
-}
-finally {
-    $env:XDG_CONFIG_HOME = $prevXdg
-    if ($null -ne $prevTestConfig -and $prevTestConfig -ne '') { $env:WINTTY_TEST_CONFIG = $prevTestConfig }
-    else { Remove-Item Env:WINTTY_TEST_CONFIG -ErrorAction SilentlyContinue }
-}
+# The helper entered above set XDG_CONFIG_HOME and armed
+# WINTTY_TEST_CONFIG for the child.
+$proc = Start-Process -FilePath $WinttyExe -PassThru
 
 Write-Host "Wintty PID $($proc.Id) hosting vttest section $Section ($Distro)."
 Write-Host "Move the window to the primary monitor, screenshot, then: Stop-Process -Id $($proc.Id)"

--- a/windows/scripts/vttest/run-vttest-section.ps1
+++ b/windows/scripts/vttest/run-vttest-section.ps1
@@ -45,13 +45,17 @@ New-Item -ItemType Directory -Force $cfgGhostty | Out-Null
     Set-Content -LiteralPath (Join-Path $cfgGhostty 'config') -Encoding utf8
 
 $prevXdg = $env:XDG_CONFIG_HOME
+$prevTestConfig = $env:WINTTY_TEST_CONFIG
 $proc = $null
 try {
     $env:XDG_CONFIG_HOME = $cfgDir
+    $env:WINTTY_TEST_CONFIG = '1'
     $proc = Start-Process -FilePath $WinttyExe -PassThru
 }
 finally {
     $env:XDG_CONFIG_HOME = $prevXdg
+    if ($null -ne $prevTestConfig -and $prevTestConfig -ne '') { $env:WINTTY_TEST_CONFIG = $prevTestConfig }
+    else { Remove-Item Env:WINTTY_TEST_CONFIG -ErrorAction SilentlyContinue }
 }
 
 Write-Host "Wintty PID $($proc.Id) hosting vttest section $Section ($Distro)."

--- a/windows/scripts/vttest/run-vttest.ps1
+++ b/windows/scripts/vttest/run-vttest.ps1
@@ -46,13 +46,17 @@ New-Item -ItemType Directory -Force $cfgGhostty | Out-Null
 # Inherit the full environment and add only the XDG override (rather than
 # -Environment, whose merge-vs-replace semantics vary). Restore afterward.
 $prevXdg = $env:XDG_CONFIG_HOME
+$prevTestConfig = $env:WINTTY_TEST_CONFIG
 $proc = $null
 try {
     $env:XDG_CONFIG_HOME = $cfgDir
+    $env:WINTTY_TEST_CONFIG = '1'
     $proc = Start-Process -FilePath $WinttyExe -PassThru
 }
 finally {
     $env:XDG_CONFIG_HOME = $prevXdg
+    if ($null -ne $prevTestConfig -and $prevTestConfig -ne '') { $env:WINTTY_TEST_CONFIG = $prevTestConfig }
+    else { Remove-Item Env:WINTTY_TEST_CONFIG -ErrorAction SilentlyContinue }
 }
 
 Write-Host "Wintty PID $($proc.Id) is hosting vttest ($Distro)."

--- a/windows/scripts/vttest/run-vttest.ps1
+++ b/windows/scripts/vttest/run-vttest.ps1
@@ -24,12 +24,17 @@ prints the launched PID; stop it with `Stop-Process -Id <pid>` when done.
 [CmdletBinding()] param(
     [Parameter(Mandatory)][string]$WinttyExe,        # path to built Wintty.exe
     [string]$Distro = 'Ubuntu-24.04',
-    [string]$VttestPath = '~/vttest',                 # vttest path inside the distro
-    [string]$OutDir = "$env:TEMP\vttest-run"          # holds the temp ghostty config
+    [string]$VttestPath = '~/vttest'                  # vttest path inside the distro
 )
 $ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot '../lib/test-config.ps1')
 
-New-Item -ItemType Directory -Force $OutDir | Out-Null
+# A per-run randomly named config root from the shared helper (the old
+# default was a fixed %TEMP%\vttest-run reused across runs). No
+# paired Exit: this harness leaves the Wintty running for an interactive
+# vttest pass, the app holds the root after this script exits, and the
+# helper's 24h sweep reaps it.
+$testConfig = Enter-WinttyTestConfig
 
 # The WinUI app ignores --command; XDG_CONFIG_HOME + `command =` is the proven
 # launch harness (see the esctest runner / #494 OSC7 work). ghostty reads
@@ -37,27 +42,15 @@ New-Item -ItemType Directory -Force $OutDir | Out-Null
 # surface silently falls back to the default shell. The command splits on spaces
 # into wsl.exe argv; `bash -lc ~/vttest` runs vttest as a login shell so tilde
 # expansion and PATH are sane, and all paths here are space-free.
-$cfgDir = Join-Path $OutDir 'cfg'
+$cfgDir = $testConfig.Dir
 $cfgGhostty = Join-Path $cfgDir 'ghostty'
 New-Item -ItemType Directory -Force $cfgGhostty | Out-Null
 "command = wsl.exe -d $Distro -- bash -lc $VttestPath" |
     Set-Content -LiteralPath (Join-Path $cfgGhostty 'config') -Encoding utf8
 
-# Inherit the full environment and add only the XDG override (rather than
-# -Environment, whose merge-vs-replace semantics vary). Restore afterward.
-$prevXdg = $env:XDG_CONFIG_HOME
-$prevTestConfig = $env:WINTTY_TEST_CONFIG
-$proc = $null
-try {
-    $env:XDG_CONFIG_HOME = $cfgDir
-    $env:WINTTY_TEST_CONFIG = '1'
-    $proc = Start-Process -FilePath $WinttyExe -PassThru
-}
-finally {
-    $env:XDG_CONFIG_HOME = $prevXdg
-    if ($null -ne $prevTestConfig -and $prevTestConfig -ne '') { $env:WINTTY_TEST_CONFIG = $prevTestConfig }
-    else { Remove-Item Env:WINTTY_TEST_CONFIG -ErrorAction SilentlyContinue }
-}
+# The helper entered above set XDG_CONFIG_HOME and armed
+# WINTTY_TEST_CONFIG for the child.
+$proc = Start-Process -FilePath $WinttyExe -PassThru
 
 Write-Host "Wintty PID $($proc.Id) is hosting vttest ($Distro)."
 Write-Host "Drive the menus from the keyboard and screenshot each section."


### PR DESCRIPTION
## What

- `WINTTY_TEST_CONFIG` arms an app-side guard: when set, Wintty refuses to run against any config root or resolved config path outside the temp directory. The refusal sits in `Program.MainImpl` ahead of the first `InitGhostty` (so before libghostty can read, create or template any config file), exits with code 4, and prints both paths to stderr. Belt checks also sit on `ConfigService`'s resolved path, on the `SeedConfigIfEmpty` write (outside its recovery `try`), and on `ConfigFileEditor.WriteAtomic`, the one choke point every Settings page, profile toggle, opacity drag and raw-editor save funnels through. `TestConfigGuardWiringTests` pins that wiring to the syntax tree.
- `--no-config` no longer constructs the real `ConfigFileEditor`: such a run gets `NoConfigFileEditor`, whose writes are refused loudly (and logged by the write scheduler and the startup migrator, which also skips its config appends under the flag). Previously every Settings-UI write on a `--no-config` run landed in the real config file.
- Every harness that launches the app now stages a per-run random temp `XDG_CONFIG_HOME` and arms the guard. The previously unisolated launchers moved onto a shared helper, `windows/scripts/lib/test-config.ps1`: `search-fuzz.ps1` (isolation unconditional; the `-RealConfig` hatch was removed later in this PR, see item B), `mouse-fuzz-probe/remain/dialogs.ps1`, `release-smoke.ps1`. The already-isolated launchers (esctest, latency-probe, vttest, mouse-smoke, tab-colors, jumplist, shader-notice, splash-race, frame-style-fuzz, the seam probes) arm beside their existing XDG staging, and `seam-client.ps1` arms for every seam harness.
- A source-scan test, `HarnessConfigIsolationScanTests`, fails naming file and line for any app launch under `windows/scripts` or the justfile that neither arms `WINTTY_TEST_CONFIG` nor goes through the helper. The script allowlist is `crash-canary`/`crash-matrix` (`+crash` is intercepted before `InitGhostty` and never reaches config) plus the user launcher `run-win-launch.ps1` (founder rule, see below); the justfile pass has no allowlist since the run-win recipes route through that launcher.

## run-win amendment (founder direction)

`just run-win` / `just run-win-release` are the USER launcher, not a test, so they keep the user's real config by default, unchanged. Both recipes now route through `windows/scripts/run-win-launch.ps1`, which resolves the mode from the environment, in this precedence:

1. `REAL_CONFIG=1`: run against the real config, overriding everything, announced with a loud red banner (a decision that visible).
2. `ISOLATED_CONFIG=1`: explicit opt-in to a fresh random temp XDG root with `WINTTY_TEST_CONFIG=1` armed.
3. `CLAUDECODE=1` (set by Claude Code in every process it spawns; verified absent from the User and Machine environments, so a human terminal never carries it): isolated by default. The April taint was an agent manual test pass through a dev build, which is exactly the path this closes.
4. Otherwise (a human terminal): the real config, unchanged.

Pinned by tests: `Run_Win_Recipes_Route_Through_The_User_Launcher_Script` and `Run_Win_Launcher_Pins_The_Founder_Rule_For_The_User_Launcher` (markers, precedence order inside `Get-RunWinMode`, the loud announcement, and no `Exit-WinttyTestConfig` after launch, since the window outlives the recipe). The justfile source scan is now strict with no allowlist: any bare `Wintty.exe` exec line in a recipe fails it, because that would bypass the agent-session default. Red first (3 failures on the pre-change tree: bare exec lines, no launcher, no routing), green after (33/33).

Live verification: with only `CLAUDECODE=1` set, the launcher staged `wintty-testcfg-<128-bit-hex>`, armed the guard, launched the app, and the 495 files under `%APPDATA%\Ghostty` hash-identical before and after; the mode matrix (7 env permutations, including `REAL_CONFIG` beating `CLAUDECODE`) passes via the probe harness.

## Items A and B: random staging everywhere, no real-config escape

(A) The fixed-name and clock-keyed staging roots moved onto randomly named roots. frame-style-fuzz and shader-notice-fuzz stage through `Enter-WinttyTestConfig` (their HHmmss-keyed `%TEMP%` stage is gone; shader fixtures live beside the config inside the helper's root, invisible to config resolution); mouse-fuzz-jumplist's `New-IsolatedConfig` uses the helper; the vttest pair (fixed `vttest-run` / `vttest-section`) and the esctest pair (fixed `esctest-run` / `latency-probe-run`) use the helper for the config root (the esctest results dir keeps its own random guid name so the report outlives the app); splash-single-instance-race's `$PID`-keyed scratch became a guid. The source scan grew `Every_Staged_Config_Root_Is_Randomly_Named`: every `XDG_CONFIG_HOME` assignment is followed through its definition chain (variables, parameter defaults, in-file functions) and fails naming file, line, and the offending definition unless the chain reaches `[guid]::NewGuid` / `New-Guid` / `GetRandomFileName` / `RandomNumberGenerator` / one of the helpers, or is a save/restore. Red first: 10 violations across 8 scripts (all of the above, pre-migration). Green after: 0.

(B) `search-fuzz.ps1` lost `-RealConfig` entirely: isolation is unconditional, staged through the helper. A test harness must not be able to point the app at the real config. If the historical 0xc000027b under an isolated root returns, that is a product bug (possibly the x:Load-overlay family, tracked on the release side), to be captured with cdb on the window-owner PID (break on `av` and `40080201` first chance) and fixed, never routed around; the param comment says exactly this. Pinned by `Search_Fuzz_Has_No_Real_Config_Escape` (no `RealConfig` code line; `Enter-WinttyTestConfig` present). Verified live: `just search-fuzz '-Seed 7 -Iterations 8'` ran the isolated default clean (22 checks, 0 findings, no startup failure), with all 495 files under `%APPDATA%\Ghostty` hash-identical before and after.

## Fix round 1 (adversarial review: 4 Mediums + Lows)

- M1: the guard's temp anchor is now the known-folder temp (`%LOCALAPPDATA%\Temp` via the known-folder API, which the process environment cannot move), never `Path.GetTempPath()`; and an armed run refuses outright when TEMP or TMP points outside that anchor. Unit tests cover the redirect-to-APPDATA and drive-root shapes; the app-level probe reran the review's exact case (exit 4 now, where the pre-fix build ran).
- M2: reads are enforced. A managed pre-pass before the CLI branch (so `+show-config` is covered too) refuses exit 4 for any `--config-file` value and any `config-file =` include chain reachable from the root's default files that resolves outside temp, expanding relative includes against the including file's directory exactly as Config.zig does. Include, flag, and chained include all refuse at app level.
- M3: the scan now judges each LAUNCH SITE (an arming line inside an if/else/switch blesses nothing, and only arms before the launch count), sees every launch form the review proved invisible (`[Process]::Start($psi)` with the target set by property, call operator, Invoke-Item, literal-path Start-Process, `cmd /c start`, explorer.exe, `dotnet run`, unresolved variables fail closed), and excludes resolved tooling targets (pwsh, cdb, the repo's BackdropStage/WindowCapture helpers), fixing the `$cdbExe` false-positive class. A synthetic fixture corpus (`ScanFixtures/`, 11 violations + 3 cleans) bakes the per-form RED into the suite. `fuzz-suite.ps1` arms every leg it launches. `run-win-launch.ps1` is allowlisted with the founder-rule reason.
- M4: the boundary compare runs on final paths: the longest existing ancestor is resolved through GetFinalPathNameByHandle (junctions and symlinks included), the anchor too, and an unresolvable existing path refuses. Real junction test refuses; symlink test skips with a reason where the host lacks the privilege. The review's write-through-the-junction case now exits 4 with nothing written.
- Lows: `--no-config` creates nothing on a fresh root (both native creates suppressed: openPath gains a no-create variant behind a new export, and writeConfigTemplate is skipped when the CLI disables default files); the xdg.zig mirror handles set-but-empty XDG_CONFIG_HOME exactly as zig does and is pinned against the zig source; the earlier signoff wording is corrected (nothing was ever carried by digest).
- REAL_CONFIG: inside an agent session (CLAUDECODE), REAL_CONFIG now requires a typed `REAL` at the console; a non-interactive console refuses with exit 3. Probed 4/4 (agent refused, human proceeds unprompted, piped/wrong confirmation refused). Residual: the truly-interactive leg could not be reproduced on this host (ttyrig cannot host pwsh here); the gate's branch is pinned by source assertions and the non-interactive refusals.

MSIX note: Claude-spawned shells see `%APPDATA%` merged with the Claude package LocalCache overlay, so an agent's own view of the real config directory is NOT the physical disk. The guard and the tests therefore never rely on the agent shell's view: the app under test resolves its own paths (the guard compares inside the app's process), and the verification probes hash `%APPDATA%\Ghostty` from a WMI-spawned cmd when the physical view is needed.

Evidence: filtered suite 49/49 (35 pre-round), full 3966 + 45 passed; app-level probe green across all cases with the real config hash-identical before and after every launch.

## Fix round 2 (re-review: 2 Mediums + 3 Lows)

- R1-1: random staging is now a POSITIVE proof. The assignment's own right-hand side carries the same tripwires the followed definitions do, and every chain must reach a random-name source (`[guid]::NewGuid`, `New-Guid`, `GetRandomFileName`, `RandomNumberGenerator`, or the helpers); a fixed literal, `$PID`, a clock format, or a `prev`-named variable that is not a real restore all fail. The restore exemption is now an exact pairing: the assigned value must trace to an earlier save FROM `$env:XDG_CONFIG_HOME` (by variable or hashtable member), so a literal like `wintty-preview` and a `$previousRun` holding a fixed path are not exempt. A fixed SUBDIRECTORY under an already-random root (`'wintty'`) stays legal. All five re-review shapes are RED fixtures (`staging-*.ps1`) plus a green control per allowed form (guid, GetRandomFileName, helper, paired restore).
- R1-2: the four invisible forms are caught: the call operator with a literal or interpolated app path (the verb no longer requires a `$variable`; target evidence reads the raw argument), the `saps` alias and a bare lowercase `start`, and COM launches (`WScript.Shell` `.Run`/`.Exec`, `Shell.Application` `.ShellExecute`, gated on the file creating the COM object). All four are RED fixtures.
- R1-3: the typed-REAL confirmation sits behind an injectable line reader and an injectable is-interactive predicate (`Confirm-RealConfigUse`), unit-probed 4/4: interactive+REAL proceeds, interactive+wrong word refuses, non-interactive with REAL piped refuses, non-interactive without stdin refuses. The real console path is unchanged, and the end-to-end gate probe still passes 4/4.
- R1-4: the debugger ruling is implemented with positional targets: `-FilePath`/call-operator/first-argument candidates decide the target, so an app path in a `-ArgumentList` no longer names the launch. A target that resolves to a debugger IS an app launch when the app is its debuggee (an app literal among the arguments, no `-p`/`-pn`/`-pid` attach flag); attach is exempt. Fixture both directions (`violation-cdb-launches-app`, `clean-cdb-attach`). The one existing debugger launcher (seam-cdb.ps1) already isolates and arms, so no corpus fix was needed.
- R1-5: the CLAUDECODE gate is documented as a visibility layer, not a boundary, in the gate's code comment and above in the run-win section; the boundary is the env-independent guard plus anchor. No code change beyond the comment.

Evidence: RED first (the two new fixture tests failed naming all five blessed staging shapes and the four invisible launch forms), then green: scan/wiring filter 9/9, full Ghostty.Tests 3967 passed / 0 failed / 1 skipped.

## Fix round 3 (re-review 2: 1 Medium + Lows; the rest accepted)

- R2-1 splatting: `@name` is now a launch candidate; the hashtable's FilePath/FileName/Path member (literal or variable, on the opener line or inside the body) is the target, so `Start-Process @sp` over `@{ FilePath = '...Wintty.exe' }` is flagged. RED fixture + an armed green control.
- R2-1 scriptblock launch: candidate tokens end at braces and parens, and brace-only tokens are dropped (a dropped candidate never counts as a decided position, so the whole-line fallback still fires); `Start-Job -ScriptBlock { Start-Process -FilePath '...Wintty.exe' }` is flagged. RED fixture.
- R2-3: a fixed root set as a one-line `param([string]$XdgRoot = ...)` default is followed; `Set-Item Env:\XDG_CONFIG_HOME` and `[Environment]::SetEnvironmentVariable('XDG_CONFIG_HOME', ...)` go through the same positive-proof randomness rule as the dollar-env assignment; and a member-shape restore through the WRONG member (`$Session.OtherXdg` when `OrigXdg` is the saved one) fails instead of blessing through the base object. All RED fixtures.
- R2-2, mixed case only: verbs and aliases match case-insensitively (`STArt-Process`, `START`, `SAPS` are ordinary PowerShell), with the bare alias rejecting hyphen continuations so `Start-Job` is not a launch by word shape. RED fixture.
- R2-2, the rest: documented in the scan's header as KNOWN, ACCEPTED LIMITS (helper-name shadowing, same-line marker smuggling, iex, conhost/rundll32, scriptblock-variable indirection, COM created in a dot-sourced helper, dot-sourced staging values), with the explicit note that the boundary is the app-side guard plus anchor and that a shape from that list in a review is still a finding; the automation accepting it is not the project welcoming it.

The reparse unit test now creates a symlink in-process first (this host allows it) with the junction fallback, so the cmd spawn denial seen on one lane slot cannot skip the reparse case.

Evidence: RED first (3 launch forms + 4 staging shapes missed, exactly the re-review's lists), then green 50/50 on the scan/guard filter and 3967 passed / 0 failed / 1 skipped in the full suite.

## Fix round 4 (re-review 3: one Low)

- R3-1 merged splats: `@name` now follows compositions. `$sp = $common + $extra` and `$sp += @{ ... }` resolve their FilePath/FileName/Path members through each operand's own hashtable definition, one or more hops (cycle-visited, depth-capped); an operand that resolves to nothing leaves the splat with NO candidate, so the whole-line fallback stays in force and a merged splat is never blessed silently. RED fixtures for the reviewer's exact shape and for `+=`, plus an armed green control for a composed isolated launch.

## Fix round 5 (final; re-review 4: two Lows)

- R4-1: an inline hashtable operand inside a composition is followed like a `$var` operand (`$b = $a + @{ FilePath = ... }` resolves the inline members; an empty `@{}` resolves to nothing). An inline operand that can be neither followed nor parsed makes the splat unresolved, so the whole-line fallback applies, as before. RED fixture (the reviewer's exact shape) plus the r4-8 `base + inline` shape now correct by design rather than by window overrun.
- R4-2: the member-scan window stops at the closing brace of THIS hashtable, including a same-line `}`, so it never reads a member from a different hashtable below. RED-then-green false-positive probe: the neighbouring hashtable holds an app FilePath, the scanned one does not, and the tooling launch stays clean.

## Why

Founder rule: every test points the app at a randomly named config file in tmp so tests never taint real installations. The investigation behind this found the managed unit tests already comply, a minority of app-launching harnesses leaked (reads and writes against the real `%APPDATA%` config), and nothing enforced any of it: `--config-file` moves reads only, `--no-config` still constructed the writer, and a forgotten `XDG_CONFIG_HOME` failed silently. With this change a harness that forgets the root gets a loud startup refusal instead of a silent write, and one that forgets the env var fails `just test-win` at review time.

## Test plan (red first, then green)

Red, on the pre-change tree:

- The source scan found 21 unguarded launch lines across 19 scripts, including the report's leaks: `search-fuzz.ps1:761`, `mouse-fuzz-probe.ps1:258`, `mouse-fuzz-remain.ps1:337`, `mouse-fuzz-dialogs.ps1:356`, `release-smoke.ps1:27`.
- The wiring tests failed 8/8: no guard call anywhere, and `App` constructed the real editor unconditionally.
- The real app, launched with `WINTTY_TEST_CONFIG=1` and `XDG_CONFIG_HOME` outside temp, ran normally: no refusal, config resolved outside temp.

Green, after:

- `dotnet test` (the three new test classes): 31/31 passed.
- Real-app matrix (`C:\wt\cfgiso-verify\verify-guard.ps1`, Debug build): armed + non-temp root refuses with exit 4 and the refusal line on stderr, creating nothing anywhere; armed + random temp root runs; guard unset + temp root runs unchanged; `--no-config` + armed + temp root runs and leaves the config file at zero bytes. SHA256 of every file under `%APPDATA%\Ghostty` recorded before and after each launch and identical in every case.
- `just signoff` PASS on every head: 883915406 (windows-tests 282s), 493bdcfcb (windows-tests 364s), 45e91be8d (windows-tests 349s), and the fix-round-1 head 576bcaa41 with its full src/-touched scope: windows-tests rc=0 in 367s, zig-fmt rc=0, zig-tests rc=0 in 3741s, each advertised as `signoff/ladder: success` on its commit. Nothing was ever carried by digest; every leg that gate_scope required ran fresh against the head it vouches for.

Note: this PR also carries a one-character fix to a pre-existing fresh-build breakage on `windows` HEAD: `NotificationHost.xaml` (from #1079) has ` -- ` inside an XML comment, and the transitive `Microsoft.WindowsAppSDK.WinUI` now restores at 2.2.1, whose stricter XAML compiler rejects it (WMC9999). Any fresh `dotnet build` of the fork fails on HEAD today without it; separate commit `59e45bc1e`.
