### PR TITLE
windows: pid in file log lines + WINTTY_STATE_BASE (multi-instance items 8, 9)

### DIFF
--- a/windows/Ghostty.Core/AppStateBase.cs
+++ b/windows/Ghostty.Core/AppStateBase.cs
@@ -1,0 +1,107 @@
+using System;
+
+namespace Ghostty.Core;
+
+/// <summary>
+/// The root every <see cref="AppIdentity"/>-derived state path is built
+/// on: the per-user known folder, or the <c>WINTTY_STATE_BASE</c>
+/// override when it is set.
+///
+/// The override exists for processes, not users: Wintty is multi-process
+/// and every process of an edition shares one set of state files, so a
+/// harness that needs two instances with separate state (#822's
+/// GUI-level multi-instance tests) or a launch that must not touch the
+/// real per-user tree has no other lever -- the paths were resolved
+/// straight from the known-folder API at each call site, compile-time in
+/// effect, with nothing in the environment able to move them. Setting
+/// <c>WINTTY_STATE_BASE</c> to a directory moves every one of those
+/// paths under it at once, both the <c>LocalApplicationData</c> half
+/// (logs, crash.log, gpu.log, icon cache, discovery cache) and the
+/// <c>ApplicationData</c> half (session.json, window-state.json,
+/// command frecency), keeping the <see cref="AppIdentity.StateDirName"/>
+/// layout segment so an overridden tree reads exactly like a real one.
+///
+/// What it deliberately does NOT move: the config tree (that is
+/// <c>XDG_CONFIG_HOME</c>'s job, guarded by
+/// <c>Ghostty.Core.Config.TestConfigGuard</c>), and libghostty's own
+/// caches, which the native side resolves without this class. A launch
+/// that needs both moved sets sets both variables.
+///
+/// A user's install never sets the variable and must never notice this
+/// class exists: unset, null, empty or whitespace-only all mean "use the
+/// real known folder", which is byte-for-byte the behaviour the call
+/// sites had before the override.
+/// </summary>
+internal static class AppStateBase
+{
+    /// <summary>
+    /// The env var that overrides the state root. Its value is the
+    /// directory itself (not a flag spelling), read on every resolution:
+    /// the decision belongs to whoever launched this process, and a test
+    /// flipping the variable between calls is the cheapest red/green
+    /// pair there is.
+    /// </summary>
+    public const string EnvVar = "WINTTY_STATE_BASE";
+
+    /// <summary>
+    /// The one place the environment is read, so tests can inject a
+    /// dictionary instead of mutating the real process environment.
+    /// Mutating the real environment from a test races every
+    /// concurrently running collection and transiently redirects every
+    /// other test's state paths; an injected reader touches nothing
+    /// outside the test itself. INTERNAL on purpose, matching
+    /// <c>TestConfigGuard.ReadEnvironment</c>: the seam exists for the
+    /// test assemblies and nothing else.
+    /// </summary>
+    internal static Func<string, string?> ReadEnvironment { get; set; } =
+        Environment.GetEnvironmentVariable;
+
+    /// <summary>
+    /// The override value, or null when it is unset or blank. The one
+    /// normalization applied is a trim: a stray space or trailing quote
+    /// from a hand-written <c>set</c> must not silently become part of
+    /// the path, and a whitespace-only value is treated as unset rather
+    /// than combined into a relative path.
+    /// </summary>
+    public static string? OverrideRoot =>
+        NormalizeOverride(ReadEnvironment(EnvVar));
+
+    /// <summary>
+    /// The pure half of <see cref="OverrideRoot"/>, separated so the
+    /// blank/trim handling is testable without touching any environment.
+    /// </summary>
+    internal static string? NormalizeOverride(string? rawValue) =>
+        string.IsNullOrWhiteSpace(rawValue) ? null : rawValue.Trim();
+
+    /// <summary>
+    /// <paramref name="realRoot"/> with the override applied: the
+    /// override when set, the argument untouched when not. For call
+    /// sites that resolve their root through an injected abstraction of
+    /// their own (the icon resolver's <c>IFileSystem.GetKnownFolder</c>)
+    /// and therefore cannot use the properties below.
+    /// </summary>
+    public static string ApplyOverride(string realRoot) =>
+        OverrideRoot ?? realRoot;
+
+    /// <summary>
+    /// The root of the local (non-roaming) state tree:
+    /// <c>%LOCALAPPDATA%</c>, or the override. May be empty exactly when
+    /// <see cref="Environment.GetFolderPath"/> returns empty (no
+    /// profile), which call sites reject rather than combine into a
+    /// relative path.
+    /// </summary>
+    public static string LocalRoot =>
+        ApplyOverride(Environment.GetFolderPath(
+            Environment.SpecialFolder.LocalApplicationData));
+
+    /// <summary>
+    /// The root of the roaming state tree: <c>%APPDATA%</c>, or the
+    /// override. With the override set, this and <see cref="LocalRoot"/>
+    /// deliberately resolve to the same directory: the override trades
+    /// the local/roaming split, which no harness needs, for one tree to
+    /// point at and delete.
+    /// </summary>
+    public static string RoamingRoot =>
+        ApplyOverride(Environment.GetFolderPath(
+            Environment.SpecialFolder.ApplicationData));
+}

