### PR TITLE
session: restore drops leaves whose built-in profile is not offered

### DIFF
--- a/windows/Ghostty.Core/Session/SessionProfileResolver.cs
+++ b/windows/Ghostty.Core/Session/SessionProfileResolver.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Ghostty.Core.Profiles;
 
 namespace Ghostty.Core.Session;
@@ -25,14 +26,17 @@ internal static class SessionProfileResolver
     internal const string BuiltInProfileIdPrefix = "wintty.builtin.";
 
     /// <summary>
-    /// The one template dialect a profile command has shipped
-    /// (<c>${env:NAME}</c>, rc.1's Headless SSH preset). Nothing expands
-    /// it on any spawn path: the dialect is retired, and the local pane
-    /// path hands <see cref="ProfileSnapshot.ResolvedCommand"/> to the OS
-    /// verbatim, so a saved leaf still carrying it would spawn the
-    /// literal token as an argument.
+    /// The exact template rc.1's Headless SSH preset carried as its
+    /// command (<c>ssh ${env:WINTTY_SSH_TARGET}</c>), compared without
+    /// case like every id and profile comparison here. It is the only
+    /// <c>${env:...}</c> token a shipped profile has ever embedded, and
+    /// it is not the user's syntax: <c>${env:NAME}</c> is live
+    /// PowerShell the spawned shell expands itself, so a user's own
+    /// one-liner runs as written -- but nothing anywhere expands THIS
+    /// token (the preset is retired, wintty-release #874), so a saved
+    /// leaf still carrying it can only spawn it literally.
     /// </summary>
-    internal const string EnvTemplateMarker = "${env:";
+    internal const string RetiredHeadlessSshTemplate = "${env:WINTTY_SSH_TARGET}";
 
     /// <summary>
     /// Exact-id resolution: re-resolve a still-existing profile fresh (so
@@ -79,9 +83,10 @@ internal static class SessionProfileResolver
 
     /// <summary>
     /// Whether a saved leaf must be dropped at restore instead of
-    /// spawned: its profile id resolves to nothing the current registry
-    /// offers, AND the fallback that would run in the profile's place
-    /// cannot be spawned as saved. Two things make a fallback unspawnable:
+    /// spawned: its profile id is unknown to the current registry
+    /// (neither offered nor hidden), AND the fallback that would run in
+    /// the profile's place cannot be spawned as saved. Two things make a
+    /// fallback unspawnable:
     /// <list type="number">
     /// <item>the id sits in the reserved built-in namespace
     /// (<see cref="BuiltInProfileIdPrefix"/>) yet nothing claims it, so
@@ -89,19 +94,23 @@ internal static class SessionProfileResolver
     /// gated off, or a tier that never shipped it; the saved command is
     /// the built-in's launch line, which the composition just decided
     /// must not launch here</item>
-    /// <item>the saved command still carries the retired
-    /// <see cref="EnvTemplateMarker"/> dialect, which no spawn path
-    /// expands, so the pane would hand the literal template token to the
+    /// <item>the saved command still embeds the retired
+    /// <see cref="RetiredHeadlessSshTemplate"/> token, which nothing
+    /// expands, so the pane would hand the literal template to the
     /// child process and die on it</item>
     /// </list>
     /// The boundary, deliberately: a leaf whose profile was merely
-    /// renamed or deleted is NOT dropped. Its saved command is the
-    /// user's own, spawnable as written, so it keeps the fallback
-    /// behaviour <see cref="ResolveLeaf"/> documents -- re-run what the
-    /// tab was actually running. Both clauses refuse the drop for that
-    /// case: an ordinary custom id with an ordinary command is kept
-    /// however unknown, and a resolvable id is kept even when its
-    /// command carries the dialect (the fresh profile wins; the fallback
+    /// renamed, deleted or HIDDEN is NOT dropped. Its saved command is
+    /// the user's own, spawnable as written (a hidden profile is still
+    /// carried by the composition -- hidden is a menu choice, not a
+    /// withdrawal; the release gate OMITS a refused preset rather than
+    /// hiding it, so genuinely gated presets stay droppable), so it
+    /// keeps the fallback behaviour <see cref="ResolveLeaf"/> documents
+    /// -- re-run what the tab was actually running. The clauses refuse
+    /// the drop for that case: an ordinary custom id with an ordinary
+    /// command is kept however unknown, an unresolvable id the registry
+    /// still hides is kept, and a resolvable id is kept even when its
+    /// command carries the token (the fresh profile wins; the fallback
     /// is never consulted).
     /// </summary>
     public static bool ShouldDropLeaf(IProfileRegistry? registry, LeafDto leaf)
@@ -112,6 +121,15 @@ internal static class SessionProfileResolver
         if (leaf.ProfileId is null) return false;
         if (ResolveById(registry, leaf.ProfileId) is not null) return false;
 
+        // Known to the composition at all, visible OR hidden: hidden is
+        // the user's choice about the menus, not a withdrawal, and the
+        // tab keeps its fallback behaviour. A gated preset is omitted
+        // from both lists, so only a genuinely withdrawn built-in falls
+        // through.
+        if (registry is not null && registry.HiddenProfiles.Any(
+                p => string.Equals(p.Id, leaf.ProfileId, StringComparison.OrdinalIgnoreCase)))
+            return false;
+
         // A withdrawn built-in: the id sits in the reserved built-in
         // namespace, yet nothing in this composition claims it -- gated
         // off here, or a tier that never shipped it. Its saved command
@@ -120,10 +138,13 @@ internal static class SessionProfileResolver
         if (leaf.ProfileId.StartsWith(BuiltInProfileIdPrefix, StringComparison.OrdinalIgnoreCase))
             return true;
 
-        // A saved command still in the retired ${env: dialect: nothing
-        // expands it, so the pane would hand the literal template token
-        // to its child process and die on it.
-        return leaf.Fallback?.ResolvedCommand.Contains(EnvTemplateMarker, StringComparison.Ordinal) ?? false;
+        // A saved command still embedding the retired Headless SSH
+        // template: nothing expands it, so the pane would hand the
+        // literal template to its child process and die on it. The
+        // user's own ${env:...} one-liners are live PowerShell the child
+        // shell expands, and are NOT matched.
+        return leaf.Fallback?.ResolvedCommand.Contains(
+            RetiredHeadlessSshTemplate, StringComparison.OrdinalIgnoreCase) ?? false;
     }
 
     /// <summary>

--- a/windows/Ghostty.Core/Session/SessionProfileResolver.cs
+++ b/windows/Ghostty.Core/Session/SessionProfileResolver.cs
@@ -1,3 +1,4 @@
+using System;
 using Ghostty.Core.Profiles;
 
 namespace Ghostty.Core.Session;
