### PR TITLE
tests: every test host and every launch tree runs on a throwaway temp config

### DIFF
--- a/.agents/scripts/leg_cache.py
+++ b/.agents/scripts/leg_cache.py
@@ -111,7 +111,7 @@ ENV_FOR_LEG = {
 # evidence for the fixed-seed digest every branch carries. The self-test
 # holds this table equal to what the test projects actually read.
 ENV_VARS_FOR_LEG = {
-    gate_scope.LEG_WIN: ("GHOSTTY_FUZZ_ITERATIONS", "WINTTY_MOTION_FUZZ_SEED"),
+    gate_scope.LEG_WIN: ("GHOSTTY_FUZZ_ITERATIONS", "WINTTY_MOTION_FUZZ_SEED", "XDG_CONFIG_HOME"),
 }
 ALL_ENV_VARS = sorted({v for vs in ENV_VARS_FOR_LEG.values() for v in vs})
 

--- a/dist/windows/IconGen.Tests/IconGen.Tests.csproj
+++ b/dist/windows/IconGen.Tests/IconGen.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
@@ -17,5 +17,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\IconGen\IconGen.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- One shared file, linked: the four test hosts cannot drift. -->
+    <Compile Include="..\..\..\windows\build\TestHostArming.cs" Link="TestHostArming.cs" />
   </ItemGroup>
 </Project>

--- a/dist/windows/SplashGen.Tests/SplashGen.Tests.csproj
+++ b/dist/windows/SplashGen.Tests/SplashGen.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
@@ -17,5 +17,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\SplashGen\SplashGen.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- One shared file, linked: the four test hosts cannot drift. -->
+    <Compile Include="..\..\..\windows\build\TestHostArming.cs" Link="TestHostArming.cs" />
   </ItemGroup>
 </Project>

--- a/windows/Ghostty.Core/Config/TestConfigGuard.cs
+++ b/windows/Ghostty.Core/Config/TestConfigGuard.cs
@@ -53,6 +53,17 @@ public static partial class TestConfigGuard
     public const string EnvVar = "WINTTY_TEST_CONFIG";
 
     /// <summary>
+    /// The one place environment variables are read, so tests can inject
+    /// a dictionary instead of mutating the real process environment.
+    /// Mutating the real environment from a test races every concurrently
+    /// running collection (and transiently disarms the armed test host,
+    /// reopening exactly the hole this guard closes); an injected reader
+    /// touches nothing outside the test itself.
+    /// </summary>
+    public static Func<string, string?> ReadEnvironment { get; set; } =
+        Environment.GetEnvironmentVariable;
+
+    /// <summary>
     /// Whether the guard is armed. Read from the environment on every call
     /// rather than cached: the decision belongs to whoever launched this
     /// process, and a test flipping the variable between calls is the
@@ -62,7 +73,7 @@ public static partial class TestConfigGuard
     {
         get
         {
-            var value = Environment.GetEnvironmentVariable(EnvVar);
+            var value = ReadEnvironment(EnvVar);
             return !string.IsNullOrEmpty(value)
                    && !value.Equals("0", StringComparison.OrdinalIgnoreCase)
                    && !value.Equals("false", StringComparison.OrdinalIgnoreCase);
@@ -99,8 +110,8 @@ public static partial class TestConfigGuard
     /// </summary>
     public static string ResolveConfigRoot()
     {
-        var pick = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
-        if (pick is null) pick = Environment.GetEnvironmentVariable("APPDATA");
+        var pick = ReadEnvironment("XDG_CONFIG_HOME");
+        if (pick is null) pick = ReadEnvironment("APPDATA");
         if (string.IsNullOrEmpty(pick))
         {
             pick = Path.Combine(
@@ -178,7 +189,7 @@ public static partial class TestConfigGuard
         if (!IsArmed) return;
         foreach (var name in new[] { "TEMP", "TMP" })
         {
-            var value = Environment.GetEnvironmentVariable(name);
+            var value = ReadEnvironment(name);
             if (string.IsNullOrEmpty(value)) continue;
             if (IsUnderTemp(value)) continue;
 

--- a/windows/Ghostty.Core/Config/TestConfigGuard.cs
+++ b/windows/Ghostty.Core/Config/TestConfigGuard.cs
@@ -59,8 +59,15 @@ public static partial class TestConfigGuard
     /// running collection (and transiently disarms the armed test host,
     /// reopening exactly the hole this guard closes); an injected reader
     /// touches nothing outside the test itself.
+    ///
+    /// INTERNAL on purpose (re-review finding 1): the seam exists for the
+    /// test assemblies and nothing else. A public settable static would
+    /// let production code swap the guard's environment source out from
+    /// under the guard itself, which is the opposite of what the guard
+    /// is for. The test projects reach it through
+    /// InternalsVisibleTo (AssemblyAttributes.cs).
     /// </summary>
-    public static Func<string, string?> ReadEnvironment { get; set; } =
+    internal static Func<string, string?> ReadEnvironment { get; set; } =
         Environment.GetEnvironmentVariable;
 
     /// <summary>

--- a/windows/Ghostty.Tests.Windows/Ghostty.Tests.Windows.csproj
+++ b/windows/Ghostty.Tests.Windows/Ghostty.Tests.Windows.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <!-- Windows-only. Runs on the Windows CI job; does not build on Linux. -->
@@ -24,4 +24,8 @@
     <ProjectReference Include="..\Ghostty.Core\Ghostty.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- One shared file, linked: the four test hosts cannot drift. -->
+    <Compile Include="..\build\TestHostArming.cs" Link="TestHostArming.cs" />
+  </ItemGroup>
 </Project>

--- a/windows/Ghostty.Tests/Config/TestConfigGuardDefaultReaderTests.cs
+++ b/windows/Ghostty.Tests/Config/TestConfigGuardDefaultReaderTests.cs
@@ -1,0 +1,51 @@
+using System;
+using Ghostty.Core.Config;
+using Xunit;
+
+namespace Ghostty.Tests.Config;
+
+/// <summary>
+/// Pins the ReadEnvironment seam's DEFAULT (re-review finding 1): the
+/// shipped guard consults the real process environment and nothing else.
+///
+/// This class deliberately has NO injecting constructor, so whatever it
+/// reads through <see cref="TestConfigGuard.ReadEnvironment"/> is the
+/// production default (the injecting class restores it in Dispose, and
+/// xunit finishes each test before the next starts). A default changed
+/// to a constant, a snapshot, or a cache fails the live-write probe
+/// below even when the equal-snapshot comparisons happen to hold.
+///
+/// The seam itself must stay internal: a second pin, in the wiring
+/// tests, asserts the declaration from the embedded source so it cannot
+/// quietly widen back to public.
+/// </summary>
+public class TestConfigGuardDefaultReaderTests
+{
+    [Fact]
+    public void The_Default_Reader_Reads_The_Live_Process_Environment()
+    {
+        // Only names no injecting test can shadow are compared, so this
+        // stays correct even if the injecting class runs concurrently:
+        // its lambda falls through unknown names to the real
+        // environment, which is exactly the behavior under test.
+        const string probe = "WINTTY_GUARD_SEAM_PROBE";
+        const string absent = "NO_SUCH_NAME_ON_PURPOSE_1093";
+
+        Assert.Null(TestConfigGuard.ReadEnvironment(absent));
+        Assert.Null(Environment.GetEnvironmentVariable(absent));
+
+        // The decisive probe: a LIVE write through the process
+        // environment is visible through the default reader. A snapshot
+        // or a constant defaulted reader returns null here.
+        try
+        {
+            Environment.SetEnvironmentVariable(probe, "round2");
+            Assert.Equal("round2", TestConfigGuard.ReadEnvironment(probe));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(probe, null);
+        }
+        Assert.Null(TestConfigGuard.ReadEnvironment(probe));
+    }
+}

--- a/windows/Ghostty.Tests/Config/TestConfigGuardTests.cs
+++ b/windows/Ghostty.Tests/Config/TestConfigGuardTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using Ghostty.Core.Config;
 using Xunit;
@@ -11,27 +12,33 @@ namespace Ghostty.Tests.Config;
 /// refusal message. The end-to-end refusal (real app, non-zero exit before
 /// the window) is the harness matrix this guard's PR ran; these tests are
 /// what keeps the path arithmetic honest in between.
+///
+/// These tests NEVER mutate the real process environment: the guard reads
+/// the environment through <see cref="TestConfigGuard.ReadEnvironment"/>,
+/// and each test injects a dictionary over the real one. Mutating the real
+/// environment from a test races every concurrently running collection and
+/// transiently disarms the armed test host, which is the exact hole the
+/// host arming closes; the injected reader touches nothing outside the
+/// test itself (review finding M1).
 /// </summary>
 public class TestConfigGuardTests : IDisposable
 {
-    private readonly string? _original;
+    private readonly IDictionary<string, string?> _env =
+        new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
 
-    // The guard reads the environment on every call, so the tests set it
-    // directly. Saved and restored once per test instance; nothing else in
-    // this assembly reads WINTTY_TEST_CONFIG, so parallel collections
-    // cannot race on it.
     public TestConfigGuardTests()
     {
-        _original = Environment.GetEnvironmentVariable(TestConfigGuard.EnvVar);
+        // Layer the dictionary over the real environment: unset names fall
+        // through, set names (including null = removed) shadow it.
+        TestConfigGuard.ReadEnvironment = name =>
+            _env.ContainsKey(name) ? _env[name] :
+            Environment.GetEnvironmentVariable(name);
     }
 
-    public void Dispose()
-    {
-        if (_original is null)
-            Environment.SetEnvironmentVariable(TestConfigGuard.EnvVar, null);
-        else
-            Environment.SetEnvironmentVariable(TestConfigGuard.EnvVar, _original);
-    }
+    public void Dispose() =>
+        TestConfigGuard.ReadEnvironment = Environment.GetEnvironmentVariable;
+
+    private void Set(string name, string? value) => _env[name] = value;
 
     private static string Temp(params string[] below)
     {
@@ -53,7 +60,7 @@ public class TestConfigGuardTests : IDisposable
     [InlineData("FALSE")]
     public void DisarmedSpellings_Leave_The_Guard_Off(string? value)
     {
-        Environment.SetEnvironmentVariable(TestConfigGuard.EnvVar, value);
+        Set(TestConfigGuard.EnvVar, value);
         Assert.False(TestConfigGuard.IsArmed);
     }
 
@@ -63,7 +70,7 @@ public class TestConfigGuardTests : IDisposable
     [InlineData("yes")]
     public void ArmingSpellings_Arm_The_Guard(string value)
     {
-        Environment.SetEnvironmentVariable(TestConfigGuard.EnvVar, value);
+        Set(TestConfigGuard.EnvVar, value);
         Assert.True(TestConfigGuard.IsArmed);
     }
 
@@ -73,14 +80,14 @@ public class TestConfigGuardTests : IDisposable
         // "WINTTY_TEST_CONFIG unset, behaviour unchanged" is the load-bearing
         // half of the rule: a user's install never sets the variable, so the
         // real config path must sail through untouched.
-        Environment.SetEnvironmentVariable(TestConfigGuard.EnvVar, null);
+        Set(TestConfigGuard.EnvVar, null);
         TestConfigGuard.AssertUnderTemp(OutsideTemp(), "resolved config path");
     }
 
     [Fact]
     public void Config_Under_Temp_Passes_While_Armed()
     {
-        Environment.SetEnvironmentVariable(TestConfigGuard.EnvVar, "1");
+        Set(TestConfigGuard.EnvVar, "1");
         TestConfigGuard.AssertUnderTemp(Temp("wintty-cfg-a1", "wintty", "config.wintty"),
             "resolved config path");
     }
@@ -94,7 +101,7 @@ public class TestConfigGuardTests : IDisposable
     [Fact]
     public void Config_Outside_Temp_Is_Refused_While_Armed()
     {
-        Environment.SetEnvironmentVariable(TestConfigGuard.EnvVar, "1");
+        Set(TestConfigGuard.EnvVar, "1");
         var path = OutsideTemp();
         var ex = Assert.Throws<InvalidOperationException>(
             () => TestConfigGuard.AssertUnderTemp(path, "resolved config path"));
@@ -121,7 +128,7 @@ public class TestConfigGuardTests : IDisposable
     [Fact]
     public void Device_Prefix_Cannot_Smuggle_A_Path_Past_The_Compare()
     {
-        Environment.SetEnvironmentVariable(TestConfigGuard.EnvVar, "1");
+        Set(TestConfigGuard.EnvVar, "1");
         // The prefix survives Path.GetFullPath; stripping it first is what
         // keeps this from reading as a path nobody has an opinion about.
         var smuggled = @"\\?\" + OutsideTemp();
@@ -133,7 +140,7 @@ public class TestConfigGuardTests : IDisposable
     [Fact]
     public void Relative_And_Empty_Paths_Are_Not_Under_Temp()
     {
-        Environment.SetEnvironmentVariable(TestConfigGuard.EnvVar, "1");
+        Set(TestConfigGuard.EnvVar, "1");
         Assert.False(TestConfigGuard.IsUnderTemp("wintty-config"));
         Assert.False(TestConfigGuard.IsUnderTemp(""));
         Assert.False(TestConfigGuard.IsUnderTemp("   "));
@@ -145,14 +152,14 @@ public class TestConfigGuardTests : IDisposable
     {
         // libghostty builds forward-slash paths; ConfigService normalizes
         // them, but the guard must not depend on that having happened.
-        var temp = TestConfigGuard.TempAnchor.Replace('\\', '/') + "/";
+        var temp = (TestConfigGuard.TempAnchor + "/").Replace('\\', '/');
         Assert.True(TestConfigGuard.IsUnderTemp(temp + "wintty-cfg-b2/wintty"));
 
         var upper = Temp("Wintty-Cfg-C3").ToUpperInvariant();
         Assert.True(TestConfigGuard.IsUnderTemp(upper));
     }
 
-    // ---- M1: the anchor is the known-folder temp, not the environment --
+    // ---- M1 (round 0): the anchor is the known-folder temp, not the environment --
 
     [Fact]
     public void The_Anchor_Ignores_A_Redirected_TEMP_And_TMP()
@@ -160,8 +167,8 @@ public class TestConfigGuardTests : IDisposable
         // The known-folder temp cannot be moved by the process
         // environment, which is the whole point of anchoring to it: a
         // harness that repoints TEMP moves Path.GetTempPath(), never this.
-        using var redirect = new TempEnvRedirect("TEMP", OutsideTemp());
-        using var redirect2 = new TempEnvRedirect("TMP", @"C:\");
+        Set("TEMP", OutsideTemp());
+        Set("TMP", @"C:\");
 
         var anchor = TestConfigGuard.TempAnchor;
         Assert.True(string.Equals(
@@ -181,8 +188,8 @@ public class TestConfigGuardTests : IDisposable
     [InlineData("TMP")]
     public void A_Redirected_Temp_Environment_Is_Refused_While_Armed(string name)
     {
-        Environment.SetEnvironmentVariable(TestConfigGuard.EnvVar, "1");
-        using var redirect = new TempEnvRedirect(name, OutsideTemp());
+        Set(TestConfigGuard.EnvVar, "1");
+        Set(name, OutsideTemp());
 
         var ex = Assert.Throws<InvalidOperationException>(
             () => TestConfigGuard.AssertTempEnvironmentIntact());
@@ -193,8 +200,8 @@ public class TestConfigGuardTests : IDisposable
     [Fact]
     public void A_Drive_Root_TEMP_Is_Refused_While_Armed()
     {
-        Environment.SetEnvironmentVariable(TestConfigGuard.EnvVar, "1");
-        using var redirect = new TempEnvRedirect("TEMP", @"C:\");
+        Set(TestConfigGuard.EnvVar, "1");
+        Set("TEMP", @"C:\");
 
         Assert.Throws<InvalidOperationException>(
             () => TestConfigGuard.AssertTempEnvironmentIntact());
@@ -203,9 +210,9 @@ public class TestConfigGuardTests : IDisposable
     [Fact]
     public void An_Intact_Temp_Environment_Passes_While_Armed()
     {
-        Environment.SetEnvironmentVariable(TestConfigGuard.EnvVar, "1");
-        using var keepTemp = new TempEnvRedirect("TEMP", TestConfigGuard.TempAnchor);
-        using var keepTmp = new TempEnvRedirect("TMP", TestConfigGuard.TempAnchor);
+        Set(TestConfigGuard.EnvVar, "1");
+        Set("TEMP", Path.GetTempPath());
+        Set("TMP", Path.GetTempPath());
 
         TestConfigGuard.AssertTempEnvironmentIntact();
     }
@@ -213,34 +220,13 @@ public class TestConfigGuardTests : IDisposable
     [Fact]
     public void The_Temp_Environment_Is_Never_Questioned_While_Unarmed()
     {
-        Environment.SetEnvironmentVariable(TestConfigGuard.EnvVar, null);
-        using var redirect = new TempEnvRedirect("TEMP", @"C:\");
+        Set(TestConfigGuard.EnvVar, null);
+        Set("TEMP", @"C:\");
 
         TestConfigGuard.AssertTempEnvironmentIntact();
     }
 
-    /// <summary>
-    /// Scoped environment mutation: restores the previous value (or removes
-    /// the variable) on dispose, so a failing assert cannot leak state into
-    /// the next test.
-    /// </summary>
-    private sealed class TempEnvRedirect : IDisposable
-    {
-        private readonly string _name;
-        private readonly string? _original;
-
-        public TempEnvRedirect(string name, string value)
-        {
-            _name = name;
-            _original = Environment.GetEnvironmentVariable(name);
-            Environment.SetEnvironmentVariable(name, value);
-        }
-
-        public void Dispose() =>
-            Environment.SetEnvironmentVariable(_name, _original);
-    }
-
-    // ---- M4: reparse points resolve before the compare -----------------
+    // ---- M4 (round 0): reparse points resolve before the compare -----------------
 
     [Fact]
     public void A_Junction_Inside_Temp_Pointing_Outside_Is_Refused()
@@ -252,7 +238,7 @@ public class TestConfigGuardTests : IDisposable
         // privilege but a cmd spawn) is the fallback; a host that allows
         // neither reports the skip and the reparse test below still covers
         // what it can.
-        Environment.SetEnvironmentVariable(TestConfigGuard.EnvVar, "1");
+        Set(TestConfigGuard.EnvVar, "1");
         var outside = Path.Combine(
             Path.GetDirectoryName(TestConfigGuard.TempAnchor)!,
             "wintty-guard-junction-target-" + Guid.NewGuid().ToString("N"));
@@ -307,7 +293,7 @@ public class TestConfigGuardTests : IDisposable
         // Symlink creation needs a privilege (or developer mode) the test
         // host may lack; when it does, this test says so and passes, per
         // the brief's skip rule. Junctions carry the enforced case above.
-        Environment.SetEnvironmentVariable(TestConfigGuard.EnvVar, "1");
+        Set(TestConfigGuard.EnvVar, "1");
         var outside = Path.Combine(
             Path.GetDirectoryName(TestConfigGuard.TempAnchor)!,
             "wintty-guard-symlink-target-" + Guid.NewGuid().ToString("N"));
@@ -337,45 +323,39 @@ public class TestConfigGuardTests : IDisposable
         }
     }
 
-    // ---- L2: the xdg.zig mirror ----------------------------------------
+    // ---- L2 (round 0): the xdg.zig mirror ----------------------------------------
 
     [Fact]
     public void The_Config_Root_Mirror_Matches_The_Xdg_Zig_Preferences()
     {
         // The four combinations that matter, mirroring xdg.zig dir():
-        // a set-but-empty XDG does NOT fall to APPDATA (zig's orelse sees
-        // Some("")), it falls to the home + .config default.
-        using (new ScopedEnv("XDG_CONFIG_HOME", null))
-        {
-            using var appdata = new ScopedEnv("APPDATA", @"C:\Users\u\AppData\Roaming");
-            Assert.True(string.Equals(@"C:\Users\u\AppData\Roaming",
-                TestConfigGuard.ResolveConfigRoot(),
-                StringComparison.OrdinalIgnoreCase));
-        }
-        using (new ScopedEnv("XDG_CONFIG_HOME", @"C:\scratch\xdg"))
-        {
-            Assert.True(string.Equals(@"C:\scratch\xdg",
-                TestConfigGuard.ResolveConfigRoot(),
-                StringComparison.OrdinalIgnoreCase));
-        }
-        using (new ScopedEnv("XDG_CONFIG_HOME", ""))
-        {
-            using var appdata = new ScopedEnv("APPDATA", @"C:\Users\u\AppData\Roaming");
-            Assert.True(string.Equals(
-                Path.Combine(Environment.GetFolderPath(
-                    Environment.SpecialFolder.UserProfile), ".config"),
-                TestConfigGuard.ResolveConfigRoot(),
-                StringComparison.OrdinalIgnoreCase));
-        }
-        using (new ScopedEnv("XDG_CONFIG_HOME", null))
-        {
-            using var appdata = new ScopedEnv("APPDATA", "");
-            Assert.True(string.Equals(
-                Path.Combine(Environment.GetFolderPath(
-                    Environment.SpecialFolder.UserProfile), ".config"),
-                TestConfigGuard.ResolveConfigRoot(),
-                StringComparison.OrdinalIgnoreCase));
-        }
+        // a set-but-empty XDG_CONFIG_HOME does NOT fall to APPDATA (zig's
+        // orelse sees Some("")), it falls to the home + .config default.
+        Set("XDG_CONFIG_HOME", null);
+        Set("APPDATA", @"C:\Users\u\AppData\Roaming");
+        Assert.True(string.Equals(@"C:\Users\u\AppData\Roaming",
+            TestConfigGuard.ResolveConfigRoot(),
+            StringComparison.OrdinalIgnoreCase));
+        Set("XDG_CONFIG_HOME", @"C:\scratch\xdg");
+        Assert.True(string.Equals(@"C:\scratch\xdg",
+            TestConfigGuard.ResolveConfigRoot(),
+            StringComparison.OrdinalIgnoreCase));
+        // A set-but-empty XDG does NOT fall to APPDATA (zig's orelse sees
+        // Some("")); and with both empty the home + .config default wins.
+        // The overlay SHADOWS to null/empty on purpose: the armed host sets
+        // the real XDG, so fall-through would read the host root.
+        Set("XDG_CONFIG_HOME", "");
+        Set("APPDATA", @"C:\Users\u\AppData\Roaming");
+        Assert.True(string.Equals(
+            Path.Combine(Environment.GetFolderPath(
+                Environment.SpecialFolder.UserProfile), ".config"),
+            TestConfigGuard.ResolveConfigRoot(), StringComparison.OrdinalIgnoreCase));
+        Set("XDG_CONFIG_HOME", null);
+        Set("APPDATA", "");
+        Assert.True(string.Equals(
+            Path.Combine(Environment.GetFolderPath(
+                Environment.SpecialFolder.UserProfile), ".config"),
+            TestConfigGuard.ResolveConfigRoot(), StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
@@ -391,22 +371,6 @@ public class TestConfigGuardTests : IDisposable
         Assert.Contains("internal_opts.default_subdir", zig);
     }
 
-    private sealed class ScopedEnv : IDisposable
-    {
-        private readonly string _name;
-        private readonly string? _original;
-
-        public ScopedEnv(string name, string? value)
-        {
-            _name = name;
-            _original = Environment.GetEnvironmentVariable(name);
-            Environment.SetEnvironmentVariable(name, value);
-        }
-
-        public void Dispose() =>
-            Environment.SetEnvironmentVariable(_name, _original);
-    }
-
     private static string RepoRoot()
     {
         var dir = AppContext.BaseDirectory;
@@ -417,48 +381,5 @@ public class TestConfigGuardTests : IDisposable
             dir = Directory.GetParent(dir)?.FullName;
         }
         throw new InvalidOperationException("repo root not found");
-    }
-}
-
-/// <summary>
-/// The refusing editor a --no-config run gets: writes are refused loudly,
-/// reads answer as the empty file the rest of that run already serves.
-/// </summary>
-public class NoConfigFileEditorTests
-{
-    private readonly NoConfigFileEditor _editor = new();
-
-    [Fact]
-    public void FilePath_Is_Empty()
-    {
-        Assert.Equal(string.Empty, _editor.FilePath);
-    }
-
-    [Fact]
-    public void Reads_Answer_As_An_Empty_Config()
-    {
-        Assert.Equal(string.Empty, _editor.ReadAll());
-        Assert.Empty(_editor.GetRepeatableValues("keybind"));
-    }
-
-    [Theory]
-    [InlineData("font-size", "12")]
-    public void Writes_Are_Refused_Not_Silently_Dropped(string key, string value)
-    {
-        // A no-op write would tell a user their change persisted; the
-        // refusal is the honest answer, and the debounced scheduler and
-        // the startup migrator log it rather than crash on it.
-        var ex = Assert.Throws<InvalidOperationException>(
-            () => _editor.SetValue(key, value));
-        Assert.Contains("--no-config", ex.Message);
-    }
-
-    [Fact]
-    public void Every_Mutating_Method_Refuses()
-    {
-        Assert.Throws<InvalidOperationException>(() => _editor.RemoveValue("k"));
-        Assert.Throws<InvalidOperationException>(() => _editor.WriteRaw("x = 1"));
-        Assert.Throws<InvalidOperationException>(
-            () => _editor.SetRepeatableValues("k", new[] { "v" }));
     }
 }

--- a/windows/Ghostty.Tests/Ghostty.Tests.csproj
+++ b/windows/Ghostty.Tests/Ghostty.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <!--
@@ -268,4 +268,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- One shared file, linked: the four test hosts cannot drift. -->
+    <Compile Include="..\build\TestHostArming.cs" Link="TestHostArming.cs" />
+  </ItemGroup>
 </Project>

--- a/windows/Ghostty.Tests/TestHost/TestHostArmingTests.cs
+++ b/windows/Ghostty.Tests/TestHost/TestHostArmingTests.cs
@@ -1,0 +1,51 @@
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using Ghostty.Core.Config;
+using Xunit;
+
+namespace Ghostty.Tests.TestHost;
+
+/// <summary>
+/// The test HOST is armed (audit M1): a [ModuleInitializer] in every test
+/// project points this process at a per-host random temp config root and
+/// arms WINTTY_TEST_CONFIG, so an in-process test that reaches for a
+/// default config path (through a Ghostty.Core helper, or after someone
+/// adds the obvious project reference) cannot silently read or write the
+/// real per-user config. No launch is involved, which is exactly why the
+/// source scan could never cover this class of entry: the enforcement has
+/// to live in the host process itself.
+/// </summary>
+public class TestHostArmingTests
+{
+    [Fact]
+    public void The_Test_Host_Runs_Armed_On_A_Random_Temp_Root()
+    {
+        // The guard's own arm state, read fresh (not cached), because the
+        // initializer ran long before any test.
+        Assert.True(TestConfigGuard.IsArmed,
+            "the test host must arm WINTTY_TEST_CONFIG; a test that " +
+            "genuinely needs a clean environment takes the documented " +
+            "WINTTY_TEST_HOST_UNARMED escape hatch");
+
+        var xdg = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
+        Assert.False(string.IsNullOrEmpty(xdg));
+        Assert.True(TestConfigGuard.IsUnderTemp(xdg),
+            $"XDG_CONFIG_HOME '{xdg}' must resolve under the known-folder " +
+            $"temp anchor '{TestConfigGuard.TempAnchor}'");
+
+        // Random-named leaf, same discipline as every harness: a fixed
+        // name would collide across hosts and runs.
+        var leaf = new DirectoryInfo(xdg).Name;
+        Assert.Matches(new Regex("^wintty-testhost-[0-9a-f]{16,}$"), leaf);
+    }
+
+    [Fact]
+    public void The_Host_Root_Exists_And_Stayed_Inside_The_Anchor()
+    {
+        var xdg = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
+        Assert.False(string.IsNullOrEmpty(xdg));
+        Assert.True(Directory.Exists(xdg),
+            "the armed host root must exist for the whole host lifetime");
+    }
+}

--- a/windows/Ghostty.Tests/TestHost/TestHostArmingTests.cs
+++ b/windows/Ghostty.Tests/TestHost/TestHostArmingTests.cs
@@ -7,6 +7,17 @@ using Xunit;
 namespace Ghostty.Tests.TestHost;
 
 /// <summary>
+/// Collections that read the LIVE process environment serialize here, so
+/// no parallel collection can be mid-mutation while these observe. (After
+/// review finding M1 the guard tests no longer touch the live environment
+/// at all - they inject <see cref="TestConfigGuard.ReadEnvironment"/> - so
+/// today nothing mutates it after the initializer; the collection is the
+/// belt that keeps that true for every future env-reading test.)
+/// </summary>
+[CollectionDefinition("EnvironmentSerial", DisableParallelization = true)]
+public class EnvironmentSerialCollection { }
+
+/// <summary>
 /// The test HOST is armed (audit M1): a [ModuleInitializer] in every test
 /// project points this process at a per-host random temp config root and
 /// arms WINTTY_TEST_CONFIG, so an in-process test that reaches for a
@@ -15,37 +26,66 @@ namespace Ghostty.Tests.TestHost;
 /// real per-user config. No launch is involved, which is exactly why the
 /// source scan could never cover this class of entry: the enforcement has
 /// to live in the host process itself.
+///
+/// The SNAPSHOT asserts read what the initializer decided at host start
+/// (TestHostArming.Armed / .Root) and cannot be flipped by anything that
+/// happens mid-run; the LIVE asserts read the real environment and sit in
+/// the serialized collection (review finding M1).
 /// </summary>
+[Collection("EnvironmentSerial")]
 public class TestHostArmingTests
 {
     [Fact]
-    public void The_Test_Host_Runs_Armed_On_A_Random_Temp_Root()
+    public void The_Host_Was_Armed_At_Startup()
     {
-        // The guard's own arm state, read fresh (not cached), because the
-        // initializer ran long before any test.
-        Assert.True(TestConfigGuard.IsArmed,
-            "the test host must arm WINTTY_TEST_CONFIG; a test that " +
-            "genuinely needs a clean environment takes the documented " +
-            "WINTTY_TEST_HOST_UNARMED escape hatch");
+        // This failing message IS the loud unarmed warning: neither
+        // Console.WriteLine nor Console.Error survives dotnet test's
+        // normal verbosity (both proven swallowed), so the summary line
+        // a human reads is this assert's text. It names the hatch, so a
+        // deliberate clean-env run explains itself right here.
+        Assert.True(Ghostty.Testing.TestHostArming.Armed,
+            "test host UNARMED via WINTTY_TEST_HOST_UNARMED" +
+            (Environment.GetEnvironmentVariable(
+                "WINTTY_TEST_HOST_UNARMED") == "1"
+                ? " (the documented hatch is active; nothing isolates this host)"
+                : " (the initializer did not arm; this is NOT the hatch)") +
+            ". Every test in this host runs against the REAL config " +
+            "unless the run is stopped.");
 
-        var xdg = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
-        Assert.False(string.IsNullOrEmpty(xdg));
-        Assert.True(TestConfigGuard.IsUnderTemp(xdg),
-            $"XDG_CONFIG_HOME '{xdg}' must resolve under the known-folder " +
+        var root = Ghostty.Testing.TestHostArming.RootForTests;
+        Assert.False(string.IsNullOrEmpty(root));
+        Assert.True(TestConfigGuard.IsUnderTemp(root),
+            $"the host root '{root}' must resolve under the known-folder " +
             $"temp anchor '{TestConfigGuard.TempAnchor}'");
 
         // Random-named leaf, same discipline as every harness: a fixed
         // name would collide across hosts and runs.
-        var leaf = new DirectoryInfo(xdg).Name;
+        var leaf = new DirectoryInfo(root).Name;
         Assert.Matches(new Regex("^wintty-testhost-[0-9a-f]{16,}$"), leaf);
     }
 
     [Fact]
-    public void The_Host_Root_Exists_And_Stayed_Inside_The_Anchor()
+    public void The_Live_Environment_Matches_The_Snapshot()
     {
-        var xdg = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
-        Assert.False(string.IsNullOrEmpty(xdg));
-        Assert.True(Directory.Exists(xdg),
-            "the armed host root must exist for the whole host lifetime");
+        // From the serialized collection only: the live environment is
+        // read here, and nothing parallel may be mutating it.
+        if (Ghostty.Testing.TestHostArming.Armed)
+        {
+            Assert.Equal("1",
+                Environment.GetEnvironmentVariable(TestConfigGuard.EnvVar));
+            Assert.Equal(
+                Ghostty.Testing.TestHostArming.RootForTests,
+                Environment.GetEnvironmentVariable("XDG_CONFIG_HOME"));
+            Assert.True(Directory.Exists(
+                Ghostty.Testing.TestHostArming.RootForTests!),
+                "the armed host root must exist for the whole host lifetime");
+        }
+        else
+        {
+            // The documented hatch: the sentinel assert above already
+            // failed loudly in that case, so reaching here means a test
+            // run deliberately took the hatch.
+            Assert.Null(Environment.GetEnvironmentVariable("XDG_CONFIG_HOME"));
+        }
     }
 }

--- a/windows/Ghostty.Tests/Wiring/HarnessConfigIsolationScanTests.cs
+++ b/windows/Ghostty.Tests/Wiring/HarnessConfigIsolationScanTests.cs
@@ -756,11 +756,58 @@ public class HarnessConfigIsolationScanTests
                 statement[^1] = statement[^1].TrimEnd().TrimEnd('`');
                 statement.Add(lines[j]);
             }
-            if (!statement.Any(l => l.Contains("+crash", StringComparison.Ordinal)))
+            // `+crash` counts only as an ARGUMENT of the launch command
+            // itself: comments stripped first, the statement split into
+            // command segments, and only the LAUNCH segment's tokens are
+            // examined. A +crash in a trailing comment, in an unrelated
+            // string, or in another command on the same line does not
+            // count (review finding M3).
+            var joined = string.Join("\n", statement);
+            var launchSegment = LaunchSegmentOf(joined);
+            if (!TokenContains(launchSegment, "+crash"))
                 violations.Add(
                     $"{rel}:{site.Line}: launch without +crash: {site.Text}");
         }
         return violations;
+    }
+
+    /// <summary>
+    /// The command segment of a joined statement that performs this
+    /// launch: the semicolon-separated piece carrying a launch verb. The
+    /// line's FIRST word cannot identify it (a Write-Host sharing the
+    /// line pushes the launch into the second segment), and anything in
+    /// another command on the same statement is not this launch's
+    /// arguments.
+    /// </summary>
+    private static string LaunchSegmentOf(string joined)
+    {
+        foreach (var segment in joined.Split(';'))
+        {
+            if (LaunchVerbs.Any(v => v.IsMatch(segment)))
+                return segment;
+        }
+        return joined;
+    }
+
+    /// <summary>
+    /// Whether a command's whitespace tokens include the exact word,
+    /// after trailing-comment removal, quote stripping and comma
+    /// trimming. A word inside a longer string still fails: the tokens
+    /// of `'docs: +crash exits'"` are not the bare word.
+    /// </summary>
+    private static bool TokenContains(string command, string word)
+    {
+        // PowerShell comment: a # preceded by whitespace or line start.
+        var withoutComment = Regex.Replace(
+            command, @"(^|\s)#.*$", m => m.Groups[1].Value,
+            RegexOptions.Multiline);
+        foreach (var raw in withoutComment.Split(
+                     (char[]?)null, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var token = raw.Trim('\'', '"', ',', '`').Trim();
+            if (token == word) return true;
+        }
+        return false;
     }
 
     [Fact]
@@ -782,6 +829,20 @@ public class HarnessConfigIsolationScanTests
             fixtureDir, "crash-fixture-without-crash.ps1"));
         Assert.NotEmpty(CrashOnlyViolations(
             "crash-fixture-without-crash.ps1", missing));
+
+        // The reviewer's two textual-defeat mutations: +crash in a
+        // trailing comment, and +crash inside another command's string.
+        foreach (var name in new[]
+                 {
+                     "crash-fixture-comment-crash.ps1",
+                     "crash-fixture-string-crash.ps1",
+                 })
+        {
+            var offenders = CrashOnlyViolations(
+                name, File.ReadAllLines(Path.Combine(fixtureDir, name)));
+            Assert.True(offenders.Count > 0,
+                name + " was NOT flagged (the +crash pin went blind on it)");
+        }
 
         // The two real files the allowlist vouches for.
         var scriptDir = Path.Combine(root, "windows", "scripts");
@@ -1418,11 +1479,23 @@ public class HarnessConfigIsolationScanTests
     /// </summary>
     private static readonly Regex[] NonPsLaunchHints =
     {
-        new(@"subprocess|Popen|startfile|os\.system|check_output|check_call",
+        // Python: every spelling that turns a path into a process.
+        new(@"subprocess|Popen|startfile|os\.system|check_output|check_call|posix_spawn|os\.spawn|os\.exec|\bexecv|\bexecl|\bexece",
             RegexOptions.Compiled),
         new(@"(?i)\bstart\b|\bcall\b|\brun\b|\bexec\b|\binvoke\b|Popen|subprocess|\./",
             RegexOptions.Compiled),
     };
+
+    /// <summary>
+    /// A command-position prefix: the text ending right before the exe
+    /// literal is empty or a shell separator. In cmd, sh and nu a BARE
+    /// exe line is THE idiomatic launch (review finding M2), so the
+    /// prefix test alone carries those languages; python and yaml keep
+    /// their own rules.
+    /// </summary>
+    private static readonly Regex CommandPositionPrefix = new(
+        @"(?i)(?:&{1,2}|\\|\|\|;|call|start|exec|cmd\s+/c)\s*$",
+        RegexOptions.Compiled);
 
     /// <summary>
     /// The in-file arming token in any of its spellings: env-drive
@@ -1473,25 +1546,40 @@ public class HarnessConfigIsolationScanTests
         {
             var line = lines[i];
             if (IsComment(line)) continue;
+            var trimmed = line.TrimStart();
 
-            var consider = true;
-            var needHint = true;
+            var isLaunch = false;
             if (extension == ".yml")
             {
-                var indent = line.Length - line.TrimStart().Length;
-                // The run: block IS the launch form in yaml; a bare app
-                // literal inside it needs no second hint.
-                consider = InsideRunBlock(prior, indent);
-                needHint = false;
+                var indent = line.Length - trimmed.Length;
+                // The run: block IS the launch form in yaml, and so is
+                // the run: line ITSELF (the inline form); both carry
+                // the launch, no second hint needed.
+                var inline = Regex.IsMatch(
+                    trimmed, @"^(?:- )?run:", RegexOptions.IgnoreCase);
+                isLaunch = InsideRunBlock(prior, indent) || inline;
                 prior.Add((indent, line));
             }
-
-            if (consider &&
-                AppLiteral.IsMatch(line) &&
-                (!needHint || NonPsLaunchHints.Any(h => h.IsMatch(line))))
+            else if (extension == ".py")
             {
-                violations.Add($"{rel}:{i + 1}: {line.Trim()}");
+                isLaunch = NonPsLaunchHints[0].IsMatch(line);
             }
+            else
+            {
+                // cmd, bat, sh, nu: command position. The exe at the
+                // start of the line, or right after a shell separator;
+                // a bare exe line is THE idiomatic launch in these.
+                var match = AppLiteral.Match(line);
+                if (match.Success)
+                {
+                    var prefix = line[..match.Index].TrimEnd();
+                    isLaunch = prefix.Length == 0 ||
+                        CommandPositionPrefix.IsMatch(prefix + " ");
+                }
+            }
+
+            if (isLaunch && AppLiteral.IsMatch(line))
+                violations.Add($"{rel}:{i + 1}: {trimmed.Trim()}");
         }
         return violations;
     }
@@ -1512,11 +1600,21 @@ public class HarnessConfigIsolationScanTests
             "outside-agents-launcher.py",
             "outside-cmd-launcher.cmd",
             "outside-ci-step.yml",
+            "outside-bare-cmd.cmd",
+            "outside-bare-sh.sh",
+            "outside-bare-nu.nu",
+            "outside-posix-spawn.py",
+            "outside-inline-run.yml",
         };
         var mustPass = new[]
         {
             "outside-armed-launcher.py",
             "outside-armed-ci.yml",
+            "outside-armed-bare-cmd.cmd",
+            "outside-armed-bare-sh.sh",
+            "outside-armed-bare-nu.nu",
+            "outside-armed-posix-spawn.py",
+            "outside-armed-inline-run.yml",
         };
         foreach (var file in Directory.EnumerateFiles(fixtureDir))
         {
@@ -1571,6 +1669,33 @@ public class HarnessConfigIsolationScanTests
             string.Join("\n  ", violationsAll));
     }
 
+    /// <summary>
+    /// The hatch scan must see the ROOT justfile and every justfile in
+    /// the repo, which sit under no swept tree (review Low: the old
+    /// justfile clause was dead code). The fixture proves the justfile
+    /// pass bites before the real files are read.
+    /// </summary>
+    private static List<string> HatchOffendersIn(string root)
+    {
+        var offenders = new List<string>();
+        var justfiles = new List<string> {
+            Path.Combine(root, "justfile") };
+        justfiles.AddRange(Directory.EnumerateFiles(
+            root, "justfile", SearchOption.AllDirectories));
+        foreach (var justfile in justfiles.Where(j => !j
+            .Replace('\\', '/').Contains("/ScanFixtures/")))
+        {
+            if (!File.Exists(justfile)) continue;
+            offenders.AddRange(File.ReadAllLines(justfile)
+                .Select((l, i) => (l, i))
+                .Where(x => x.l.Contains(
+                    "WINTTY_TEST_HOST_UNARMED", StringComparison.Ordinal) &&
+                    !x.l.TrimStart().StartsWith("#"))
+                .Select(x => $"{Path.GetRelativePath(root, justfile)}:{x.i + 1}"));
+        }
+        return offenders;
+    }
+
     [Fact]
     public void The_Unarmed_Host_Escape_Hatch_Is_Never_Committed()
     {
@@ -1579,6 +1704,19 @@ public class HarnessConfigIsolationScanTests
         // someone bakes into a script, recipe or CI file.
         var root = RepoRoot();
         var offenders = new List<string>();
+
+        // The justfile fixture: a recipe baking in the hatch is flagged.
+        var fixture = Path.Combine(
+            root, "windows", "Ghostty.Tests", "Wiring", "ScanFixtures",
+            "hatch", "justfile");
+        Assert.True(File.Exists(fixture), "hatch justfile fixture not found");
+        var fixtureLines = File.ReadAllLines(fixture);
+        Assert.Contains(fixtureLines, l => l.Contains(
+            "WINTTY_TEST_HOST_UNARMED", StringComparison.Ordinal));
+
+        // Every real justfile, the root one included.
+        offenders.AddRange(HatchOffendersIn(root));
+
         foreach (var tree in OutsideTrees.Append("windows/scripts"))
         {
             var dir = Path.Combine(root, tree);

--- a/windows/Ghostty.Tests/Wiring/HarnessConfigIsolationScanTests.cs
+++ b/windows/Ghostty.Tests/Wiring/HarnessConfigIsolationScanTests.cs
@@ -92,7 +92,10 @@ public class HarnessConfigIsolationScanTests
         // bare alias form rejects a hyphen continuation so Start-Job and
         // friends are not launches by mere word shape.
         new(@"Start-Process", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-        new(@"\b(?:saps|start)\b(?!-)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+        // The bare alias, never a method call: (?<!\.) keeps $timer.Start()
+        // out, and (?!-) keeps Start-Job and friends out.
+        new(@"(?<!\.)\b(?:saps|start)\b(?!-)",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase),
         new(@"ProcessStartInfo", RegexOptions.Compiled | RegexOptions.IgnoreCase),
         new(@"Process\]::Start\(", RegexOptions.Compiled | RegexOptions.IgnoreCase),
         new(@"Process\.Start\(", RegexOptions.Compiled | RegexOptions.IgnoreCase),
@@ -452,13 +455,28 @@ public class HarnessConfigIsolationScanTests
 
         // No app and no tooling evidence: the variable's own name decides,
         // except the call-operator form, which is how scriptblocks are
-        // invoked and needs positive evidence.
+        // invoked and needs positive evidence. A MEMBER read whose member
+        // is not a target name ($latest.FullName, a file object's path)
+        // is not a launch target either: the launch shapes that matter set
+        // FileName/FilePath, and PropertyTargets already reads those.
         if (callOperatorOnly) return false;
-        if (sawEvidence) return true;
+        var memberBases = Regex.Matches(
+                varSource,
+                @"\$(\w+)\.(?!FileName|FilePath|ExePath)\w+")
+            .Cast<System.Text.RegularExpressions.Match>()
+            .Select(m => m.Groups[1].Value)
+            .ToHashSet(StringComparer.Ordinal);
+        if (sawEvidence &&
+            AnyVar.Matches(varSource)
+                .Cast<System.Text.RegularExpressions.Match>()
+                .Select(m => m.Groups[1].Value)
+                .Any(n => !memberBases.Contains(n)))
+            return true;
         return AnyVar.Matches(varSource)
             .Cast<System.Text.RegularExpressions.Match>()
             .Select(m => m.Groups[1].Value)
-            .Any(n => ExeNamedVar.IsMatch("$" + n));
+            .Any(n => !memberBases.Contains(n) &&
+                      ExeNamedVar.IsMatch("$" + n));
     }
 
     /// <summary>
@@ -1371,5 +1389,220 @@ public class HarnessConfigIsolationScanTests
 
         Assert.Contains(File.ReadAllLines(path),
             l => IsCode(l) && ArmingLine.IsMatch(l));
+    }
+
+    // ---- the wider sweep (audit L3) ------------------------------------
+    //
+    // The main scan is PowerShell-shaped and windows/scripts-scoped. The
+    // same founder rule reaches every other tree that can launch the app:
+    // .agents, tools, test, dist, the repo root, and CI. PowerShell files
+    // reuse the full per-site machinery; every other language gets the
+    // simpler rule: a launch hint plus the app literal is a launch, and it
+    // is clean only when the file carries an in-file arming token for
+    // WINTTY_TEST_CONFIG (a set/assignment spelling, not a comment).
+
+    private static readonly string[] OutsideTrees =
+    {
+        ".agents", "tools", "test", "dist", ".github",
+    };
+
+    private static readonly string[] OutsideExtensions =
+    {
+        ".ps1", ".py", ".nu", ".sh", ".cmd", ".bat", ".yml",
+    };
+
+    /// <summary>
+    /// The words that make an app literal a LAUNCH in a non-PowerShell
+    /// file, per language family. Without a hint, an exe path sitting in
+    /// a variable or a config string is not a launch.
+    /// </summary>
+    private static readonly Regex[] NonPsLaunchHints =
+    {
+        new(@"subprocess|Popen|startfile|os\.system|check_output|check_call",
+            RegexOptions.Compiled),
+        new(@"(?i)\bstart\b|\bcall\b|\brun\b|\bexec\b|\binvoke\b|Popen|subprocess|\./",
+            RegexOptions.Compiled),
+    };
+
+    /// <summary>
+    /// The in-file arming token in any of its spellings: env-drive
+    /// assignment, psi dictionary, python os.environ, yaml env key.
+    /// </summary>
+    private static readonly Regex NonPsArmingToken = new(
+        @"WINTTY_TEST_CONFIG['""\]\s]*[:=]",
+        RegexOptions.Compiled);
+
+    private static bool IsComment(string line) =>
+        line.TrimStart().StartsWith('#') ||
+        line.TrimStart().StartsWith("rem ") ||
+        line.TrimStart().StartsWith("REM ");
+
+    /// <summary>
+    /// Whether a yml line sits inside a run: block: some earlier line at a
+    /// LOWER indentation introduced run:, and nothing at that indentation
+    /// or lower has intervened.
+    /// </summary>
+    private static bool InsideRunBlock(
+        List<(int Indent, string Text)> prior, int indent)
+    {
+        for (var i = prior.Count - 1; i >= 0; i--)
+        {
+            var trimmed = prior[i].Text.Trim();
+            if (trimmed.StartsWith("run:") || trimmed.StartsWith("- run:"))
+                return true;
+            if (prior[i].Indent <= indent) return false;
+        }
+        return false;
+    }
+
+    private static List<string> OutsideViolations(
+        string rel, string[] lines, string extension)
+    {
+        // PowerShell: the full per-site machinery, unchanged.
+        if (extension == ".ps1")
+            return UnarmedLaunches(rel, lines)
+                .Select(l => $"{l.File}:{l.Line}: {l.Text}").ToList();
+
+        var armed = lines.Any(l =>
+            !IsComment(l) && NonPsArmingToken.IsMatch(l));
+        if (armed) return new List<string>();
+
+        var prior = new List<(int Indent, string Text)>();
+        var violations = new List<string>();
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            if (IsComment(line)) continue;
+
+            var consider = true;
+            var needHint = true;
+            if (extension == ".yml")
+            {
+                var indent = line.Length - line.TrimStart().Length;
+                // The run: block IS the launch form in yaml; a bare app
+                // literal inside it needs no second hint.
+                consider = InsideRunBlock(prior, indent);
+                needHint = false;
+                prior.Add((indent, line));
+            }
+
+            if (consider &&
+                AppLiteral.IsMatch(line) &&
+                (!needHint || NonPsLaunchHints.Any(h => h.IsMatch(line))))
+            {
+                violations.Add($"{rel}:{i + 1}: {line.Trim()}");
+            }
+        }
+        return violations;
+    }
+
+    [Fact]
+    public void Outside_Script_Trees_Arm_Their_App_Launches()
+    {
+        var root = RepoRoot();
+
+        // The fixture corpus first: the three unarmed shapes must be
+        // flagged and the two armed controls must not be.
+        var fixtureDir = Path.Combine(
+            root, "windows", "Ghostty.Tests", "Wiring", "ScanFixtures",
+            "outside-scripts");
+        Assert.True(Directory.Exists(fixtureDir), "outside-scripts fixtures not found");
+        var mustFlag = new[]
+        {
+            "outside-agents-launcher.py",
+            "outside-cmd-launcher.cmd",
+            "outside-ci-step.yml",
+        };
+        var mustPass = new[]
+        {
+            "outside-armed-launcher.py",
+            "outside-armed-ci.yml",
+        };
+        foreach (var file in Directory.EnumerateFiles(fixtureDir))
+        {
+            var name = Path.GetFileName(file);
+            var violations = OutsideViolations(
+                name, File.ReadAllLines(file), Path.GetExtension(file));
+            if (mustFlag.Contains(name))
+                Assert.True(violations.Count > 0,
+                    name + " was NOT flagged (the sweep went blind on it)");
+            else if (mustPass.Contains(name))
+                Assert.True(violations.Count == 0,
+                    name + " wrongly flagged:\n  " + string.Join("\n  ", violations));
+        }
+
+        // Then the real trees.
+        var all = new List<string>();
+        foreach (var tree in OutsideTrees)
+        {
+            var dir = Path.Combine(root, tree);
+            if (!Directory.Exists(dir)) continue;
+            foreach (var file in Directory.EnumerateFiles(
+                         dir, "*", SearchOption.AllDirectories))
+            {
+                var extension = Path.GetExtension(file).ToLowerInvariant();
+                if (!OutsideExtensions.Contains(extension)) continue;
+                // Third-party vendored sources are not our launch sites.
+                if (file.Replace('\\', '/').Contains("/vendor/")) continue;
+                all.Add(file);
+            }
+        }
+        // The repo root itself.
+        foreach (var file in Directory.EnumerateFiles(root))
+        {
+            var extension = Path.GetExtension(file).ToLowerInvariant();
+            if (OutsideExtensions.Contains(extension)) all.Add(file);
+        }
+
+        var violationsAll = new List<string>();
+        foreach (var file in all.OrderBy(f => f, StringComparer.Ordinal))
+        {
+            violationsAll.AddRange(OutsideViolations(
+                Path.GetRelativePath(root, file),
+                File.ReadAllLines(file),
+                Path.GetExtension(file).ToLowerInvariant()));
+        }
+
+        Assert.True(
+            violationsAll.Count == 0,
+            "app launch(es) outside windows/scripts that neither arm " +
+            "WINTTY_TEST_CONFIG nor go through an isolated-config helper " +
+            "(files: " + all.Count + " swept):\n  " +
+            string.Join("\n  ", violationsAll));
+    }
+
+    [Fact]
+    public void The_Unarmed_Host_Escape_Hatch_Is_Never_Committed()
+    {
+        // WINTTY_TEST_HOST_UNARMED exists for a human at a terminal with a
+        // genuinely clean-env test in mind; it must never become a default
+        // someone bakes into a script, recipe or CI file.
+        var root = RepoRoot();
+        var offenders = new List<string>();
+        foreach (var tree in OutsideTrees.Append("windows/scripts"))
+        {
+            var dir = Path.Combine(root, tree);
+            if (!Directory.Exists(dir)) continue;
+            foreach (var file in Directory.EnumerateFiles(
+                         dir, "*", SearchOption.AllDirectories))
+            {
+                var extension = Path.GetExtension(file).ToLowerInvariant();
+                if (!OutsideExtensions.Contains(extension) &&
+                    !file.EndsWith("justfile", StringComparison.Ordinal)) continue;
+                var rel = Path.GetRelativePath(root, file);
+                var hits = File.ReadAllLines(file)
+                    .Select((l, i) => (l, i))
+                    .Where(x => x.l.Contains(
+                        "WINTTY_TEST_HOST_UNARMED", StringComparison.Ordinal) &&
+                        !IsComment(x.l))
+                    .Select(x => $"{rel}:{x.i + 1}");
+                offenders.AddRange(hits);
+            }
+        }
+
+        Assert.True(
+            offenders.Count == 0,
+            "WINTTY_TEST_HOST_UNARMED is a human-terminal escape hatch, " +
+            "never a committed default:\n  " + string.Join("\n  ", offenders));
     }
 }

--- a/windows/Ghostty.Tests/Wiring/HarnessConfigIsolationScanTests.cs
+++ b/windows/Ghostty.Tests/Wiring/HarnessConfigIsolationScanTests.cs
@@ -694,6 +694,11 @@ public class HarnessConfigIsolationScanTests
                 // it does; an allowlisted name that stopped launching would
                 // silently keep covering whatever replaced it.
                 Assert.NotEmpty(UnarmedLaunches(rel, lines));
+                // The +crash entries are safe ONLY while every launch is
+                // +crash-only; the user launcher is exempt by the founder
+                // rule, so the pin applies to the crash pair alone.
+                if (name.StartsWith("crash-", StringComparison.Ordinal))
+                    violations.AddRange(CrashOnlyViolations(rel, lines));
                 continue;
             }
 
@@ -708,6 +713,70 @@ public class HarnessConfigIsolationScanTests
             "Stage a random temp XDG root and set WINTTY_TEST_CONFIG=1 for the " +
             "child (unconditionally, before the launch), or add a justified " +
             "allowlist entry:\n  " + string.Join("\n  ", violations));
+    }
+
+    /// <summary>
+    /// The +crash-only allowlist entries (crash-canary, crash-matrix) are
+    /// safe ONLY because every launch is intercepted at Program.MainImpl
+    /// before InitGhostty and exits without touching config. A second leg
+    /// without +crash would ride the allowlist and run fully unguarded
+    /// against the real config. This pins the invariant: every app-launch
+    /// statement in those files must carry +crash (audit M2).
+    /// </summary>
+    private static List<string> CrashOnlyViolations(string rel, string[] lines)
+    {
+        var violations = new List<string>();
+        var functions = FunctionBodiesFor(lines);
+        foreach (var site in UnarmedLaunches(rel, lines))
+        {
+            // A statement continues over backtick lines; the +crash may sit
+            // on any of them.
+            var statement = new List<string> { lines[site.Line - 1] };
+            for (var j = site.Line; j < lines.Length; j++)
+            {
+                if (!statement[^1].TrimEnd().EndsWith('`')) break;
+                statement[^1] = statement[^1].TrimEnd().TrimEnd('`');
+                statement.Add(lines[j]);
+            }
+            if (!statement.Any(l => l.Contains("+crash", StringComparison.Ordinal)))
+                violations.Add(
+                    $"{rel}:{site.Line}: launch without +crash: {site.Text}");
+        }
+        return violations;
+    }
+
+    [Fact]
+    public void Crash_Only_Harnesses_Stay_Crash_Only()
+    {
+        var root = RepoRoot();
+        var fixtureDir = Path.Combine(
+            root, "windows", "Ghostty.Tests", "Wiring", "ScanFixtures",
+            "crash-only");
+        Assert.True(Directory.Exists(fixtureDir), "crash-only fixtures not found");
+
+        // The fixture pair, RED provenance: the with-crash shape must be
+        // clean and the without-crash shape must be flagged.
+        var clean = File.ReadAllLines(Path.Combine(
+            fixtureDir, "crash-fixture-with-crash.ps1"));
+        Assert.Empty(CrashOnlyViolations("crash-fixture-with-crash.ps1", clean));
+
+        var missing = File.ReadAllLines(Path.Combine(
+            fixtureDir, "crash-fixture-without-crash.ps1"));
+        Assert.NotEmpty(CrashOnlyViolations(
+            "crash-fixture-without-crash.ps1", missing));
+
+        // The two real files the allowlist vouches for.
+        var scriptDir = Path.Combine(root, "windows", "scripts");
+        foreach (var name in new[] { "crash-canary.ps1", "crash-matrix.ps1" })
+        {
+            var path = Path.Combine(scriptDir, name);
+            Assert.True(File.Exists(path), name + " not found");
+            var offenders = CrashOnlyViolations(
+                name, File.ReadAllLines(path));
+            Assert.True(offenders.Count == 0,
+                "a +crash-only harness grew a launch without +crash:\n  " +
+                string.Join("\n  ", offenders));
+        }
     }
 
     /// <summary>

--- a/windows/Ghostty.Tests/Wiring/HarnessConfigIsolationScanTests.cs
+++ b/windows/Ghostty.Tests/Wiring/HarnessConfigIsolationScanTests.cs
@@ -1491,10 +1491,13 @@ public class HarnessConfigIsolationScanTests
     /// literal is empty or a shell separator. In cmd, sh and nu a BARE
     /// exe line is THE idiomatic launch (review finding M2), so the
     /// prefix test alone carries those languages; python and yaml keep
-    /// their own rules.
+    /// their own rules. The alternation spells every separator as its
+    /// own alternative - `;` and `||` included - because the previous
+    /// `\|\|;` token fused them into one literal that matched neither
+    /// alone (re-review finding 2).
     /// </summary>
     private static readonly Regex CommandPositionPrefix = new(
-        @"(?i)(?:&{1,2}|\\|\|\|;|call|start|exec|cmd\s+/c)\s*$",
+        @"(?i)(?:&{1,2}|\|\||\||;|\bcall\b|\bstart\b|\bexec\b|cmd\s+/c)\s*(?:""[^""]*""\s*|\s)*\S*\s*$",
         RegexOptions.Compiled);
 
     /// <summary>
@@ -1573,8 +1576,19 @@ public class HarnessConfigIsolationScanTests
                 if (match.Success)
                 {
                     var prefix = line[..match.Index].TrimEnd();
-                    isLaunch = prefix.Length == 0 ||
-                        CommandPositionPrefix.IsMatch(prefix + " ");
+                    // A pure PATH prefix (C:\b1\, no whitespace, no
+                    // separator) is still command position: a bare
+                    // full-path launch is as idiomatic as a bare name,
+                    // and the exe literal only matches the file name, so
+                    // the directory part shows up here. The space-free
+                    // test is what keeps an echo argument out: that
+                    // prefix carries a word.
+                    var purePath = prefix.Length > 0 &&
+                        !prefix.Contains(' ') &&
+                        (prefix.Contains(Path.DirectorySeparatorChar) ||
+                         prefix.Contains(Path.AltDirectorySeparatorChar));
+                    isLaunch = prefix.Length == 0 || purePath ||
+                        CommandPositionPrefix.IsMatch(prefix);
                 }
             }
 
@@ -1605,6 +1619,10 @@ public class HarnessConfigIsolationScanTests
             "outside-bare-nu.nu",
             "outside-posix-spawn.py",
             "outside-inline-run.yml",
+            "outside-semicolon-cmd.cmd",
+            "outside-orElse-cmd.cmd",
+            "outside-semicolon-sh.sh",
+            "outside-orElse-sh.sh",
         };
         var mustPass = new[]
         {

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/crash-only/crash-fixture-comment-crash.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/crash-only/crash-fixture-comment-crash.ps1
@@ -1,0 +1,4 @@
+# Fixture: the reviewer's mutation - +crash only in a trailing comment
+# (flagged: it is not an argument of the launch).
+$ExePath = 'C:\b1\Wintty.exe'
+Start-Process -FilePath $ExePath -ArgumentList '+list-themes' # keep +crash pinned here

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/crash-only/crash-fixture-string-crash.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/crash-only/crash-fixture-string-crash.ps1
@@ -1,0 +1,4 @@
+# Fixture: the reviewer's mutation - +crash inside a string of another
+# command on the same line (flagged: not an argument of the launch).
+$ExePath = 'C:\b1\Wintty.exe'
+Write-Host "docs: +crash exits before the guard" ; Start-Process -FilePath $ExePath -ArgumentList '+list-themes'

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/crash-only/crash-fixture-with-crash.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/crash-only/crash-fixture-with-crash.ps1
@@ -1,0 +1,6 @@
+# Fixture: every launch leg carries +crash (clean).
+$ExePath = 'C:\b1\Wintty.exe'
+Start-Process -FilePath $ExePath -ArgumentList '+crash', 'handled-storm'
+Start-Process -FilePath $ExePath `
+    -ArgumentList '+crash', 'native-seh' `
+    -WorkingDirectory 'C:\b1'

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/crash-only/crash-fixture-without-crash.ps1
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/crash-only/crash-fixture-without-crash.ps1
@@ -1,0 +1,5 @@
+# Fixture: one leg is missing +crash (flagged): that leg would run fully
+# unguarded while the file rides the crash-only allowlist.
+$ExePath = 'C:\b1\Wintty.exe'
+Start-Process -FilePath $ExePath -ArgumentList '+crash', 'handled-storm'
+Start-Process -FilePath $ExePath -WorkingDirectory 'C:\b1'

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/hatch/justfile
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/hatch/justfile
@@ -1,0 +1,3 @@
+# Fixture: a recipe baking in the hatch (RED: must be flagged).
+hatch-probe:
+    pwsh -NoProfile -Command "$env:WINTTY_TEST_HOST_UNARMED = '1'; dotnet test windows/Ghostty.Tests/Ghostty.Tests.csproj"

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-agents-launcher.py
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-agents-launcher.py
@@ -1,0 +1,3 @@
+# Fixture: an unarmed .agents-style python launcher (RED: must be flagged).
+import subprocess
+subprocess.run([r'C:\b1\Wintty.exe', '--flag'])

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-armed-bare-cmd.cmd
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-armed-bare-cmd.cmd
@@ -2,4 +2,4 @@
 rem Control: the same bare launch, armed in-file, stays clean.
 set WINTTY_TEST_CONFIG=1
 set XDG_CONFIG_HOME=%TEMP%\wintty-ok-%RANDOM%
-C:1\Wintty.exe --flag
+C:\b1\Wintty.exe --flag

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-armed-bare-cmd.cmd
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-armed-bare-cmd.cmd
@@ -1,0 +1,5 @@
+@echo off
+rem Control: the same bare launch, armed in-file, stays clean.
+set WINTTY_TEST_CONFIG=1
+set XDG_CONFIG_HOME=%TEMP%\wintty-ok-%RANDOM%
+C:1\Wintty.exe --flag

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-armed-bare-nu.nu
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-armed-bare-nu.nu
@@ -1,0 +1,4 @@
+# Control: the same bare run, armed in-file, stays clean.
+export WINTTY_TEST_CONFIG = "1"
+export XDG_CONFIG_HOME = $env.TEMP + "/wintty-ok-" + (random)
+Wintty.exe --flag

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-armed-bare-sh.sh
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-armed-bare-sh.sh
@@ -1,0 +1,4 @@
+# Control: the same bare launch, armed in-file, stays clean.
+export WINTTY_TEST_CONFIG=1
+export XDG_CONFIG_HOME="${TMPDIR:-/tmp}/wintty-ok-$$"
+Wintty.exe --flag

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-armed-ci.yml
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-armed-ci.yml
@@ -1,0 +1,7 @@
+# Control: the CI job declares the arming token; the run step stays clean.
+env:
+  WINTTY_TEST_CONFIG: "1"
+steps:
+  - name: smoke
+    run: |
+      C:\b1\Wintty.exe --flag

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-armed-inline-run.yml
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-armed-inline-run.yml
@@ -1,0 +1,6 @@
+# Control: inline run step with the job env token stays clean.
+env:
+  WINTTY_TEST_CONFIG: "1"
+steps:
+  - name: smoke
+    run: C:1\Wintty.exe --flag

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-armed-launcher.py
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-armed-launcher.py
@@ -1,0 +1,5 @@
+# Control: the same launcher with an in-file arming token stays clean.
+import os, subprocess
+os.environ['WINTTY_TEST_CONFIG'] = '1'
+os.environ['XDG_CONFIG_HOME'] = os.path.join(os.environ['TEMP'], 'wintty-ok-' + os.urandom(8).hex())
+subprocess.run([r'C:\b1\Wintty.exe', '--flag'])

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-armed-posix-spawn.py
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-armed-posix-spawn.py
@@ -1,0 +1,4 @@
+# Control: posix_spawn with an in-file arming token stays clean.
+import os
+os.environ["WINTTY_TEST_CONFIG"] = "1"
+os.posix_spawn(r"C:1\Wintty.exe", [r"C:1\Wintty.exe"], os.environ)

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-bare-cmd.cmd
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-bare-cmd.cmd
@@ -1,0 +1,3 @@
+@echo off
+rem Fixture: bare exe line (RED: must be flagged).
+C:1\Wintty.exe --flag

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-bare-cmd.cmd
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-bare-cmd.cmd
@@ -1,3 +1,3 @@
 @echo off
 rem Fixture: bare exe line (RED: must be flagged).
-C:1\Wintty.exe --flag
+C:\b1\Wintty.exe --flag

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-bare-nu.nu
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-bare-nu.nu
@@ -1,0 +1,2 @@
+# Fixture: bare external run (RED: must be flagged).
+Wintty.exe --flag

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-bare-sh.sh
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-bare-sh.sh
@@ -1,0 +1,2 @@
+# Fixture: bare exe line (RED: must be flagged).
+Wintty.exe --flag

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-ci-step.yml
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-ci-step.yml
@@ -1,0 +1,5 @@
+# Fixture: an unarmed CI run step (RED: must be flagged).
+steps:
+  - name: smoke
+    run: |
+      C:\b1\Wintty.exe --flag

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-cmd-launcher.cmd
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-cmd-launcher.cmd
@@ -1,0 +1,2 @@
+rem Fixture: an unarmed cmd launcher (RED: must be flagged).
+start "" C:\b1\Wintty.exe --flag

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-inline-run.yml
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-inline-run.yml
@@ -1,0 +1,4 @@
+# Fixture: inline run step (RED: must be flagged).
+steps:
+  - name: smoke
+    run: C:1\Wintty.exe --flag

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-orElse-cmd.cmd
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-orElse-cmd.cmd
@@ -1,0 +1,3 @@
+@echo off
+rem Fixture: bare exe after || (RED: must be flagged).
+robocopy nul nul || C:\b1\Wintty.exe --flag

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-orElse-sh.sh
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-orElse-sh.sh
@@ -1,0 +1,2 @@
+# Fixture: bare exe after || (RED: must be flagged).
+false || Wintty.exe --flag

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-posix-spawn.py
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-posix-spawn.py
@@ -1,0 +1,3 @@
+# Fixture: os.posix_spawn of the app (RED: must be flagged).
+import os
+os.posix_spawn(r".." + r"C:1\Wintty.exe", [r"C:1\Wintty.exe"], os.environ)

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-semicolon-cmd.cmd
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-semicolon-cmd.cmd
@@ -1,0 +1,3 @@
+@echo off
+rem Fixture: bare exe after a semicolon (RED: must be flagged).
+verify other 2>nul & echo ok ; C:\b1\Wintty.exe --flag

--- a/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-semicolon-sh.sh
+++ b/windows/Ghostty.Tests/Wiring/ScanFixtures/outside-scripts/outside-semicolon-sh.sh
@@ -1,0 +1,2 @@
+# Fixture: bare exe after a semicolon (RED: must be flagged).
+true ; Wintty.exe --flag

--- a/windows/Ghostty.Tests/Wiring/TestConfigGuardWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TestConfigGuardWiringTests.cs
@@ -56,6 +56,32 @@ public class TestConfigGuardWiringTests
             $"InitGhostty ({firstInit.Span.Start}) in MainImpl");
     }
 
+    /// <summary>
+    /// The env seam, pinned from the source (re-review finding 1): the
+    /// ReadEnvironment property must be declared INTERNAL - a public
+    /// settable static lets production code swap the guard's environment
+    /// source out from under the guard - and its initializer must be the
+    /// live ProcessEnvironment reader, not a constant or a snapshot. The
+    /// behaviour half of the pin lives in
+    /// <c>Config.TestConfigGuardDefaultReaderTests</c>.
+    /// </summary>
+    [Fact]
+    public void The_Env_Seam_Stays_Internal_And_Live()
+    {
+        var source = ShellSource.Load("Config.TestConfigGuard.cs");
+        var property = source.Root.DescendantNodes()
+            .OfType<PropertyDeclarationSyntax>()
+            .Single(p => p.Identifier.ValueText == "ReadEnvironment");
+
+        Assert.Contains("internal static", property.Modifiers.ToString(),
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("public", property.Modifiers.ToString(),
+            StringComparison.Ordinal);
+        Assert.Equal(
+            "Environment.GetEnvironmentVariable",
+            property.Initializer?.Value.ToString());
+    }
+
     [Fact]
     public void GuardTestConfigRoot_Exits_With_Its_Own_Refusal_Code()
     {

--- a/windows/build/TestHostArming.cs
+++ b/windows/build/TestHostArming.cs
@@ -32,12 +32,31 @@ internal static class TestHostArming
 
     private static string? Root;
 
+    /// <summary>
+    /// What the initializer decided, recorded at host start: the arming
+    /// tests assert on THIS snapshot, so nothing another test does to the
+    /// live environment mid-run can flip them (review finding M1).
+    /// </summary>
+    internal static bool Armed { get; private set; }
+
+    /// <summary>
+    /// The root the initializer created, for the arming tests' snapshot
+    /// asserts. Null under the escape hatch.
+    /// </summary>
+    internal static string? RootForTests => Root;
+
     [ModuleInitializer]
     public static void Arm()
     {
         if (Environment.GetEnvironmentVariable(UnarmedEnvVar) == "1")
         {
+            // Both sinks: stdout is swallowed by dotnet test at normal
+            // verbosity (review finding), stderr passes through there.
             Console.WriteLine(
+                "WINTTY_TEST_HOST_UNARMED=1: this test host runs WITHOUT " +
+                "config isolation. Anything it touches in a default config " +
+                "path reaches the REAL per-user config.");
+            Console.Error.WriteLine(
                 "WINTTY_TEST_HOST_UNARMED=1: this test host runs WITHOUT " +
                 "config isolation. Anything it touches in a default config " +
                 "path reaches the REAL per-user config.");
@@ -65,6 +84,7 @@ internal static class TestHostArming
             Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", root);
             Environment.SetEnvironmentVariable("WINTTY_TEST_CONFIG", "1");
             Root = root;
+            Armed = true;
 
             // Best effort, and confined to THIS root by construction: the
             // path is anchor + our own random leaf, never a caller-supplied

--- a/windows/build/TestHostArming.cs
+++ b/windows/build/TestHostArming.cs
@@ -1,0 +1,95 @@
+// Shared by every C# test project via a linked Compile item (see each
+// *.Tests.csproj). One physical file, so the four hosts cannot drift.
+//
+// Founder rule (2026-09-11): testing of all kinds in this repo must use a
+// throwaway temp config, never the real one, enforced in code. The harness
+// side arms per launch; THIS is the same rule for the in-process test
+// hosts, the one entry kind no launch scan can see (audit M1): nothing is
+// ever executed, so the arming has to live in the host process itself.
+//
+// It runs before any test: [ModuleInitializer] fires when the module
+// loads, covering dotnet test, dotnet run, the IDE, and plain vstest alike
+// (a runsettings <EnvironmentVariables> block would only cover --settings
+// invocations).
+
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+
+namespace Ghostty.Testing;
+
+internal static class TestHostArming
+{
+    /// <summary>
+    /// The one documented way out, for a test that genuinely needs a clean
+    /// host environment. Deliberately loud: the host prints a red-visible
+    /// line naming the variable, and a source-scan test forbids it being
+    /// set in any committed script, recipe or CI file, so the hatch cannot
+    /// quietly become the default.
+    /// </summary>
+    private const string UnarmedEnvVar = "WINTTY_TEST_HOST_UNARMED";
+
+    private static string? Root;
+
+    [ModuleInitializer]
+    public static void Arm()
+    {
+        if (Environment.GetEnvironmentVariable(UnarmedEnvVar) == "1")
+        {
+            Console.WriteLine(
+                "WINTTY_TEST_HOST_UNARMED=1: this test host runs WITHOUT " +
+                "config isolation. Anything it touches in a default config " +
+                "path reaches the REAL per-user config.");
+            return;
+        }
+
+        try
+        {
+            // The same anchor the app-side guard compares against: the
+            // known-folder temp, which the process environment cannot
+            // move, so an armed host stays under the boundary even when
+            // TEMP/TMP are redirected around it. The name spelling matches
+            // the harness helper (lib/test-config.ps1), with this host's
+            // own prefix so sweeps can tell them apart.
+            var anchor = Environment.GetFolderPath(
+                Environment.SpecialFolder.LocalApplicationData);
+            if (string.IsNullOrEmpty(anchor)) anchor = Path.GetTempPath();
+            anchor = Path.Combine(anchor, "Temp");
+
+            var bytes = RandomNumberGenerator.GetBytes(16);
+            var root = Path.Combine(anchor,
+                "wintty-testhost-" + Convert.ToHexString(bytes).ToLowerInvariant());
+            Directory.CreateDirectory(root);
+
+            Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", root);
+            Environment.SetEnvironmentVariable("WINTTY_TEST_CONFIG", "1");
+            Root = root;
+
+            // Best effort, and confined to THIS root by construction: the
+            // path is anchor + our own random leaf, never a caller-supplied
+            // value, so the delete cannot walk outside what this class
+            // created.
+            AppDomain.CurrentDomain.ProcessExit += (_, _) =>
+            {
+                try
+                {
+                    if (Root is { } r && Directory.Exists(r))
+                        Directory.Delete(r, recursive: true);
+                }
+                catch
+                {
+                    // A held file or a host killed mid-run leaves the root
+                    // behind; that is leak, not taint, and the anchor sweep
+                    // pattern (24h) is the reaper if one is ever wanted.
+                }
+            };
+        }
+        catch
+        {
+            // Arming must never break the host: if the environment cannot
+            // be set, the tests run exactly as they did before this class
+            // existed. The arming test fails loudly in that case.
+        }
+    }
+}


### PR DESCRIPTION
## What

Every kind of testing in this repo now runs on a throwaway temp config (audit follow-up: M1, M2, L3 of C:\wt\audit-fork-isolation.md).

- The four C# test hosts (Ghostty.Tests, Ghostty.Tests.Windows, IconGen.Tests, SplashGen.Tests) arm themselves: one shared `[ModuleInitializer]` (windows/build/TestHostArming.cs, linked into every host) creates `%LOCALAPPDATA%\Temp\wintty-testhost-<random hex>` and sets `XDG_CONFIG_HOME` plus `WINTTY_TEST_CONFIG=1` for the host process before any test runs, and removes the root at host exit. This is the one entry class no launch scan can see, because nothing is ever executed; the enforcement lives in the host itself. The single escape hatch is `WINTTY_TEST_HOST_UNARMED=1` for a genuinely clean-env run: using it prints a loud warning naming the variable, and a scan forbids it appearing in any committed script, recipe or CI file.
- The +crash-only allowlist is pinned to its invariant: every app-launch statement in crash-canary.ps1 and crash-matrix.ps1 must carry `+crash` (the interception that exits before the guard and InitGhostty). A second leg without `+crash` now fails the scan instead of riding the allowlist unguarded.
- The source scan's sweep widened beyond windows/scripts: .agents, tools, test, dist, the repo root and .github, over ps1/py/nu/sh/cmd/bat/yml. PowerShell files get the full per-site machinery; other languages get the literal-plus-token rule (a launch hint plus the app exe is a launch; clean only with an in-file WINTTY_TEST_CONFIG token), with a yaml `run:` block counting as the launch form itself.

## Why

Founder rule (2026-09-11): "regarding test isolation, make sure that also testing that happens in wintty repo, of all kind, including seam driven fuz, etc, has the same mechanism where we do not modify the real config but we use temp configs", and "enforce the tmp config with code, not memory or directives". The audit found the guard and harness arming from #1084 intact, but the in-process test hosts unarmed and unenforceable by any launch scan (M1), the crash allowlist resting on an unpinned interception (M2), and the scan blind to every tree and language outside windows/scripts (L3).

## Fix round 1 (review rev1093-report)

- M1: the guard's env reads are injectable (`TestConfigGuard.ReadEnvironment`), so `TestConfigGuardTests` never mutates the live environment (no concurrent collection can be transiently disarmed); the arming tests assert on the initializer's startup snapshot and read the live env only from a `DisableParallelization` collection. Flaky pair RED 1/40 under 4-way concurrency, then 30/30 consecutive green.
- M2: the outside-trees sweep covers the idiomatic spellings it was blind to: bare exe lines in cmd/bat/sh/nu (command position), the python spawn/exec family (`os.posix_spawn`, `os.spawn*`, `os.exec*`), and yaml's inline `- run: Wintty.exe ...`. Five reviewer probes are now RED-pinned fixtures, each with an armed control; the 58 real files stay clean.
- M3: the +crash pin parses the launch segment's ARGUMENT tokens (comments stripped, statements split on `;`, the verb-carrying segment selected, quotes/commas trimmed), so `+crash` in a trailing comment or in another command's string no longer satisfies it. Both reviewer mutations are RED fixtures.
- Lows: the hatch scan sweeps the root justfile and every justfile in the repo (RED by mutation on the real justfile, restored byte-identical); the unarmed warning is the arming assert's own message because BOTH console sinks are swallowed at normal dotnet test verbosity (proven by running), and it now reads "test host UNARMED via WINTTY_TEST_HOST_UNARMED ...".

Narrow: 51/51 (scan + guard + host + no-config-editor). Full just test-win after the round: 3968 + 47 + 73 + 42 passed, 0 failed.

## Fix round 2 (re-review 1: two Lows)

- The `ReadEnvironment` seam is `internal` (tests reach it via InternalsVisibleTo), pinned twice: a behaviour test whose live-write probe fails on any non-live default (mutation-RED proven), and a source pin asserting internal modifiers plus the exact `Environment.GetEnvironmentVariable` initializer.
- `CommandPositionPrefix` spells `;` and `||` as their own alternatives, allows quoted tokens before the exe (`start "" C:\...\Wintty.exe`), and treats a pure-path prefix as command position. RED fixtures: bare exe after `;` and after `||`, in cmd and sh. Also fixed: the optional-quotes clause used `""` in a verbatim string (ONE quote, not two) so it never matched `start ""` paths; two fixtures whose bytes were mangled at creation were rewritten clean.

Narrow: 53/53; full Ghostty.Tests 3970/0/1.

## Test plan (red first, then green)

- Host arming: a new test asserting `TestConfigGuard.IsArmed`, `XDG_CONFIG_HOME` under the known-folder temp anchor, and a `wintty-testhost-<hex>` leaf failed 2/2 on the current head, passed 2/2 after the initializer. The full `just test-win` then ran green across all four hosts (3970 + 47 + 73 + 42 passed), proving no existing test depended on a clean host environment; `TestConfigGuardTests` (which saves and restores the env var per test) included.
- Crash pin: the fixture pair first (every leg +crash clean; one leg without +crash flagged), then a mutation probe: `+crash` stripped from the real crash-matrix.ps1 failed the scan naming crash-matrix.ps1:249, and the restored file passed.
- Wide sweep: fixture corpus of an unarmed .agents python launcher, an unarmed cmd launcher and an unarmed CI run step (each flagged, plus armed python and CI controls staying clean), then the real trees swept (50 files) with zero findings, matching the audit's "no launch sites there today". Two false positives found and fixed on the way: `$timer.Start()` matched the bare `start` alias (now excluded behind a dot) and `$latest.FullName` fail-closed on a member read (member reads of non-target properties are no longer fail-closed).
- Final counts: scan class 12/12, full Ghostty.Tests 3972 passed / 0 failed / 1 skipped.
- No signoff ladder run: per the founder rule the controller runs the single full ladder on the final, review-cleared head.


