### PR TITLE
build: bump Microsoft.WindowsAppSDK 2.2.0 to 2.4.0, WinUI 2.2.1 to 2.3.6 (#1089)

### DIFF
--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -195,7 +195,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.2.0" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.4.0" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.7705" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.269" PrivateAssets="all" />
     <!--

--- a/windows/Ghostty/packages.lock.json
+++ b/windows/Ghostty/packages.lock.json
@@ -45,19 +45,20 @@
       },
       "Microsoft.WindowsAppSDK": {
         "type": "Direct",
-        "requested": "[2.2.0, )",
-        "resolved": "2.2.0",
-        "contentHash": "kUgzkxWkqxUNpUwDU4mnNwlkDwSO8sO1SiUTFXD2YKW+SKTVB4rJjqmOLqMgBQbz4yfs+dLjmpeKXtV4Uf9c/Q==",
+        "requested": "[2.4.0, )",
+        "resolved": "2.4.0",
+        "contentHash": "sdS48CFL5EqzFB5a63Rr6qdK5l8NqmxWKJ/DXwsF8waCDLXdD8SjSnIOfpxzq4f4aUhaeXEAwVRA9rD8QvM+2g==",
         "dependencies": {
-          "Microsoft.WindowsAppSDK.AI": "2.2.3",
+          "Microsoft.WindowsAppSDK.AI": "2.4.4",
           "Microsoft.WindowsAppSDK.Base": "2.0.4",
           "Microsoft.WindowsAppSDK.DWrite": "2.1.0",
-          "Microsoft.WindowsAppSDK.Foundation": "2.1.0",
-          "Microsoft.WindowsAppSDK.InteractiveExperiences": "2.0.15",
-          "Microsoft.WindowsAppSDK.ML": "2.1.70",
-          "Microsoft.WindowsAppSDK.Runtime": "[2.2.0]",
+          "Microsoft.WindowsAppSDK.Foundation": "2.3.9",
+          "Microsoft.WindowsAppSDK.InteractiveExperiences": "2.1.6",
+          "Microsoft.WindowsAppSDK.ML": "2.1.74",
+          "Microsoft.WindowsAppSDK.Runtime": "[2.4.0]",
+          "Microsoft.WindowsAppSDK.Search": "2.4.4",
           "Microsoft.WindowsAppSDK.Widgets": "2.0.5",
-          "Microsoft.WindowsAppSDK.WinUI": "2.2.1"
+          "Microsoft.WindowsAppSDK.WinUI": "2.3.6"
         }
       },
       "ExCSS": {
@@ -147,8 +148,8 @@
       },
       "Microsoft.Windows.AI.MachineLearning": {
         "type": "Transitive",
-        "resolved": "2.1.70",
-        "contentHash": "3Ft/INx7j/paN68bttIWGsVCs/DNJEWtjm460Z5vyxIEiWHdtBFRi+bBVlu322+r8oqN1GZtB3QDV9qoY1w7mg==",
+        "resolved": "2.1.74",
+        "contentHash": "/Z1yAQ0J53eD1RrOl5anTDS0UQOgneERY//hLljwGcWeUX9ynCvOl5qUxAsfWvwsZZGcvV4WKjAvnAtA6N5i+w==",
         "dependencies": {
           "System.Numerics.Tensors": "9.0.0"
         }
@@ -178,11 +179,11 @@
       },
       "Microsoft.WindowsAppSDK.AI": {
         "type": "Transitive",
-        "resolved": "2.2.3",
-        "contentHash": "q3VpuZIoqUJfMmd6HWNJKanpSqG4REI0iWyGzcEXl4yU4w1jR06HOoubcPQCToxnlYKEU0SUExghzw5CBExD4A==",
+        "resolved": "2.4.4",
+        "contentHash": "nwgZKIWa97bxP3UYahv9LK1WAftzsEu3x/Ws9hCs5QG9mOf25ODrhv7BOGfYvptEhrh+XhoqCa8etSVQRr8cmw==",
         "dependencies": {
           "Microsoft.WindowsAppSDK.Base": "2.0.4",
-          "Microsoft.WindowsAppSDK.Foundation": "2.1.0"
+          "Microsoft.WindowsAppSDK.Foundation": "2.3.9"
         }
       },
       "Microsoft.WindowsAppSDK.Base": {
@@ -204,37 +205,47 @@
       },
       "Microsoft.WindowsAppSDK.Foundation": {
         "type": "Transitive",
-        "resolved": "2.1.0",
-        "contentHash": "Urz1WrsXHYDHYrCPIWZlSTwgXwghEXlS6lY62Hk3vZE0GZ3hyYrMM7a+p6RrXC55GEgrRhOTRqXqcH2ZL/UWRA==",
+        "resolved": "2.3.9",
+        "contentHash": "lnfSoKvuMN2nv/NyMDWHX5u2K/tdg8AiyW+z30/YmCbJZp1k38B8/d4pKf+RjgkQbSGbIikN4irae72FXA3X5Q==",
         "dependencies": {
           "Microsoft.WindowsAppSDK.Base": "2.0.4",
-          "Microsoft.WindowsAppSDK.InteractiveExperiences": "2.0.15"
+          "Microsoft.WindowsAppSDK.InteractiveExperiences": "2.1.3"
         }
       },
       "Microsoft.WindowsAppSDK.InteractiveExperiences": {
         "type": "Transitive",
-        "resolved": "2.0.15",
-        "contentHash": "aQ9uzAIhTaN9zkclrtVg6kylpF+hESU+tC0bHarOCWdBz8ShZ7gt+gKwEmjKiqtPv6sRrRglyLLNVSPfb8KmMQ==",
+        "resolved": "2.1.6",
+        "contentHash": "j7pyWfsXPQFTEWX22GgC6/JDzliBpwKESJzglCOv8wRJI7SmXiPdYqQnBI2gSKC1slJIpkczVdmmpvHmxPxyOw==",
         "dependencies": {
           "Microsoft.WindowsAppSDK.Base": "2.0.4"
         }
       },
       "Microsoft.WindowsAppSDK.ML": {
         "type": "Transitive",
-        "resolved": "2.1.70",
-        "contentHash": "Okbb/lBv2YBDH6bjhrMCQBANsopvZJjdu+ZFNVcx5LafM+dsjEVFBnPkakmA/rwRbuP+N4q/GYoKH60uwH9jRA==",
+        "resolved": "2.1.74",
+        "contentHash": "9Vd1ikH+n6pbqhgmCn+zNulJ6gIp9Hz9bC++ka1Uphh2gule6HiT6Jr25N/fQoEc4I9xOTKkn3DtlcpHlcocaw==",
         "dependencies": {
-          "Microsoft.Windows.AI.MachineLearning": "[2.1.70, 3.0.0)",
+          "Microsoft.Windows.AI.MachineLearning": "[2.1.74, 3.0.0)",
           "Microsoft.WindowsAppSDK.Base": "2.0.4",
           "Microsoft.WindowsAppSDK.Foundation": "2.0.21"
         }
       },
       "Microsoft.WindowsAppSDK.Runtime": {
         "type": "Transitive",
-        "resolved": "2.2.0",
-        "contentHash": "6wQYALaneLbZjl0oN4hoS9CB+0Jy5dlFHyw1G9Yg9hPPmZup5bACMdWMUom9ME06/8YOso4T42p3mm6l7cD+Kg==",
+        "resolved": "2.4.0",
+        "contentHash": "ioljT2/zivSWb6Hc375VPrRrauE5O49OccruHQFI23NdwGERCFBgCr1qCYhFciTxAX9hOMkJeAx0/Wo6Z5y6eg==",
         "dependencies": {
           "Microsoft.WindowsAppSDK.Base": "2.0.4"
+        }
+      },
+      "Microsoft.WindowsAppSDK.Search": {
+        "type": "Transitive",
+        "resolved": "2.4.4",
+        "contentHash": "3IXnSBTBBQpqp3B+0R5FUEzcAHFwq4DVEDukVdqk3nP+X4LA10yPLO/uQgDaxtDxwhMJcEXX3vrKFdQTWSAOwg==",
+        "dependencies": {
+          "Microsoft.WindowsAppSDK.AI": "[2.4.4]",
+          "Microsoft.WindowsAppSDK.Base": "2.0.4",
+          "Microsoft.WindowsAppSDK.Foundation": "2.3.9"
         }
       },
       "Microsoft.WindowsAppSDK.Widgets": {
@@ -247,13 +258,13 @@
       },
       "Microsoft.WindowsAppSDK.WinUI": {
         "type": "Transitive",
-        "resolved": "2.2.1",
-        "contentHash": "w8KuqJB7IphDRXAGNVuRq+oGeoGycc4ZAraA+OIpsGm/boEKHLkwXmzNDaNrVlnsDpjxQFWE2XVp0hXjlWJqxw==",
+        "resolved": "2.3.6",
+        "contentHash": "01ImKF+wYm2aehRWS2GpKeoBL1RutDcJOUSTSo3fkLjOSr+gKPcUGDAtIUwZcQTvHWOct6hT1jKIdyxbJIhpBA==",
         "dependencies": {
           "Microsoft.Web.WebView2": "1.0.3719.77",
           "Microsoft.WindowsAppSDK.Base": "2.0.4",
-          "Microsoft.WindowsAppSDK.Foundation": "2.1.0",
-          "Microsoft.WindowsAppSDK.InteractiveExperiences": "2.0.15"
+          "Microsoft.WindowsAppSDK.Foundation": "2.3.9",
+          "Microsoft.WindowsAppSDK.InteractiveExperiences": "2.1.3"
         }
       },
       "ShimSkiaSharp": {
@@ -375,19 +386,19 @@
       },
       "Microsoft.Windows.AI.MachineLearning": {
         "type": "Transitive",
-        "resolved": "2.1.70",
-        "contentHash": "3Ft/INx7j/paN68bttIWGsVCs/DNJEWtjm460Z5vyxIEiWHdtBFRi+bBVlu322+r8oqN1GZtB3QDV9qoY1w7mg==",
+        "resolved": "2.1.74",
+        "contentHash": "/Z1yAQ0J53eD1RrOl5anTDS0UQOgneERY//hLljwGcWeUX9ynCvOl5qUxAsfWvwsZZGcvV4WKjAvnAtA6N5i+w==",
         "dependencies": {
           "System.Numerics.Tensors": "9.0.0"
         }
       },
       "Microsoft.WindowsAppSDK.Foundation": {
         "type": "Transitive",
-        "resolved": "2.1.0",
-        "contentHash": "Urz1WrsXHYDHYrCPIWZlSTwgXwghEXlS6lY62Hk3vZE0GZ3hyYrMM7a+p6RrXC55GEgrRhOTRqXqcH2ZL/UWRA==",
+        "resolved": "2.3.9",
+        "contentHash": "lnfSoKvuMN2nv/NyMDWHX5u2K/tdg8AiyW+z30/YmCbJZp1k38B8/d4pKf+RjgkQbSGbIikN4irae72FXA3X5Q==",
         "dependencies": {
           "Microsoft.WindowsAppSDK.Base": "2.0.4",
-          "Microsoft.WindowsAppSDK.InteractiveExperiences": "2.0.15"
+          "Microsoft.WindowsAppSDK.InteractiveExperiences": "2.1.3"
         }
       },
       "runtime.win-x64.Microsoft.DotNet.ILCompiler": {


### PR DESCRIPTION
Depends on #1087 (branched from its branch; the lock files are what makes this bump a reviewable diff instead of an invisible float). Rebase onto `windows` follows once that lands. Founder decision for the next release: WinUI 2.3.6.

## What and why

`Microsoft.WindowsAppSDK` moves 2.2.0 -> 2.4.0. The bump is one csproj line plus the regenerated `packages.lock.json`: every restore on the ladder is locked, so the pin change is refused until the lock is regenerated, and the lock diff is the whole review surface.

## Lock diff

Every component lands exactly on the 2.4.0 nuspec floor, nothing above it (NuGet's lowest-applicable rule):

| component | 2.2.0 (old lock) | 2.4.0 (new lock) |
|---|---|---|
| WinUI | 2.2.1 | 2.3.6 |
| Runtime | [2.2.0] | [2.4.0] |
| Foundation | 2.1.0 | 2.3.9 |
| AI | 2.2.3 | 2.4.4 |
| InteractiveExperiences | 2.0.15 | 2.1.6 |
| ML | 2.1.70 | 2.1.74 |
| Search | - | 2.4.4 (new) |
| Base / DWrite / Widgets | 2.0.4 / 2.1.0 / 2.0.5 | unchanged |

## Search component decision: keep it

Search 2.4.4 is new in the metapackage and the app does not use it. It adds exactly two files to the self-contained payload: `Microsoft.Windows.Search.dll` (3,379,512 B) and `Microsoft.Windows.Search.winmd` (40,248 B) = 3,419,760 bytes. The managed projection dll is trimmed away entirely under NativeAOT.

It is kept because there is no supported and documented way to exclude one component: the metapackage is all-or-nothing, and `MicrosoftWindowsAppSDKFilesExcluded` is an undocumented Remove hook inside Base's self-contained targets (nothing on learn.microsoft.com or in the WindowsAppSDK repo documents it). Using it anyway would leave Search's `package.appxfragment` feeding the generated SxS manifest, so the app manifest would carry activatableClass entries for a dll that is not shipped - the same class of latent activation failure this release is guarding against, bought for 3.4 MB. Swapping the metapackage for a hand-rolled per-component reference list is documented granularity but rewrites the whole dependency shape; that would be its own change if it is ever wanted.

## Build breaks: none in source

Debug and Release solution builds are clean against 2.4.0 with zero errors and no new warning classes (the standing CS8602/CS8604/CS0105/CA1416/WMC1510/IL2xxx set is unchanged). CsWinRT1028 (the one warning promoted to error) stays silent. The NativeAOT publish is also clean - two publish-time failures seen while verifying are NOT product breaks and need no code change:

- `error CS0759 ... _XamlGeneratedCreateApplicationInstance` fires only in a warm obj that still holds 2.2.1-era `.g.i.cs` files next to freshly generated 2.3.6 ones (XamlCompiler 3.0.0.2606 vs 2608): the new `.g.cs` has the implementing declaration, the stale `.g.i.cs` lacks the defining one. A clean `windows/Ghostty/obj` (or any fresh checkout, which is what CI and the tiers build) is unaffected. Adding the defining declaration to App.xaml.cs is NOT a fix: on a clean tree the generated file already provides it and a second one is CS0755. Clean your obj once after pulling this bump.
- `error MSB3073 ... 'vswhere.exe' is not recognized` is the known ILC/findvcvarsall environment issue (NoDefaultCurrentDirectoryInExePath in pwsh/bash); the release build already ships a vswhere-on-path helper script for it. Dot-source that before publishing.

Also worth recording: `dotnet publish -r win-x64 /p:RestoreLockedMode=true` (restore-in-publish, locked) fails NU1004 because the committed locks record no runtime identifiers - pre-existing #1087 shape, unchanged by 2.4.0. The working sequence is the one release-smoke.ps1 uses: restore first, then publish `--no-restore`.

## Insights dll (#1088): still missing, #1088 stays

microsoft/WindowsAppSDK#6725 merged 2026-09-03, after 2.4.0 shipped. Verified on this bump: the self-contained NativeAOT publish output contains zero Insights-named files; `Microsoft.WindowsAppRuntime.Insights.Resource.dll` exists only inside the framework MSIX (`tools/MSIX/win10-x64/Microsoft.WindowsAppRuntime.2.msix`), exactly as in 2.2.0. #1088 is still needed and is NOT droppable. No conflict with this branch: #1088's full diff applies cleanly on this head (verified with git apply --check), its csproj block inserts ~400 lines away from the version pin, and it reads the version-independent `$(PkgMicrosoft_WindowsAppSDK_Runtime)` property, so it keeps working under 2.4.0 as-is.

## Publish size delta vs 2.2.0

Same tree, same zig-out, both published NativeAOT win-x64 Release:

- total folder: 425,758,056 -> 446,013,148 B (+20.3 MB), but +12.3 MB of that is Wintty.pdb (symbol archive, swept before shipping)
- shipped (non-pdb): +7,917,940 B (+2.8%), of which Search is 3,419,760 B; the rest is the other components' own growth (Controls.pri +0.8 MB, resources.19h1 +0.5 MB, dcompi.dll +1.6 MB, XAML dlls +0.5 MB, AI text +0.1 MB)
- files: 422 -> 424 (exactly the Search pair)

## Test plan

- `just signoff` green at the exact head (release-gate + windows-tests, locked restore included).
- NativeAOT publish of the head, launched through the fork's isolated harness (WINTTY_TEST_CONFIG armed, random temp XDG_CONFIG_HOME): app starts and stays up; command palette opens and closes via UIA (the x:Load-overlay class); the shader-notice NotificationHost banner shows on its positive case (notification path); screenshots reviewed for attached panes; no Error or Crit lines in the app log tail for the runs.

All green at head `04ec5e45c`: `just signoff` PASS (release-gate 89.6s, windows-tests 282.2s, locked restore and lock drift gate included; `signoff/ladder success` advertised on the commit). AOT launch smoke up at 5s; dialogs fuzz alive with the palette invoked repeatedly, crashGrew=false, all checks true; shader-notice-fuzz clean (positive case raised the banner, reasons=load); screenshots show attached rendering panes; app log tail Info/Warn only, zero Error/Crit.

Closes #1089