@@ -13,6 +14,26 @@ namespace Ghostty.Core.Session;
 /// </summary>
 internal static class SessionProfileResolver
 {
+    /// <summary>
+    /// The reserved id namespace for built-in / preset profiles: ids a
+    /// shipping composition prepends to the config source (tier overlays
+    /// like the Headless SSH preset) rather than anything the user's own
+    /// config declares. The registry compares ids without case, so the
+    /// prefix match does too; a user override of a built-in id resolves
+    /// normally and is never treated as withdrawn.
+    /// </summary>
+    internal const string BuiltInProfileIdPrefix = "wintty.builtin.";
+
+    /// <summary>
+    /// The one template dialect a profile command has shipped
+    /// (<c>${env:NAME}</c>, rc.1's Headless SSH preset). Nothing expands
+    /// it on any spawn path: the dialect is retired, and the local pane
+    /// path hands <see cref="ProfileSnapshot.ResolvedCommand"/> to the OS
+    /// verbatim, so a saved leaf still carrying it would spawn the
+    /// literal token as an argument.
+    /// </summary>
+    internal const string EnvTemplateMarker = "${env:";
+
     /// <summary>
     /// Exact-id resolution: re-resolve a still-existing profile fresh (so
     /// profile edits take effect), or null if the id is unknown/null.
@@ -54,6 +75,55 @@ internal static class SessionProfileResolver
                 Icon: new IconSpec.BundledKey("default"),
                 Visuals: EffectiveVisualOverrides.Empty), leaf.Cwd);
         return null;
+    }
+
+    /// <summary>
+    /// Whether a saved leaf must be dropped at restore instead of
+    /// spawned: its profile id resolves to nothing the current registry
+    /// offers, AND the fallback that would run in the profile's place
+    /// cannot be spawned as saved. Two things make a fallback unspawnable:
+    /// <list type="number">
+    /// <item>the id sits in the reserved built-in namespace
+    /// (<see cref="BuiltInProfileIdPrefix"/>) yet nothing claims it, so
+    /// this machine's composition is refusing to offer that built-in --
+    /// gated off, or a tier that never shipped it; the saved command is
+    /// the built-in's launch line, which the composition just decided
+    /// must not launch here</item>
+    /// <item>the saved command still carries the retired
+    /// <see cref="EnvTemplateMarker"/> dialect, which no spawn path
+    /// expands, so the pane would hand the literal template token to the
+    /// child process and die on it</item>
+    /// </list>
+    /// The boundary, deliberately: a leaf whose profile was merely
+    /// renamed or deleted is NOT dropped. Its saved command is the
+    /// user's own, spawnable as written, so it keeps the fallback
+    /// behaviour <see cref="ResolveLeaf"/> documents -- re-run what the
+    /// tab was actually running. Both clauses refuse the drop for that
+    /// case: an ordinary custom id with an ordinary command is kept
+    /// however unknown, and a resolvable id is kept even when its
+    /// command carries the dialect (the fresh profile wins; the fallback
+    /// is never consulted).
+    /// </summary>
+    public static bool ShouldDropLeaf(IProfileRegistry? registry, LeafDto leaf)
+    {
+        // Only the fallback arm is droppable. A resolvable profile id
+        // re-resolves fresh, and a legacy no-profile leaf spawns the
+        // default shell; neither is a fossil.
+        if (leaf.ProfileId is null) return false;
+        if (ResolveById(registry, leaf.ProfileId) is not null) return false;
+
+        // A withdrawn built-in: the id sits in the reserved built-in
+        // namespace, yet nothing in this composition claims it -- gated
+        // off here, or a tier that never shipped it. Its saved command
+        // is the built-in's own launch line, which this machine just
+        // decided must not launch.
+        if (leaf.ProfileId.StartsWith(BuiltInProfileIdPrefix, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        // A saved command still in the retired ${env: dialect: nothing
+        // expands it, so the pane would hand the literal template token
+        // to its child process and die on it.
+        return leaf.Fallback?.ResolvedCommand.Contains(EnvTemplateMarker, StringComparison.Ordinal) ?? false;
     }
 
     /// <summary>

--- a/windows/Ghostty.Core/Session/SessionTree.cs
+++ b/windows/Ghostty.Core/Session/SessionTree.cs
@@ -52,22 +52,37 @@ internal static class SessionTree
     /// Rebuild a <see cref="PaneNode"/> tree from a dto. <paramref name="makeLeaf"/>
     /// turns a <see cref="LeafDto"/> into a <see cref="LeafPane"/> (the app
     /// layer re-resolves the profile and sets <see cref="LeafPane.Snapshot"/>;
-    /// <see cref="LeafPane.Tag"/> is left null for the host to populate).
+    /// <see cref="LeafPane.Tag"/> is left null for the host to populate), or
+    /// returns null to refuse the leaf (restore drops it -- see
+    /// <see cref="SessionProfileResolver.ShouldDropLeaf"/>). A split whose
+    /// children were all refused is refused in turn, and a split left with
+    /// one survivor collapses to that survivor: a divider around a single
+    /// pane is not a split the user made. Splits that survive keep their
+    /// saved orientation and clamped ratio.
     /// </summary>
-    public static PaneNode RebuildTree(PaneNodeDto dto, Func<LeafDto, LeafPane> makeLeaf)
+    public static PaneNode? RebuildTree(PaneNodeDto dto, Func<LeafDto, LeafPane?> makeLeaf)
     {
         ArgumentNullException.ThrowIfNull(dto);
         ArgumentNullException.ThrowIfNull(makeLeaf);
         return dto switch
         {
-            SplitDto s => new SplitPane(
-                s.Orientation,
-                RebuildTree(s.Child1, makeLeaf),
-                RebuildTree(s.Child2, makeLeaf),
-                Math.Clamp(s.Ratio, SplitPane.MinRatio, SplitPane.MaxRatio)),
+            SplitDto s => SplitOrCollapse(s, makeLeaf),
             LeafDto l => makeLeaf(l),
             _ => throw new ArgumentException($"Unknown PaneNodeDto type: {dto.GetType()}"),
         };
+
+        static PaneNode? SplitOrCollapse(SplitDto s, Func<LeafDto, LeafPane?> makeLeaf)
+        {
+            var child1 = RebuildTree(s.Child1, makeLeaf);
+            var child2 = RebuildTree(s.Child2, makeLeaf);
+            if (child1 is null) return child2;
+            if (child2 is null) return child1;
+            return new SplitPane(
+                s.Orientation,
+                child1,
+                child2,
+                Math.Clamp(s.Ratio, SplitPane.MinRatio, SplitPane.MaxRatio));
+        }
     }
 
     /// <summary>Path of Child1(false)/Child2(true) steps from root to target; empty if target is root.</summary>

--- a/windows/Ghostty.Tests/Session/SessionProfileResolverTests.cs
+++ b/windows/Ghostty.Tests/Session/SessionProfileResolverTests.cs
@@ -13,13 +13,21 @@ public class SessionProfileResolverTests
     private sealed class FakeProfileRegistry : IProfileRegistry
     {
         private readonly Dictionary<string, ResolvedProfile> _byId = new();
+        private readonly List<ResolvedProfile> _hidden = new();
         public long Version { get; } = 7;
         public IReadOnlyList<ResolvedProfile> Profiles => new List<ResolvedProfile>(_byId.Values);
-        public IReadOnlyList<ResolvedProfile> HiddenProfiles => Array.Empty<ResolvedProfile>();
+        public IReadOnlyList<ResolvedProfile> HiddenProfiles => _hidden;
         public string? DefaultProfileId { get; set; }
         public event Action<IProfileRegistry>? ProfilesChanged { add { } remove { } }
 
         public void Add(ResolvedProfile p) => _byId[p.Id] = p;
+
+        /// <summary>
+        /// Hide a profile the way the real composition does: it stays
+        /// carried (HiddenProfiles) but is NOT resolvable, because the
+        /// real registry builds its id map from the visible list only.
+        /// </summary>
+        public void Hide(ResolvedProfile p) => _hidden.Add(p);
         public ResolvedProfile? Resolve(string profileId) =>
             _byId.TryGetValue(profileId, out var p) ? p : null;
         public Task RefreshDiscoveryAsync(CancellationToken ct) => Task.CompletedTask;
@@ -296,15 +304,66 @@ public class SessionProfileResolverTests
             new FakeProfileRegistry(), Leaf(null, null)));
     }
 