--- a/windows/Ghostty.Core/Commands/FrecencyStore.cs
+++ b/windows/Ghostty.Core/Commands/FrecencyStore.cs
@@ -63,7 +63,7 @@ internal sealed partial class FrecencyStore
     }
 
     private static string FilePath => Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        AppStateBase.RoamingRoot,
         AppIdentity.StateDirName,
         "command-frecency.json");
 

--- a/windows/Ghostty.Core/Logging/FileLoggerProvider.cs
+++ b/windows/Ghostty.Core/Logging/FileLoggerProvider.cs
@@ -42,6 +42,13 @@ internal sealed class FileLoggerProvider : ILoggerProvider, IAsyncDisposable
     // Dispose() on every registered provider.
     private int _disposed;
 
+    // Read once: the pid is constant for the life of the process, and the
+    // writer loop is the hot path this class already allocates carefully
+    // for. It lands on every line (#854 item 8) because every process of
+    // an edition appends to the same day file, so an unattributable line
+    // is one nobody can act on when several instances are interleaved.
+    private readonly int _pid = Environment.ProcessId;
+
     // Reused across FormatRecord calls on the single writer task. Not
     // thread-safe, which is fine: only WriterLoopAsync touches it.
     // Caching it removes the per-record StringBuilder allocation the
@@ -414,8 +421,12 @@ internal sealed class FileLoggerProvider : ILoggerProvider, IAsyncDisposable
 
     private int FormatRecord(in LogRecord r, byte[] buffer)
     {
-        // 2026-04-17T14:23:17.042Z | Warn  | 2100 | Category | Message\r\n
+        // 2026-04-17T14:23:17.042Z | Warn  | 4312 | 2100 | Category | Message\r\n
         //   [indented stack lines on exception]
+        // The pid sits between the level and the event id, not before the
+        // level, because downstream line parsers anchor on the head:
+        // scripts/app-run-health.ps1 (#847) matches `timestamp | level |`
+        // and a field there is invisible to it.
         var sb = _formatBuilder;
         sb.Clear();
         // AppendFormat writes the timestamp directly into sb's buffer,
@@ -424,6 +435,8 @@ internal sealed class FileLoggerProvider : ILoggerProvider, IAsyncDisposable
         sb.AppendFormat(CultureInfo.InvariantCulture, "{0:yyyy-MM-ddTHH:mm:ss.fffZ}", r.Timestamp)
           .Append(" | ")
           .Append(LevelTag(r.Level))
+          .Append(" | ")
+          .Append(_pid)
           .Append(" | ")
           .Append(r.EventId.Id)
           .Append(" | ")

--- a/windows/Ghostty.Core/Profiles/WindowsIconResolver.cs
+++ b/windows/Ghostty.Core/Profiles/WindowsIconResolver.cs
@@ -216,7 +216,10 @@ internal sealed class WindowsIconResolver(IFileSystem fs) : IIconResolver
 
     private string? CachePathFor(string sha)
     {
+        // The root comes from the injected fs (tests fake the known
+        // folder), so the state-base override is applied to that value
+        // rather than read through AppStateBase.LocalRoot.
         var local = fs.GetKnownFolder(KnownFolderId.LocalAppData);
-        return local is null ? null : Path.Combine(local, AppIdentity.StateDirName, "IconCache", sha + ".png");
+        return local is null ? null : Path.Combine(AppStateBase.ApplyOverride(local), AppIdentity.StateDirName, "IconCache", sha + ".png");
     }
 }

