### PR TITLE
app: focus the restored pane at launch

### DIFF
--- a/windows/Ghostty.Tests/Wiring/RestoredPaneFocusWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/RestoredPaneFocusWiringTests.cs
@@ -1,0 +1,118 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// #815: a window whose panes were rebuilt by a session restore came up
+/// with no keyboard focus in any of them, so every chord -- palette, new
+/// tab -- was dead until the user clicked a pane. The restore path makes
+/// no focus call of its own; the only ask is the load-time
+/// <c>TerminalControl.OnLoaded</c> focus, which a window still behind the
+/// splash cannot take, and which lands on whichever restored leaf loads
+/// last rather than the active one.
+///
+/// The fix is a one-shot focus of the active leaf on the window's first
+/// activation, through the same <see cref="MainWindow"/> seam the palette
+/// and notification focus-returns use. These guards pin that wiring; they
+/// cannot prove keyboard focus actually lands, which is only observable
+/// on a live UIA tree.
+/// </summary>
+public class RestoredPaneFocusWiringTests
+{
+    private static ShellSource MainWindow() => ShellSource.Load("MainWindow.xaml.cs");
+
+    /// <summary>
+    /// The one-shot handler, as a node. A local function in the window's
+    /// constructor, twin of the session-restored announcement arm.
+    /// </summary>
+    private static LocalFunctionStatementSyntax Handler()
+    {
+        var found = MainWindow().Root.DescendantNodes()
+            .OfType<LocalFunctionStatementSyntax>()
+            .Where(f => f.Identifier.ValueText == "OnFirstActivationFocusActiveLeaf")
+            .ToList();
+        Assert.True(found.Count == 1,
+            $"expected one local function OnFirstActivationFocusActiveLeaf, found {found.Count}");
+        return found[0];
+    }
+
+    /// <summary>
+    /// Every `Activated += OnFirstActivationFocusActiveLeaf` registration.
+    /// Matched structurally so a comment or a string can never satisfy it.
+    /// </summary>
+    private static List<AssignmentExpressionSyntax> Registrations() =>
+        MainWindow().Root.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.Left is IdentifierNameSyntax { Identifier.ValueText: "Activated" }
+                        && a.IsKind(SyntaxKind.AddAssignmentExpression)
+                        && a.Right is IdentifierNameSyntax
+                        {
+                            Identifier.ValueText: "OnFirstActivationFocusActiveLeaf"
+                        })
+            .ToList();
+
+    [Fact]
+    public void FirstActivation_ArmsTheFocusOnEveryRegularWindow()
+    {
+        // Exactly one registration, and it lives inside the regular-window
+        // gate: the quake window's Show() owns its own focus choreography,
+        // and a one-shot that fired on the hidden quake window's startup
+        // activation would be spent before the user ever summoned it.
+        var registrations = Registrations();
+        Assert.Single(registrations);
+        var gate = registrations[0].Ancestors().OfType<IfStatementSyntax>().FirstOrDefault();
+        Assert.NotNull(gate);
+        Assert.Contains("!IsQuickTerminal", gate.Condition.ToString());
+    }
+
+    [Fact]
+    public void TheHandler_IsOneShot_AndWaitsForARealActivation()
+    {
+        var handler = Handler();
+
+        // One-shot: it takes itself back off, so the arm can never fight a
+        // later deliberate focus (search box, palette) on reactivation.
+        Assert.Contains(handler.DescendantNodes().OfType<AssignmentExpressionSyntax>(),
+            a => a.Left is IdentifierNameSyntax { Identifier.ValueText: "Activated" }
+                 && a.IsKind(SyntaxKind.SubtractAssignmentExpression));
+
+        // The startup dance (the hidden quake window's activate-and-hide)
+        // deactivates this window before it settles, so a Deactivated edge
+        // must not spend the one shot.
+        var guard = Assert.Single(handler.DescendantNodes().OfType<IfStatementSyntax>());
+        Assert.Contains("Deactivated", guard.Condition.ToString());
+    }
+
+    [Fact]
+    public void TheHandler_FocusesTheActivePaneThroughTheSharedSeam()
+    {
+        // FocusActiveLeaf resolves the active tab's active leaf at run
+        // time, which is what makes this heal a restore whose leaves
+        // loaded in the wrong focus order. Pinned as the single effect so
+        // the arm cannot grow into something that grabs focus on its own.
+        Assert.Single(Handler().Calls("FocusActiveLeaf"));
+    }
+
+    [Fact]
+    public void FocusActiveLeaf_DeferencesTheFocusPastTheActivationChurn()
+    {
+        // The arm fires inside the Activated event, where WinUI is still
+        // moving focus itself; the focus must land on a later dispatcher
+        // turn, never synchronously and never off a sleep. The whole
+        // enqueued body is pinned, folded across its line breaks: it
+        // resolves the pane at fire time from the manager (so a restore
+        // that replaced leaves still finds the active one) and focuses it
+        // programmatically.
+        var enqueue = MainWindow().Method("FocusActiveLeaf")
+            .Call("DispatcherQueue.TryEnqueue");
+        var body = Assert.IsType<ParenthesizedLambdaExpressionSyntax>(enqueue.ArgExpression(0))
+            .Body;
+        Assert.Equal(
+            "_tabManager.ActiveTab?.PaneHost?.ActiveLeaf?.Terminal() .Focus(FocusState.Programmatic)",
+            string.Join(" ", body.ToString().Split((char[])null,
+                StringSplitOptions.RemoveEmptyEntries)));
+    }
+}

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -681,6 +681,32 @@ public sealed partial class MainWindow : Window
                 Activated -= OnFirstActivationAnnounceRestore;
                 AnnounceSessionRestored();
             }