+    // Hidden is a menu choice about a profile the composition still
+    // carries, not a withdrawal: hiding the offered preset from the
+    // flyout must not delete the saved tabs that ran it. Only a
+    // built-in id the registry does not know AT ALL (visible or
+    // hidden) is withdrawn -- the release gate omits a refused preset
+    // from both lists rather than hiding it.
     [Fact]
-    public void ShouldDropLeaf_UnresolvableCustomIdWithTemplateCommand_IsDropped()
+    public void ShouldDropLeaf_HiddenOfferedBuiltIn_IsKept()
     {
-        // The dialect rule is general: nothing on any spawn path expands
-        // the retired template, so the pane would hand the literal token
-        // to its child process whatever profile wrote it.
+        var reg = new FakeProfileRegistry();
+        reg.Hide(Profile("wintty.builtin.headless-ssh", "ssh fleet-gw"));
+        var leaf = Leaf("wintty.builtin.headless-ssh", "ssh fleet-gw");
+
+        Assert.False(SessionProfileResolver.ShouldDropLeaf(reg, leaf));
+    }
+
+    [Fact]
+    public void ShouldDropLeaf_HiddenCustomProfile_IsKept()
+    {
+        var reg = new FakeProfileRegistry();
+        reg.Hide(Profile("my-dev-box", "cmd.exe /k echo hi"));
+        var leaf = Leaf("my-dev-box", "cmd.exe /k echo hi");
+
+        Assert.False(SessionProfileResolver.ShouldDropLeaf(reg, leaf));
+    }
+
+    // ${env:NAME} is live PowerShell (the env: drive): the child shell
+    // expands it, so a user's own one-liner runs as written and a leaf
+    // carrying it keeps the fallback behaviour.
+    [Fact]
+    public void ShouldDropLeaf_OrdinaryEnvVarOneLiner_IsKept()
+    {
         var leaf = Leaf("custom", "pwsh -NoProfile -c echo ${env:BUILD_ID}");
 
+        Assert.False(SessionProfileResolver.ShouldDropLeaf(new FakeProfileRegistry(), leaf));
+    }
+
+    // The one token that is NOT the user's: the retired Headless SSH
+    // preset's own template, compared without case like every profile
+    // comparison here.
+    [Theory]
+    [InlineData("ssh ${env:WINTTY_SSH_TARGET}")]
+    [InlineData("ssh ${ENV:WINTTY_SSH_TARGET}")]
+    [InlineData("pwsh -c ${env:wintty_ssh_target}")]
+    public void ShouldDropLeaf_ExactRetiredTemplateCommand_IsDropped(string command)
+    {
+        var leaf = Leaf("custom", command);
+
         Assert.True(SessionProfileResolver.ShouldDropLeaf(new FakeProfileRegistry(), leaf));
+    }
+
+    [Fact]
+    public void ShouldDropLeaf_CustomIdWithNoFallback_IsKept()
+    {
+        // A save old enough to predate fallback recording: the leaf
+        // resolves to nothing, names no built-in, and has no command to
+        // judge -- it keeps the legacy default-shell spawn.
+        var leaf = new LeafDto { ProfileId = "custom" };
+
+        Assert.False(SessionProfileResolver.ShouldDropLeaf(new FakeProfileRegistry(), leaf));
     }
 
     [Theory]

--- a/windows/Ghostty.Tests/Session/SessionProfileResolverTests.cs
+++ b/windows/Ghostty.Tests/Session/SessionProfileResolverTests.cs
@@ -239,4 +239,89 @@ public class SessionProfileResolverTests
             cwd,
             SessionProfileResolver.ResolveLeaf(reg, LeafWithCwd("pwsh", cwd))!.WorkingDirectory);
     }