--- a/windows/Ghostty.Tests/AppStateBaseSeamIsolationTests.cs
+++ b/windows/Ghostty.Tests/AppStateBaseSeamIsolationTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Threading;
+using Ghostty.Core;
+using Xunit;
+
+namespace Ghostty.Tests;
+
+/// <summary>
+/// The isolation half of the seam serialization pin (#854 item 9 review):
+/// while a test in the <c>AppStateBaseSeamSerial</c> collection holds a
+/// shadowed <see cref="AppStateBase.ReadEnvironment"/>, this collection,
+/// which only reads state roots the way every ordinary parallel
+/// collection does, must keep seeing the real environment.
+///
+/// <c>AppStateBase.ReadEnvironment</c> is a process-wide static seam, so
+/// a swapped reader is visible to every concurrently running collection
+/// for the duration of the test that swapped it; the serialized
+/// collection is what keeps the shadow from leaking. This test samples
+/// the override for a window and fails on the first shadowed read,
+/// which is exactly the leak that serialization exists to prevent. Its
+/// writer partner is
+/// <see cref="AppStateBaseTests.TheShadowIsHeld_ForTheParallelIsolationReader"/>,
+/// which holds a shadow for longer than this samples.
+/// </summary>
+public class AppStateBaseSeamIsolationTests
+{
+    [Fact]
+    public void WhileTheShadowIsHeld_AParallelReaderKeepsTheRealRoot()
+    {
+        var deadline = Environment.TickCount64 + 1500;
+        do
+        {
+            var shadow = AppStateBase.OverrideRoot;
+            Assert.True(shadow is null,
+                "a parallel, read-only collection saw the seam shadow " +
+                $"'{shadow}': AppStateBase.ReadEnvironment was swapped by a " +
+                "concurrent test. Every test that swaps the seam must sit in " +
+                "the AppStateBaseSeamSerial collection.");
+            Thread.Sleep(10);
+        }
+        while (Environment.TickCount64 < deadline);
+    }
+}