+
+            // #815: that same splash-hidden stretch is why a restored
+            // window's panes came up with no keyboard focus in any of
+            // them. The restore path asks for focus only at load time
+            // (TerminalControl.OnLoaded), which a window that is not yet
+            // foreground cannot take, and which lands on whichever
+            // restored leaf happened to load last rather than the active
+            // one -- so every chord was dead until the user clicked a
+            // pane. First activation is the first moment the window is
+            // foreground and focus can land (the announce seam's own
+            // measurement), so hand focus to the active pane once, there.
+            // Armed for every regular window, not just a restored one,
+            // because the same gap hits any window that appears without a
+            // click: a reopened closed window, a tab detached to a new
+            // window, and a window a single-instance forward opened in
+            // the running primary (#1095). FocusActiveLeaf resolves the
+            // active leaf at fire time and defers through the dispatcher,
+            // so this never fights the activation churn it fires inside.
+            // The quake window is excluded: its Show() owns its focus.
+            Activated += OnFirstActivationFocusActiveLeaf;
+            void OnFirstActivationFocusActiveLeaf(object s, WindowActivatedEventArgs e)
+            {
+                if (e.WindowActivationState == Microsoft.UI.Xaml.WindowActivationState.Deactivated) return;
+                Activated -= OnFirstActivationFocusActiveLeaf;
+                FocusActiveLeaf();
+            }
         }
 
         if (!IsQuickTerminal)


### PR DESCRIPTION
# app: focus the restored pane at launch

## The bug

A window whose panes a session restore rebuilt came up with no keyboard focus in any of them, so `Ctrl+Shift+P`, `Ctrl+T` and every other chord did nothing until the user clicked a pane. The restore path (`SessionRestorer`, `SessionManager`, `MainWindow`'s restore branch) makes no focus call of its own; the only ask is the load-time `TerminalControl.OnLoaded` focus, which:

- a window still behind the splash cannot take (a non-foreground window does not take keyboard focus), and
- lands on whichever restored leaf happens to load last, not the active one.

## The fix

One-shot focus of the active pane on the window's **first activation**, through the existing `FocusActiveLeaf` seam (which resolves the active leaf at fire time and defers through the dispatcher, so it never fights the activation churn it fires inside). First activation is the same edge the session-restored announcement already uses, with its own measurement that activation is the first moment the window is foreground and focus can land.

Armed for **every regular window**, not just a restored one, because the same gap hits any window that appears without a click:

- the startup restore and `ReopenClosedWindow` (restore ctor),
- a tab detached to a new window (`CreateForAdoption`: the adopted control's `OnLoaded` never re-runs, so nothing re-focused it),
- a window a single-instance forward opens in the running primary (#1095),
- plain cold start (same target control as the load-time focus, so no behavior change).

The quake window is excluded; its `Show()` owns its focus choreography.

## Tests

- RED first: `RestoredPaneFocusWiringTests` (4 facts) pins the arm (registration inside the regular-window gate, one-shot detach, Deactivated guard, focus through the shared seam) and the seam's dispatcher deferral. Three failed before the fix, the fourth pins the pre-existing `FocusActiveLeaf` shape and was already green.
- Narrow suites at the final head: Ghostty.Tests `Wiring|Session` filter, 734 passed, 0 failed. Tests.Windows has no automated coverage in this area (its focus tests are skipped manual smoke specs; the project does not reference the app project).
- Live verification, 2 GUI launches on the wintty-desktop lane through the seam harness (random temp `XDG_CONFIG_HOME` per launch): launch 1 seeded a session (2 tabs, tab 1 split, right leaf active) and let it persist; launch 2 restored it and `get-state` (FocusManager-based) reported `focusedLeaf=1 focusedElement='TerminalControl'` with the restored `activeLeaf=1` and **no click in between**. Per the UIA driver findings, chords land exactly when the terminal element has focus, which is the piece that was missing.

## Tier notes for the next pin move

- The insertion sits in the `MainWindow` ctor's `if (!IsQuickTerminal && Content is FrameworkElement fe)` block, below every existing tier hunk, so no tier patch needs re-anchoring.
- The new wiring test parses `MainWindow.xaml.cs`, which tiers extend under `#if SPONSOR_BUILD`; the tiers' ShellSource patch already defines that symbol, so the test parses the tier file as well, and its assertions hold there.
- **Gated-tier behavior to watch:** the sponsor login gate pulls focus off the terminal when it attaches. This arm fires at first activation and could land focus on the pane under a gate that attached earlier in startup (primary windows, Edit A). The gate's own focus choreography should re-assert on window activation; that is tier-visible code (`LoginGateView`), so it belongs in the release repo at the pin move, not behind a fork-visible conditional.