+
+    // ShouldDropLeaf carves one exception out of the fallback behaviour
+    // pinned above: a leaf whose id resolves to nothing offered AND whose
+    // saved fallback cannot be spawned as saved. rc.1 saved Headless SSH
+    // tabs exactly so (wintty-release #874 gates the preset off Desktop /
+    // Pro Legacy / target-less Enterprise; #823 is the bug), and they
+    // restored as local panes running the literal template, re-saving
+    // themselves on every launch.
+    [Fact]
+    public void ShouldDropLeaf_StaleBuiltInWithTemplateCommand_IsDropped()
+    {
+        var leaf = Leaf("wintty.builtin.headless-ssh", "ssh ${env:WINTTY_SSH_TARGET}");
+
+        Assert.True(SessionProfileResolver.ShouldDropLeaf(new FakeProfileRegistry(), leaf));
+    }
+
+    [Fact]
+    public void ShouldDropLeaf_WithdrawnBuiltInEvenWithPlainCommand_IsDropped()
+    {
+        // Post-gate Enterprise saves carry the plain validated command; a
+        // target withdrawn later (the gate closing again) must not keep
+        // re-spawning it past the gate.
+        var leaf = Leaf("wintty.builtin.headless-ssh", "ssh fleet-gw");
+
+        Assert.True(SessionProfileResolver.ShouldDropLeaf(new FakeProfileRegistry(), leaf));
+    }
+
+    // THE boundary: the user's own command is spawnable as saved, so a
+    // profile that was merely renamed or deleted keeps the fallback.
+    [Fact]
+    public void ShouldDropLeaf_OrdinaryRenamedCustomProfile_IsKept()
+    {
+        var leaf = Leaf("my-dev-box", "cmd.exe /k echo hi");
+
+        Assert.False(SessionProfileResolver.ShouldDropLeaf(new FakeProfileRegistry(), leaf));
+    }
+
+    [Fact]
+    public void ShouldDropLeaf_ResolvingIdIsNeverDropped_EvenWithTemplateCommand()
+    {
+        // An admin override claiming the built-in id resolves (user wins
+        // on id conflicts); the fresh profile is used and the fallback is
+        // never consulted.
+        var reg = new FakeProfileRegistry();
+        reg.Add(Profile("wintty.builtin.headless-ssh", "ssh ${env:WINTTY_SSH_TARGET}"));
+        var leaf = Leaf("wintty.builtin.headless-ssh", "ssh ${env:WINTTY_SSH_TARGET}");
+
+        Assert.False(SessionProfileResolver.ShouldDropLeaf(reg, leaf));
+    }
+
+    [Fact]
+    public void ShouldDropLeaf_LegacyNoProfileLeaf_IsKept()
+    {
+        Assert.False(SessionProfileResolver.ShouldDropLeaf(
+            new FakeProfileRegistry(), Leaf(null, null)));
+    }
+
+    [Fact]
+    public void ShouldDropLeaf_UnresolvableCustomIdWithTemplateCommand_IsDropped()
+    {
+        // The dialect rule is general: nothing on any spawn path expands
+        // the retired template, so the pane would hand the literal token
+        // to its child process whatever profile wrote it.
+        var leaf = Leaf("custom", "pwsh -NoProfile -c echo ${env:BUILD_ID}");
+
+        Assert.True(SessionProfileResolver.ShouldDropLeaf(new FakeProfileRegistry(), leaf));
+    }
+
+    [Theory]
+    [InlineData("WINTTY.BUILTIN.headless-ssh")] // ids compare without case, like the registry
+    [InlineData("wintty.builtin.")]             // degenerate bare prefix
+    public void ShouldDropLeaf_ReservedBuiltInNamespace_MatchesWithoutCase(string id)
+    {
+        Assert.True(SessionProfileResolver.ShouldDropLeaf(
+            new FakeProfileRegistry(), Leaf(id, "whatever.exe")));
+    }
+
+    [Theory]
+    [InlineData("wintty.custom-box")]   // near the namespace, not in it
+    [InlineData("wintty-builtin.ssh")]  // a dash is not a dot
+    public void ShouldDropLeaf_IdsOutsideTheReservedNamespace_AreOrdinary(string id)
+    {
+        Assert.False(SessionProfileResolver.ShouldDropLeaf(
+            new FakeProfileRegistry(), Leaf(id, "whatever.exe")));
+    }
 }