--- a/windows/Ghostty.Tests/AppStateBaseTests.cs
+++ b/windows/Ghostty.Tests/AppStateBaseTests.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using Ghostty.Core;
+using Xunit;
+
+namespace Ghostty.Tests;
+
+/// <summary>
+/// The state-base override's behaviour (#854 item 9): unset it changes
+/// nothing, set it replaces the known-folder root, and the blank and
+/// padded spellings a hand-written `set` produces are normalized rather
+/// than combined into the path. The wiring half -- that every state path
+/// actually goes through the helper -- lives in
+/// <c>Wiring.AppStateBaseWiringTests</c>.
+///
+/// These tests NEVER mutate the real process environment: the roots are
+/// read through <see cref="AppStateBase.ReadEnvironment"/>, and each
+/// test injects a dictionary over the real one, the same shape
+/// <c>Config.TestConfigGuardTests</c> uses. Mutating the real
+/// environment from a test races every concurrently running collection
+/// and transiently redirects every other test's state paths.
+/// </summary>
+public class AppStateBaseTests : IDisposable
+{
+    private readonly IDictionary<string, string?> _env =
+        new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+
+    public AppStateBaseTests()
+    {
+        // Layer the dictionary over the real environment: unset names
+        // fall through, set names (including null = removed) shadow it.
+        AppStateBase.ReadEnvironment = name =>
+            _env.ContainsKey(name) ? _env[name] :
+            Environment.GetEnvironmentVariable(name);
+    }
+
+    public void Dispose() =>
+        AppStateBase.ReadEnvironment = Environment.GetEnvironmentVariable;
+
+    private void Set(string? value) => _env[AppStateBase.EnvVar] = value;
+
+    private static string RealLocalRoot => Environment.GetFolderPath(
+        Environment.SpecialFolder.LocalApplicationData);
+
+    private static string RealRoamingRoot => Environment.GetFolderPath(
+        Environment.SpecialFolder.ApplicationData);
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    public void UnsetOrBlankSpellings_Keep_The_Real_Known_Folders(string? value)
+    {
+        // A user's install never sets the variable: unset and every
+        // blank spelling must be byte-for-byte the pre-override value,
+        // not the blank combined into a relative path.
+        Set(value);
+
+        Assert.Null(AppStateBase.OverrideRoot);
+        Assert.Equal(RealLocalRoot, AppStateBase.LocalRoot);
+        Assert.Equal(RealRoamingRoot, AppStateBase.RoamingRoot);
+        Assert.Equal(RealLocalRoot, AppStateBase.ApplyOverride(RealLocalRoot));
+    }
+
+    [Fact]
+    public void ASetValue_Replaces_Both_Roots()
+    {
+        // Both halves of the state tree move together: the override
+        // trades the local/roaming split for one tree to point at, so a
+        // harness redirects every state file with one variable.
+        Set(@"C:\harness\state");
+
+        Assert.Equal(@"C:\harness\state", AppStateBase.OverrideRoot);
+        Assert.Equal(@"C:\harness\state", AppStateBase.LocalRoot);
+        Assert.Equal(@"C:\harness\state", AppStateBase.RoamingRoot);
+        Assert.Equal(@"C:\harness\state", AppStateBase.ApplyOverride(RealLocalRoot));
+    }
+
+    [Theory]
+    [InlineData(" C:\\harness\\state ", "C:\\harness\\state")]
+    [InlineData("\tC:\\harness\\state\n", "C:\\harness\\state")]
+    public void APaddedValue_Is_Trimmed_Not_Combined(string raw, string trimmed)
+    {
+        // A stray space or trailing quote from a hand-written `set` must
+        // not silently become part of the path.
+        _env[AppStateBase.EnvVar] = raw;
+
+        Assert.Equal(trimmed, AppStateBase.OverrideRoot);
+        Assert.Equal(trimmed, AppStateBase.LocalRoot);
+    }
+
+    [Fact]
+    public void The_Env_Var_Is_Named_For_What_It_Overrides()
+    {
+        // The name is load-bearing twice over: harnesses spell it, and
+        // the app-run tooling that will attribute per-process state
+        // trees reads it. A rename here breaks both with no compile-time
+        // signal, so the spelling is pinned.
+        Assert.Equal("WINTTY_STATE_BASE", AppStateBase.EnvVar);
+    }
+}

--- a/windows/Ghostty.Tests/AppStateBaseTests.cs
+++ b/windows/Ghostty.Tests/AppStateBaseTests.cs
@@ -1,9 +1,20 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using Ghostty.Core;
 using Xunit;
 
 namespace Ghostty.Tests;
+
+/// <summary>
+/// Collections that swap <see cref="AppStateBase.ReadEnvironment"/>
+/// serialize here, so no parallel collection resolving a state root can
+/// observe the shadow mid-test. Marker class only; see
+/// <see cref="AppStateBaseTests"/> and
+/// <see cref="AppStateBaseSeamIsolationTests"/> for the contract.
+/// </summary>
+[CollectionDefinition("AppStateBaseSeamSerial", DisableParallelization = true)]
+public class AppStateBaseSeamSerialCollection { }
 
 /// <summary>
 /// The state-base override's behaviour (#854 item 9): unset it changes
@@ -19,7 +30,18 @@ namespace Ghostty.Tests;
 /// <c>Config.TestConfigGuardTests</c> uses. Mutating the real
 /// environment from a test races every concurrently running collection
 /// and transiently redirects every other test's state paths.
+///
+/// The injected reader is still a process-wide static, so the class sits
+/// in the <c>AppStateBaseSeamSerial</c> collection: without the
+/// serialization, a concurrently running collection that resolves a
+/// state root (any reader, not just a swapper) observes the shadow for
+/// the duration of each test method here. That leak was shown red by
+/// <see cref="AppStateBaseSeamIsolationTests"/> before the collection
+/// was adopted, and that test stays as the pin that the serialization
+/// holds. Every future test that swaps the seam joins this collection;
+/// the pattern is #1093's <c>EnvironmentSerial</c>.
 /// </summary>
