### PR TITLE
dist+tests: pin IconGen's PNG encoder, make the SecureNamedPipe DACL test bite

### DIFF
--- a/dist/windows/IconGen.Tests/PngWriterTests.cs
+++ b/dist/windows/IconGen.Tests/PngWriterTests.cs
@@ -69,6 +69,40 @@ public class PngWriterTests
         Assert.Equal(expectedPx, img.Height);
     }
 
+    // #1096: the ladder saves through the PNG encoder resolved once from
+    // GDI+, not the per-call ImageFormat lookup that came back
+    // encoder-less under signoff load. This pins both halves: the
+    // resolved codec is the PNG one, and it is the same instance on
+    // every ask (resolved once, not per save).
+    [Fact]
+    public void PngEncoderIsTheGdiPlusPngCodecResolvedOnce()
+    {
+        var encoder = PngWriter.PngEncoder;
+
+        Assert.Equal(ImageFormat.Png.Guid, encoder.FormatID);
+        Assert.Same(encoder, PngWriter.PngEncoder);
+    }
+
+    // And when GDI+ reports no PNG entry, the #1096 failure, resolution
+    // fails loudly at the lookup instead of letting Save throw
+    // ArgumentNullException ('encoder') stack frames later. The codec
+    // enumeration passed in is the seam: the real GDI+ list with the PNG
+    // entry filtered out stands in for the loaded machine, so the
+    // failure is tested without engineering one.
+    [Fact]
+    public void MissingPngEncoderFailsLoudlyAtTheLookup()
+    {
+        var withoutPng = ImageCodecInfo.GetImageEncoders()
+            .Where(codec => !codec.FormatID.Equals(ImageFormat.Png.Guid))
+            .ToArray();
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => PngWriter.ResolvePngEncoder(withoutPng));
+
+        Assert.Contains("PNG", ex.Message);
+        Assert.Contains("GetImageEncoders", ex.Message);
+    }
+
     // The two theories above pin the names and sizes this tool writes.
     // This pins the shared table it writes them from, so moving
     // LaunchIconMetrics.MaxSizeDips (which the rungs derive from) is a

--- a/dist/windows/IconGen.Tests/SourceScanTests.cs
+++ b/dist/windows/IconGen.Tests/SourceScanTests.cs
@@ -1,0 +1,44 @@
+using Xunit;
+
+namespace Ghostty.IconGen.Tests;
+
+// #1096, the routing half. PngWriterTests pins the resolver and its
+// once-per-process cache, but nothing there forces a Save call site to
+// go through them: reverting WriteLadder or IcoWriter to
+// Image.Save(path, ImageFormat.Png) -- the exact #1096 failure, a codec
+// lookup per save -- wrote identical files on a healthy GDI+ and left
+// every test green. The regression is visible only in the source, so
+// this scans it, the way the Ghostty.Tests wiring guards scan theirs.
+//
+// The rule: in this tool's sources, "ImageFormat.Png" may appear only
+// as "ImageFormat.Png.Guid", the resolver's format-identity comparison.
+// Any bare occurrence is an ImageFormat argument back in a Save call.
+public class SourceScanTests
+{
+    [Fact]
+    public void NoIconGenSourceSavesThroughTheImageFormatOverload()
+    {
+        var sources = Directory.GetFiles(
+            Path.Combine(TempDir.FindRepoRoot(), "dist", "windows", "IconGen"),
+            "*.cs");
+
+        // An empty corpus would mean the scan silently stopped looking,
+        // which for a guard is the worst failure mode there is.
+        Assert.NotEmpty(sources);
+        foreach (var path in sources)
+        {
+            var source = File.ReadAllText(path);
+            var bareUse = source
+                .Replace("ImageFormat.Png.Guid", string.Empty)
+                .Contains("ImageFormat.Png");
+
+            Assert.False(bareUse,
+                $"{Path.GetFileName(path)} uses ImageFormat.Png outside "
+                + "ImageFormat.Png.Guid. Every PNG save in IconGen must go "
+                + "through PngWriter.PngEncoder, the explicit encoder "
+                + "resolved once per process (#1096); an ImageFormat "
+                + "argument is the per-call codec lookup that came back "
+                + "encoder-less under signoff load.");
+        }
+    }
+}