--- a/windows/Ghostty.Tests/Session/SessionProfileResolverTests.cs
+++ b/windows/Ghostty.Tests/Session/SessionProfileResolverTests.cs
@@ -12,7 +12,11 @@ public class SessionProfileResolverTests
 {
     private sealed class FakeProfileRegistry : IProfileRegistry
     {
-        private readonly Dictionary<string, ResolvedProfile> _byId = new();
+        // The real registry compares ids OrdinalIgnoreCase (its resolve
+        // map is built with that comparer); the fake must match or its
+        // answers drift from production on case-variant saved ids.
+        private readonly Dictionary<string, ResolvedProfile> _byId =
+            new(StringComparer.OrdinalIgnoreCase);
         private readonly List<ResolvedProfile> _hidden = new();
         public long Version { get; } = 7;
         public IReadOnlyList<ResolvedProfile> Profiles => new List<ResolvedProfile>(_byId.Values);
@@ -327,6 +331,20 @@ public class SessionProfileResolverTests
         reg.Hide(Profile("my-dev-box", "cmd.exe /k echo hi"));
         var leaf = Leaf("my-dev-box", "cmd.exe /k echo hi");
 
+        Assert.False(SessionProfileResolver.ShouldDropLeaf(reg, leaf));
+    }
+
+    [Fact]
+    public void ShouldDropLeaf_MixedCaseSavedIdOfAnOfferedBuiltIn_ResolvesAndIsKept()
+    {
+        // Ids compare without case in the real registry, so a save in
+        // odd case still resolves to the offered profile; this row is
+        // what keeps the fake's comparer honest about that.
+        var reg = new FakeProfileRegistry();
+        reg.Add(Profile("wintty.builtin.headless-ssh", "ssh fleet-gw"));
+        var leaf = Leaf("WINTTY.BUILTIN.HEADLESS-SSH", "ssh fleet-gw");
+
+        Assert.NotNull(SessionProfileResolver.ResolveById(reg, leaf.ProfileId));
         Assert.False(SessionProfileResolver.ShouldDropLeaf(reg, leaf));
     }
 

--- a/windows/Ghostty.Tests/Session/SessionTreeTests.cs
+++ b/windows/Ghostty.Tests/Session/SessionTreeTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using Ghostty.Core.Panes;
 using Ghostty.Core.Profiles;
@@ -132,5 +133,141 @@ public class SessionTreeTests
 
         var rebuilt = (SplitPane)SessionTree.RebuildTree(dto, d => new LeafPane { Snapshot = Snap(d.ProfileId!) });
         Assert.Equal(expected, rebuilt.Ratio, precision: 6);
+    }
+
+    // makeLeaf returning null is a refusal: restore drops the leaf (a
+    // saved pane whose profile is gone AND whose fallback cannot be
+    // spawned). A split it empties collapses; a tree with nothing left
+    // refuses in turn so the caller can drop the tab.
+    private static LeafPane? KeepAllBut(LeafDto d) =>
+        d.ProfileId!.StartsWith("refuse", StringComparison.Ordinal)
+            ? null
+            : new LeafPane { Snapshot = Snap(d.ProfileId!) };
+
+    [Fact]
+    public void RebuildTree_RefusedLeaf_CollapsesItsSplit()
+    {
+        var dto = new SplitDto
+        {
+            Orientation = PaneOrientation.Vertical,
+            Child1 = new LeafDto { ProfileId = "keep" },
+            Child2 = new LeafDto { ProfileId = "refuse" },
+        };
+
+        var rebuilt = SessionTree.RebuildTree(dto, KeepAllBut);
+
+        // No one-pane split: the survivor IS the root now.
+        var leaf = Assert.IsType<LeafPane>(rebuilt);
+        Assert.Equal("keep", leaf.Snapshot!.ProfileId);
+    }
+
+    [Fact]
+    public void RebuildTree_NestedRefusals_PromoteTheSurvivor()
+    {
+        // (refuse - keep) - refuse-too: both splits lose a side.
+        var dto = new SplitDto
+        {
+            Orientation = PaneOrientation.Vertical,
+            Child1 = new SplitDto
+            {
+                Orientation = PaneOrientation.Horizontal,
+                Child1 = new LeafDto { ProfileId = "refuse" },
+                Child2 = new LeafDto { ProfileId = "keep" },
+            },
+            Child2 = new LeafDto { ProfileId = "refuse-too" },
+        };
+
+        var rebuilt = SessionTree.RebuildTree(dto, KeepAllBut);
+
+        var leaf = Assert.IsType<LeafPane>(rebuilt);
+        Assert.Equal("keep", leaf.Snapshot!.ProfileId);
+    }
+
+    [Fact]
+    public void RebuildTree_TwoSurvivors_KeepTheirSplit()
+    {
+        // keep - (refuse - keep): the outer split keeps both sides, the
+        // inner collapses. Refusals must never take a live split down.
+        var dto = new SplitDto
+        {
+            Orientation = PaneOrientation.Vertical,
+            Ratio = 0.7,
+            Child1 = new LeafDto { ProfileId = "keep-a" },
+            Child2 = new SplitDto
+            {
+                Orientation = PaneOrientation.Horizontal,
+                Child1 = new LeafDto { ProfileId = "refuse" },
+                Child2 = new LeafDto { ProfileId = "keep-b" },
+            },
+        };
+
+        var rebuilt = Assert.IsType<SplitPane>(SessionTree.RebuildTree(dto, KeepAllBut));
+
+        Assert.Equal(0.7, rebuilt.Ratio, precision: 6);
+        var a = Assert.IsType<LeafPane>(rebuilt.Child1);
+        var b = Assert.IsType<LeafPane>(rebuilt.Child2);
+        Assert.Equal("keep-a", a.Snapshot!.ProfileId);
+        Assert.Equal("keep-b", b.Snapshot!.ProfileId);
+    }
+
+    [Fact]
+    public void RebuildTree_AllLeavesRefused_ReturnsNull()
+    {
+        LeafPane? Refuse(LeafDto _) => null;
+
+        Assert.Null(SessionTree.RebuildTree(new LeafDto { ProfileId = "x" }, Refuse));
+        Assert.Null(SessionTree.RebuildTree(new SplitDto
+        {
+            Orientation = PaneOrientation.Vertical,
+            Child1 = new LeafDto { ProfileId = "x" },
+            Child2 = new LeafDto { ProfileId = "y" },
+        }, Refuse));
+    }
+
+    [Fact]
+    public void RebuildTree_ResolverDrivenDrop_RemovesTheStaleLeafFromTheNextSave()
+    {
+        // The restore the way SessionRestorer drives it: refuse exactly
+        // what SessionProfileResolver.ShouldDropLeaf refuses, spawn the
+        // rest through ResolveLeaf. A stale rc.1 Headless SSH leaf
+        // beside an ordinary custom leaf, on a machine where nothing
+        // resolves (Desktop: the preset is not offered at all).
+        IProfileRegistry? registry = null;
+        var dto = new SplitDto
+        {
+            Orientation = PaneOrientation.Horizontal,
+            Child1 = new LeafDto
+            {
+                ProfileId = "wintty.builtin.headless-ssh",
+                Fallback = new LeafCommand
+                {
+                    ResolvedCommand = "ssh ${env:WINTTY_SSH_TARGET}",
+                    DisplayName = "Headless SSH",
+                },
+            },
+            Child2 = new LeafDto
+            {
+                ProfileId = "my-dev-box",
+                Fallback = new LeafCommand
+                {
+                    ResolvedCommand = "cmd.exe /k echo hi",
+                    DisplayName = "dev",
+                },
+            },
+        };
+
+        var rebuilt = SessionTree.RebuildTree(dto, leaf =>
+            SessionProfileResolver.ShouldDropLeaf(registry, leaf)
+                ? null
+                : new LeafPane { Snapshot = SessionProfileResolver.ResolveLeaf(registry, leaf) });
+
+        var survivor = Assert.IsType<LeafPane>(rebuilt);
+        Assert.Equal("my-dev-box", survivor.Snapshot!.ProfileId);
+        Assert.Equal("cmd.exe /k echo hi", survivor.Snapshot.ResolvedCommand);
+
+        // The save after that restore cannot resurrect the leaf: the
+        // rebuilt tree, captured back, carries only the survivor.
+        var resaved = Assert.IsType<LeafDto>(SessionTree.CaptureTree(rebuilt));
+        Assert.Equal("my-dev-box", resaved.ProfileId);
     }
 }

--- a/windows/Ghostty.Tests/Session/SessionTreeTests.cs
+++ b/windows/Ghostty.Tests/Session/SessionTreeTests.cs
@@ -270,4 +270,33 @@ public class SessionTreeTests
         var resaved = Assert.IsType<LeafDto>(SessionTree.CaptureTree(rebuilt));
         Assert.Equal("my-dev-box", resaved.ProfileId);
     }
+
+    [Fact]
+    public void RebuildTree_ResolverDrivenKeep_OrdinaryOneLinerSurvives()
+    {
+        // The same driven shape, keep side: an unresolvable custom
+        // profile whose command embeds ${env:BUILD_ID} is the user's
+        // own live PowerShell, not the retired template, so restore,
+        // duplicate and reopen all rebuild it with its command intact.
+        IProfileRegistry? registry = null;
+        var dto = new LeafDto
+        {
+            ProfileId = "custom",
+            Fallback = new LeafCommand
+            {
+                ResolvedCommand = "pwsh -NoProfile -c echo ${env:BUILD_ID}",
+                DisplayName = "build",
+            },
+        };
+
+        var rebuilt = SessionTree.RebuildTree(dto, leaf =>
+            SessionProfileResolver.ShouldDropLeaf(registry, leaf)
+                ? null
+                : new LeafPane { Snapshot = SessionProfileResolver.ResolveLeaf(registry, leaf) });
+
+        var survivor = Assert.IsType<LeafPane>(rebuilt);
+        Assert.Equal("custom", survivor.Snapshot!.ProfileId);
+        Assert.Equal("pwsh -NoProfile -c echo ${env:BUILD_ID}",
+            survivor.Snapshot.ResolvedCommand);
+    }
 }

