### PR TITLE
build: ship the Windows App SDK Insights resource dll in every self-contained publish (#1086)

### DIFF
--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -598,6 +598,81 @@
   </Target>
 
   <!--
+    Ship Microsoft.WindowsAppRuntime.Insights.Resource.dll in every
+    self-contained publish (#1086, wintty-release #808).
+
+    Windows App SDK 2.x self-contained never lays this dll down: the
+    component packages copy only runtimes-framework\win-<arch>\native
+    (Foundation ships Microsoft.WindowsAppRuntime.dll there WITHOUT it),
+    and Base 2.0.4's targets deleted the framework-MSIX extraction path
+    1.8 had. The dll exists only inside the framework MSIX bundled in the
+    Microsoft.WindowsAppSDK.Runtime nupkg, and Microsoft.WindowsAppRuntime.
+    dll loads it by name when AppNotificationManager.Register() initialises
+    the notification platform's telemetry, so a publish without it is a
+    build whose toasts are all dead (microsoft/WindowsAppSDK#6071, fixed
+    upstream 2026-09-03 by #6725/#6737 but not in any stable package yet).
+
+    The dll is extracted from the framework MSIX of whatever Runtime
+    package THIS build restored ($(PkgMicrosoft_WindowsAppSDK_Runtime) is
+    NuGet-generated), so it stays in lockstep with the resolved version,
+    including under the NuGet lock files (#1085). The unzip lands in obj\
+    and is incremental (Inputs/Outputs on the MSIX vs its AppxManifest.
+    xml, the marker trick the 1.8 targets used); only the resource dll is
+    copied into the publish folder. A Runtime package whose MSIX drops or
+    renames the dll fails the build here instead of shipping dead toasts.
+  -->
+  <PropertyGroup>
+    <_WinAppSdkInsightsDllName>Microsoft.WindowsAppRuntime.Insights.Resource.dll</_WinAppSdkInsightsDllName>
+    <_WinAppSdkInsightsArch Condition="'$(Platform)' == 'x64'">x64</_WinAppSdkInsightsArch>
+    <_WinAppSdkInsightsArch Condition="'$(Platform)' == 'x86' or '$(Platform)' == 'Win32'">x86</_WinAppSdkInsightsArch>
+    <_WinAppSdkInsightsArch Condition="'$(Platform)' == 'arm64' or '$(Platform)' == 'ARM64'">arm64</_WinAppSdkInsightsArch>
+    <!-- Exe or WinExe: this project is WinExe (the WinUI props rewrite a
+         GUI app's Exe), and no Library project may grow the unzip. -->
+    <_WinAppSdkInsightsActive Condition="'$(WindowsAppSDKSelfContained)' == 'true' and ('$(OutputType)' == 'Exe' or '$(OutputType)' == 'WinExe') and '$(PkgMicrosoft_WindowsAppSDK_Runtime)' != '' and '$(_WinAppSdkInsightsArch)' != ''">true</_WinAppSdkInsightsActive>
+    <_WinAppSdkInsightsMsixDir Condition="'$(_WinAppSdkInsightsActive)' == 'true'">$([MSBuild]::NormalizeDirectory('$(PkgMicrosoft_WindowsAppSDK_Runtime)', 'tools', 'MSIX', 'win10-$(_WinAppSdkInsightsArch)'))</_WinAppSdkInsightsMsixDir>
+    <!-- Anchored on MSBuildProjectDirectory, not $(IntermediateOutputPath):
+         this PropertyGroup sits in the project body, where IntermediateOutputPath
+         is still empty (Common.CurrentVersion.targets computes it only after the
+         body), so a relative composition resolved against the dotnet CWD and
+         the unzip landed at the repo root. Absolute and stable for the
+         Inputs/Outputs marker either way. -->
+    <_WinAppSdkInsightsContentDir Condition="'$(_WinAppSdkInsightsActive)' == 'true'">$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', 'obj', 'WinAppSdkInsights', '$(Platform)', '$(Configuration)'))</_WinAppSdkInsightsContentDir>
+  </PropertyGroup>
+  <!--
+    The framework MSIX only, two glob shapes because the package name is
+    two-part in 1.8 (Microsoft.WindowsAppRuntime.1.8.msix) and one-part in
+    2.x (Microsoft.WindowsAppRuntime.2.msix). Main/DDLM/Singleton variants
+    are excluded by the literal extension-char prefix.
+  -->
+  <ItemGroup Condition="'$(_WinAppSdkInsightsActive)' == 'true'">
+    <_WinAppSdkInsightsMsix Include="$(_WinAppSdkInsightsMsixDir)Microsoft.WindowsAppRuntime.?.msix" />
+    <_WinAppSdkInsightsMsix Include="$(_WinAppSdkInsightsMsixDir)Microsoft.WindowsAppRuntime.?.?.msix" />
+  </ItemGroup>
+  <Target Name="_ExtractWinAppSdkFrameworkMsixContent"
+          Condition="'$(_WinAppSdkInsightsActive)' == 'true'"
+          Inputs="@(_WinAppSdkInsightsMsix)"
+          Outputs="$(_WinAppSdkInsightsContentDir)AppxManifest.xml">
+    <Error Condition="'@(_WinAppSdkInsightsMsix)' == ''"
+           Text="No Microsoft.WindowsAppRuntime framework MSIX found under $(_WinAppSdkInsightsMsixDir). The Windows App SDK runtime package layout changed; the Insights resource dll (#1086) cannot be extracted. Expected Microsoft.WindowsAppRuntime.?.msix or Microsoft.WindowsAppRuntime.?.?.msix." />
+    <Unzip SourceFiles="@(_WinAppSdkInsightsMsix)"
+           DestinationFolder="$(_WinAppSdkInsightsContentDir)"
+           SkipUnchangedFiles="true"
+           OverwriteReadOnlyFiles="true" />
+  </Target>
+  <Target Name="CopyWinAppSdkInsightsResourceDll"
+          AfterTargets="Publish"
+          DependsOnTargets="_ExtractWinAppSdkFrameworkMsixContent"
+          Condition="'$(_WinAppSdkInsightsActive)' == 'true' and '$(PublishDir)' != ''">
+    <Error Condition="!Exists('$(_WinAppSdkInsightsContentDir)$(_WinAppSdkInsightsDllName)')"
+           Text="$(_WinAppSdkInsightsDllName) is not inside the framework MSIX (@(_WinAppSdkInsightsMsix)). The Windows App SDK runtime payload changed; toast registration (#1086) would fail at launch. Check what the package now ships and update this target." />
+    <Copy SourceFiles="$(_WinAppSdkInsightsContentDir)$(_WinAppSdkInsightsDllName)"
+          DestinationFolder="$(PublishDir)"
+          SkipUnchangedFiles="true" />
+    <Message Importance="high"
+             Text="Copied $(_WinAppSdkInsightsDllName) from the Windows App SDK framework MSIX into $(PublishDir) so AppNotificationManager.Register() can load it (#1086)." />
+  </Target>
+
+  <!--
     IconGen's sources and the master rasters become items at evaluation
     time because MSBuild does not expand wildcards inside an Inputs
     attribute: it takes the literal path, finds no such file, and rebuilds

--- a/windows/scripts/release-smoke.ps1
+++ b/windows/scripts/release-smoke.ps1
@@ -27,14 +27,53 @@ $testConfig = Enter-WinttyTestConfig
 $script:Launched = @()
 
 function Invoke-LaunchSmoke {
-    param([Parameter(Mandatory)][string]$Exe, [Parameter(Mandatory)][string]$Label)
+    param(
+        [Parameter(Mandatory)][string]$Exe,
+        [Parameter(Mandatory)][string]$Label,
+        # The published exe must have loaded the Windows App SDK Insights
+        # resource dll (#1086): Register() runs on every launch and loads it
+        # by name, so its presence among the live process's modules is the
+        # direct observation that toast registration got past the resource
+        # load. Without the dll in the publish folder Register() throws
+        # "Unable to load resource dll" and every toast is dead.
+        [switch]$RequireInsightsDll
+    )
 
     $since = Get-WinttyLaunchStamp
     $script:Launched += [pscustomobject]@{ Since = $since; Exe = $Exe }
+    if ($RequireInsightsDll) {
+        $dll = Join-Path (Split-Path $Exe) 'Microsoft.WindowsAppRuntime.Insights.Resource.dll'
+        if (-not (Test-Path $dll)) {
+            throw ("publish folder lacks Microsoft.WindowsAppRuntime.Insights.Resource.dll " +
+                   "($dll): AppNotificationManager.Register() throws on every launch and " +
+                   "every toast is dead (#1086). The Ghostty.csproj publish target that " +
+                   "extracts it from the Windows App SDK runtime package did not run.")
+        }
+    }
     $proc = Start-Process -FilePath $Exe -PassThru -WorkingDirectory (Split-Path $Exe)
-    Start-Sleep -Seconds 3
-    $proc.Refresh()
+    $insightsLoaded = $false
+    $deadline = (Get-Date).AddSeconds(10)
+    while (-not $proc.HasExited -and (Get-Date) -lt $deadline) {
+        Start-Sleep -Milliseconds 500
+        $proc.Refresh()
+        if (-not $RequireInsightsDll) { continue }
+        foreach ($m in $proc.Modules) {
+            if ($m.ModuleName -ieq 'Microsoft.WindowsAppRuntime.Insights.Resource.dll') {
+                $insightsLoaded = $true
+                break
+            }
+        }
+        if ($insightsLoaded) { break }
+    }
     if ($proc.HasExited) { throw "$Label Wintty exited early code=$($proc.ExitCode)" }
+    if ($RequireInsightsDll -and -not $insightsLoaded) {
+        try { $proc.Kill($true) } catch { }
+        Stop-WinttyStartedAfter -Since $since -ExePath $Exe
+        throw ("Microsoft.WindowsAppRuntime.Insights.Resource.dll was NOT loaded by the " +
+               "published app: AppNotificationManager.Register() threw and every toast " +
+               "from this build is dead (#1086). The dll file is present but WinAppRT " +
+               "did not load it.")
+    }
     # Kill the tree: the shell runs as a child and a wedged one outlives a
     # Stop-Process on the parent alone.
     try { $proc.Kill($true); [void]$proc.WaitForExit(3000) } catch { }
@@ -77,10 +116,21 @@ try {
         }
         if (-not $pubExe -or -not (Test-Path $pubExe)) { throw 'NativeAOT publish exe not found' }
         Write-Host "aot publish ok: $pubExe"
+        # #1086 gate, file half: the publish must carry the Insights
+        # resource dll before anything launches.
+        $insightsDll = Join-Path (Split-Path $pubExe) 'Microsoft.WindowsAppRuntime.Insights.Resource.dll'
+        if (-not (Test-Path $insightsDll)) {
+            throw ("publish folder lacks Microsoft.WindowsAppRuntime.Insights.Resource.dll " +
+                   "($insightsDll): AppNotificationManager.Register() throws on every " +
+                   "launch and every toast is dead (#1086, wintty-release #808). The " +
+                   "Ghostty.csproj publish target that extracts it from the Windows App " +
+                   "SDK runtime package did not run.")
+        }
+        Write-Host "insights resource dll ok: $insightsDll"
         if (-not $SkipLaunch) {
-            Write-Host '== launch NativeAOT smoke (3s) =='
+            Write-Host '== launch NativeAOT smoke (module check) =='
             Start-Sleep -Milliseconds 400
-            Invoke-LaunchSmoke -Exe $pubExe -Label 'aot'
+            Invoke-LaunchSmoke -Exe $pubExe -Label 'aot' -RequireInsightsDll
         }
     }
 


### PR DESCRIPTION
## What

Every self-contained publish of the app now carries `Microsoft.WindowsAppRuntime.Insights.Resource.dll`, and the release smoke fails a publish that lacks it or whose process never loads it.

## Why

#1086: Windows App SDK 2.x self-contained never lays this dll down. The metapackage's Base 2.0.4 targets deleted the framework-MSIX extraction path 1.8 had, and the component packages only copy `runtimes-framework\win-<arch>\native`, where Foundation ships `Microsoft.WindowsAppRuntime.dll` WITHOUT the resource dll. The dll exists only inside the framework MSIX bundled in the `Microsoft.WindowsAppSDK.Runtime` nupkg (`tools\MSIX\win10-<arch>\Microsoft.WindowsAppRuntime.?.msix`). `Microsoft.WindowsAppRuntime.dll` loads it by name when `AppNotificationManager.Register()` initialises the notification platform's telemetry, so without it Register() throws "Unable to load resource dll" on every launch (microsoft/WindowsAppSDK#6071 / #6387, fixed upstream 2026-09-03 by #6725/#6737, in no stable package yet) and every toast is dead: update available, update failed, sign-in, renew. The regression came with #527 (WinAppSDK 2.2.0 self-contained); the installed editions' logs carry the failure on every launch.

## The change

- `windows/Ghostty/Ghostty.csproj`: after `Publish`, for self-contained Exe/WinExe builds with the Runtime package resolved, a target unzips that package's framework MSIX into `obj\...\WinAppSdkInsights\` (incremental: Inputs/Outputs on the MSIX vs its AppxManifest.xml, the marker trick the 1.8 targets used) and copies only `Microsoft.WindowsAppRuntime.Insights.Resource.dll` into the publish folder. x64, x86 and arm64 map to their `win10-<arch>` MSIX dirs. Two fail-loud errors cover a Runtime package whose MSIX disappears or no longer contains the dll, so an upstream layout change is a build error instead of silently dead toasts. The dll comes from whatever Runtime package THIS build restored (`$(PkgMicrosoft_WindowsAppSDK_Runtime)`, NuGet-generated), so it stays in lockstep with the resolved version, including under the NuGet lock files from #1085: locking changes which package restores, not how the property is set.
- `windows/scripts/release-smoke.ps1`: after the NativeAOT publish it asserts the dll is in the publish folder, and the AOT launch smoke now polls the live process's modules and fails unless the dll is loaded there (Register() runs on every launch; the module list is the direct observation that registration got past the resource load, independent of log levels). Launches keep the existing per-run random temp config root with the WINTTY_TEST_CONFIG guard armed.

## Test plan

- RED: release-smoke on this branch WITHOUT the csproj target (target stashed): build-dll-release, build-win-release, the AOT publish and the isolated launches all succeed, then the new gate fails with "publish folder lacks Microsoft.WindowsAppRuntime.Insights.Resource.dll".
- GREEN: with the target restored, the same run passes end to end and logs the target's "Copied ... (#1086)" message; the published app loads the dll (module check) under the isolated config root, and %APPDATA%\Ghostty is byte-identical before and after every launch.
- win-x64 verified end to end here; arm64 is covered by the same mapping against the package's `win10-arm64` MSIX dir (present in the 2.2.0 package) but not cross-built in this run.

Depends on #1084 (this branch is based on it: a fresh restore needs its NotificationHost.xaml fix, and the smoke leans on its test-config guard). Rebase onto `windows` once it merges. When a stable Windows App SDK ships #6725, drop the target and bump the package.

Closes #1086