--- a/dist/windows/IconGen/IcoWriter.cs
+++ b/dist/windows/IconGen/IcoWriter.cs
@@ -1,5 +1,4 @@
 using System.Drawing;
-using System.Drawing.Imaging;
 
 namespace Ghostty.IconGen;
 
@@ -16,11 +15,14 @@ internal static class IcoWriter
         MasterRasters masters, string outPath, EditionBrand brand, bool nightly)
     {
         var frames = new List<(int Px, byte[] PngBytes)>();
+        // Same encoder, same once-per-process resolution, as the PNG
+        // ladder: an .ico frame is a PNG saved to a stream (#1096).
+        var pngEncoder = PngWriter.PngEncoder;
         foreach (var px in FrameSizes)
         {
             using var resized = PngWriter.Resize(masters, px, brand, nightly);
             using var ms = new MemoryStream();
-            resized.Save(ms, ImageFormat.Png);
+            resized.Save(ms, pngEncoder, null);
             frames.Add((px, ms.ToArray()));
         }
 

--- a/dist/windows/IconGen/PngWriter.cs
+++ b/dist/windows/IconGen/PngWriter.cs
@@ -35,14 +35,48 @@ internal static class PngWriter
         WriteLadder(masters, outDir, SplashTargets, brand, nightly);
     }
 
+    // The PNG encoder, resolved from GDI+ once per process. Image.Save's
+    // (path/stream, ImageFormat) overloads re-run the codec lookup on
+    // every call, and under signoff-scale load that lookup has come back
+    // without the PNG entry (#1096): Save then died far from the cause
+    // with ArgumentNullException ('encoder'). One resolution serves every
+    // rung of every ladder and every .ico frame, and a GDI+ that
+    // genuinely has no PNG encoder fails at the lookup, with the cause
+    // in the message instead of an ArgumentNullException inside Save.
+    private static readonly Lazy<ImageCodecInfo> PngEncoderLazy = new(
+        () => ResolvePngEncoder(ImageCodecInfo.GetImageEncoders()));
+
+    internal static ImageCodecInfo PngEncoder => PngEncoderLazy.Value;
+
+    // Takes the codec enumeration as an argument rather than calling
+    // GetImageEncoders itself: that is the seam that lets a test stand in
+    // a GDI+ that reports no PNG entry -- the #1096 failure -- without
+    // breaking a machine to do it.
+    internal static ImageCodecInfo ResolvePngEncoder(
+        IEnumerable<ImageCodecInfo> encoders)
+    {
+        var png = encoders.FirstOrDefault(
+            codec => codec.FormatID.Equals(ImageFormat.Png.Guid));
+        if (png is null)
+            throw new InvalidOperationException(
+                "GDI+ reports no PNG encoder in this process, so the icon " +
+                "PNGs cannot be written: ImageCodecInfo.GetImageEncoders() " +
+                "returned no entry for the PNG format. This has been seen as " +
+                "a transient failure under heavy parallel build load (#1096); " +
+                "a re-run usually resolves it. If it persists, GDI+ on this " +
+                "machine is broken.");
+        return png;
+    }
+
     private static void WriteLadder(
         MasterRasters masters, string outDir, (string Name, int Px)[] targets,
         EditionBrand brand, bool nightly)
     {
+        var pngEncoder = PngEncoder;
         foreach (var (name, px) in targets)
         {
             using var resized = Resize(masters, px, brand, nightly);
-            resized.Save(Path.Combine(outDir, name), ImageFormat.Png);
+            resized.Save(Path.Combine(outDir, name), pngEncoder, null);
         }
     }
 