--- a/windows/Ghostty.Tests/Wiring/SessionRestoreDropWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/SessionRestoreDropWiringTests.cs
@@ -1,0 +1,124 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// Behaviour facts live in SessionTreeTests and
+/// SessionProfileResolverTests (drop, collapse, keep, never-resaved);
+/// these are the wiring guards for the hops in the WinUI restorer a
+/// unit test cannot see: the drop decision is wired into the rebuild,
+/// an emptied tab is not rebuilt at all, the restore says so exactly
+/// once, and only the restore site hands the restorer a logger (the
+/// reopen/duplicate sites drop silently by design).
+/// </summary>
+public class SessionRestoreDropWiringTests
+{
+    // BuildTab has two overloads now: the public single-tab entry and
+    // the private worker BuildTabs also drives (it carries the dropped
+    // names out). The drop wiring lives in the worker.
+    private static MethodDeclarationSyntax WorkerBuildTab(ShellSource src)
+    {
+        var both = src.Root.DescendantNodes().OfType<MethodDeclarationSyntax>()
+            .Where(m => m.Identifier.ValueText == "BuildTab")
+            .ToList();
+        Assert.True(both.Count == 2,
+            $"expected the public entry and the private worker, found {both.Count}");
+        return both.Single(m => m.ParameterList.Parameters.Count == 2);
+    }
+
+    private static bool ReturnsNull(ReturnStatementSyntax r) =>
+        r.Expression is LiteralExpressionSyntax l
+            && l.IsKind(SyntaxKind.NullLiteralExpression);
+
+    [Fact]
+    public void BuildTab_RefusesThroughTheResolver_BeforeResolving()
+    {
+        var buildTab = WorkerBuildTab(ShellSource.Load("Session.SessionRestorer.cs"));
+
+        var rebuild = buildTab.Call("SessionTree.RebuildTree");
+        var lambda = Assert.IsAssignableFrom<LambdaExpressionSyntax>(rebuild.ArgExpression(1));
+
+        // The refusal IS the resolver's decision, asked before anything
+        // spawns, and its arm is the lambda's one null return.
+        var ask = lambda.Calls("SessionProfileResolver.ShouldDropLeaf");
+        Assert.Single(ask);
+        var resolve = lambda.Calls("SessionProfileResolver.ResolveLeaf");
+        Assert.Single(resolve);
+        Assert.True(ask[0].SpanStart < resolve[0].SpanStart,
+            "the drop decision must be asked before the leaf resolves");
+
+        var nullReturns = lambda.DescendantNodes().OfType<ReturnStatementSyntax>()
+            .Where(ReturnsNull).ToList();
+        Assert.Single(nullReturns);
+    }
+
+    [Fact]
+    public void BuildTab_AnAllRefusedTree_BuildsNoTab()
+    {
+        var buildTab = WorkerBuildTab(ShellSource.Load("Session.SessionRestorer.cs"));
+
+        // RebuildTree hands back null when every leaf was refused; the
+        // tab must translate that into "no tab" so it is neither
+        // restored nor, never built, re-saved. The null return has to
+        // sit after the rebuild (the one inside the lambda is the
+        // per-leaf refusal, not the tab's).
+        var rebuild = buildTab.Call("SessionTree.RebuildTree");
+        Assert.Contains(buildTab.DescendantNodes().OfType<ReturnStatementSyntax>(),
+            r => ReturnsNull(r) && r.SpanStart > rebuild.Span.End);
+    }
+
+    [Fact]
+    public void BuildTabs_LoggedOncePerRestore_NotPerLeaf()
+    {
+        var buildTabs = ShellSource.Load("Session.SessionRestorer.cs").Method("BuildTabs");
+
+        var notice = buildTabs.Calls("_logger.LogSessionRestoreDroppedLeaves");
+        Assert.Single(notice);
+
+        // And only when something actually went: the call is guarded by
+        // the drop count, not fired unconditionally.
+        var guard = notice[0].Ancestors().OfType<IfStatementSyntax>().FirstOrDefault();
+        Assert.NotNull(guard);
+        Assert.Contains("dropped.Count", guard!.Condition.ToString());
+    }
+
+    [Fact]
+    public void OnlyTheRestoreSite_HandsTheRestorerALogger()
+    {
+        var mainWindow = ShellSource.Load("MainWindow.xaml.cs");
+        var restorers = mainWindow.Root.DescendantNodes().OfType<ObjectCreationExpressionSyntax>()
+            .Where(o => o.Type.ToString().Contains("SessionRestorer")).ToList();
+        Assert.True(restorers.Count == 3,
+            $"expected restore, reopen and duplicate sites, found {restorers.Count}");
+
+        // The restore site is the one that logs; reopen and duplicate
+        // capture live tabs, where a refusal is not a real state.
+        var logged = restorers.Where(o => o.ArgumentList!.Arguments.Count == 3
+            && o.ArgumentList.Arguments[2].ToString().Contains("CreateLogger")).ToList();
+        Assert.Single(logged);
+    }
+
+    [Fact]
+    public void AnEmptyRestore_FallsThroughToTheFreshDefaultTab()
+    {
+        var mainWindow = ShellSource.Load("MainWindow.xaml.cs");
+
+        // The chain's last hop: when every tab of a saved window is
+        // dropped, BuildTabs comes back empty and the ctor must keep the
+        // fresh-start default-tab path it already had. The guard on the
+        // restoredTabs assignment is what keeps an empty list from
+        // seeding an empty window.
+        var assignment = mainWindow.Root.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.Left.ToString() == "restoredTabs"
+                        && a.Right.ToString() == "built")
+            .ToList();
+        Assert.Single(assignment);
+        var guard = assignment[0].Ancestors().OfType<IfStatementSyntax>().FirstOrDefault();
+        Assert.NotNull(guard);
+        Assert.Contains("built.Count", guard!.Condition.ToString());
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/SessionRestoreDropWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/SessionRestoreDropWiringTests.cs
@@ -121,4 +121,24 @@ public class SessionRestoreDropWiringTests
         Assert.NotNull(guard);
         Assert.Contains("built.Count", guard!.Condition.ToString());
     }
+
+    [Fact]
+    public void ReopenAndDuplicate_RideTheSameDropDecision()
+    {
+        var mainWindow = ShellSource.Load("MainWindow.xaml.cs");
+
+        // A leaf the rule KEEPS (an ordinary env-var one-liner, say)
+        // must still duplicate and reopen: both call sites go through
+        // the same BuildTab worker the restore does, so one
+        // ShouldDropLeaf decision covers all three paths. The chained
+        // spelling in DuplicateTab (restorer on one line, .BuildTab on
+        // the next) needs the suffix match.
+        var reopen = mainWindow.Method("ReopenClosedTab");
+        Assert.Single(reopen.Calls("restorer.BuildTab"));
+
+        var duplicate = mainWindow.Method("DuplicateTab");
+        Assert.Single(duplicate.DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .Where(i => i.CalleeText().EndsWith(".BuildTab", System.StringComparison.Ordinal)));
+    }
 }

--- a/windows/Ghostty/Logging/LogEvents.cs
+++ b/windows/Ghostty/Logging/LogEvents.cs
@@ -98,6 +98,7 @@ internal static class LogEvents
         public const int LoadFailed   = 2800;
         public const int SaveFailed   = 2801;
         public const int DeleteFailed = 2802;