+[Collection("AppStateBaseSeamSerial")]
 public class AppStateBaseTests : IDisposable
 {
     private readonly IDictionary<string, string?> _env =
@@ -98,5 +120,21 @@ public class AppStateBaseTests : IDisposable
         // trees reads it. A rename here breaks both with no compile-time
         // signal, so the spelling is pinned.
         Assert.Equal("WINTTY_STATE_BASE", AppStateBase.EnvVar);
+    }
+
+    [Fact]
+    public void TheShadowIsHeld_ForTheParallelIsolationReader()
+    {
+        // Driver for AppStateBaseSeamIsolationTests: this class is the
+        // AppStateBaseSeamSerial collection, so holding a shadowed seam
+        // here is safe only if that serialization is real. The parallel
+        // reader samples OverrideRoot for its whole window and fails if
+        // the shadow leaks out of this collection, which is the red
+        // state the serialization was adopted to remove (#1093's
+        // EnvironmentSerial is the precedent). The hold must outlast the
+        // reader's sampling window; Dispose restores the real reader.
+        Set(@"C:\wintty-seam-shadow");
+        Assert.Equal(@"C:\wintty-seam-shadow", AppStateBase.OverrideRoot);
+        Thread.Sleep(3000);
     }
 }

--- a/windows/Ghostty.Tests/Logging/FileLoggerProviderTests.cs
+++ b/windows/Ghostty.Tests/Logging/FileLoggerProviderTests.cs
@@ -41,7 +41,38 @@ public class FileLoggerProviderTests : IDisposable
         Assert.Single(files);
         Assert.Equal("ghostty-20260417.log", Path.GetFileName(files[0]));
         var body = ReadAllTextShared(files[0]);
-        Assert.Contains(" | Warn  | 42 | TestCategory | hello", body);
+        // The pid is part of the pinned line shape (#854 item 8); the
+        // dedicated test covers why. This assert keeps the whole format
+        // honest, so it spells the field out rather than matching a
+        // prefix that would survive a field being dropped.
+        Assert.Contains($" | Warn  | {Environment.ProcessId} | 42 | TestCategory | hello", body);
+    }
+
+    [Fact]
+    public async Task EveryLineNamesTheProcessId()
+    {
+        // Multi-instance attribution (#854 item 8): every process of an
+        // edition appends to the same ghostty-YYYYMMDD.log (the writer
+        // coexists with a live second instance by design), so a line
+        // without a pid cannot be attributed to the process that wrote
+        // it -- "which instance warned?" is unanswerable, both for a
+        // human reading the file and for the #847 app-run health check,
+        // which cannot tell the launched instance's warnings from a
+        // stray one still running. The pid rides between the level and
+        // the event id: the health check's line regex anchors on
+        // `timestamp | level |`, so a field there is invisible to it.
+        var clock = new FakeClock(new DateTime(2026, 4, 17, 14, 0, 0, DateTimeKind.Utc));
+        await using var sink = new FileLoggerProvider(
+            NewOptions(_tempDir), clock, RealFileSystem.Instance);
+        var logger = sink.CreateLogger("TestCategory");
+
+        logger.LogWarning(new EventId(42, "TestEvent"), "hello");
+
+        await DrainAsync(sink);
+        var body = ReadAllTextShared(Path.Combine(_tempDir, "ghostty-20260417.log"));
+        Assert.Contains(
+            $" | Warn  | {Environment.ProcessId} | 42 | TestCategory | hello",
+            body);
     }
 
     [Fact]