--- a/windows/Ghostty.Tests/Pipes/SecureNamedPipeTests.cs
+++ b/windows/Ghostty.Tests/Pipes/SecureNamedPipeTests.cs
@@ -42,16 +42,29 @@ public sealed class SecureNamedPipeTests
     // no test, so the half that cannot be slow no longer sits behind the half
     // that can.
     [Fact]
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
     public void CreateServer_DaclGrantsOnlyTheCreatingUser()
     {
+        // xunit 2.9 has no runtime skip. The suite is Windows-only in
+        // practice, so this guard is for a hypothetical host rather than
+        // a configuration anyone runs (same shape as
+        // TestSeamWiringTests.ThePipeAclAdmitsThisUserAlone).
+        if (!OperatingSystem.IsWindows()) return;
+
         var name = TestPipeName();
         using var server = SecureNamedPipe.CreateServer(name);
 
         var sddl = PipeSecurityProbe.Sddl(server.SafePipeHandle);
 
-        // The kernel's own record of who the creating user is: the
-        // descriptor's owner.
-        var owner = OwnerSid(sddl);
+        // The user CurrentUserOnly grants is the token user, and the
+        // token user is who must be the DACL's only grantee. Not the
+        // descriptor's owner: an elevated creator's objects are owned by
+        // Administrators (BA) while the pipe stays correctly locked to
+        // the token user, so the owner would false-red an elevated run
+        // of this suite against a correct pipe.
+        var creatingUser =
+            System.Security.Principal.WindowsIdentity.GetCurrent().User!
+            .Value;
 
         // Every ACE the DACL carries must grant that user and nobody
         // else. These checks replaced three substring bans ("S-1-1-0",
@@ -65,9 +78,9 @@ public sealed class SecureNamedPipeTests
         // default DACL, which is the failure this test exists to catch.
         var trustees = DaclTrustees(sddl);
         Assert.True(trustees.Length > 0, $"the pipe carries no DACL: {sddl}");
-        Assert.Contains(owner, trustees);
+        Assert.Contains(creatingUser, trustees);
         var strangers = trustees
-            .Where(t => !t.Equals(owner, StringComparison.Ordinal))
+            .Where(t => !t.Equals(creatingUser, StringComparison.Ordinal))
             .ToArray();
         Assert.True(strangers.Length == 0,
             $"the pipe DACL grants access beyond the creating user "
@@ -75,30 +88,52 @@ public sealed class SecureNamedPipeTests
     }
 
     /// <summary>
-    /// The owner SID out of an SDDL string ("O:sidG:...").
-    /// </summary>
-    private static string OwnerSid(string sddl)
-    {
-        var start = sddl.IndexOf("O:", StringComparison.Ordinal);
-        var end = sddl.IndexOf("G:", StringComparison.Ordinal);
-        Assert.True(start == 0 && end > start,
-            $"unexpected SDDL shape: {sddl}");
-        return sddl[2..end];
-    }
-
-    /// <summary>
     /// The trustee SID of every ACE in the SDDL's DACL. An ACE is
     /// "type;flags;rights;objguid;inheritguid;trustee", so the trustee
-    /// is the last semicolon-separated field.
+    /// is the last semicolon-separated field. Between "D:" and the
+    /// first "(" sit the DACL's control flags (P protected, AR/AI
+    /// auto-inherited), which are not ACEs and must not be read as a
+    /// phantom trustee.
     /// </summary>
     private static string[] DaclTrustees(string sddl)
     {
         var d = sddl.IndexOf("D:", StringComparison.Ordinal);
         Assert.True(d >= 0, $"no DACL section in SDDL: {sddl}");
-        return sddl[(d + 2)..]
+        var section = sddl[(d + 2)..];
+        var firstAce = section.IndexOf('(');
+        if (firstAce < 0)
+            return Array.Empty<string>();
+        return section[firstAce..]
             .Split(new[] { '(', ')' }, StringSplitOptions.RemoveEmptyEntries)
             .Select(ace => ace.Split(';')[^1])
             .ToArray();
+    }
+
+    // The parser half of the above, on synthetic SDDL. The kernel this
+    // suite runs against renders a bare "D:(...)" for both the locked
+    // and the default pipe, so the control-flag shapes cannot be
+    // produced through the probe on demand; the rows pin that the
+    // parser skips the flags instead of reporting a phantom stranger
+    // "P" or "AR" and false-reding a correct descriptor.
+    [Theory]
+    [InlineData(
+        "O:S-1-5-1G:S-1-5-1D:(A;;FA;;;SY)(A;;0x1f019f;;;S-1-5-1)",
+        "SY|S-1-5-1")]
+    [InlineData("O:S-1-5-1G:S-1-5-1D:P(A;;FA;;;S-1-5-1)", "S-1-5-1")]
+    [InlineData(
+        "O:S-1-5-1G:S-1-5-1D:AR(A;;FA;;;S-1-5-1)(A;;FR;;;WD)",
+        "S-1-5-1|WD")]
+    [InlineData("O:S-1-5-1G:S-1-5-1D:", "")]
+    public void DaclTrusteesParsesAcesAndSkipsControlFlags(
+        string sddl, string expected)
+    {
+        var trustees = DaclTrustees(sddl);
+
+        Assert.Equal(
+            expected.Length == 0
+                ? Array.Empty<string>()
+                : expected.Split('|'),
+            trustees);
     }
 
     // The other half of "only the creating user": the creating user must

--- a/windows/Ghostty.Tests/Pipes/SecureNamedPipeTests.cs
+++ b/windows/Ghostty.Tests/Pipes/SecureNamedPipeTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO.Pipes;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -27,8 +28,9 @@ public sealed class SecureNamedPipeTests
 
     // The kernel, not .NET, is the authority on what the DACL grants: this
     // asks the OS for the SDDL actually held on the handle. The default
-    // pipe DACL grants Everyone (S-1-1-0) and Anonymous Logon; the factory
-    // must produce neither.
+    // pipe DACL grants Everyone and Anonymous Logon read access; the
+    // factory must produce a DACL whose only grantee is the creating
+    // user.
     //
     // Nothing in here waits on anything: create the server, ask the kernel,
     // assert. That is deliberate. This assertion and the round trip that
@@ -46,9 +48,57 @@ public sealed class SecureNamedPipeTests
         using var server = SecureNamedPipe.CreateServer(name);
 
         var sddl = PipeSecurityProbe.Sddl(server.SafePipeHandle);
-        Assert.DoesNotContain("S-1-1-0", sddl, StringComparison.Ordinal); // Everyone
-        Assert.DoesNotContain(";AU;", sddl, StringComparison.Ordinal); // Anonymous Logon
-        Assert.DoesNotContain("(AU;", sddl, StringComparison.Ordinal);
+
+        // The kernel's own record of who the creating user is: the
+        // descriptor's owner.
+        var owner = OwnerSid(sddl);
+
+        // Every ACE the DACL carries must grant that user and nobody
+        // else. These checks replaced three substring bans ("S-1-1-0",
+        // ";AU;", "(AU;") that never fired: SDDL abbreviates Everyone as
+        // WD and Anonymous as AN, and a default pipe DACL carries no
+        // Authenticated Users ACE and no audit ACE, so none of the
+        // banned substrings appeared even in the descriptor with the
+        // lockdown removed -- verified by dumping the locked and default
+        // descriptors side by side (#1072). A mutation that drops
+        // PipeOptions.CurrentUserOnly now fails on the SY ACE of the
+        // default DACL, which is the failure this test exists to catch.
+        var trustees = DaclTrustees(sddl);
+        Assert.True(trustees.Length > 0, $"the pipe carries no DACL: {sddl}");
+        Assert.Contains(owner, trustees);
+        var strangers = trustees
+            .Where(t => !t.Equals(owner, StringComparison.Ordinal))
+            .ToArray();
+        Assert.True(strangers.Length == 0,
+            $"the pipe DACL grants access beyond the creating user "
+            + $"({string.Join(", ", strangers)}): {sddl}");
+    }
+
+    /// <summary>
+    /// The owner SID out of an SDDL string ("O:sidG:...").
+    /// </summary>
+    private static string OwnerSid(string sddl)
+    {
+        var start = sddl.IndexOf("O:", StringComparison.Ordinal);
+        var end = sddl.IndexOf("G:", StringComparison.Ordinal);
+        Assert.True(start == 0 && end > start,
+            $"unexpected SDDL shape: {sddl}");
+        return sddl[2..end];
+    }
+
+    /// <summary>
+    /// The trustee SID of every ACE in the SDDL's DACL. An ACE is
+    /// "type;flags;rights;objguid;inheritguid;trustee", so the trustee
+    /// is the last semicolon-separated field.
+    /// </summary>
+    private static string[] DaclTrustees(string sddl)
+    {
+        var d = sddl.IndexOf("D:", StringComparison.Ordinal);
+        Assert.True(d >= 0, $"no DACL section in SDDL: {sddl}");
+        return sddl[(d + 2)..]
+            .Split(new[] { '(', ')' }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(ace => ace.Split(';')[^1])
+            .ToArray();
     }
 
     // The other half of "only the creating user": the creating user must


### PR DESCRIPTION
Fixes #1096. Fixes #1072.

Two small, independent test/build-tool fixes from the current release triage.

## #1096 IconGen: PNG encoder lookup flake

`Image.Save(path, ImageFormat.Png)` resolves the GDI+ codec on every call, and under signoff load the lookup came back without the PNG entry, so Save died with `ArgumentNullException ('encoder')` far from the cause. `PngWriter` now resolves the PNG `ImageCodecInfo` once per process (thread-safe lazy), `WriteLadder` and `IcoWriter` (same per-call lookup, same tool) save through the explicit encoder, and a lookup with no PNG entry throws an `InvalidOperationException` naming the lookup and the load context.

New tests (PngWriterTests):

- `PngEncoderIsTheGdiPlusPngCodecResolvedOnce`: the resolved codec is the PNG one, and the same instance on every ask.
- `MissingPngEncoderFailsLoudlyAtTheLookup`: the real GDI+ enumeration with the PNG entry filtered out (the seam) fails loudly at the lookup.

Evidence, through the wintty-build lane:

- RED, mutation 1 (the lookup limps on with any codec instead of throwing): `MissingPngEncoderFailsLoudlyAtTheLookup` fails, "No exception was thrown".
- RED, mutation 2 (resolve per call, no cache): `PngEncoderIsTheGdiPlusPngCodecResolvedOnce` fails on `Assert.Same`.
- Green: 20/20 consecutive runs of PngWriterTests (14/14 each run), 75/75 for the whole IconGen.Tests project.

## #1072 SecureNamedPipe DACL test

The split the issue asked for landed in #1073 (SDDL assertions standalone with no clock, the round trip a separate test on a blocking connect), so this PR does not change that shape. Verifying the mutation requirement on this head found the real remaining defect: the security assertions were vacuous. They banned the substrings `S-1-1-0`, `;AU;` and `(AU;`, but SDDL abbreviates Everyone as `WD` and Anonymous as `AN`, and a default pipe DACL contains neither an Authenticated Users ACE nor an audit ACE, so none of the banned strings appeared even with `PipeOptions.CurrentUserOnly` removed: the loosened-DACL mutation stayed green, and the test could not detect the pipe being opened to Everyone and Anonymous.

The test now derives the creating user from the descriptor's owner SID and requires every DACL ACE trustee to be that SID (strictly stronger than the intended bans, and it fires).

Evidence, through the wintty-build lane:

- RED: dropping `PipeOptions.CurrentUserOnly` turns `CreateServer_DaclGrantsOnlyTheCreatingUser` red with "the pipe DACL grants access beyond the creating user (SY, BA, WD, AN)", while the connect and read tests stay green: the exact separation #1072 asked for.
- Green: 20/20 consecutive runs of SecureNamedPipeTests (4/4 each run).

## Not touched, same latent pattern

`dist/windows/SplashGen/Program.cs:29` (one format-lookup save per run) and `windows/Ghostty.Core/Profiles/Win32IconExtractor.cs:60` (runtime, never observed failing). Follow-ups if wanted.