+        public const int RestoreDroppedLeaves = 2803;
     }
 
     // 2900-2999: Single-instance mode. The serving half's ids

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -807,8 +807,11 @@ public sealed partial class MainWindow : Window
         List<TabModel>? restoredTabs = null;
         // One restorer for both halves: BuildTabs records the saved-tab
         // pairing the group restore reads back, so the seeding block and
-        // the group block must use the same instance.
-        var restorer = new Ghostty.Session.SessionRestorer(_factory, App.ProfileRegistry);
+        // the group block must use the same instance. The logger is what
+        // makes dropped leaves (a preset this build does not offer) say
+        // so: exactly one notice per restore.
+        var restorer = new Ghostty.Session.SessionRestorer(
+            _factory, App.ProfileRegistry, loggerFactory.CreateLogger<Ghostty.Session.SessionRestorer>());
         if (restore is { Tabs.Count: > 0 })
         {
             var built = restorer.BuildTabs(restore);

--- a/windows/Ghostty/Session/SessionRestorer.cs
+++ b/windows/Ghostty/Session/SessionRestorer.cs
@@ -163,7 +163,7 @@ internal sealed class SessionRestorer
 internal static partial class SessionRestorerLogExtensions
 {
     [LoggerMessage(EventId = LogEvents.Session.RestoreDroppedLeaves,
-                   Level = LogLevel.Warning, Message = "Session restore dropped {Count} saved pane(s) whose profile is no longer offered: {Names}")]
+                   Level = LogLevel.Warning, Message = "Session restore dropped {Count} saved pane(s) whose profile this build does not offer ({Names}); the next session save removes them for good. To get them back: enable or unhide the profile in Settings, or for Headless SSH set WINTTY_SSH_TARGET or launch with --ssh user@host")]
     internal static partial void LogSessionRestoreDroppedLeaves(
         this ILogger<SessionRestorer> logger, int count, string names);
 }

--- a/windows/Ghostty/Session/SessionRestorer.cs
+++ b/windows/Ghostty/Session/SessionRestorer.cs
@@ -163,7 +163,7 @@ internal sealed class SessionRestorer
 internal static partial class SessionRestorerLogExtensions
 {
     [LoggerMessage(EventId = LogEvents.Session.RestoreDroppedLeaves,
-                   Level = LogLevel.Warning, Message = "Session restore dropped {Count} saved pane(s) whose profile this build does not offer ({Names}); the next session save removes them for good. To get them back: enable or unhide the profile in Settings, or for Headless SSH set WINTTY_SSH_TARGET or launch with --ssh user@host")]
+                   Level = LogLevel.Warning, Message = "Session restore dropped {Count} saved pane(s) whose profile this build does not offer ({Names}); the next session save removes them for good. Headless SSH panes return once WINTTY_SSH_TARGET is set or you launch with --ssh user@host; any other withdrawn built-in has no restore path in this build")]
     internal static partial void LogSessionRestoreDroppedLeaves(
         this ILogger<SessionRestorer> logger, int count, string names);
 }

--- a/windows/Ghostty/Session/SessionRestorer.cs
+++ b/windows/Ghostty/Session/SessionRestorer.cs
@@ -3,43 +3,66 @@ using Ghostty.Core.Panes;
 using Ghostty.Core.Profiles;
 using Ghostty.Core.Session;
 using Ghostty.Core.Tabs;
+using Ghostty.Logging;
 using Ghostty.Tabs;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Ghostty.Session;
 
 /// <summary>
 /// Reconstructs <see cref="TabModel"/>s (with tree-seeded pane hosts) from
 /// a persisted <see cref="WindowSession"/>. Profiles are re-resolved by id
-/// so edits take effect; a removed profile falls back to the saved command.
+/// so edits take effect; a removed profile falls back to the saved command,
+/// except a leaf whose id resolves to nothing offered and whose saved
+/// command cannot be spawned (a withdrawn built-in, or the retired
+/// <c>${env:}</c> template), which is dropped rather than spawned dead.
 /// </summary>
 internal sealed class SessionRestorer
 {
     private readonly PaneHostFactory _factory;
     private readonly IProfileRegistry? _registry;
+    private readonly ILogger<SessionRestorer> _logger;
     // The saved tab paired with the model built from it, in saved order.
     // Group membership is a saved TAB field (GroupId), and BuildTab skips
     // tabs whose tree would not rebuild, so the pairing -- not list
     // position -- is what maps members back onto their group.
     private readonly List<(TabSession Source, TabModel Tab)> _built = new();
 
-    public SessionRestorer(PaneHostFactory factory, IProfileRegistry? registry)
+    public SessionRestorer(
+        PaneHostFactory factory,
+        IProfileRegistry? registry,
+        ILogger<SessionRestorer>? logger = null)
     {
         _factory = factory;
         _registry = registry;
+        _logger = logger ?? NullLogger<SessionRestorer>.Instance;
     }
 
     public List<TabModel> BuildTabs(WindowSession window)
     {
         var result = new List<TabModel>();
         _built.Clear();
+        var dropped = new List<string>();
         foreach (var tabDto in window.Tabs)
         {
-            if (BuildTab(tabDto) is { } tab)
+            if (BuildTab(tabDto, dropped) is { } tab)
             {
                 result.Add(tab);
                 _built.Add((tabDto, tab));
             }
         }
+
+        // One notice per restore naming everything that went, not a line
+        // per leaf: a gated preset can take a whole saved window's worth
+        // of tabs with it, and per-leaf spam would say the same thing N
+        // times. Only the restore pass logs (it owns the logger); the
+        // reopen/duplicate entry points below drop silently, and their
+        // captures come from live tabs, where a refusal is not a real
+        // state.
+        if (dropped.Count > 0)
+            _logger.LogSessionRestoreDroppedLeaves(dropped.Count, string.Join(", ", dropped));
+
         return result;
     }
 
@@ -72,17 +95,31 @@ internal sealed class SessionRestorer
     /// <summary>
     /// Rebuild a single <see cref="TabModel"/> (tree-seeded pane host, fresh
     /// shells) from one persisted <see cref="TabSession"/>, or null if the
-    /// snapshot has no tree. Used by <see cref="BuildTabs"/> and by the
-    /// same-session reopen-closed-tab path.
+    /// snapshot has no tree -- or if every leaf in it was dropped, in which
+    /// case the tab is not restored at all and, never built, is not
+    /// re-saved. Used by the same-session reopen-closed-tab path (drops
+    /// there are silent: no restore logger is in play).
     /// </summary>
-    public TabModel? BuildTab(TabSession tabDto)
+    public TabModel? BuildTab(TabSession tabDto) => BuildTab(tabDto, new List<string>());
+
+    private TabModel? BuildTab(TabSession tabDto, List<string> dropped)
     {
         if (tabDto.Tree is null) return null;
 
         // Rebuild the structure; each leaf re-resolves its own profile
-        // (exact id, else its saved fallback command).
-        var root = SessionTree.RebuildTree(tabDto.Tree,
-            leaf => new LeafPane { Snapshot = SessionProfileResolver.ResolveLeaf(_registry, leaf) });
+        // (exact id, else its saved fallback command). A refused leaf is
+        // dropped: RebuildTree collapses the splits it empties and hands
+        // back null when nothing survives.
+        var root = SessionTree.RebuildTree(tabDto.Tree, leaf =>
+        {
+            if (SessionProfileResolver.ShouldDropLeaf(_registry, leaf))
+            {
+                dropped.Add(DroppedLeafName(leaf));
+                return null;
+            }
+            return new LeafPane { Snapshot = SessionProfileResolver.ResolveLeaf(_registry, leaf) };
+        });
+        if (root is null) return null;
 
         var active = SessionTree.Resolve(root, tabDto.ActiveLeafPath) as LeafPane
                      ?? PaneTree.FirstLeaf(root);
@@ -110,4 +147,23 @@ internal sealed class SessionRestorer
 
         return tab;
     }
+
+    /// <summary>
+    /// How a dropped leaf is named in the restore notice: the display
+    /// name its profile carried when it was saved (the name the user
+    /// saw on the tab), falling back to the raw id for saves that
+    /// predate a display name.
+    /// </summary>
+    private static string DroppedLeafName(LeafDto leaf) =>
+        !string.IsNullOrEmpty(leaf.Fallback?.DisplayName)
+            ? leaf.Fallback!.DisplayName
+            : leaf.ProfileId!;
+}
+
+internal static partial class SessionRestorerLogExtensions
+{
+    [LoggerMessage(EventId = LogEvents.Session.RestoreDroppedLeaves,
+                   Level = LogLevel.Warning, Message = "Session restore dropped {Count} saved pane(s) whose profile is no longer offered: {Names}")]
+    internal static partial void LogSessionRestoreDroppedLeaves(
+        this ILogger<SessionRestorer> logger, int count, string names);
 }