--- a/windows/Ghostty.Tests/Wiring/AppStateBaseWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/AppStateBaseWiringTests.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// The state-base override's wiring (#854 item 9): every path the shell
+/// derives from <c>AppIdentity.StateDirName</c> must take its root from
+/// <c>AppStateBase</c> (the <c>WINTTY_STATE_BASE</c> override), never
+/// straight from <c>Environment.GetFolderPath</c> or an injected
+/// <c>GetKnownFolder</c> call, or the override cannot move it and the
+/// multi-instance GUI tests (#822) that rely on it write into the real
+/// per-user state tree.
+///
+/// These are wiring guards, not behaviour tests (the resolution behaviour
+/// lives in <c>AppStateBaseTests</c>). What they prove is shape: a
+/// <c>Path.Combine</c> that names the state directory names the helper
+/// too. A new state path added without the helper, or a converted site
+/// edited back to the raw known-folder root, fails here with the file
+/// and the offending argument list.
+///
+/// The rule is textual over each combine's parsed argument list, so it
+/// also catches the hoisted form: a root assigned from
+/// <c>GetFolderPath</c> into a local and then combined no longer names
+/// the helper anywhere in the combine, and is refused just the same.
+/// </summary>
+public class AppStateBaseWiringTests
+{
+    [Fact]
+    public void NoStateDirCombine_TakesItsRoot_FromTheRawKnownFolder()
+    {
+        var offenders = new List<string>();
+
+        foreach (var file in ShellSource.AllFiles())
+        {
+            foreach (var combine in file.Root.DescendantNodes()
+                         .OfType<InvocationExpressionSyntax>()
+                         .Where(i => i.CalleeText().EndsWith(
+                             "Path.Combine", StringComparison.Ordinal)))
+            {
+                var args = combine.ArgumentList.ToString();
+                if (!args.Contains("StateDirName", StringComparison.Ordinal))
+                    continue;
+
+                // The load-bearing half: the state directory's root must
+                // come from the override-aware helper, not from the raw
+                // known-folder value. This refuses both spellings at once
+                // -- a combine over GetFolderPath/GetKnownFolder directly,
+                // and a combine over a local that was fed by one.
+                if (!args.Contains("AppStateBase", StringComparison.Ordinal))
+                    offenders.Add($"{file.Name}: Path.Combine{args}");
+            }
+        }
+
+        Assert.True(
+            offenders.Count == 0,
+            $"{offenders.Count} Path.Combine call(s) build a state path from " +
+            "AppIdentity.StateDirName without AppStateBase, so WINTTY_STATE_BASE " +
+            "cannot move them:\n  " + string.Join("\n  ", offenders));
+    }
+}

--- a/windows/Ghostty/Accessibility/HighContrastOverrideFile.cs
+++ b/windows/Ghostty/Accessibility/HighContrastOverrideFile.cs
@@ -23,7 +23,7 @@ internal static class HighContrastOverrideFile
         try
         {
             var dir = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                AppStateBase.LocalRoot,
                 AppIdentity.StateDirName);
             Directory.CreateDirectory(dir);
             var path = Path.Combine(dir, "high-contrast.conf");

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -450,9 +450,7 @@ public partial class App : Application
         // `%LOCALAPPDATA%\Wintty\`.
         try
         {
-            var localAppData = Environment.GetFolderPath(
-                Environment.SpecialFolder.LocalApplicationData);
-            var dir = Path.Combine(localAppData, AppIdentity.StateDirName);
+            var dir = Path.Combine(AppStateBase.LocalRoot, AppIdentity.StateDirName);
             Directory.CreateDirectory(dir);
             var path = Path.Combine(dir, "crash.log");
             lock (_crashLogLock)
@@ -493,7 +491,7 @@ public partial class App : Application
         try
         {
             var root = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                Ghostty.Core.AppStateBase.LocalRoot,
                 Ghostty.Core.AppIdentity.StateDirName);
             var markerPath = Path.Combine(root, "last-launch");
 
@@ -765,7 +763,7 @@ public partial class App : Application
         // App.LogUnhandled already uses for crash.log, so a user reporting a bug only has
         // one folder to attach.
         var logDir = System.IO.Path.Combine(
-            System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData),
+            Ghostty.Core.AppStateBase.LocalRoot,
             Ghostty.Core.AppIdentity.StateDirName, "logs");
         var (factory, fileSink, filters) = Ghostty.Core.Logging.LoggingBootstrap.Build(
             logLevel: _configService.LogLevel,
@@ -944,7 +942,7 @@ public partial class App : Application
         // command-palette consumers can plug in without touching this
         // file again.
         var discoveryCachePath = System.IO.Path.Combine(
-            System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData),
+            Ghostty.Core.AppStateBase.LocalRoot,
             Ghostty.Core.AppIdentity.StateDirName, "DiscoveryCache", "v2.json");
         var winttyVersion = typeof(App).Assembly.GetName().Version?.ToString() ?? "dev";
 

--- a/windows/Ghostty/Diagnostics/HangWatchdog.cs
+++ b/windows/Ghostty/Diagnostics/HangWatchdog.cs
@@ -152,7 +152,7 @@ internal static class HangWatchdog
     private static (string Log, string Dump) Paths(int pid)
     {
         var root = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            Ghostty.Core.AppStateBase.LocalRoot,
             Ghostty.Core.AppIdentity.StateDirName);
         return (
             Path.Combine(root, "crash.log"),

--- a/windows/Ghostty/Diagnostics/NativeStderrCapture.cs
+++ b/windows/Ghostty/Diagnostics/NativeStderrCapture.cs
@@ -32,7 +32,7 @@ internal static partial class NativeStderrCapture
     private const long MaxBytes = 8 * 1024 * 1024;
 
     private static string LogPath => Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        Ghostty.Core.AppStateBase.LocalRoot,
         Ghostty.Core.AppIdentity.StateDirName,
         "native-stderr.log");
 

--- a/windows/Ghostty/Program.cs
+++ b/windows/Ghostty/Program.cs
@@ -263,7 +263,7 @@ public static partial class Program
     /// combine and can only turn a failure into a success.
     /// </remarks>
     private static string GpuLogPath => _gpuLogPath ??= Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        AppStateBase.LocalRoot,
         AppIdentity.StateDirName, "gpu.log");
 
     /// <summary>
@@ -741,22 +741,26 @@ public static partial class Program
     /// </summary>
     /// <remarks>
     /// Its own method, and its own try, because