### PR DESCRIPTION
# session: restore must not spawn a leaf whose built-in profile is not offered

Fork half of the follow-up fix from the release-side review: a saved leaf whose profile id resolves to nothing
the registry offers fell back to its saved command and spawned it
locally, even when that command could not run. Headless SSH tabs saved by an earlier release
carry the retired `${env:WINTTY_SSH_TARGET}` template, so on every tier
where that preset is not offered the restored pane ran the literal
string, died on ssh's own DNS error, and was re-saved on each launch.

## The rule (after review round 1)

A leaf is dropped at restore when its id is unknown to the registry
(neither offered nor hidden) AND its saved fallback is not spawnable:

- the id sits in the reserved `wintty.builtin.*` namespace yet no
  profile claims it: this machine's composition is refusing to offer
  that built-in (gated off, or a tier that never shipped it), and its
  saved command is the built-in's own launch line;
- or the saved command embeds the exact retired template
  `${env:WINTTY_SSH_TARGET}` (case-insensitive), which nothing
  expands: the pane would hand the literal template to its child
  process.

The boundary, deliberately narrow:

- a leaf whose profile was merely renamed or deleted is KEPT: its
  saved command is the user's own, spawnable as written, and it keeps
  the documented fallback behaviour (re-run what the tab actually ran);
- a leaf whose id the registry still HIDES is KEPT: hiding is a menu
  choice about a profile the composition still carries, not a
  withdrawal. The release gate omits a refused preset rather than
  hiding it, so gated presets stay droppable;
- the user's own `${env:NAME}` one-liners are KEPT: that is live
  PowerShell the spawned shell expands, so only the exact retired
  Headless SSH token counts as unspawnable;
- a resolvable id is never dropped, even with the token in its command
  (the fresh profile wins; the fallback is never consulted), and a
  legacy no-profile leaf is never dropped.

## Consequences

- Splits emptied by a drop collapse to their survivor; a split that
  keeps both sides keeps its saved ratio.
- A tab emptied of every leaf is not rebuilt at all, so it is not
  restored and, never built, is not re-saved.
- A window left with no tabs takes the existing fresh-start default
  path (the `built.Count > 0` guard already there).
- Exactly one warning per restore (event 2803) names the count and the
  dropped profiles' display names, says the next save removes them for
  good, and offers only the arms that can actually recover a dropped
  leaf: Headless SSH panes return once `WINTTY_SSH_TARGET` is set or
  you launch with `--ssh user@host`; any other withdrawn built-in has
  no restore path in this build (in this build a hidden profile is KEPT, so
  unhiding can never be the recovery for a dropped leaf). This is log-only by design: the restore path has
  no user-visible notice channel today (the toast service serves hang
  evidence and inspector notices), so inventing one is out of scope
  here. The reopen and duplicate-tab paths share the drop decision but
  stay silent: their captures come from live tabs.

`SessionProfileResolver.ShouldDropLeaf` owns the decision,
`SessionTree.RebuildTree` takes a nullable leaf factory and collapses
emptied splits, `SessionRestorer.BuildTab` drops and `BuildTabs` logs.

## Tests (RED first)

Round 0: the new rows failed to compile on `windows` (no
`ShouldDropLeaf`); with the API behind a refuses-nothing stub, 6 rows
failed. Round 1 (hidden-set keep, exact-template narrowing): 4 rows
failed against the round-0 code (hidden offered builtin kept, ordinary
env-var one-liner kept, the case-variant retired template dropped, the
driven-path keep row), then green at d9c3548e.

At the current head: Session filter 164/164, Wiring namespace 612/612
(including the reopen/duplicate pin), and the WinUI app project
compiles against the freshly built `ghostty.dll`. Pins include: stale
builtin dropped, withdrawn builtin with plain command dropped, exact
retired template dropped in three spellings, renamed custom kept,
hidden offered builtin kept, hidden custom kept, ordinary env-var
one-liner kept, resolvable id kept, legacy leaf kept, custom id with
no fallback kept, namespace case rows, a mixed-case saved id of an
offered builtin resolving and kept (the fake registry's comparer now
matches the real OrdinalIgnoreCase one), split collapse / promotion /
two-survivors / all-refused, the capture of a rebuilt tree carrying no
dropped leaf, and wiring guards for the drop-before-resolve order, the
all-refused tab, the one-notice log, the restore-site logger, the
empty-restore fresh-start fallback, and reopen/duplicate riding the
same decision. Round 2 (notice arms, fake comparer): the mixed-case
row failed against the case-sensitive fake, then green at 33b12b8.

The release tiers pick this up at the next pin move.