-    /// <c>Environment.GetFolderPath</c> is the call that fails on a broken
-    /// profile - the same call the lazy <see cref="GpuLogPath"/> exists to keep
-    /// out of the type initializer. An empty result is rejected rather than
-    /// combined, because Path.Combine would turn it into a relative path and
-    /// scatter crash logs across whatever the current directory happened to be.
+    /// <c>AppStateBase.LocalRoot</c>'s known-folder read is the call that
+    /// fails on a broken profile - the same call the lazy
+    /// <see cref="GpuLogPath"/> exists to keep out of the type initializer.
+    /// An empty result is rejected rather than combined, because
+    /// Path.Combine would turn it into a relative path and scatter crash
+    /// logs across whatever the current directory happened to be.
     /// </remarks>
     private static string? TryGetFallbackCrashLogPath()
     {
         try
         {
-            var localAppData = Environment.GetFolderPath(
-                Environment.SpecialFolder.LocalApplicationData);
+            var localAppData = AppStateBase.LocalRoot;
             if (string.IsNullOrEmpty(localAppData))
                 return null;
 
-            return Path.Combine(localAppData, AppIdentity.StateDirName, CrashLogFileName);
+            // ApplyOverride rather than a second LocalRoot read: the root
+            // is already resolved above and only needs the override
+            // stamped on it for the state-base wiring rule, which wants
+            // the combine itself to name the helper.
+            return Path.Combine(AppStateBase.ApplyOverride(localAppData), AppIdentity.StateDirName, CrashLogFileName);
         }
         catch
         {

--- a/windows/Ghostty/Session/SessionStore.cs
+++ b/windows/Ghostty/Session/SessionStore.cs
@@ -24,7 +24,7 @@ internal sealed class SessionStore
     // thread whose whole job is to be on screen first. Save creates the
     // directory, because writing is the only operation that needs one.
     private static string Dir => Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        AppStateBase.RoamingRoot,
         AppIdentity.StateDirName);
 
     internal static string FilePath => Path.Combine(Dir, "session.json");

--- a/windows/Ghostty/Settings/WindowState.cs
+++ b/windows/Ghostty/Settings/WindowState.cs
@@ -65,7 +65,7 @@ internal sealed class WindowState
         get
         {
             var dir = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                AppStateBase.RoamingRoot,
                 AppIdentity.StateDirName);
             Directory.CreateDirectory(dir);
             return dir;

--- a/windows/docs/logging.md
+++ b/windows/docs/logging.md
@@ -37,8 +37,14 @@ boundary, so a long-running session prunes itself.
 Line format is pipe-separated, easy to grep:
 
 ```
-2026-04-17T14:23:17.042Z | Warn  | 2100 | Ghostty.Clipboard.WinUiClipboardBackend | clipboard read failed: 0x8001010E
+2026-04-17T14:23:17.042Z | Warn  | 4312 | 2100 | Ghostty.Clipboard.WinUiClipboardBackend | clipboard read failed: 0x8001010E
 ```
+
+The third field is the process id: every process of an edition appends to
+the same day file, so it is what keeps a line attributable when several
+instances interleave (# 854 item 8). It sits after the level because
+downstream parsers, including the app-run health check, anchor on
+`timestamp | level |`.
 
 When a log call includes an exception, the record line is followed by
 indented frames (up to 10) so the stack is readable in the same file.


### PR DESCRIPTION
## What

The fork half of the multi-instance tracking list, items 8 and 9 (the two fork items in scope now; 1, 3, 5, 6 are deferred per the triage ruling, 2, 4, 7 live on the release side). Two commits, one per item, each with its RED test shown failing first.

### Item 8: the pid in every file log line

`FileLoggerProvider.FormatRecord` wrote `timestamp | level | event id | category | message`, and every process of an edition appends to the same `ghostty-YYYYMMDD.log`, so interleaved lines were not attributable to a process, including by the app-run health check. The pid now rides between the level and the event id: the health check's line regex anchors on `timestamp | level |`, so its parsing is unchanged and it gains the field for free. RED: `FileLoggerProviderTests.EveryLineNamesTheProcessId` (failed at 118bd50f9: `Sub-string not found: " | Warn  | 272392 | 42 | ..."`), then green.

### Item 9: `WINTTY_STATE_BASE` moves the AppIdentity state tree

Every state path derived from `AppIdentity.StateDirName` (session.json, window-state.json, command-frecency, logs dir, crash.log, gpu.log, native-stderr.log, hang dumps, high-contrast.conf, discovery cache, icon cache) resolved its known folder inline at the call site, so nothing in the environment could move the tree; the GUI-level multi-instance tests need exactly that lever. New `Ghostty.Core/AppStateBase`: `WINTTY_STATE_BASE` replaces the known-folder root when set (blank spellings mean unset, padded values are trimmed), and leaves the value untouched when not, so a user install never notices. All 11 call sites now take their root from it; the icon resolver applies `ApplyOverride` to its injected `fs.GetKnownFolder` value. RED: `AppStateBaseWiringTests` refused all 11 raw `Path.Combine`s (listed them by file), then green; `AppStateBaseTests` covers the resolution behaviour over the injected-reader seam.

The native half is untouched and orthogonal: `ghostty_set_state_dir_name` (the `ShipDigital\<packId>` name segment) still moves the name, this moves the root.

## Tests

RED shown for both items before the fixes, then the full `Ghostty.Tests` suite at the final head: **4003 passed, 1 skipped (pre-existing), 0 failed** (`dotnet test windows/Ghosty.Tests/Ghostty.Tests.csproj -p:Platform=x64 -p:RestoreLockedMode=true`).

## Patch-friendliness at the next pin move

Verified against the release head with `git apply --check` of every first-toucher patch over files this PR edits:

- **Needs re-anchoring: the pro and pro-legacy icon-resolver patches.** They rewrite `CachePathFor` itself; the fix is one line in the re-anchored hunk: `Path.Combine(AppStateBase.ApplyOverride(local), AppIdentity.StateDirName, "IconCache", filename)`. Confirmed the patch applies at the parent fork head and fails only because of this PR.
- Applies cleanly (context intact, offset drift only): the FileLoggerProvider and FileLoggerProviderTests patches (the new `_pid` field was deliberately placed to keep the `_formatBuilder`-to-ctor context), plus the other first-touchers over these files. Later series members were cleared by context-string inspection; none quote the edited lines.

Follow-up for the release side (none block this PR; they are override-blind, not broken): tier-added state paths that still combine `GetFolderPath`/`GetKnownFolder` with `StateDirName` should route through `AppStateBase` so the override covers them too (the sessiond, sponsor update and sponsor auth dirs, and the tier-added overlay paths).

Closes nothing on its own; ships when the release pins advance past 118bd50f9.
